### PR TITLE
fix/36: Declare all required Android permissions

### DIFF
--- a/app.json
+++ b/app.json
@@ -21,7 +21,23 @@
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#ffffff"
       },
-      "permissions": ["android.permission.QUERY_ALL_PACKAGES"],
+      "permissions": [
+        "android.permission.QUERY_ALL_PACKAGES",
+        "android.permission.READ_CONTACTS",
+        "android.permission.READ_SMS",
+        "android.permission.SEND_SMS",
+        "android.permission.READ_CALL_LOG",
+        "android.permission.CALL_PHONE",
+        "android.permission.READ_PHONE_STATE",
+        "android.permission.CAMERA",
+        "android.permission.ACCESS_FINE_LOCATION",
+        "android.permission.ACCESS_WIFI_STATE",
+        "android.permission.CHANGE_WIFI_STATE",
+        "android.permission.BLUETOOTH",
+        "android.permission.BLUETOOTH_CONNECT",
+        "android.permission.READ_CALENDAR",
+        "android.permission.POST_NOTIFICATIONS"
+      ],
       "edgeToEdgeEnabled": true,
       "predictiveBackGestureEnabled": false
     },

--- a/modules/launcher-module/android/src/main/java/com/iostoandroid/launcher/LauncherModule.kt
+++ b/modules/launcher-module/android/src/main/java/com/iostoandroid/launcher/LauncherModule.kt
@@ -486,7 +486,7 @@ class LauncherModule : Module() {
 
         AsyncFunction("requestAllPermissions") {
             val activity = appContext.currentActivity ?: throw Exception("No activity")
-            val permissions = arrayOf(
+            val permissions = mutableListOf(
                 android.Manifest.permission.READ_CONTACTS,
                 android.Manifest.permission.READ_CALL_LOG,
                 android.Manifest.permission.CALL_PHONE,
@@ -494,25 +494,39 @@ class LauncherModule : Module() {
                 android.Manifest.permission.SEND_SMS,
                 android.Manifest.permission.CAMERA,
                 android.Manifest.permission.ACCESS_FINE_LOCATION,
-                android.Manifest.permission.READ_PHONE_STATE
+                android.Manifest.permission.READ_PHONE_STATE,
+                android.Manifest.permission.READ_CALENDAR
             )
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
+                permissions.add(android.Manifest.permission.BLUETOOTH_CONNECT)
+            }
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
+                permissions.add(android.Manifest.permission.POST_NOTIFICATIONS)
+            }
             val REQUEST_CODE = 1001
             if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
-                activity.requestPermissions(permissions, REQUEST_CODE)
+                activity.requestPermissions(permissions.toTypedArray(), REQUEST_CODE)
             }
             true
         }
 
         AsyncFunction("checkPermissions") {
-            val perms = mapOf(
+            val perms = mutableMapOf(
                 "contacts" to hasPermission(android.Manifest.permission.READ_CONTACTS),
                 "callLog" to hasPermission(android.Manifest.permission.READ_CALL_LOG),
                 "phone" to hasPermission(android.Manifest.permission.CALL_PHONE),
                 "sms" to hasPermission(android.Manifest.permission.READ_SMS),
                 "sendSms" to hasPermission(android.Manifest.permission.SEND_SMS),
                 "camera" to hasPermission(android.Manifest.permission.CAMERA),
-                "location" to hasPermission(android.Manifest.permission.ACCESS_FINE_LOCATION)
+                "location" to hasPermission(android.Manifest.permission.ACCESS_FINE_LOCATION),
+                "calendar" to hasPermission(android.Manifest.permission.READ_CALENDAR)
             )
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
+                perms["bluetooth"] = hasPermission(android.Manifest.permission.BLUETOOTH_CONNECT)
+            }
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
+                perms["notifications"] = hasPermission(android.Manifest.permission.POST_NOTIFICATIONS)
+            }
             perms
         }
     }

--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -53,6 +53,11 @@ const PERMISSIONS = [
     label: 'Location',
     description: 'See nearby WiFi networks',
   },
+  {
+    icon: 'calendar' as const,
+    label: 'Calendar',
+    description: 'View upcoming events',
+  },
 ];
 
 export function OnboardingScreen({ onDone }: OnboardingScreenProps) {


### PR DESCRIPTION
## Summary
- Added 14 missing Android permissions to `app.json` that the Kotlin native module uses
- Updated `LauncherModule.kt` to request calendar, bluetooth, and notifications permissions
- Updated OnboardingScreen to show calendar permission

Closes #36

## Test plan
- [ ] `npx expo prebuild --clean` generates correct AndroidManifest.xml
- [ ] All permissions appear in manifest
- [ ] Onboarding requests all permissions on fresh install