### PR TITLE
fix: remove App Drawer — iOS doesn't have one

### DIFF
--- a/src/navigation/TabNavigator.tsx
+++ b/src/navigation/TabNavigator.tsx
@@ -4,7 +4,7 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 // Launcher
 import { LauncherHomeScreen } from '../screens/LauncherHomeScreen';
 import { MultitaskScreen } from '../screens/MultitaskScreen';
-import { AppDrawerScreen } from '../screens/AppDrawerScreen';
+
 import { LockScreen } from '../screens/LockScreen';
 import { ControlCenterScreen } from '../screens/ControlCenterScreen';
 
@@ -63,7 +63,7 @@ export function TabNavigator() {
     }}>
       {/* Launcher home — the ROOT screen, fullscreen, no tabs */}
       <Stack.Screen name="HomeMain" component={LauncherHomeScreen} />
-      <Stack.Screen name="AppDrawer" component={AppDrawerScreen} />
+      {/* App Drawer removed — iOS doesn't have one. All apps are on home pages. App Library is the last page. */}
       <Stack.Screen name="LockScreen" component={LockScreen} options={{ animation: 'fade', gestureEnabled: false }} />
       <Stack.Screen name="ControlCenter" component={ControlCenterScreen} options={{ animation: 'fade', presentation: 'transparentModal', gestureEnabled: false }} />
       <Stack.Screen name="NotificationCenter" component={NotificationCenterScreen} options={{ animation: 'fade', presentation: 'transparentModal' }} />

--- a/src/screens/LauncherHomeScreen.tsx
+++ b/src/screens/LauncherHomeScreen.tsx
@@ -501,7 +501,7 @@ export function LauncherHomeScreen() {
       const { translationY, absoluteY, absoluteX, velocityY } = event;
 
       if (translationY < -60 && velocityY < -200) {
-        runOnJS(navigateTo)('AppDrawer');
+        runOnJS(navigateTo)('AppLibrary');
       } else if (translationY > 60 && velocityY > 200 && absoluteY < 350) {
         if (absoluteX < SCREEN_WIDTH / 2) {
           runOnJS(navigateTo)('NotificationCenter');
@@ -509,7 +509,7 @@ export function LauncherHomeScreen() {
           runOnJS(navigateTo)('ControlCenter');
         }
       } else if (translationY > 60 && velocityY > 200 && absoluteY >= 350) {
-        runOnJS(navigateToWithParams)('AppDrawer', { searchFocused: true });
+        runOnJS(navigateToWithParams)('AppLibrary', { searchFocused: true });
       }
     });
 
@@ -968,7 +968,7 @@ export function LauncherHomeScreen() {
       <PageDots total={totalPages} current={currentPage} />
       <Pressable
         style={styles.searchLabel}
-        onPress={isJiggling ? exitJiggle : () => navigation.navigate('AppDrawer')}
+        onPress={isJiggling ? exitJiggle : () => navigation.navigate('AppLibrary')}
         accessibilityLabel="Search apps"
         accessibilityRole="search"
       >


### PR DESCRIPTION
Replace Android-style drawer with iOS App Library (last page)