### PR TITLE
fix: built-in iOS apps visible in home grid and dock

### DIFF
--- a/src/screens/LauncherHomeScreen.tsx
+++ b/src/screens/LauncherHomeScreen.tsx
@@ -634,21 +634,39 @@ export function LauncherHomeScreen() {
       />
     );
 
-  // Build display items: folders appear as single grid cells, their member apps are hidden
+  // Build display items: virtual built-in apps + real apps + folders
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const gridItems = useMemo((): GridItem[] => {
     const items: GridItem[] = [];
     const appsInFolders = new Set(folders.flatMap(f => f.apps));
+    const dockPkgs = new Set(dockApps.map(a => a.packageName));
+
+    // Add virtual built-in apps to the grid (if not in dock)
+    const virtualApps: InstalledApp[] = Object.entries(BUILT_IN_APPS).map(([pkg, name]) => ({
+      name,
+      packageName: pkg,
+      icon: '',
+      isSystem: false,
+    }));
+    for (const vApp of virtualApps) {
+      if (!dockPkgs.has(vApp.packageName) && !appsInFolders.has(vApp.packageName)) {
+        items.push({ type: 'app', app: vApp });
+      }
+    }
+
+    // Add folders
     for (const folder of folders) {
       items.push({ type: 'folder', folder });
     }
+
+    // Add real installed apps (not in dock, not in folders)
     for (const app of nonDockApps) {
       if (!appsInFolders.has(app.packageName)) {
         items.push({ type: 'app', app });
       }
     }
     return items;
-  }, [nonDockApps, folders]);
+  }, [nonDockApps, dockApps, folders]);
 
   // Paginate grid items
   const pages: GridItem[][] = [];

--- a/src/store/AppsStore.tsx
+++ b/src/store/AppsStore.tsx
@@ -90,15 +90,25 @@ export function AppsProvider({ children }: { children: React.ReactNode }) {
       if (savedLayout) {
         try {
           const parsed = JSON.parse(savedLayout);
-          dockApps = parsed.dockApps || DEFAULT_DOCK;
           homeApps = parsed.homeApps || [];
+          // Only use saved dock if it contains our virtual apps (otherwise it's stale data)
+          const savedDock = parsed.dockApps || [];
+          const hasVirtualApps = DEFAULT_DOCK.some((pkg: string) => savedDock.includes(pkg));
+          dockApps = hasVirtualApps ? savedDock : DEFAULT_DOCK;
         } catch { /* ignore */ }
+      }
+
+      // Ensure our built-in apps are always in the dock
+      for (const pkg of DEFAULT_DOCK) {
+        if (!dockApps.includes(pkg)) {
+          dockApps = [...dockApps.slice(0, 3), pkg]; // keep max 4, ensure built-in present
+        }
       }
 
       // Filter dock apps to only include installed or virtual ones
       dockApps = dockApps.filter((pkg: string) =>
         apps.some((app: InstalledApp) => app.packageName === pkg) || VIRTUAL_APPS_MAP[pkg]
-      );
+      ).slice(0, 4); // max 4 in dock
 
       setState({
         allApps: apps,


### PR DESCRIPTION
Phone/Messages/Contacts/Settings always visible as colored icons in grid + dock