### PR TITLE
fix/39: Implement all empty handlers in settings screens

### DIFF
--- a/src/screens/settings/AboutScreen.tsx
+++ b/src/screens/settings/AboutScreen.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, Text, ScrollView, StyleSheet, Platform } from 'react-native';
+import { View, Text, ScrollView, StyleSheet, Platform, Alert } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTheme } from '../../theme/ThemeContext';
 import {
@@ -93,7 +93,7 @@ export function AboutScreen({ navigation }: { navigation: any }) {
           <CupertinoListSection footer="This app demonstrates iOS Cupertino-style UI components running natively on Android using React Native and Expo.">
             <CupertinoListTile
               title="Legal & Regulatory"
-              onPress={() => {}}
+              onPress={() => Alert.alert('Legal', 'iOS Theme Launcher v1.0\n\nThis app is not affiliated with Apple Inc.')}
             />
           </CupertinoListSection>
         </View>

--- a/src/screens/settings/AccessibilityScreen.tsx
+++ b/src/screens/settings/AccessibilityScreen.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, Text, ScrollView, StyleSheet } from 'react-native';
+import { View, Text, ScrollView, StyleSheet, Alert } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTheme } from '../../theme/ThemeContext';
 import { useSettings } from '../../store/SettingsStore';
@@ -45,7 +45,7 @@ export function AccessibilityScreen({ navigation }: { navigation: any }) {
                 <Text style={[typography.body, { color: colors.secondaryLabel }]}>Off</Text>
               }
               showChevron
-              onPress={() => {}}
+              onPress={() => openSystemPanel('accessibility')}
             />
             <CupertinoListTile
               title="Zoom"
@@ -53,12 +53,12 @@ export function AccessibilityScreen({ navigation }: { navigation: any }) {
                 <Text style={[typography.body, { color: colors.secondaryLabel }]}>Off</Text>
               }
               showChevron
-              onPress={() => {}}
+              onPress={() => openSystemPanel('accessibility')}
             />
             <CupertinoListTile
               title="Display & Text Size"
               showChevron
-              onPress={() => {}}
+              onPress={() => openSystemPanel('accessibility')}
             />
             <CupertinoListTile
               title="Bold Text"
@@ -79,12 +79,12 @@ export function AccessibilityScreen({ navigation }: { navigation: any }) {
             <CupertinoListTile
               title="Touch"
               showChevron
-              onPress={() => {}}
+              onPress={() => openSystemPanel('accessibility')}
             />
             <CupertinoListTile
               title="Face ID & Attention"
               showChevron
-              onPress={() => {}}
+              onPress={() => openSystemPanel('security')}
             />
             <CupertinoListTile
               title="Switch Control"
@@ -92,7 +92,7 @@ export function AccessibilityScreen({ navigation }: { navigation: any }) {
                 <Text style={[typography.body, { color: colors.secondaryLabel }]}>Off</Text>
               }
               showChevron
-              onPress={() => {}}
+              onPress={() => openSystemPanel('accessibility')}
             />
           </CupertinoListSection>
         </View>
@@ -103,7 +103,7 @@ export function AccessibilityScreen({ navigation }: { navigation: any }) {
             <CupertinoListTile
               title="Hearing Devices"
               showChevron
-              onPress={() => {}}
+              onPress={() => openSystemPanel('accessibility')}
             />
             <CupertinoListTile
               title="Sound Recognition"
@@ -111,12 +111,12 @@ export function AccessibilityScreen({ navigation }: { navigation: any }) {
                 <Text style={[typography.body, { color: colors.secondaryLabel }]}>Off</Text>
               }
               showChevron
-              onPress={() => {}}
+              onPress={() => openSystemPanel('accessibility')}
             />
             <CupertinoListTile
               title="Subtitles & Captioning"
               showChevron
-              onPress={() => {}}
+              onPress={() => openSystemPanel('accessibility')}
             />
           </CupertinoListSection>
         </View>
@@ -137,7 +137,7 @@ export function AccessibilityScreen({ navigation }: { navigation: any }) {
             <CupertinoListTile
               title="Per-App Settings"
               showChevron
-              onPress={() => {}}
+              onPress={() => Alert.alert('Per-App Settings', 'Customize settings for individual apps.')}
             />
           </CupertinoListSection>
         </View>

--- a/src/screens/settings/BackupRestoreScreen.tsx
+++ b/src/screens/settings/BackupRestoreScreen.tsx
@@ -131,7 +131,7 @@ export function BackupRestoreScreen({ navigation }: { navigation: any }) {
                     {lastBackupTime}
                   </Text>
                 }
-                onPress={() => {}}
+                onPress={() => Alert.alert('Last Backup', `Your last backup was on ${lastBackupTime}.`)}
               />
             )}
           </CupertinoListSection>

--- a/src/screens/settings/BluetoothScreen.tsx
+++ b/src/screens/settings/BluetoothScreen.tsx
@@ -15,7 +15,7 @@ export function BluetoothScreen({ navigation }: { navigation: any }) {
   const { theme, typography, spacing } = useTheme();
   const { colors } = theme;
   const insets = useSafeAreaInsets();
-  const { bluetooth, toggleBluetooth } = useDevice();
+  const { bluetooth, toggleBluetooth, openSystemPanel } = useDevice();
 
   return (
     <View style={[styles.container, { backgroundColor: colors.systemGroupedBackground }]}>
@@ -60,7 +60,7 @@ export function BluetoothScreen({ navigation }: { navigation: any }) {
                       {bluetooth.name}
                     </Text>
                   }
-                  onPress={() => {}}
+                  onPress={() => openSystemPanel('bluetooth')}
                 />
               </CupertinoListSection>
             </View>
@@ -78,7 +78,7 @@ export function BluetoothScreen({ navigation }: { navigation: any }) {
                         backgroundColor: colors.systemBlue,
                       }}
                       showChevron
-                      onPress={() => {}}
+                      onPress={() => openSystemPanel('bluetooth')}
                     />
                   ))}
                 </CupertinoListSection>
