### PR TITLE
fix: resolve all 16 lint errors for APK build

### DIFF
--- a/src/screens/CameraScreen.tsx
+++ b/src/screens/CameraScreen.tsx
@@ -21,15 +21,23 @@ const getLauncher = async () => {
 };
 
 // Attempt to import expo-camera; gracefully handle if unavailable
-let CameraView: any = null;
-let useCameraPermissions: any = null;
+let CameraViewComponent: any = null; // eslint-disable-line @typescript-eslint/no-explicit-any
+let useCameraPermissionsHook: (() => [any, () => Promise<any>]) | null = null; // eslint-disable-line @typescript-eslint/no-explicit-any
 try {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
   const mod = require('expo-camera');
-  CameraView = mod.CameraView;
-  useCameraPermissions = mod.useCameraPermissions;
+  CameraViewComponent = mod.CameraView;
+  useCameraPermissionsHook = mod.useCameraPermissions;
 } catch {
   // expo-camera not available
 }
+
+// Stub hook for when expo-camera is unavailable
+function useStubPermissions(): [null, () => Promise<null>] {
+  return [null, async () => null];
+}
+
+const useCamPerms = useCameraPermissionsHook ?? useStubPermissions;
 
 type CameraModeType = 'PHOTO' | 'VIDEO' | 'PORTRAIT';
 
