### PR TITLE
fix/40: Implement empty handlers in main screens

### DIFF
--- a/src/screens/ComponentsGalleryScreen.tsx
+++ b/src/screens/ComponentsGalleryScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { View, Text, ScrollView, StyleSheet, Platform } from 'react-native';
+import { View, Text, ScrollView, StyleSheet, Platform, Alert } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTheme } from '../theme/ThemeContext';
 import {
@@ -220,10 +220,10 @@ export function ComponentsGalleryScreen() {
         <View style={{ borderRadius: 12, overflow: 'hidden' }}>
           <CupertinoSwipeableRow
             trailingActions={[
-              { label: 'Delete', color: '#FF3B30', onPress: () => {} },
+              { label: 'Delete', color: '#FF3B30', onPress: () => Alert.alert('Demo', 'Delete action triggered.') },
             ]}
             leadingActions={[
-              { label: 'Pin', color: '#FF9500', onPress: () => {} },
+              { label: 'Pin', color: '#FF9500', onPress: () => Alert.alert('Demo', 'Pin action triggered.') },
             ]}
           >
             <View style={[
@@ -246,12 +246,12 @@ export function ComponentsGalleryScreen() {
           <CupertinoListTile
             title="Messages"
             leading={{ name: 'chatbubble-ellipses', color: '#FFF', backgroundColor: '#34C759' }}
-            onPress={() => {}}
+            onPress={() => Alert.alert('Demo', 'Messages action triggered.')}
           />
           <CupertinoListTile
             title="FaceTime"
             leading={{ name: 'videocam', color: '#FFF', backgroundColor: '#34C759' }}
-            onPress={() => {}}
+            onPress={() => Alert.alert('Demo', 'FaceTime action triggered.')}
           />
           <CupertinoListTile
             title="Mail"
@@ -261,7 +261,7 @@ export function ComponentsGalleryScreen() {
                 <Text style={[typography.caption2, { color: '#FFF', fontWeight: '600' }]}>3</Text>
               </View>
             }
-            onPress={() => {}}
+            onPress={() => Alert.alert('Demo', 'Mail action triggered.')}
           />
         </CupertinoListSection>
 
@@ -286,9 +286,9 @@ export function ComponentsGalleryScreen() {
           title="Choose Action"
           message="Select one of the options below"
           options={[
-            { label: 'Share', onPress: () => {} },
-            { label: 'Save to Photos', onPress: () => {} },
-            { label: 'Delete', onPress: () => {}, destructive: true },
+            { label: 'Share', onPress: () => Alert.alert('Demo', 'Share action triggered.') },
+            { label: 'Save to Photos', onPress: () => Alert.alert('Demo', 'Save to Photos action triggered.') },
+            { label: 'Delete', onPress: () => Alert.alert('Demo', 'Delete action triggered.'), destructive: true },
           ]}
         />
 
@@ -298,8 +298,8 @@ export function ComponentsGalleryScreen() {
           title="Delete Photo?"
           message="This action cannot be undone."
           actions={[
-            { label: 'Cancel', onPress: () => {}, style: 'cancel' },
-            { label: 'Delete', onPress: () => {}, style: 'destructive' },
+            { label: 'Cancel', onPress: () => setShowAlert(false), style: 'cancel' },
+            { label: 'Delete', onPress: () => { setShowAlert(false); Alert.alert('Demo', 'Delete confirmed.'); }, style: 'destructive' },
           ]}
         />
       </ScrollView>

--- a/src/screens/ControlCenterScreen.tsx
+++ b/src/screens/ControlCenterScreen.tsx
@@ -301,7 +301,7 @@ export function ControlCenterScreen({ navigation }: { navigation: any; route: an
                 </View>
                 <View style={styles.musicControls}>
                   <Pressable
-                    onPress={() => {}}
+                    onPress={() => Alert.alert('Previous Track', 'Media controls require an active media session.')}
                     accessibilityLabel="Previous track"
                     style={styles.musicBtn}
                   >
@@ -319,7 +319,7 @@ export function ControlCenterScreen({ navigation }: { navigation: any; route: an
                     />
                   </Pressable>
                   <Pressable
-                    onPress={() => {}}
+                    onPress={() => Alert.alert('Next Track', 'Media controls require an active media session.')}
                     accessibilityLabel="Next track"
                     style={styles.musicBtn}
                   >

--- a/src/screens/ConversationScreen.tsx
+++ b/src/screens/ConversationScreen.tsx
@@ -314,7 +314,13 @@ export function ConversationScreen({ navigation, route }: { navigation: any; rou
         ]}
       >
         <Pressable
-          onPress={() => {}}
+          onPress={() => {
+            Alert.alert('Add Attachment', 'Choose an option', [
+              { text: 'Take Photo', onPress: () => Alert.alert('Coming Soon', 'Attachment support will be added in a future update.') },
+              { text: 'Photo Library', onPress: () => Alert.alert('Coming Soon', 'Attachment support will be added in a future update.') },
+              { text: 'Cancel', style: 'cancel' },
+            ]);
+          }}
           hitSlop={8}
           style={styles.plusButton}
           accessibilityRole="button"

--- a/src/screens/ProfileScreen.tsx
+++ b/src/screens/ProfileScreen.tsx
@@ -128,7 +128,7 @@ export function ProfileScreen() {
                   {profile.appleId}
                 </Text>
               }
-              onPress={() => {}}
+              onPress={() => Alert.alert('Apple ID', 'Apple ID settings are managed by the system.')}
             />
             <CupertinoListTile
               title="iCloud"
@@ -138,17 +138,17 @@ export function ProfileScreen() {
                   {profile.icloudStorage}
                 </Text>
               }
-              onPress={() => {}}
+              onPress={() => Alert.alert('iCloud', 'iCloud storage management will be available in a future update.')}
             />
             <CupertinoListTile
               title="Media & Purchases"
               leading={{ name: 'bag', color: '#FFF', backgroundColor: '#FF2D55' }}
-              onPress={() => {}}
+              onPress={() => Alert.alert('Media & Purchases', 'Manage your subscriptions and purchase history.')}
             />
             <CupertinoListTile
               title="Find My"
               leading={{ name: 'location', color: '#FFF', backgroundColor: '#34C759' }}
-              onPress={() => {}}
+              onPress={() => Alert.alert('Find My', 'No other devices connected.')}
             />
           </CupertinoListSection>
 


### PR DESCRIPTION
## Summary
- Replaced empty handlers in ControlCenterScreen, ConversationScreen, ProfileScreen, ComponentsGalleryScreen
- Music controls show media session info, attachment button shows options, profile actions show dialogs

Closes #40