@@ -96,7 +96,7 @@ export function BluetoothScreen({ navigation }: { navigation: any }) {
                       </Text>
                     }
                     showChevron={false}
-                    onPress={() => {}}
+                    onPress={() => openSystemPanel('bluetooth')}
                   />
                 </CupertinoListSection>
               </View>

--- a/src/screens/settings/CellularScreen.tsx
+++ b/src/screens/settings/CellularScreen.tsx
@@ -125,7 +125,7 @@ export function CellularScreen({ navigation }: { navigation: any }) {
                 backgroundColor: colors.systemGray,
               }}
               showChevron
-              onPress={() => {}}
+              onPress={() => openSystemPanel('security')}
             />
           </CupertinoListSection>
         </View>

--- a/src/screens/settings/DateTimeScreen.tsx
+++ b/src/screens/settings/DateTimeScreen.tsx
@@ -59,7 +59,7 @@ export function DateTimeScreen({ navigation }: { navigation: any }) {
                   {settings.timezone}
                 </Text>
               }
-              onPress={() => {}}
+              onPress={() => openSystemPanel('date_time')}
             />
             <CupertinoListTile
               title="24-Hour Time"

--- a/src/screens/settings/GeneralScreen.tsx
+++ b/src/screens/settings/GeneralScreen.tsx
@@ -1,8 +1,9 @@
 import React, { useState } from 'react';
-import { View, Text, ScrollView, StyleSheet } from 'react-native';
+import { View, Text, ScrollView, StyleSheet, Alert } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTheme } from '../../theme/ThemeContext';
 import { useSettings } from '../../store/SettingsStore';
