### PR TITLE
fix(ci): add AsyncStorage Maven repo for Gradle builds

### DIFF
--- a/app.json
+++ b/app.json
@@ -26,6 +26,9 @@
     },
     "web": {
       "favicon": "./assets/favicon.png"
-    }
+    },
+    "plugins": [
+      "./plugins/withAsyncStorageRepo"
+    ]
   }
 }

--- a/plugins/withAsyncStorageRepo.js
+++ b/plugins/withAsyncStorageRepo.js
@@ -1,0 +1,22 @@
+const { withProjectBuildGradle } = require("expo/config-plugins");
+
+/**
+ * Adds the AsyncStorage local Maven repository to the project-level build.gradle.
+ * AsyncStorage v3+ ships a KMP artifact (storage-android) in a local_repo directory
+ * that Gradle needs to resolve.
+ */
+module.exports = function withAsyncStorageRepo(config) {
+  return withProjectBuildGradle(config, (config) => {
+    const contents = config.modResults.contents;
+    const repoLine =
+      'maven { url(new File(["node", "--print", "require.resolve(\'@react-native-async-storage/async-storage/package.json\')"].execute(null, rootDir).text.trim(), "../android/local_repo")) }';
+
+    if (!contents.includes("asyncstorage") && !contents.includes("shared_storage")) {
+      config.modResults.contents = contents.replace(
+        /allprojects\s*\{\s*repositories\s*\{/,
+        `allprojects {\n    repositories {\n        ${repoLine}`
+      );
+    }
+    return config;
+  });
+};


### PR DESCRIPTION
## Summary
- AsyncStorage v3 ships `storage-android` in a local Maven repo that Gradle can't resolve from mavenCentral/google
- Adds Expo config plugin that injects the local repo path into `build.gradle` during `expo prebuild`

## Context
This fixes the `Could not find org.asyncstorage.shared_storage:storage-android:1.0.0` error in v0.0.3 release build.