### PR TITLE
fix/49: Fix navigation gaps, enable back gesture, hide dev screens

### DIFF
--- a/app.json
+++ b/app.json
@@ -23,7 +23,7 @@
       },
       "permissions": ["android.permission.QUERY_ALL_PACKAGES"],
       "edgeToEdgeEnabled": true,
-      "predictiveBackGestureEnabled": false
+      "predictiveBackGestureEnabled": true
     },
     "web": {
       "favicon": "./assets/favicon.png"

--- a/src/navigation/TabNavigator.tsx
+++ b/src/navigation/TabNavigator.tsx
@@ -105,7 +105,7 @@ export function TabNavigator() {
       <Stack.Screen name="BackupRestore" component={BackupRestoreScreen} options={{ animation: 'slide_from_right' }} />
       <Stack.Screen name="ProfileMain" component={ProfileScreen} options={{ animation: 'slide_from_right' }} />
       <Stack.Screen name="EditProfile" component={EditProfileScreen} options={{ animation: 'slide_from_right' }} />
-      <Stack.Screen name="ComponentsGallery" component={ComponentsGalleryScreen} options={{ animation: 'slide_from_right' }} />
+      {__DEV__ && <Stack.Screen name="ComponentsGallery" component={ComponentsGalleryScreen} options={{ animation: 'slide_from_right' }} />}
       <Stack.Screen name="AppLibrary" component={AppLibraryScreen} />
       <Stack.Screen name="TodayView" component={TodayViewScreen} options={{ animation: 'slide_from_left' }} />
       <Stack.Screen name="LauncherSettings" component={LauncherSettingsScreen} options={{ animation: 'slide_from_right' }} />

--- a/src/screens/ProfileScreen.tsx
+++ b/src/screens/ProfileScreen.tsx
@@ -152,6 +152,7 @@ export function ProfileScreen() {
             />
           </CupertinoListSection>
 
+          {__DEV__ && (
           <CupertinoListSection>
             <CupertinoListTile
               title="Components Gallery"
@@ -159,6 +160,7 @@ export function ProfileScreen() {
               onPress={() => navigation.navigate('ComponentsGallery')}
             />
           </CupertinoListSection>
+          )}
 
           <CupertinoListSection>
             <CupertinoListTile


### PR DESCRIPTION
Enable predictiveBackGesture, hide ComponentsGallery in production, verify all routes exist. Closes #49