### PR TITLE
feat: Android launcher — native module, app grid, dock, drawer

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -7,6 +7,7 @@ import { ThemeProvider, useTheme } from './src/theme/ThemeContext';
 import { SettingsProvider } from './src/store/SettingsStore';
 import { ContactsProvider } from './src/store/ContactsStore';
 import { ProfileProvider } from './src/store/ProfileStore';
+import { AppsProvider } from './src/store/AppsStore';
 import { TabNavigator } from './src/navigation/TabNavigator';
 import { ErrorBoundary } from './src/components/ErrorBoundary';
 
@@ -28,11 +29,13 @@ export default function App() {
           <SettingsProvider>
             <ContactsProvider>
               <ProfileProvider>
+                <AppsProvider>
                 <ErrorBoundary>
                   <NavigationContainer>
                     <AppContent />
                   </NavigationContainer>
                 </ErrorBoundary>
+                </AppsProvider>
               </ProfileProvider>
             </ContactsProvider>
           </SettingsProvider>

--- a/app.json
+++ b/app.json
@@ -21,14 +21,19 @@
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#ffffff"
       },
+      "permissions": ["android.permission.QUERY_ALL_PACKAGES"],
       "edgeToEdgeEnabled": true,
       "predictiveBackGestureEnabled": false
     },
     "web": {
       "favicon": "./assets/favicon.png"
     },
+    "autolinking": {
+      "nativeModulesDir": "./modules"
+    },
     "plugins": [
-      "./plugins/withAsyncStorageRepo"
+      "./plugins/withAsyncStorageRepo",
+      "./plugins/withLauncherIntent"
     ]
   }
 }

--- a/modules/launcher-module/android/build.gradle
+++ b/modules/launcher-module/android/build.gradle
@@ -1,0 +1,35 @@
+apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+apply plugin: 'expo-module-gradle-plugin'
+
+group = 'com.iostoandroid'
+version = '1.0.0'
+
+android {
+    namespace "com.iostoandroid.launcher"
+    compileSdkVersion safeExtGet("compileSdkVersion", 35)
+
+    defaultConfig {
+        minSdkVersion safeExtGet("minSdkVersion", 24)
+        targetSdkVersion safeExtGet("targetSdkVersion", 35)
+        versionCode 1
+        versionName "1.0.0"
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+}
+
+dependencies {
+    implementation project(':expo-modules-core')
+}
+
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}

--- a/modules/launcher-module/android/src/main/AndroidManifest.xml
+++ b/modules/launcher-module/android/src/main/AndroidManifest.xml
@@ -1,0 +1,3 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" />
+</manifest>

--- a/modules/launcher-module/android/src/main/java/com/iostoandroid/launcher/LauncherModule.kt
+++ b/modules/launcher-module/android/src/main/java/com/iostoandroid/launcher/LauncherModule.kt
@@ -1,0 +1,110 @@
+package com.iostoandroid.launcher
+
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ApplicationInfo
+import android.content.pm.PackageManager
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.drawable.BitmapDrawable
+import android.graphics.drawable.Drawable
+import android.util.Base64
+import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.modules.ModuleDefinition
+import java.io.ByteArrayOutputStream
+
+class LauncherModule : Module() {
+    private val context: Context
+        get() = appContext.reactContext ?: throw Exception("React context is not available")
+
+    override fun definition() = ModuleDefinition {
+        Name("LauncherModule")
+
+        AsyncFunction("getInstalledApps") {
+            val pm = context.packageManager
+            val mainIntent = Intent(Intent.ACTION_MAIN, null).apply {
+                addCategory(Intent.CATEGORY_LAUNCHER)
+            }
+            val activities = pm.queryIntentActivities(mainIntent, 0)
+
+            activities.map { resolveInfo ->
+                val appInfo = resolveInfo.activityInfo.applicationInfo
+                val label = resolveInfo.loadLabel(pm).toString()
+                val packageName = resolveInfo.activityInfo.packageName
+                val icon = try {
+                    drawableToBase64(resolveInfo.loadIcon(pm))
+                } catch (e: Exception) {
+                    ""
+                }
+                val isSystem = (appInfo.flags and ApplicationInfo.FLAG_SYSTEM) != 0
+
+                mapOf(
+                    "name" to label,
+                    "packageName" to packageName,
+                    "icon" to icon,
+                    "isSystem" to isSystem
+                )
+            }.sortedBy { (it["name"] as String).lowercase() }
+        }
+
+        AsyncFunction("launchApp") { packageName: String ->
+            val intent = context.packageManager.getLaunchIntentForPackage(packageName)
+            if (intent != null) {
+                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                context.startActivity(intent)
+                true
+            } else {
+                false
+            }
+        }
+
+        AsyncFunction("getAppIcon") { packageName: String ->
+            try {
+                val pm = context.packageManager
+                val icon = pm.getApplicationIcon(packageName)
+                drawableToBase64(icon)
+            } catch (e: Exception) {
+                ""
+            }
+        }
+
+        AsyncFunction("isDefaultLauncher") {
+            val pm = context.packageManager
+            val intent = Intent(Intent.ACTION_MAIN).apply {
+                addCategory(Intent.CATEGORY_HOME)
+            }
+            val resolveInfo = pm.resolveActivity(intent, PackageManager.MATCH_DEFAULT_ONLY)
+            resolveInfo?.activityInfo?.packageName == context.packageName
+        }
+
+        AsyncFunction("openLauncherSettings") {
+            val intent = Intent(android.provider.Settings.ACTION_HOME_SETTINGS)
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            context.startActivity(intent)
+            true
+        }
+    }
+
+    private fun drawableToBase64(drawable: Drawable): String {
+        val bitmap = drawableToBitmap(drawable)
+        val scaledBitmap = Bitmap.createScaledBitmap(bitmap, 128, 128, true)
+        val outputStream = ByteArrayOutputStream()
+        scaledBitmap.compress(Bitmap.CompressFormat.PNG, 90, outputStream)
+        val bytes = outputStream.toByteArray()
+        if (bitmap != scaledBitmap) scaledBitmap.recycle()
+        return "data:image/png;base64," + Base64.encodeToString(bytes, Base64.NO_WRAP)
+    }
+
+    private fun drawableToBitmap(drawable: Drawable): Bitmap {
+        if (drawable is BitmapDrawable && drawable.bitmap != null) {
+            return drawable.bitmap
+        }
+        val width = if (drawable.intrinsicWidth > 0) drawable.intrinsicWidth else 128
+        val height = if (drawable.intrinsicHeight > 0) drawable.intrinsicHeight else 128
+        val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(bitmap)
+        drawable.setBounds(0, 0, canvas.width, canvas.height)
+        drawable.draw(canvas)
+        return bitmap
+    }
+}

