### PR TITLE
ci: add GitHub Actions workflow to build Android APK on release

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -1,0 +1,57 @@
+name: Build Android APK
+
+on:
+  release:
+    types: [published]
+
+  # Allow manual trigger for testing
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build APK
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: temurin
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Generate native Android project
+        run: npx expo prebuild --platform android --clean
+
+      - name: Make Gradlew executable
+        run: chmod +x android/gradlew
+
+      - name: Build release APK
+        working-directory: android
+        run: ./gradlew assembleRelease
+
+      - name: Upload APK as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: iosToAndroid-${{ github.event.release.tag_name || 'dev' }}
+          path: android/app/build/outputs/apk/release/*.apk
+
+      - name: Upload APK to release
+        if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v2
+        with:
+          files: android/app/build/outputs/apk/release/*.apk

--- a/app.json
+++ b/app.json
@@ -16,6 +16,7 @@
       "supportsTablet": true
     },
     "android": {
+      "package": "com.iostoandroid.app",
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#ffffff"


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow that builds a release APK when a GitHub release is published
- Support manual `workflow_dispatch` trigger for testing
- APK is uploaded as a workflow artifact and attached to the GitHub release for easy install
- Add `android.package` to app.json (required for `expo prebuild`)

## Test plan
- [ ] Trigger the workflow manually from the Actions tab to verify APK builds
- [ ] Create a test release and confirm APK is attached to the release page
- [ ] Download the APK and install on an Android device

https://claude.ai/code/session_01Bw2eMTGKpaGkY4T7m2ei4d