+import { useDevice } from '../../store/DeviceStore';
 import {
   CupertinoNavigationBar,
   CupertinoListSection,
@@ -17,6 +18,7 @@ export function GeneralScreen({ navigation }: { navigation: any }) {
   const { colors } = theme;
   const insets = useSafeAreaInsets();
   const { settings, update } = useSettings();
+  const { openSystemPanel } = useDevice();
   const [showShutdown, setShowShutdown] = useState(false);
   const [showAirdropPicker, setShowAirdropPicker] = useState(false);
   const [showBgRefreshPicker, setShowBgRefreshPicker] = useState(false);
@@ -67,8 +69,8 @@ export function GeneralScreen({ navigation }: { navigation: any }) {
               }
               onPress={() => setShowAirdropPicker(true)}
             />
-            <CupertinoListTile title="AirPlay & Handoff" onPress={() => {}} />
-            <CupertinoListTile title="CarPlay" onPress={() => {}} />
+            <CupertinoListTile title="AirPlay & Handoff" onPress={() => Alert.alert('AirPlay & Handoff', 'Not available on Android devices.')} />
+            <CupertinoListTile title="CarPlay" onPress={() => Alert.alert('CarPlay', 'Not available on Android devices.')} />
           </CupertinoListSection>
         </View>
 
@@ -103,20 +105,20 @@ export function GeneralScreen({ navigation }: { navigation: any }) {
               }
               onPress={() => navigation.navigate('LanguageRegion')}
             />
-            <CupertinoListTile title="Dictionary" onPress={() => {}} />
+            <CupertinoListTile title="Dictionary" onPress={() => openSystemPanel('locale')} />
           </CupertinoListSection>
         </View>
 
         <View style={{ paddingHorizontal: spacing.md }}>
           <CupertinoListSection>
             <CupertinoListTile title="VPN & Device Management" onPress={() => navigation.navigate('Vpn')} />
-            <CupertinoListTile title="Legal & Regulatory" onPress={() => {}} />
+            <CupertinoListTile title="Legal & Regulatory" onPress={() => Alert.alert('Legal', 'iOS Theme Launcher v1.0\n\nThis app is not affiliated with Apple Inc.')} />
           </CupertinoListSection>
         </View>
 
         <View style={{ paddingHorizontal: spacing.md }}>
           <CupertinoListSection>
-            <CupertinoListTile title="Transfer or Reset Device" onPress={() => {}} />
+            <CupertinoListTile title="Transfer or Reset Device" onPress={() => Alert.alert('Reset', 'Go to Android Settings to reset your device.', [{ text: 'Open Settings', onPress: () => openSystemPanel('reset') }, { text: 'Cancel' }])} />
             <CupertinoListTile title="Backup & Restore" onPress={() => navigation.navigate('BackupRestore')} />
             <CupertinoListTile title="Shut Down" showChevron={false} onPress={() => setShowShutdown(true)} />
           </CupertinoListSection>

--- a/src/screens/settings/HotspotScreen.tsx
+++ b/src/screens/settings/HotspotScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { View, Text, ScrollView, StyleSheet } from 'react-native';
+import { View, Text, ScrollView, StyleSheet, Alert } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTheme } from '../../theme/ThemeContext';
 import { useSettings } from '../../store/SettingsStore';
@@ -68,7 +68,7 @@ export function HotspotScreen({ navigation }: { navigation: any }) {
                 backgroundColor: colors.systemBlue,
               }}
               showChevron
-              onPress={() => {}}
+              onPress={() => openSystemPanel('tethering')}
             />
           </CupertinoListSection>
         </View>
@@ -102,7 +102,7 @@ export function HotspotScreen({ navigation }: { navigation: any }) {
                 backgroundColor: colors.systemOrange,
               }}
               showChevron
-              onPress={() => {}}
+              onPress={() => Alert.alert('Family Sharing', 'Not available on Android devices.')}
             />
           </CupertinoListSection>
         </View>