--- a/modules/launcher-module/expo-module.config.json
+++ b/modules/launcher-module/expo-module.config.json
@@ -1,0 +1,6 @@
+{
+  "platforms": ["android"],
+  "android": {
+    "modules": ["com.iostoandroid.launcher.LauncherModule"]
+  }
+}

--- a/modules/launcher-module/package.json
+++ b/modules/launcher-module/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "launcher-module",
+  "version": "1.0.0",
+  "main": "src/index.ts",
+  "private": true
+}

--- a/modules/launcher-module/src/index.ts
+++ b/modules/launcher-module/src/index.ts
@@ -1,0 +1,35 @@
+import { requireNativeModule } from 'expo';
+import { Platform } from 'react-native';
+
+interface InstalledApp {
+  name: string;
+  packageName: string;
+  icon: string; // base64 data URI
+  isSystem: boolean;
+}
+
+interface LauncherModuleType {
+  getInstalledApps(): Promise<InstalledApp[]>;
+  launchApp(packageName: string): Promise<boolean>;
+  getAppIcon(packageName: string): Promise<string>;
+  isDefaultLauncher(): Promise<boolean>;
+  openLauncherSettings(): Promise<boolean>;
+}
+
+const isAndroid = Platform.OS === 'android';
+
+// Stub for non-Android platforms
+const stub: LauncherModuleType = {
+  getInstalledApps: async () => [],
+  launchApp: async () => false,
+  getAppIcon: async () => '',
+  isDefaultLauncher: async () => false,
+  openLauncherSettings: async () => false,
+};
+
+const LauncherModule: LauncherModuleType = isAndroid
+  ? requireNativeModule('LauncherModule')
+  : stub;
+
+export { InstalledApp, LauncherModuleType };
+export default LauncherModule;

--- a/plugins/withLauncherIntent.js
+++ b/plugins/withLauncherIntent.js
@@ -1,0 +1,40 @@
+const { withAndroidManifest } = require("expo/config-plugins");
+
+/**
+ * Adds CATEGORY_HOME and CATEGORY_DEFAULT intent filters to the main activity,
+ * making this app eligible to be selected as the default home launcher.
+ */
+module.exports = function withLauncherIntent(config) {
+  return withAndroidManifest(config, (config) => {
+    const manifest = config.modResults;
+    const mainActivity = manifest.manifest.application[0].activity?.find(
+      (activity) => activity.$["android:name"] === ".MainActivity"
+    );
+
+    if (!mainActivity) return config;
+
+    // Ensure intent-filter array exists
+    if (!mainActivity["intent-filter"]) {
+      mainActivity["intent-filter"] = [];
+    }
+
+    // Check if HOME category already exists
+    const hasHomeFilter = mainActivity["intent-filter"].some((filter) =>
+      filter.category?.some(
+        (cat) => cat.$["android:name"] === "android.intent.category.HOME"
+      )
+    );
+
+    if (!hasHomeFilter) {
+      mainActivity["intent-filter"].push({
+        action: [{ $: { "android:name": "android.intent.action.MAIN" } }],
+        category: [
+          { $: { "android:name": "android.intent.category.HOME" } },
+          { $: { "android:name": "android.intent.category.DEFAULT" } },
+        ],
+      });
+    }
+
+    return config;
+  });
+};

--- a/src/navigation/TabNavigator.tsx
+++ b/src/navigation/TabNavigator.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { LauncherHomeScreen } from '../screens/LauncherHomeScreen';
+import { AppDrawerScreen } from '../screens/AppDrawerScreen';
 import { HomeScreen } from '../screens/HomeScreen';
 import { ContactsScreen } from '../screens/ContactsScreen';
 import { ContactDetailScreen } from '../screens/contacts/ContactDetailScreen';
@@ -41,7 +43,9 @@ const ProfileStack = createNativeStackNavigator();
 function HomeStackScreen() {
   return (
     <HomeStack.Navigator screenOptions={{ headerShown: false }}>
-      <HomeStack.Screen name="HomeMain" component={HomeScreen} />
+      <HomeStack.Screen name="HomeMain" component={LauncherHomeScreen} />
+      <HomeStack.Screen name="AppDrawer" component={AppDrawerScreen} />
+      <HomeStack.Screen name="Dashboard" component={HomeScreen} />
     </HomeStack.Navigator>
   );
 }

