### PR TITLE
fix(ci): auto-release reads version from latest git tag, not app.json

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -89,10 +89,16 @@ jobs:
             console.log(`Determined bump: ${bump}`);
             core.setOutput('bump', bump);
 
-      - name: Read current version and compute next
+      - name: Read current version from latest git tag and compute next
         id: version
         run: |
-          CURRENT=$(node -p "require('./app.json').expo.version")
+          # Use the latest semver git tag as the source of truth (not app.json)
+          LATEST_TAG=$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -n1)
+          if [ -z "$LATEST_TAG" ]; then
+            CURRENT="0.0.0"
+          else
+            CURRENT="${LATEST_TAG#v}"
+          fi
           echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
 
           IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
@@ -107,7 +113,7 @@ jobs:
           NEXT="${MAJOR}.${MINOR}.${PATCH}"
           echo "next=$NEXT" >> "$GITHUB_OUTPUT"
           echo "tag=v${NEXT}" >> "$GITHUB_OUTPUT"
-          echo "Version: $CURRENT → $NEXT ($BUMP)"
+          echo "Version: $CURRENT → $NEXT ($BUMP) [from tag: $LATEST_TAG]"
 
       - name: Update version in app.json and package.json
         run: |

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "iosToAndroid",
     "slug": "iosToAndroid",
-    "version": "1.1.0",
+    "version": "1.8.4",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iostoandroid",
-  "version": "1.1.0",
+  "version": "1.8.4",
   "main": "index.ts",
   "scripts": {
     "start": "expo start",


### PR DESCRIPTION
## Summary

- Auto-release workflow now reads the **latest git tag** (`git tag --sort=-v:refname`) instead of `app.json` to determine the current version
- Synced `app.json` and `package.json` to `1.8.4` to match the actual latest tag

## Problem

The previous run failed because `app.json` had `1.0.0` while the latest tag was `v1.8.4`. The workflow bumped to `1.1.0`, which collided with the already-existing `v1.1.0` tag.

## How it works now

1. Finds the latest semver tag: `git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -n1`
2. Strips the `v` prefix to get the base version
3. Bumps based on issue labels (same logic as before)
4. Updates `app.json` and `package.json` to the new version
5. Creates tag + release

If no tags exist, it falls back to `0.0.0`.

## Test plan

- [ ] Merge this PR → should create `v1.9.0` (enhancement labels on referenced issues = minor bump)

https://claude.ai/code/session_01MNaGUdHS2rmV4oCZVsiams