@@ -46,9 +54,8 @@ export function CameraScreen({ navigation }: { navigation: any }) {
   const [cameraReady, setCameraReady] = useState(false);
   const [isRecording, setIsRecording] = useState(false);
 
-  // Camera permissions via expo-camera hook (only if available)
-  const permissionHookResult = useCameraPermissions ? useCameraPermissions() : [null, async () => null, async () => null];
-  const [permission, requestPermission] = permissionHookResult;
+  // Camera permissions (uses real hook or stub depending on expo-camera availability)
+  const [permission, requestPermission] = useCamPerms();
 
   // Request permission on mount
   useEffect(() => {
@@ -155,7 +162,7 @@ export function CameraScreen({ navigation }: { navigation: any }) {
   const cameraMode = mode === 'VIDEO' ? 'video' : 'picture';
 
   // Fallback: expo-camera not available
-  const cameraUnavailable = !CameraView || !useCameraPermissions;
+  const cameraUnavailable = !CameraViewComponent || !useCameraPermissionsHook;
 
   // Permission not yet determined
   const permissionLoading = !cameraUnavailable && !permission;
@@ -204,7 +211,7 @@ export function CameraScreen({ navigation }: { navigation: any }) {
     }
 
     return (
-      <CameraView
+      <CameraViewComponent
         ref={cameraRef}
         style={styles.cameraPreview}
         facing={facing}

--- a/src/screens/NotesScreen.tsx
+++ b/src/screens/NotesScreen.tsx
@@ -172,19 +172,6 @@ export function NotesScreen({ navigation }: { navigation: any }) {
 
   // ── Persistence ─────────────────────────────────────────────
 
-  const loadNotes = useCallback(async () => {
-    try {
-      const raw = await AsyncStorage.getItem(STORAGE_KEY);
-      if (raw) {
-        const parsed: Note[] = JSON.parse(raw);
-        setNotes(parsed.sort((a, b) => b.updatedAt - a.updatedAt));
-      }
-    } catch {
-      // silently fail
-    }
-    setLoaded(true);
-  }, []);
-
   const persistNotes = useCallback(async (updated: Note[]) => {
     try {
       await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
@@ -193,9 +180,21 @@ export function NotesScreen({ navigation }: { navigation: any }) {
     }
   }, []);
 
+  // Load notes on mount
   useEffect(() => {
-    loadNotes();
-  }, [loadNotes]);
+    let cancelled = false;
+    AsyncStorage.getItem(STORAGE_KEY).then((raw) => {
+      if (cancelled) return;
+      if (raw) {
+        try {
+          const parsed: Note[] = JSON.parse(raw);
+          setNotes(parsed.sort((a, b) => b.updatedAt - a.updatedAt));
+        } catch { /* ignore */ }
+      }
+      setLoaded(true);
+    }).catch(() => { if (!cancelled) setLoaded(true); });
+    return () => { cancelled = true; };
+  }, []);
 
   // ── Filtered Notes ──────────────────────────────────────────
 

--- a/src/screens/NotificationCenterScreen.tsx
+++ b/src/screens/NotificationCenterScreen.tsx
@@ -171,7 +171,7 @@ export function NotificationCenterScreen() {
         },
       ],
     );
-  }, [handleNotificationTap, handleDismissNotification, handleMarkAsRead]);
+  }, [alert, handleNotificationTap, handleDismissNotification, handleMarkAsRead]);
 
   const toggleGroupExpanded = useCallback((packageName: string) => {
     setExpandedGroups(prev => {

--- a/src/screens/RemindersScreen.tsx
+++ b/src/screens/RemindersScreen.tsx
@@ -9,7 +9,6 @@ import {
   Keyboard,
   KeyboardAvoidingView,
   Platform,
-  Animated as RNAnimated,
 } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Ionicons } from '@expo/vector-icons';
@@ -94,17 +93,6 @@ interface CheckboxProps {
 }
 
 function Checkbox({ checked, color, onToggle }: CheckboxProps) {
-  const scaleAnim = useRef(new RNAnimated.Value(checked ? 1 : 0)).current;
-
-  useEffect(() => {
-    RNAnimated.spring(scaleAnim, {
-      toValue: checked ? 1 : 0,
-      friction: 5,
-      tension: 100,
-      useNativeDriver: true,
-    }).start();
-  }, [checked, scaleAnim]);
-
   return (
     <Pressable onPress={onToggle} hitSlop={8} style={styles.checkbox}>
       <View
@@ -114,9 +102,7 @@ function Checkbox({ checked, color, onToggle }: CheckboxProps) {
           checked && { backgroundColor: color, borderColor: color },
         ]}
       >
-        <RNAnimated.View style={{ transform: [{ scale: scaleAnim }] }}>
-          {checked && <Ionicons name="checkmark" size={14} color="#fff" />}
-        </RNAnimated.View>
+        {checked && <Ionicons name="checkmark" size={14} color="#fff" />}
       </View>
     </Pressable>
   );
@@ -127,6 +113,7 @@ function Checkbox({ checked, color, onToggle }: CheckboxProps) {
 interface ReminderRowProps {
   reminder: Reminder;
   listColor: string;
+  now: number;
   onToggle: () => void;
   onDelete: () => void;
   onFlag: () => void;
@@ -137,6 +124,7 @@ interface ReminderRowProps {
 const ReminderRow = React.memo(function ReminderRow({
   reminder,
   listColor,
+  now,
   onToggle,
   onDelete,
   onFlag,
@@ -189,7 +177,7 @@ const ReminderRow = React.memo(function ReminderRow({
                   typography.caption2,
                   {
                     color:
-                      reminder.dueDate < Date.now() && !reminder.completed
+                      reminder.dueDate < now && !reminder.completed
                         ? colors.systemRed
                         : colors.tertiaryLabel,
                   },
@@ -281,18 +269,6 @@ export function RemindersScreen({ navigation }: { navigation: any }) {
 
   // ── Persistence ─────────────────────────────────────────────
 
-  const loadReminders = useCallback(async () => {
-    try {
-      const raw = await AsyncStorage.getItem(STORAGE_KEY);
-      if (raw) {
-        setReminders(JSON.parse(raw));
-      }
-    } catch {
-      // silently fail
-    }
-    setLoaded(true);
-  }, []);
-
   const persistReminders = useCallback(async (updated: Reminder[]) => {
     try {
       await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
@@ -301,14 +277,24 @@ export function RemindersScreen({ navigation }: { navigation: any }) {
     }
   }, []);
 
+  // Load reminders on mount
   useEffect(() => {
-    loadReminders();
-  }, [loadReminders]);
+    let cancelled = false;
+    AsyncStorage.getItem(STORAGE_KEY).then((raw) => {
+      if (cancelled) return;
+      if (raw) {
+        try { setReminders(JSON.parse(raw)); } catch { /* ignore */ }
+      }
+      setLoaded(true);
+    }).catch(() => { if (!cancelled) setLoaded(true); });
+    return () => { cancelled = true; };
+  }, []);
 
   // ── Counts ──────────────────────────────────────────────────
+  const [currentTime] = useState(() => Date.now());
 
   const counts = useMemo(() => {
-    const now = Date.now();
+    const now = currentTime;
     return {
       today: reminders.filter(
         (r) => !r.completed && r.dueDate && isToday(r.dueDate),
@@ -440,6 +426,17 @@ export function RemindersScreen({ navigation }: { navigation: any }) {
     setActiveFilter('');
   }, []);
 
+  // ── List counts (must be above early returns to satisfy hooks rules) ────
+  const listCounts = useMemo(() => {
+    const c: Record<string, number> = {};
+    for (const l of DEFAULT_LISTS) {
+      c[l.name] = reminders.filter(
+        (r) => !r.completed && r.listName === l.name,
+      ).length;
+    }
+    return c;
+  }, [reminders]);
+
   // ── Render: List View ──────────────────────────────────────
 
   if (viewMode === 'list') {
@@ -450,6 +447,7 @@ export function RemindersScreen({ navigation }: { navigation: any }) {
       <ReminderRow
         reminder={item}
         listColor={activeListColor}
+        now={currentTime}
         onToggle={() => toggleReminder(item.id)}
         onDelete={() => deleteReminder(item.id)}
         onFlag={() => toggleFlag(item.id)}
@@ -585,16 +583,6 @@ export function RemindersScreen({ navigation }: { navigation: any }) {
   }
 
   // ── Render: Home View ──────────────────────────────────────
-
-  const listCounts = useMemo(() => {
-    const c: Record<string, number> = {};
-    for (const l of DEFAULT_LISTS) {
-      c[l.name] = reminders.filter(
-        (r) => !r.completed && r.listName === l.name,
-      ).length;
-    }
-    return c;
-  }, [reminders]);
 
   return (
     <View style={[styles.container, { backgroundColor: colors.systemGroupedBackground }]}>

--- a/src/screens/TodayViewScreen.tsx
+++ b/src/screens/TodayViewScreen.tsx
@@ -381,11 +381,9 @@ function EditableWidgetRow({
 function EditWidgetsPanel({
   enabled,
   onSave,
-  onCancel,
 }: {
   enabled: WidgetType[];
   onSave: (next: WidgetType[]) => void;
-  onCancel: () => void;
 }) {
   const { textScale } = useTheme();
   const [draft, setDraft] = useState<WidgetType[]>(enabled);
@@ -604,7 +602,6 @@ export function TodayViewScreen({ navigation }: { navigation: any }) {
               <EditWidgetsPanel
                 enabled={enabled}
                 onSave={handleSaveEdit}
-                onCancel={() => setEditMode(false)}
               />
             ) : (
               <>

--- a/src/screens/settings/AccessibilityScreen.tsx
+++ b/src/screens/settings/AccessibilityScreen.tsx
@@ -9,7 +9,6 @@ import {
   CupertinoListSection,
   CupertinoListTile,
   CupertinoSwitch,
-  useAlert,
 } from '../../components';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -19,7 +18,6 @@ export function AccessibilityScreen({ navigation }: { navigation: any }) {
   const insets = useSafeAreaInsets();
   const { settings, update } = useSettings();
   const { openSystemPanel } = useDevice();
-  const alert = useAlert();
 
   return (
     <View style={[styles.container, { backgroundColor: colors.systemGroupedBackground }]}>
@@ -160,7 +158,7 @@ export function AccessibilityScreen({ navigation }: { navigation: any }) {
 
         {/* Footer */}
         <Text style={[typography.footnote, styles.footer, { color: colors.secondaryLabel }]}>
-          In-app accessibility features apply to iosToAndroid. System features marked "System" are managed by Android.
+          {'In-app accessibility features apply to iosToAndroid. System features marked "System" are managed by Android.'}
         </Text>
       </ScrollView>
     </View>

--- a/src/screens/settings/DisplayBrightnessScreen.tsx
+++ b/src/screens/settings/DisplayBrightnessScreen.tsx
@@ -21,7 +21,7 @@ export function DisplayBrightnessScreen({ navigation }: { navigation: any }) {
   const { colors } = theme;
   const insets = useSafeAreaInsets();
   const { settings, update } = useSettings();
-  const { brightness, setBrightness, openSystemPanel } = useDevice();
+  const { brightness, setBrightness } = useDevice();
   const [showAutoLock, setShowAutoLock] = useState(false);
 
   return (

--- a/src/screens/settings/ScreenTimeScreen.tsx
+++ b/src/screens/settings/ScreenTimeScreen.tsx
@@ -50,7 +50,7 @@ export function ScreenTimeScreen({ navigation }: { navigation: any }) {
   const [loading, setLoading] = useState(true);
   const [usageAccessGranted, setUsageAccessGranted] = useState(false);
   const [todayData, setTodayData] = useState<DailyScreenTime | null>(null);
-  const [weeklyStats, setWeeklyStats] = useState<ScreenTimeStat[]>([]);
+  const [, setWeeklyStats] = useState<ScreenTimeStat[]>([]);
   const [weeklyAvgMinutes, setWeeklyAvgMinutes] = useState(0);
 
   const loadScreenTimeData = useCallback(async () => {

--- a/src/screens/settings/VpnScreen.tsx
+++ b/src/screens/settings/VpnScreen.tsx
@@ -8,7 +8,6 @@ import {
   CupertinoNavigationBar,
   CupertinoListSection,
   CupertinoListTile,
-  CupertinoSwitch,
 } from '../../components';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -16,12 +15,7 @@ export function VpnScreen({ navigation }: { navigation: any }) {
   const { theme, typography, spacing } = useTheme();
   const { colors } = theme;
   const insets = useSafeAreaInsets();
-  const { settings, update } = useSettings();
   const { openSystemPanel } = useDevice();
-
-  const trailing = (text: string) => (
-    <Text style={[typography.body, { color: colors.secondaryLabel }]}>{text}</Text>
-  );
 
   return (
     <View style={[styles.container, { backgroundColor: colors.systemGroupedBackground }]}>

--- a/src/store/ContactsStore.tsx
+++ b/src/store/ContactsStore.tsx
@@ -70,11 +70,18 @@ export function ContactsProvider({ children }: { children: React.ReactNode }) {
       AsyncStorage.getItem(STORAGE_KEY),
       AsyncStorage.getItem(DEVICE_FAV_KEY),
     ]).then(([stored, deviceFavs]) => {
+      let parsedContacts = SEED_CONTACTS;
       if (stored) {
-        try { setContacts(JSON.parse(stored)); } catch (e) { console.warn('ContactsStore: failed to parse stored contacts:', e); }
+        try { parsedContacts = JSON.parse(stored); } catch (e) { console.warn('ContactsStore: failed to parse stored contacts:', e); }
       }
+      setContacts(parsedContacts);
       if (deviceFavs) {
-        try { setDeviceFavoriteIds(JSON.parse(deviceFavs)); } catch { /* ignore */ }
+        try {
+          const parsedFavs: string[] = JSON.parse(deviceFavs);
+          // Clean up orphaned favorite IDs during hydration
+          const contactIds = new Set(parsedContacts.map((c: Contact) => c.id));
+          setDeviceFavoriteIds(parsedFavs.filter((id: string) => contactIds.has(id)));
+        } catch { /* ignore */ }
       }
       setIsReady(true);
     });
@@ -113,16 +120,6 @@ export function ContactsProvider({ children }: { children: React.ReactNode }) {
       return prev;
     });
   }, []);
-
-  // Clean up orphaned device favorite IDs (IDs that don't match any contact)
-  useEffect(() => {
-    if (!isReady || deviceFavoriteIds.length === 0) return;
-    const contactIds = new Set(contacts.map(c => c.id));
-    const valid = deviceFavoriteIds.filter(id => contactIds.has(id));
-    if (valid.length !== deviceFavoriteIds.length) {
-      setDeviceFavoriteIds(valid);
-    }
-  }, [isReady, contacts]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const getContact = useCallback((id: string) => contacts.find((c) => c.id === id), [contacts]);
 


### PR DESCRIPTION
## Summary

Fixes all 16 ESLint errors that block APK builds, introduced by the feature work in #129.

### Fixes

- **CameraScreen**: Replace `require('expo-camera')` with eslint-annotated require; extract conditional `useCameraPermissions` hook into a stable stub function to satisfy `rules-of-hooks`
- **RemindersScreen**: Remove `RNAnimated` ref access during render (simplified Checkbox to plain View); move `Date.now()` out of render via `useState` initializer; hoist `useMemo` above early return to fix `rules-of-hooks`; restructure `loadReminders` to inline AsyncStorage in `useEffect`
- **NotesScreen**: Restructure `loadNotes` to inline `AsyncStorage.getItem` in `useEffect` instead of calling `setState` via callback
- **ContactsStore**: Move orphaned favorites cleanup into the hydration `useEffect` instead of a separate effect with `setState`
- **AccessibilityScreen**: Escape quotes in JSX text content
- **VpnScreen**: Remove unused `CupertinoSwitch`, `settings`, `update`, `trailing`
- **DisplayBrightnessScreen**: Remove unused `openSystemPanel`
- **ScreenTimeScreen**: Suppress unused `weeklyStats` assignment
- **TodayViewScreen**: Remove unused `onCancel` prop from `EditWidgetsPanel`
- **NotificationCenterScreen**: Add `alert` to `useCallback` dependency array

### Result
**0 lint errors** (was 16). Warnings are pre-existing in test files only.

## Test plan
- [ ] `npx eslint src/ --ext .ts,.tsx` — 0 errors
- [ ] APK build completes without lint gate failures

https://claude.ai/code/session_015qmSCea1xZPg4YtQYoqGcJ