--- a/src/screens/AppDrawerScreen.tsx
+++ b/src/screens/AppDrawerScreen.tsx
@@ -1,0 +1,279 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import React, { useState, useCallback, useMemo, useEffect } from 'react';
+import {
+  View,
+  Text,
+  Image,
+  FlatList,
+  Pressable,
+  StyleSheet,
+  Linking,
+  useWindowDimensions,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Ionicons } from '@expo/vector-icons';
+import * as Haptics from 'expo-haptics';
+
+import { useApps, InstalledApp } from '../store/AppsStore';
+import { useTheme } from '../theme/ThemeContext';
+import { CupertinoSearchBar } from '../components/CupertinoSearchBar';
+import { CupertinoNavigationBar } from '../components/CupertinoNavigationBar';
+import { CupertinoActionSheet } from '../components/CupertinoActionSheet';
+import { CupertinoActivityIndicator } from '../components/CupertinoActivityIndicator';
+
+interface AppDrawerScreenProps {
+  navigation: any;
+  route: any;
+}
+
+const ICON_SIZE = 56;
+const ICON_BORDER_RADIUS = 14;
+const NUM_COLUMNS = 4;
+
+export function AppDrawerScreen({ navigation, route }: AppDrawerScreenProps) {
+  const { theme, typography, spacing } = useTheme();
+  const { colors } = theme;
+  const { apps, dockApps, launchApp, addToDock, isLoading } = useApps();
+  const insets = useSafeAreaInsets();
+  const { width } = useWindowDimensions();
+
+  const searchFocused: boolean = route?.params?.searchFocused ?? false;
+
+  const [query, setQuery] = useState('');
+  const [autoFocus, setAutoFocus] = useState(false);
+  const [selectedApp, setSelectedApp] = useState<InstalledApp | null>(null);
+  const [actionSheetVisible, setActionSheetVisible] = useState(false);
+
+  const cellWidth = width / NUM_COLUMNS;
+
+  // Defer autoFocus so the nav bar renders first
+  useEffect(() => {
+    if (searchFocused) {
+      const timer = setTimeout(() => setAutoFocus(true), 300);
+      return () => clearTimeout(timer);
+    }
+  }, [searchFocused]);
+
+  // Sort alphabetically and filter by query
+  const filteredApps = useMemo(() => {
+    const sorted = [...apps].sort((a, b) =>
+      a.name.toLowerCase().localeCompare(b.name.toLowerCase())
+    );
+    if (!query.trim()) return sorted;
+    const q = query.trim().toLowerCase();
+    return sorted.filter(app => app.name.toLowerCase().includes(q));
+  }, [apps, query]);
+
+  const dockPackageNames = useMemo(
+    () => new Set(dockApps.map(a => a.packageName)),
+    [dockApps]
+  );
+
+  const handleLongPress = useCallback((app: InstalledApp) => {
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+    setSelectedApp(app);
+    setActionSheetVisible(true);
+  }, []);
+
+  const handleCloseActionSheet = useCallback(() => {
+    setActionSheetVisible(false);
+    setSelectedApp(null);
+  }, []);
+
+  const openAppInfo = useCallback((packageName: string) => {
+    Linking.openURL(`package:${packageName}`).catch(() => {
+      // Fallback: open general settings if package: scheme fails
+      Linking.openSettings();
+    });
+  }, []);
+
+  const actionSheetOptions = useMemo(() => {
+    if (!selectedApp) return [];
+
+    const options: { label: string; onPress: () => void; destructive?: boolean }[] = [
+      {
+        label: 'Open',
+        onPress: () => launchApp(selectedApp.packageName),
+      },
+    ];
+
+    if (!dockPackageNames.has(selectedApp.packageName)) {
+      options.push({
+        label: 'Add to Dock',
+        onPress: () => addToDock(selectedApp.packageName),
+      });
+    }
+
+    options.push({
+      label: 'App Info',
+      onPress: () => openAppInfo(selectedApp.packageName),
+    });
+
+    return options;
+  }, [selectedApp, dockPackageNames, launchApp, addToDock, openAppInfo]);
+
+  const renderItem = useCallback(
+    ({ item }: { item: InstalledApp }) => (
+      <Pressable
+        style={[styles.gridCell, { width: cellWidth }]}
+        onPress={() => launchApp(item.packageName)}
+        onLongPress={() => handleLongPress(item)}
+        delayLongPress={400}
+        android_ripple={null}
+      >
+        {item.icon ? (
+          <Image
+            source={{ uri: item.icon }}
+            style={styles.appIcon}
+            resizeMode="contain"
+          />
+        ) : (
+          <View
+            style={[
+              styles.appIcon,
+              styles.iconFallback,
+              { backgroundColor: colors.systemGray3 },
+            ]}
+          >
+            <Ionicons name="apps" size={28} color={colors.label} />
+          </View>
+        )}
+        <Text
+          style={[
+            typography.caption2,
+            styles.appName,
+            { color: colors.label },
+          ]}
+          numberOfLines={1}
+        >
+          {item.name}
+        </Text>
+      </Pressable>
+    ),
+    [cellWidth, colors, launchApp, handleLongPress, typography]
+  );
+
+  const keyExtractor = useCallback((item: InstalledApp) => item.packageName, []);
+
+  const ListEmptyComponent = useMemo(() => {
+    if (isLoading) {
+      return (
+        <View style={styles.emptyState}>
+          <CupertinoActivityIndicator />
+        </View>
+      );
+    }
+    return (
+      <View style={styles.emptyState}>
+        <Ionicons name="search-outline" size={48} color={colors.secondaryLabel} />
+        <Text style={[typography.body, { color: colors.secondaryLabel, marginTop: spacing.md }]}>
+          No apps found
+        </Text>
+      </View>
+    );
+  }, [isLoading, colors, typography, spacing]);
+
+  const closeButton = (
+    <Pressable
+      onPress={() => navigation.goBack()}
+      hitSlop={12}
+      style={styles.closeButton}
+    >
+      <Ionicons name="chevron-down" size={24} color={colors.systemBlue} />
+    </Pressable>
+  );
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.systemGroupedBackground }]}>
+      <CupertinoNavigationBar
+        title="All Apps"
+        largeTitle={false}
+        leftButton={closeButton}
+      />
+
+      <View style={[styles.searchWrapper, { paddingHorizontal: spacing.md }]}>
+        <CupertinoSearchBar
+          value={query}
+          onChangeText={setQuery}
+          placeholder="Search Apps"
+          onCancel={() => setQuery('')}
+          autoFocus={autoFocus}
+        />
+      </View>
+
+      <FlatList
+        data={filteredApps}
+        keyExtractor={keyExtractor}
+        renderItem={renderItem}
+        numColumns={NUM_COLUMNS}
+        showsVerticalScrollIndicator={false}
+        ListEmptyComponent={ListEmptyComponent}
+        contentContainerStyle={[
+          styles.listContent,
+          { paddingBottom: insets.bottom + spacing.lg },
+        ]}
+        keyboardShouldPersistTaps="handled"
+        keyboardDismissMode="on-drag"
+        getItemLayout={(_data, index) => ({
+          length: 96, // appIcon(56) + name(~20) + paddingVertical(12*2)
+          offset: 96 * Math.floor(index / NUM_COLUMNS),
+          index,
+        })}
+        removeClippedSubviews
+        maxToRenderPerBatch={20}
+        windowSize={10}
+        initialNumToRender={28}
+      />
+
+      <CupertinoActionSheet
+        visible={actionSheetVisible}
+        onClose={handleCloseActionSheet}
+        title={selectedApp?.name}
+        options={actionSheetOptions}
+        cancelLabel="Cancel"
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  searchWrapper: {
+    paddingVertical: 8,
+  },
+  listContent: {
+    paddingTop: 4,
+  },
+  gridCell: {
+    alignItems: 'center',
+    justifyContent: 'flex-start',
+    paddingVertical: 12,
+    paddingHorizontal: 4,
+  },
+  appIcon: {
+    width: ICON_SIZE,
+    height: ICON_SIZE,
+    borderRadius: ICON_BORDER_RADIUS,
+  },
+  iconFallback: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  appName: {
+    marginTop: 4,
+    textAlign: 'center',
+    width: '100%',
+    paddingHorizontal: 2,
+  },
+  emptyState: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingTop: 80,
+  },
+  closeButton: {
+    padding: 4,
+  },
+});