--- a/src/screens/settings/LanguageRegionScreen.tsx
+++ b/src/screens/settings/LanguageRegionScreen.tsx
@@ -47,27 +47,27 @@ export function LanguageRegionScreen({ navigation }: { navigation: any }) {
             <CupertinoListTile
               title="Preferred Language"
               trailing={trailing(settings.language)}
-              onPress={() => {}}
+              onPress={() => openSystemPanel('locale')}
             />
             <CupertinoListTile
               title="Region"
               trailing={trailing(settings.region)}
-              onPress={() => {}}
+              onPress={() => openSystemPanel('locale')}
             />
             <CupertinoListTile
               title="Calendar"
               trailing={trailing('Gregorian')}
-              onPress={() => {}}
+              onPress={() => openSystemPanel('locale')}
             />
             <CupertinoListTile
               title="Temperature"
               trailing={trailing('°C')}
-              onPress={() => {}}
+              onPress={() => openSystemPanel('locale')}
             />
             <CupertinoListTile
               title="Measurement System"
               trailing={trailing('Metric')}
-              onPress={() => {}}
+              onPress={() => openSystemPanel('locale')}
             />
             <CupertinoListTile
               title="Number Format"

--- a/src/screens/settings/NotificationsScreen.tsx
+++ b/src/screens/settings/NotificationsScreen.tsx
@@ -105,7 +105,7 @@ export function NotificationsScreen({ navigation }: { navigation: any }) {
               trailing={
                 <Text style={[typography.body, { color: colors.secondaryLabel }]}>Off</Text>
               }
-              onPress={() => {}}
+              onPress={() => openSystemPanel('notification')}
             />
           </CupertinoListSection>
         </View>

--- a/src/screens/settings/PrivacyScreen.tsx
+++ b/src/screens/settings/PrivacyScreen.tsx
@@ -97,7 +97,7 @@ export function PrivacyScreen({ navigation }: { navigation: any }) {
                   </Text>
                 }
                 showChevron
-                onPress={() => {}}
+                onPress={() => openSystemPanel('privacy')}
               />
             ))}
           </CupertinoListSection>

--- a/src/screens/settings/ScreenTimeScreen.tsx
+++ b/src/screens/settings/ScreenTimeScreen.tsx
@@ -1,6 +1,6 @@
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 import React from 'react';
-import { View, Text, ScrollView, StyleSheet } from 'react-native';
+import { View, Text, ScrollView, StyleSheet, Alert } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTheme } from '../../theme/ThemeContext';
 import { useSettings } from '../../store/SettingsStore';
@@ -88,7 +88,7 @@ export function ScreenTimeScreen({ navigation }: { navigation: any }) {
                       {formatMinutes(settings.dailyLimit)}
                     </Text>
                   }
-                  onPress={() => {}}
+                  onPress={() => Alert.alert('Daily Limit', 'Use Android Digital Wellbeing to configure app timers.')}
                 />
               </CupertinoListSection>
             </View>
@@ -115,7 +115,7 @@ export function ScreenTimeScreen({ navigation }: { navigation: any }) {
                           {settings.downtimeStart}
                         </Text>
                       }
-                      onPress={() => {}}
+                      onPress={() => Alert.alert('Downtime Start', 'Configure downtime schedule in Android Digital Wellbeing settings.')}
                     />
                     <CupertinoListTile
                       title="End"
@@ -124,7 +124,7 @@ export function ScreenTimeScreen({ navigation }: { navigation: any }) {
                           {settings.downtimeEnd}
                         </Text>
                       }
-                      onPress={() => {}}
+                      onPress={() => Alert.alert('Downtime End', 'Configure downtime schedule in Android Digital Wellbeing settings.')}
                     />
                   </>
                 )}
@@ -141,11 +141,11 @@ export function ScreenTimeScreen({ navigation }: { navigation: any }) {
                       {settings.dailyLimit > 0 ? 'On' : 'Off'}
                     </Text>
                   }
-                  onPress={() => {}}
+                  onPress={() => Alert.alert('App Limits', 'Use Android Digital Wellbeing to set app timers.')}
                 />
                 <CupertinoListTile
                   title="Content & Privacy Restrictions"
-                  onPress={() => {}}
+                  onPress={() => Alert.alert('Content & Privacy Restrictions', 'Use Android parental controls to manage content restrictions.')}
                 />
               </CupertinoListSection>
             </View>

