### PR TITLE
fix(ci): add write permissions for release uploads

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -7,6 +7,9 @@ on:
   # Allow manual trigger for testing
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   build:
     name: Build APK


### PR DESCRIPTION
## Summary
- Adds `permissions: contents: write` to the build-apk workflow so `softprops/action-gh-release` can attach APK files to releases