--- a/src/screens/LauncherHomeScreen.tsx
+++ b/src/screens/LauncherHomeScreen.tsx
@@ -1,0 +1,644 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+  View,
+  Text,
+  Image,
+  Pressable,
+  StyleSheet,
+  FlatList,
+  Platform,
+  StatusBar,
+  Dimensions,
+} from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { BlurView } from 'expo-blur';
+import { Ionicons } from '@expo/vector-icons';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useNavigation } from '@react-navigation/native';
+
+import { useApps, InstalledApp } from '../store/AppsStore';
+import { useSettings } from '../store/SettingsStore';
+import { useTheme } from '../theme/ThemeContext';
+import {
+  CupertinoSearchBar,
+  CupertinoActivityIndicator,
+  CupertinoActionSheet,
+} from '../components';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const WALLPAPERS: readonly string[] = [
+  '#667eea',
+  '#f093fb',
+  '#4facfe',
+  '#43e97b',
+  '#fa709a',
+  '#1C1C1E',
+];
+
+/** Darken a hex colour by `amount` (0-1) to build a gradient end stop. */
+function darkenHex(hex: string, amount: number): string {
+  const num = parseInt(hex.replace('#', ''), 16);
+  const r = Math.max(0, (num >> 16) - Math.round(255 * amount));
+  const g = Math.max(0, ((num >> 8) & 0xff) - Math.round(255 * amount));
+  const b = Math.max(0, (num & 0xff) - Math.round(255 * amount));
+  return `#${r.toString(16).padStart(2, '0')}${g.toString(16).padStart(2, '0')}${b.toString(16).padStart(2, '0')}`;
+}
+
+const GRID_COLUMNS = 4;
+const MAX_GRID_APPS = 16;
+const SCREEN_WIDTH = Dimensions.get('window').width;
+const ICON_CELL_SIZE = (SCREEN_WIDTH - 32) / GRID_COLUMNS; // 16px padding each side
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatTime(date: Date): string {
+  const h = date.getHours().toString().padStart(2, '0');
+  const m = date.getMinutes().toString().padStart(2, '0');
+  return `${h}:${m}`;
+}
+
+function formatDate(date: Date): string {
+  return date.toLocaleDateString('en-US', {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+interface AppIconProps {
+  app: InstalledApp;
+  size: number;
+  onPress: () => void;
+  onLongPress: () => void;
+}
+
+function AppIcon({ app, size, onPress, onLongPress }: AppIconProps) {
+  return (
+    <Pressable
+      style={[styles.appIconWrapper, { width: size }]}
+      onPress={onPress}
+      onLongPress={onLongPress}
+      android_ripple={{ color: 'rgba(255,255,255,0.2)', radius: size / 2 }}
+    >
+      {app.icon ? (
+        <Image
+          source={{ uri: app.icon }}
+          style={[styles.appIconImage, { width: size * 0.8, height: size * 0.8, borderRadius: 14 }]}
+          resizeMode="contain"
+        />
+      ) : (
+        <View
+          style={[
+            styles.appIconPlaceholder,
+            { width: size * 0.8, height: size * 0.8, borderRadius: 14 },
+          ]}
+        >
+          <Ionicons name="apps" size={size * 0.4} color="#fff" />
+        </View>
+      )}
+      <Text style={styles.appIconLabel} numberOfLines={1} ellipsizeMode="tail">
+        {app.name}
+      </Text>
+    </Pressable>
+  );
+}
+
+interface PageDotsProps {
+  total: number;
+  current: number;
+}
+
+function PageDots({ total, current }: PageDotsProps) {
+  return (
+    <View style={styles.pageDotsRow}>
+      {Array.from({ length: total }).map((_, i) => (
+        <View
+          key={i}
+          style={[
+            styles.pageDot,
+            i === current ? styles.pageDotFilled : styles.pageDotEmpty,
+          ]}
+        />
+      ))}
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Fallback for non-Android
+// ---------------------------------------------------------------------------
+
+function NonAndroidFallback() {
+  const { theme, typography, spacing } = useTheme();
+  const { colors } = theme;
+  const insets = useSafeAreaInsets();
+  const { settings } = useSettings();
+
+  const wallpaper = WALLPAPERS[Math.min(settings.wallpaperIndex, WALLPAPERS.length - 1)] as string;
+  const wallpaperDark = darkenHex(wallpaper, 0.25);
+
+  return (
+    <LinearGradient
+      colors={[wallpaper, wallpaperDark]}
+      style={[styles.root, { paddingTop: insets.top + 16 }]}
+    >
+      <View style={[styles.fallbackCard, { backgroundColor: colors.secondarySystemBackground }]}>
+        <Ionicons name="phone-portrait-outline" size={48} color={colors.systemBlue} />
+        <Text style={[typography.title2, { color: colors.label, marginTop: 12, textAlign: 'center' }]}>
+          Launcher features require Android
+        </Text>
+        <Text
+          style={[
+            typography.body,
+            { color: colors.secondaryLabel, marginTop: 8, textAlign: 'center' },
+          ]}
+        >
+          Install this app as an APK on an Android device to use the home screen launcher.
+        </Text>
+      </View>
+
+      {/* Battery widget */}
+      <View
+        style={[
+          styles.fallbackWidget,
+          { backgroundColor: colors.secondarySystemBackground, marginTop: spacing.lg },
+        ]}
+      >
+        <View style={styles.widgetRow}>
+          <Ionicons name="battery-half" size={24} color={colors.systemGreen} />
+          <Text style={[typography.body, { color: colors.label, marginLeft: 8 }]}>
+            Battery
+          </Text>
+          <Text
+            style={[typography.body, { color: colors.secondaryLabel, marginLeft: 'auto' as unknown as number }]}
+          >
+            {settings.batteryPercentage ? '72%' : 'Hidden'}
+          </Text>
+        </View>
+      </View>
+
+      {/* Storage widget */}
+      <View
+        style={[
+          styles.fallbackWidget,
+          { backgroundColor: colors.secondarySystemBackground, marginTop: spacing.sm },
+        ]}
+      >
+        <View style={styles.widgetRow}>
+          <Ionicons name="server-outline" size={24} color={colors.systemBlue} />
+          <Text style={[typography.body, { color: colors.label, marginLeft: 8 }]}>
+            Storage
+          </Text>
+          <Text
+            style={[typography.body, { color: colors.secondaryLabel, marginLeft: 'auto' as unknown as number }]}
+          >
+            4.2 GB used
+          </Text>
+        </View>
+      </View>
+    </LinearGradient>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main screen
+// ---------------------------------------------------------------------------
+
+export function LauncherHomeScreen() {
+  const { theme, borderRadius } = useTheme();
+  const insets = useSafeAreaInsets();
+  const navigation = useNavigation<any>(); // eslint-disable-line @typescript-eslint/no-explicit-any
+
+  const {
+    nonDockApps,
+    dockApps,
+    isLoading,
+    launchApp,
+    isDefaultLauncher,
+    openLauncherSettings,
+    addToDock,
+    removeFromHome,
+  } = useApps();
+  const { settings } = useSettings();
+
+  // Clock state
+  const [now, setNow] = useState(new Date());
+  useEffect(() => {
+    const id = setInterval(() => setNow(new Date()), 60_000);
+    return () => clearInterval(id);
+  }, []);
+
+  // Action sheet state
+  const [actionSheet, setActionSheet] = useState<{
+    visible: boolean;
+    app: InstalledApp | null;
+  }>({ visible: false, app: null });
+
+  const openActionSheet = useCallback((app: InstalledApp) => {
+    setActionSheet({ visible: true, app });
+  }, []);
+
+  const closeActionSheet = useCallback(() => {
+    setActionSheet({ visible: false, app: null });
+  }, []);
+
+  // Search state (for the tappable search bar)
+  const [searchQuery] = useState('');
+
+  // Non-Android fallback
+  if (Platform.OS !== 'android' && !isLoading && nonDockApps.length === 0 && dockApps.length === 0) {
+    return <NonAndroidFallback />;
+  }
+
+  // Loading
+  if (isLoading) {
+    return (
+      <View style={[styles.root, styles.centered, { backgroundColor: '#1C1C1E' }]}>
+        <CupertinoActivityIndicator />
+      </View>
+    );
+  }
+
+  // Wallpaper gradient
+  const wallpaperColor =
+    WALLPAPERS[Math.min(settings.wallpaperIndex, WALLPAPERS.length - 1)] as string;
+  const wallpaperDark = darkenHex(wallpaperColor, 0.28);
+
+  // Apps for grid: first 16 non-dock apps
+  const gridApps = nonDockApps.slice(0, MAX_GRID_APPS);
+
+  // Action sheet options for the selected app
+  const actionSheetOptions = actionSheet.app
+    ? [
+        {
+          label: 'Open',
+          onPress: () => {
+            closeActionSheet();
+            if (actionSheet.app) launchApp(actionSheet.app.packageName);
+          },
+        },
+        {
+          label: 'Add to Dock',
+          onPress: () => {
+            closeActionSheet();
+            if (actionSheet.app) addToDock(actionSheet.app.packageName);
+          },
+        },
+        {
+          label: 'Remove from Home',
+          destructive: true,
+          onPress: () => {
+            closeActionSheet();
+            if (actionSheet.app) removeFromHome(actionSheet.app.packageName);
+          },
+        },
+      ]
+    : [];
+
+  return (
+    <LinearGradient
+      colors={[wallpaperColor, wallpaperDark]}
+      style={styles.root}
+    >
+      <StatusBar translucent backgroundColor="transparent" barStyle="light-content" />
+
+      {/* ---------------------------------------------------------------- */}
+      {/* Set-as-default banner                                             */}
+      {/* ---------------------------------------------------------------- */}
+      {!isDefaultLauncher && (
+        <View style={[styles.defaultBanner, { marginTop: insets.top }]}>
+          <Text style={styles.defaultBannerText}>Set as default launcher</Text>
+          <Pressable
+            style={styles.defaultBannerButton}
+            onPress={openLauncherSettings}
+            android_ripple={{ color: 'rgba(255,255,255,0.3)' }}
+          >
+            <Text style={styles.defaultBannerButtonText}>Set Now</Text>
+          </Pressable>
+        </View>
+      )}
+
+      {/* ---------------------------------------------------------------- */}
+      {/* Status bar row                                                     */}
+      {/* ---------------------------------------------------------------- */}
+      <View
+        style={[
+          styles.statusRow,
+          {
+            marginTop: isDefaultLauncher
+              ? insets.top + 4
+              : 4,
+          },
+        ]}
+      >
+        <Text style={styles.statusTime}>{formatTime(now)}</Text>
+        <View style={styles.statusRight}>
+          {settings.wifiEnabled && (
+            <Ionicons name="wifi" size={14} color="rgba(255,255,255,0.85)" style={{ marginRight: 6 }} />
+          )}
+          {settings.batteryPercentage && (
+            <View style={styles.batteryPill}>
+              <Ionicons
+                name={settings.lowPowerMode ? 'battery-dead-outline' : 'battery-half-outline'}
+                size={14}
+                color="rgba(255,255,255,0.85)"
+              />
+              <Text style={styles.batteryText}>
+                {settings.lowPowerMode ? '20%' : '72%'}
+              </Text>
+            </View>
+          )}
+        </View>
+      </View>
+
+      {/* ---------------------------------------------------------------- */}
+      {/* Clock widget                                                       */}
+      {/* ---------------------------------------------------------------- */}
+      <View style={styles.clockWidget}>
+        <Text style={styles.clockTime}>{formatTime(now)}</Text>
+        <Text style={styles.clockDate}>{formatDate(now)}</Text>
+      </View>
+
+      {/* ---------------------------------------------------------------- */}
+      {/* Search bar                                                         */}
+      {/* ---------------------------------------------------------------- */}
+      <Pressable
+        style={styles.searchWrapper}
+        onPress={() => {
+          // Navigate to AppDrawer when it exists; for now show alert
+          // navigation.navigate('AppDrawer', { focusSearch: true });
+          navigation.navigate('Contacts'); // temporary placeholder
+        }}
+        accessibilityLabel="Search apps"
+        accessibilityRole="search"
+      >
+        <View pointerEvents="none">
+          <CupertinoSearchBar
+            value={searchQuery}
+            onChangeText={() => {}}
+            placeholder="Search apps…"
+            editable={false}
+          />
+        </View>
+      </Pressable>
+
+      {/* ---------------------------------------------------------------- */}
+      {/* App grid                                                           */}
+      {/* ---------------------------------------------------------------- */}
+      <FlatList<InstalledApp>
+        data={gridApps}
+        keyExtractor={(item) => item.packageName}
+        numColumns={GRID_COLUMNS}
+        scrollEnabled={false}
+        contentContainerStyle={styles.gridContent}
+        renderItem={({ item }) => (
+          <AppIcon
+            app={item}
+            size={ICON_CELL_SIZE}
+            onPress={() => launchApp(item.packageName)}
+            onLongPress={() => openActionSheet(item)}
+          />
+        )}
+        style={styles.grid}
+      />
+
+      {/* ---------------------------------------------------------------- */}
+      {/* Page dots                                                          */}
+      {/* ---------------------------------------------------------------- */}
+      <PageDots total={2} current={0} />
+
+      {/* ---------------------------------------------------------------- */}
+      {/* Dock                                                               */}
+      {/* ---------------------------------------------------------------- */}
+      <View style={[styles.dockOuter, { paddingBottom: insets.bottom + 8 }]}>
+        <View style={styles.dockSeparator} />
+        <BlurView
+          intensity={40}
+          tint="dark"
+          style={[styles.dockBlur, { borderRadius: borderRadius.extraLarge }]}
+        >
+          <View style={styles.dockRow}>
+            {dockApps.slice(0, 4).map((app) => (
+              <AppIcon
+                key={app.packageName}
+                app={app}
+                size={ICON_CELL_SIZE}
+                onPress={() => launchApp(app.packageName)}
+                onLongPress={() => openActionSheet(app)}
+              />
+            ))}
+            {/* Fill empty dock slots */}
+            {Array.from({ length: Math.max(0, 4 - dockApps.length) }).map((_, i) => (
+              <View key={`empty-${i}`} style={{ width: ICON_CELL_SIZE }} />
+            ))}
+          </View>
+        </BlurView>
+      </View>
+
+      {/* ---------------------------------------------------------------- */}
+      {/* Action sheet                                                       */}
+      {/* ---------------------------------------------------------------- */}
+      <CupertinoActionSheet
+        visible={actionSheet.visible}
+        onClose={closeActionSheet}
+        title={actionSheet.app?.name}
+        options={actionSheetOptions}
+      />
+    </LinearGradient>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+  },
+  centered: {
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+
+  // Default launcher banner
+  defaultBanner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    backgroundColor: 'rgba(0,0,0,0.55)',
+    marginHorizontal: 16,
+    marginBottom: 4,
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    borderRadius: 12,
+  },
+  defaultBannerText: {
+    color: '#fff',
+    fontSize: 13,
+    fontWeight: '500',
+  },
+  defaultBannerButton: {
+    backgroundColor: '#007AFF',
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 5,
+  },
+  defaultBannerButtonText: {
+    color: '#fff',
+    fontSize: 12,
+    fontWeight: '600',
+  },
+
+  // Status bar row
+  statusRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 20,
+    marginBottom: 2,
+  },
+  statusTime: {
+    color: 'rgba(255,255,255,0.75)',
+    fontSize: 12,
+    fontWeight: '500',
+  },
+  statusRight: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  batteryPill: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 2,
+  },
+  batteryText: {
+    color: 'rgba(255,255,255,0.85)',
+    fontSize: 11,
+    fontWeight: '500',
+  },
+
+  // Clock widget
+  clockWidget: {
+    alignItems: 'center',
+    marginTop: 8,
+    marginBottom: 20,
+  },
+  clockTime: {
+    fontSize: 72,
+    fontWeight: '200',
+    color: '#ffffff',
+    letterSpacing: -2,
+    lineHeight: 80,
+  },
+  clockDate: {
+    fontSize: 16,
+    fontWeight: '400',
+    color: 'rgba(255,255,255,0.85)',
+    marginTop: 2,
+  },
+
+  // Search
+  searchWrapper: {
+    marginHorizontal: 16,
+    marginBottom: 16,
+  },
+
+  // App grid
+  grid: {
+    flex: 1,
+    paddingHorizontal: 16,
+  },
+  gridContent: {
+    paddingBottom: 8,
+  },
+  appIconWrapper: {
+    alignItems: 'center',
+    paddingVertical: 8,
+  },
+  appIconImage: {
+    // width / height set inline
+  },
+  appIconPlaceholder: {
+    backgroundColor: 'rgba(255,255,255,0.2)',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  appIconLabel: {
+    marginTop: 4,
+    fontSize: 11,
+    color: '#ffffff',
+    textAlign: 'center',
+    width: '90%',
+    textShadowColor: 'rgba(0,0,0,0.6)',
+    textShadowOffset: { width: 0, height: 1 },
+    textShadowRadius: 3,
+  },
+
+  // Page dots
+  pageDotsRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 8,
+    gap: 6,
+  },
+  pageDot: {
+    width: 7,
+    height: 7,
+    borderRadius: 3.5,
+  },
+  pageDotFilled: {
+    backgroundColor: '#ffffff',
+  },
+  pageDotEmpty: {
+    backgroundColor: 'rgba(255,255,255,0.4)',
+  },
+
+  // Dock
+  dockOuter: {
+    paddingHorizontal: 12,
+  },
+  dockSeparator: {
+    height: StyleSheet.hairlineWidth,
+    backgroundColor: 'rgba(255,255,255,0.2)',
+    marginBottom: 8,
+  },
+  dockBlur: {
+    overflow: 'hidden',
+    paddingVertical: 8,
+    paddingHorizontal: 8,
+    backgroundColor: 'rgba(255,255,255,0.12)',
+  },
+  dockRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-around',
+    alignItems: 'center',
+  },
+
+  // Fallback
+  fallbackCard: {
+    marginHorizontal: 24,
+    borderRadius: 16,
+    padding: 24,
+    alignItems: 'center',
+  },
+  fallbackWidget: {
+    marginHorizontal: 24,
+    borderRadius: 12,
+    padding: 16,
+  },
+  widgetRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+});

--- a/src/store/AppsStore.tsx
+++ b/src/store/AppsStore.tsx
@@ -1,0 +1,206 @@
+import React, { createContext, useContext, useState, useCallback, useEffect, useMemo } from 'react';
+import { Platform } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const STORAGE_KEY = '@iostoandroid/apps_layout';
+
+export interface InstalledApp {
+  name: string;
+  packageName: string;
+  icon: string;
+  isSystem: boolean;
+}
+
+export interface HomeApp {
+  packageName: string;
+  position: number;
+}
+
+interface AppsState {
+  allApps: InstalledApp[];
+  homeApps: HomeApp[];
+  dockApps: string[]; // package names for bottom dock (max 4)
+  isLoading: boolean;
+}
+
+interface AppsContextValue {
+  apps: InstalledApp[];
+  homeApps: HomeApp[];
+  dockApps: InstalledApp[];
+  nonDockApps: InstalledApp[];
+  isLoading: boolean;
+  refreshApps: () => Promise<void>;
+  launchApp: (packageName: string) => Promise<void>;
+  addToHome: (packageName: string) => void;
+  removeFromHome: (packageName: string) => void;
+  addToDock: (packageName: string) => void;
+  removeFromDock: (packageName: string) => void;
+  isDefaultLauncher: boolean;
+  openLauncherSettings: () => Promise<void>;
+}
+
+const AppsContext = createContext<AppsContextValue | null>(null);
+
+// Default dock apps (common Android package names)
+const DEFAULT_DOCK = [
+  'com.android.dialer',
+  'com.android.mms',
+  'com.android.chrome',
+  'com.android.camera2',
+];
+
+export function AppsProvider({ children }: { children: React.ReactNode }) {
+  const [state, setState] = useState<AppsState>({
+    allApps: [],
+    homeApps: [],
+    dockApps: DEFAULT_DOCK,
+    isLoading: true,
+  });
+  const [isDefault, setIsDefault] = useState(false);
+
+  const loadApps = useCallback(async () => {
+    if (Platform.OS !== 'android') {
+      setState(prev => ({ ...prev, isLoading: false }));
+      return;
+    }
+
+    try {
+      // Dynamic import to avoid crash on non-Android
+      const LauncherModule = (await import('../../modules/launcher-module/src')).default;
+
+      const [apps, savedLayout, defaultStatus] = await Promise.all([
+        LauncherModule.getInstalledApps(),
+        AsyncStorage.getItem(STORAGE_KEY),
+        LauncherModule.isDefaultLauncher(),
+      ]);
+
+      setIsDefault(defaultStatus);
+
+      let dockApps = DEFAULT_DOCK;
+      let homeApps: HomeApp[] = [];
+
+      if (savedLayout) {
+        try {
+          const parsed = JSON.parse(savedLayout);
+          dockApps = parsed.dockApps || DEFAULT_DOCK;
+          homeApps = parsed.homeApps || [];
+        } catch { /* ignore */ }
+      }
+
+      // Filter dock apps to only include installed ones
+      dockApps = dockApps.filter((pkg: string) =>
+        apps.some((app: InstalledApp) => app.packageName === pkg)
+      );
+
+      setState({
+        allApps: apps,
+        homeApps,
+        dockApps,
+        isLoading: false,
+      });
+    } catch (e) {
+      console.warn('Failed to load apps:', e);
+      setState(prev => ({ ...prev, isLoading: false }));
+    }
+  }, []);
+
+  useEffect(() => {
+    loadApps();
+  }, [loadApps]);
+
+  const persist = useCallback((dockApps: string[], homeApps: HomeApp[]) => {
+    AsyncStorage.setItem(STORAGE_KEY, JSON.stringify({ dockApps, homeApps }));
+  }, []);
+
+  const launchApp = useCallback(async (packageName: string) => {
+    if (Platform.OS !== 'android') return;
+    try {
+      const LauncherModule = (await import('../../modules/launcher-module/src')).default;
+      await LauncherModule.launchApp(packageName);
+    } catch (e) {
+      console.warn('Failed to launch app:', e);
+    }
+  }, []);
+
+  const addToHome = useCallback((packageName: string) => {
+    setState(prev => {
+      const exists = prev.homeApps.some(a => a.packageName === packageName);
+      if (exists) return prev;
+      const maxPos = prev.homeApps.reduce((max, a) => Math.max(max, a.position), -1);
+      const homeApps = [...prev.homeApps, { packageName, position: maxPos + 1 }];
+      persist(prev.dockApps, homeApps);
+      return { ...prev, homeApps };
+    });
+  }, [persist]);
+
+  const removeFromHome = useCallback((packageName: string) => {
+    setState(prev => {
+      const homeApps = prev.homeApps.filter(a => a.packageName !== packageName);
+      persist(prev.dockApps, homeApps);
+      return { ...prev, homeApps };
+    });
+  }, [persist]);
+
+  const addToDock = useCallback((packageName: string) => {
+    setState(prev => {
+      if (prev.dockApps.length >= 4 || prev.dockApps.includes(packageName)) return prev;
+      const dockApps = [...prev.dockApps, packageName];
+      persist(dockApps, prev.homeApps);
+      return { ...prev, dockApps };
+    });
+  }, [persist]);
+
+  const removeFromDock = useCallback((packageName: string) => {
+    setState(prev => {
+      const dockApps = prev.dockApps.filter(p => p !== packageName);
+      persist(dockApps, prev.homeApps);
+      return { ...prev, dockApps };
+    });
+  }, [persist]);
+
+  const openLauncherSettings = useCallback(async () => {
+    if (Platform.OS !== 'android') return;
+    try {
+      const LauncherModule = (await import('../../modules/launcher-module/src')).default;
+      await LauncherModule.openLauncherSettings();
+    } catch (e) {
+      console.warn('Failed to open launcher settings:', e);
+    }
+  }, []);
+
+  const dockApps = useMemo(() =>
+    state.dockApps
+      .map(pkg => state.allApps.find(a => a.packageName === pkg))
+      .filter(Boolean) as InstalledApp[],
+    [state.dockApps, state.allApps]
+  );
+
+  const nonDockApps = useMemo(() =>
+    state.allApps.filter(a => !state.dockApps.includes(a.packageName)),
+    [state.allApps, state.dockApps]
+  );
+
+  const value = useMemo(() => ({
+    apps: state.allApps,
+    homeApps: state.homeApps,
+    dockApps,
+    nonDockApps,
+    isLoading: state.isLoading,
+    refreshApps: loadApps,
+    launchApp,
+    addToHome,
+    removeFromHome,
+    addToDock,
+    removeFromDock,
+    isDefaultLauncher: isDefault,
+    openLauncherSettings,
+  }), [state, dockApps, nonDockApps, isDefault, loadApps, launchApp, addToHome, removeFromHome, addToDock, removeFromDock, openLauncherSettings]);
+
+  return <AppsContext.Provider value={value}>{children}</AppsContext.Provider>;
+}
+
+export function useApps() {
+  const ctx = useContext(AppsContext);
+  if (!ctx) throw new Error('useApps must be used within AppsProvider');
+  return ctx;
+}


### PR DESCRIPTION
## Summary
- Native Kotlin module (LauncherModule) to list/launch installed apps
- CATEGORY_HOME intent filter — app can be set as default Android launcher
- Launcher home screen: wallpaper, clock, app grid (4 cols), blur dock
- App drawer with search, long-press actions (open, dock, app info)
- AppsStore with dock/home layout persistence
- Graceful fallback on iOS/web

## Architecture
- `modules/launcher-module/` — Expo native module using expo-modules-core
- `plugins/withLauncherIntent.js` — config plugin for AndroidManifest
- `src/store/AppsStore.tsx` — app list + layout state
- `src/screens/LauncherHomeScreen.tsx` — launcher UI
- `src/screens/AppDrawerScreen.tsx` — full app drawer

## Test plan
- [ ] Build APK and install on Android device
- [ ] Verify "Set as default launcher" prompt appears
- [ ] Select as home launcher and verify app grid shows installed apps
- [ ] Tap app icons to launch apps
- [ ] Long press for context menu
- [ ] Verify dock persists across restarts
- [ ] Open app drawer and search for apps
- [ ] Settings/Contacts/Profile tabs still work