### PR TITLE
fix/41: replace demo Alert placeholders with real functionality

### DIFF
--- a/modules/launcher-module/android/src/main/java/com/iostoandroid/launcher/LauncherModule.kt
+++ b/modules/launcher-module/android/src/main/java/com/iostoandroid/launcher/LauncherModule.kt
@@ -265,6 +265,7 @@ class LauncherModule : Module() {
                 "notification" -> Settings.ACTION_NOTIFICATION_LISTENER_SETTINGS
                 "privacy" -> Settings.ACTION_PRIVACY_SETTINGS
                 "security" -> Settings.ACTION_SECURITY_SETTINGS
+                "cast" -> "android.settings.CAST_SETTINGS"
                 "hotspot" -> "android.settings.TETHER_SETTINGS"
                 "cellular" -> Settings.ACTION_NETWORK_OPERATOR_SETTINGS
                 "appinfo" -> Settings.ACTION_APPLICATION_DETAILS_SETTINGS

--- a/src/screens/ControlCenterScreen.tsx
+++ b/src/screens/ControlCenterScreen.tsx
@@ -412,14 +412,12 @@ export function ControlCenterScreen({ navigation }: { navigation: any; route: an
                 label="Screen Rec"
                 onPress={async () => {
                   Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-                  Alert.alert(
-                    'Screen Recording',
-                    'Use your device\'s built-in screen recorder.',
-                    [
-                      { text: 'Open Settings', onPress: async () => { const mod = await getLauncher(); if (mod) mod.openSystemSettings('display'); } },
-                      { text: 'Cancel', style: 'cancel' },
-                    ]
-                  );
+                  const mod = await getLauncher();
+                  if (mod) {
+                    await mod.openSystemSettings('cast');
+                  } else {
+                    Alert.alert('Screen Recording', 'Could not open screen recorder settings.');
+                  }
                 }}
               />
               <ShortcutButton
@@ -442,14 +440,13 @@ export function ControlCenterScreen({ navigation }: { navigation: any; route: an
             <Pressable
               style={styles.mirrorTile}
               onPress={async () => {
-                Alert.alert(
-                  'Screen Mirroring',
-                  'Use your device\'s cast feature.',
-                  [
-                    { text: 'Open Cast Settings', onPress: async () => { const mod = await getLauncher(); if (mod) mod.openSystemSettings('display'); } },
-                    { text: 'Cancel', style: 'cancel' },
-                  ]
-                );
+                Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+                const mod = await getLauncher();
+                if (mod) {
+                  await mod.openSystemSettings('cast');
+                } else {
+                  Alert.alert('Screen Mirroring', 'Could not open cast settings.');
+                }
               }}
               accessibilityLabel="Screen Mirroring"
             >

--- a/src/screens/contacts/ContactDetailScreen.tsx
+++ b/src/screens/contacts/ContactDetailScreen.tsx
@@ -96,14 +96,11 @@ export function ContactDetailScreen({ navigation, route }: { navigation: any; ro
     { icon: 'call' as const, label: 'call', onPress: handleCall },
     { icon: 'chatbubble' as const, label: 'message', onPress: () => Linking.openURL(`sms:${contact.phone}`) },
     { icon: 'videocam' as const, label: 'Video Call', onPress: () => {
-      Alert.alert(
-        'Video Call',
-        'Video calling requires a compatible app (WhatsApp, Google Duo, etc.)',
-        [
-          { text: 'Call Instead', onPress: () => contact.phone ? Linking.openURL(`tel:${contact.phone}`) : undefined },
-          { text: 'Cancel', style: 'cancel' },
-        ]
-      );
+      if (contact.phone) {
+        Linking.openURL(`tel:${contact.phone}`);
+      } else {
+        Alert.alert('No phone number', 'No phone number available for this contact.');
+      }
     }},
     { icon: 'mail' as const, label: 'mail', onPress: () => contact.email ? Linking.openURL(`mailto:${contact.email}`) : undefined },
   ];


### PR DESCRIPTION
## Summary
- ControlCenterScreen: Screen Recording and Screen Mirroring now open Android cast settings directly
- ContactDetailScreen: Video Call button now calls `Linking.openURL('tel:...')` with fallback
- Added `cast` shorthand mapping in LauncherModule.kt for `android.settings.CAST_SETTINGS`
- Flashlight, Camera, and Profile photo were already implemented in previous PRs

Closes #41