--- a/src/screens/settings/SoftwareUpdateScreen.tsx
+++ b/src/screens/settings/SoftwareUpdateScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { View, Text, ScrollView, StyleSheet } from 'react-native';
+import { View, Text, ScrollView, StyleSheet, Alert } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTheme } from '../../theme/ThemeContext';
 import {
@@ -69,7 +69,7 @@ export function SoftwareUpdateScreen({ navigation }: { navigation: any }) {
               <CupertinoButton
                 title="Download and Install"
                 variant="filled"
-                onPress={() => {}}
+                onPress={() => Alert.alert('Software Update', 'This is a demo app. No actual update is available.')}
                 style={{ marginTop: spacing.md }}
               />
             </View>

--- a/src/screens/settings/SoundsHapticsScreen.tsx
+++ b/src/screens/settings/SoundsHapticsScreen.tsx
@@ -62,7 +62,7 @@ export function SoundsHapticsScreen({ navigation }: { navigation: any }) {
                   {settings.ringtone}
                 </Text>
               }
-              onPress={() => {}}
+              onPress={() => openSystemPanel('sound')}
             />
             <CupertinoListTile
               title="Text Tone"
@@ -71,7 +71,7 @@ export function SoundsHapticsScreen({ navigation }: { navigation: any }) {
                   {settings.textTone}
                 </Text>
               }
-              onPress={() => {}}
+              onPress={() => openSystemPanel('sound')}
             />
           </CupertinoListSection>
         </View>

--- a/src/screens/settings/VpnScreen.tsx
+++ b/src/screens/settings/VpnScreen.tsx
@@ -106,7 +106,7 @@ export function VpnScreen({ navigation }: { navigation: any }) {
             <CupertinoListTile
               title="Add VPN Configuration..."
               leading={{ name: 'add-circle-outline', color: '#FFFFFF', backgroundColor: colors.systemBlue }}
-              onPress={() => {}}
+              onPress={() => openSystemPanel('vpn')}
             />
           </CupertinoListSection>
         </View>

--- a/src/screens/settings/WallpaperScreen.tsx
+++ b/src/screens/settings/WallpaperScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { View, Text, Image, ScrollView, StyleSheet, Pressable } from 'react-native';
+import { View, Text, Image, ScrollView, StyleSheet, Pressable, Alert } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import * as ImagePicker from 'expo-image-picker';
@@ -164,7 +164,7 @@ export function WallpaperScreen({ navigation }: { navigation: any }) {
                 </Text>
               }
               showChevron
-              onPress={() => {}}
+              onPress={() => Alert.alert('Set Lock Screen', 'Wallpaper applied to lock screen within the app. To change your Android wallpaper, use your device settings.')}
             />
             <CupertinoListTile
               title="Set Home Screen"
@@ -174,7 +174,7 @@ export function WallpaperScreen({ navigation }: { navigation: any }) {
                 </Text>
               }
               showChevron
-              onPress={() => {}}
+              onPress={() => Alert.alert('Set Home Screen', 'Wallpaper applied to home screen within the app. To change your Android wallpaper, use your device settings.')}
             />
           </CupertinoListSection>
         </View>

--- a/src/screens/settings/WifiScreen.tsx
+++ b/src/screens/settings/WifiScreen.tsx
@@ -15,7 +15,7 @@ export function WifiScreen({ navigation }: { navigation: any }) {
   const { theme, typography, spacing } = useTheme();
   const { colors } = theme;
   const insets = useSafeAreaInsets();
-  const { wifi, toggleWifi } = useDevice();
+  const { wifi, toggleWifi, openSystemPanel } = useDevice();
 
   return (
     <View style={[styles.container, { backgroundColor: colors.systemGroupedBackground }]}>
@@ -69,7 +69,7 @@ export function WifiScreen({ navigation }: { navigation: any }) {
                       ) : undefined
                     }
                     showChevron={connected}
-                    onPress={() => {}}
+                    onPress={() => openSystemPanel('wifi')}
                   />
                 );
               })}
@@ -85,14 +85,14 @@ export function WifiScreen({ navigation }: { navigation: any }) {
                 trailing={
                   <Text style={[typography.body, { color: colors.secondaryLabel }]}>Ask</Text>
                 }
-                onPress={() => {}}
+                onPress={() => openSystemPanel('wifi')}
               />
               <CupertinoListTile
                 title="Auto-Join Hotspot"
                 trailing={
                   <Text style={[typography.body, { color: colors.secondaryLabel }]}>Never</Text>
                 }
-                onPress={() => {}}
+                onPress={() => openSystemPanel('wifi')}
               />
             </CupertinoListSection>
           </View>


### PR DESCRIPTION
## Summary
- Replaced 45+ `onPress={() => {}}` across 17 settings screens
- Handlers open relevant Android system settings panels, show info alerts, or navigate to sub-screens
- Zero empty handlers remain in settings screens

Closes #39