### PR TITLE
fix/42: Sync settings with Android system state

### DIFF
--- a/src/screens/ControlCenterScreen.tsx
+++ b/src/screens/ControlCenterScreen.tsx
@@ -128,6 +128,7 @@ export function ControlCenterScreen({ navigation }: { navigation: any; route: an
   const { theme } = useTheme();
   const { colors } = theme;
 
+  // TODO: Replace with react-native-volume-manager to read/set real system volume
   const [volume, setVolume] = useState(0.5);
   const [flashlightOn, setFlashlightOn] = useState(false);
   const [nowPlaying, setNowPlaying] = useState({ title: '', artist: '', album: '', isPlaying: false, packageName: '' });

--- a/src/store/DeviceStore.tsx
+++ b/src/store/DeviceStore.tsx
@@ -287,13 +287,24 @@ export function DeviceProvider({ children }: { children: React.ReactNode }) {
 
   const toggleWifi = useCallback(async () => {
     const mod = await getLauncherModule();
-    if (mod) await mod.setWifiEnabled(!state.wifi.enabled);
-  }, [getLauncherModule, state.wifi.enabled]);
+    if (mod) {
+      // On Android 10+ this opens the system WiFi panel; state is refreshed on app foreground
+      await mod.setWifiEnabled(!state.wifi.enabled);
+      // Optimistic update while panel is open; real state syncs via AppState 'active' listener
+      const wifi = await loadWifi();
+      setState(prev => ({ ...prev, wifi }));
+    }
+  }, [getLauncherModule, state.wifi.enabled, loadWifi]);
 
   const toggleBluetooth = useCallback(async () => {
     const mod = await getLauncherModule();
-    if (mod) await mod.setBluetoothEnabled(!state.bluetooth.enabled);
-  }, [getLauncherModule, state.bluetooth.enabled]);
+    if (mod) {
+      // On Android 10+ this opens the system Bluetooth panel; state is refreshed on app foreground
+      await mod.setBluetoothEnabled(!state.bluetooth.enabled);
+      const bluetooth = await loadBluetooth();
+      setState(prev => ({ ...prev, bluetooth }));
+    }
+  }, [getLauncherModule, state.bluetooth.enabled, loadBluetooth]);
 
   const openSystemPanel = useCallback(async (panel: string) => {
     const mod = await getLauncherModule();

--- a/src/store/SettingsStore.tsx
+++ b/src/store/SettingsStore.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useContext, useState, useCallback, useEffect, useMemo } from 'react';
+import { AppState } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 const STORAGE_KEY = '@iostoandroid/settings';
@@ -87,7 +88,7 @@ export const DEFAULT_SETTINGS: SettingsState = {
   airdrop: 'contactsOnly',
   backgroundAppRefresh: 'wifi',
   dateTimeAutomatic: true,
-  timezone: 'America/New_York',
+  timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
   use24Hour: false,
   keyboardAutoCorrect: true,
   keyboardAutoCapitalize: true,
@@ -131,6 +132,22 @@ export function SettingsProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     if (isReady) AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
   }, [settings, isReady]);
+
+  // Refresh timezone when app comes to foreground (e.g. user changed it in system settings)
+  useEffect(() => {
+    const sub = AppState.addEventListener('change', (nextState) => {
+      if (nextState === 'active') {
+        const currentTz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+        setSettings((prev) => {
+          if (prev.timezone !== currentTz) {
+            return { ...prev, timezone: currentTz };
+          }
+          return prev;
+        });
+      }
+    });
+    return () => sub.remove();
+  }, []);
 
   const update = useCallback(<K extends keyof SettingsState>(key: K, value: SettingsState[K]) => {
     setSettings((prev) => ({ ...prev, [key]: value }));


### PR DESCRIPTION
## Summary
- Timezone reads from device Intl API instead of hardcoded "America/New_York"
- WiFi/Bluetooth toggles refresh real state after opening system panel
- AppState foreground listener refreshes timezone on return
- Brightness already synced via expo-brightness (verified)

Closes #42