### PR TITLE
feat: iOS gaps and polish — icons, permissions, swipe rows, reminders, clock, weather

### DIFF
--- a/src/screens/ClockScreen.tsx
+++ b/src/screens/ClockScreen.tsx
@@ -425,7 +425,11 @@ function WorldClockTab() {
       <Modal visible={showAddModal} animationType="slide" presentationStyle="pageSheet">
         <View style={[styles.modalContainer, { backgroundColor: colors.systemBackground }]}>
           <View style={styles.modalHeader}>
-            <Pressable onPress={() => { setShowAddModal(false); setSearchQuery(''); }}>
+            <Pressable
+              onPress={() => { setShowAddModal(false); setSearchQuery(''); }}
+              hitSlop={12}
+              style={{ padding: 4 }}
+            >
               <Text style={[typography.body, { color: colors.systemOrange }]}>Cancel</Text>
             </Pressable>
             <Text style={[typography.headline, { color: colors.label }]}>Choose a City</Text>
@@ -744,13 +748,21 @@ function AlarmTab() {
       <Modal visible={showAddModal} animationType="slide" presentationStyle="pageSheet">
         <View style={[styles.modalContainer, { backgroundColor: colors.systemBackground }]}>
           <View style={styles.modalHeader}>
-            <Pressable onPress={() => { setShowAddModal(false); setEditingAlarmId(null); }}>
+            <Pressable
+              onPress={() => { setShowAddModal(false); setEditingAlarmId(null); }}
+              hitSlop={12}
+              style={{ padding: 4 }}
+            >
               <Text style={[typography.body, { color: colors.systemOrange }]}>Cancel</Text>
             </Pressable>
             <Text style={[typography.headline, { color: colors.label }]}>
               {editingAlarmId ? 'Edit Alarm' : 'Add Alarm'}
             </Text>
-            <Pressable onPress={handleSaveAlarm}>
+            <Pressable
+              onPress={handleSaveAlarm}
+              hitSlop={12}
+              style={{ padding: 4 }}
+            >
               <Text style={[typography.body, { color: colors.systemOrange, fontWeight: '600' }]}>
                 Save
               </Text>

--- a/src/screens/ContactsScreen.tsx
+++ b/src/screens/ContactsScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useCallback } from 'react';
+import React, { useState, useMemo, useCallback, useEffect } from 'react';
 import { View, Text, Image, SectionList, StyleSheet, Pressable, RefreshControl, Linking } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -110,6 +110,14 @@ export function ContactsScreen() {
   const sections = useMemo(() => groupByLetter(filteredContacts), [filteredContacts]);
 
   const sectionLetters = useMemo(() => sections.map((s) => s.title), [sections]);
+
+  // Auto-request contacts permission on first open, like iOS Contacts app
+  useEffect(() => {
+    if (deviceReady && deviceContacts.length === 0) {
+      requestContactsPermission();
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [deviceReady]);
 
   const handleRefresh = useCallback(async () => {
     setRefreshing(true);

--- a/src/screens/MessagesScreen.tsx
+++ b/src/screens/MessagesScreen.tsx
@@ -290,18 +290,26 @@ export function MessagesScreen() {
     }).catch(() => {});
   }, []);
 
+  // Auto-request SMS permission on mount
   useEffect(() => {
     (async () => {
       if (Platform.OS !== 'android') {
         setHasSmsPermission(false);
         return;
       }
-      const granted = await PermissionsAndroid.check(
+      const alreadyGranted = await PermissionsAndroid.check(
         PermissionsAndroid.PERMISSIONS.READ_SMS,
       );
-      setHasSmsPermission(granted);
+      if (alreadyGranted) {
+        setHasSmsPermission(true);
+        return;
+      }
+      // Ask immediately — iOS Messages does this on first open
+      const result = await device.requestSmsPermission();
+      setHasSmsPermission(result);
     })();
-  }, [device.messages]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const conversations = useMemo(
     () => groupConversations(device.messages).filter(

--- a/src/store/DeviceStore.tsx
+++ b/src/store/DeviceStore.tsx
@@ -1,9 +1,10 @@
 import React, { createContext, useContext, useState, useCallback, useEffect, useMemo } from 'react';
-import { Platform, AppState } from 'react-native';
+import { Platform, AppState, PermissionsAndroid } from 'react-native';
 import * as Battery from 'expo-battery';
 import * as Brightness from 'expo-brightness';
 import * as Network from 'expo-network';
 import * as Contacts from 'expo-contacts';
+import * as Location from 'expo-location';
 
 export interface DeviceWifi {
   enabled: boolean;
@@ -241,11 +242,9 @@ export function DeviceProvider({ children }: { children: React.ReactNode }) {
     try {
       let locationQuery = '';
       try {
-        const { status } = await import('expo-location').then((m) => m.requestForegroundPermissionsAsync());
+        const { status } = await Location.requestForegroundPermissionsAsync();
         if (status === 'granted') {
-          const loc = await import('expo-location').then((m) =>
-            m.getCurrentPositionAsync({ accuracy: 3 }),
-          );
+          const loc = await Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.Balanced });
           locationQuery = `${loc.coords.latitude.toFixed(4)},${loc.coords.longitude.toFixed(4)}`;
         }
       } catch { /* fall back to IP geolocation */ }
@@ -368,7 +367,20 @@ export function DeviceProvider({ children }: { children: React.ReactNode }) {
   }, [loadContacts]);
 
   const requestSmsPermission = useCallback(async () => {
-    // SMS permission is requested at runtime by the system when the native module accesses it
+    if (Platform.OS === 'android') {
+      try {
+        const granted = await PermissionsAndroid.request(
+          PermissionsAndroid.PERMISSIONS.READ_SMS,
+          {
+            title: 'SMS Access',
+            message: 'Allow this app to read your SMS messages?',
+            buttonPositive: 'Allow',
+            buttonNegative: 'Deny',
+          },
+        );
+        if (granted !== PermissionsAndroid.RESULTS.GRANTED) return false;
+      } catch { return false; }
+    }
     const messages = await loadMessages();
     setState(prev => ({ ...prev, messages }));
     return messages.length > 0;


### PR DESCRIPTION
## Summary

- **Icons**: Switch all inactive/default Ionicons to `-outline` variants to match iOS SF Symbols conventions (filled icons reserved for active/selected/status states)
- **Permissions**: Auto-request SMS and Contacts permissions on first screen open, matching iOS native app behavior. Fix `requestSmsPermission` in DeviceStore to actually call `PermissionsAndroid.request()` (previously it silently failed)
- **Weather GPS**: Fix static `expo-location` import so geolocation works — dynamic import was silently falling back to IP-based location
- **Clock**: Fix alarm modal Save/Cancel buttons unresponsive on Android (add `hitSlop` + padding). Add alarm editing modal (tap existing alarm to edit)
- **Swipe rows**: Fix all-rows-open-at-once bug — `CupertinoSwipeableRow` now accepts `isOpen`/`onOpen` props; parent tracks which row is open and closes others
- **Messages**: Mark-as-read on conversation open; swipe-left Mark Read/Unread action; Edit mode with bulk select/delete; red unread count badge
- **Conversation**: Long-press Copy + Delete message actions
- **Reminders**: Custom list creation, edit reminder modal, custom date picker chip, recurrence support
- **CI**: Build APK in auto-release workflow

## Test plan

- [ ] Open Messages → swipe one row → only that row opens; swipe another → first closes
- [ ] Open Messages → swipe left on a row → "Mark Unread" / "Mark Read" action appears
- [ ] Tap "Edit" in Messages → checkboxes appear → select multiple → Delete works
- [ ] Open Contacts for the first time → permission dialog appears automatically
- [ ] Open Messages for the first time → SMS permission dialog appears automatically
- [ ] Open Weather → uses real GPS coordinates (not IP-based city)
- [ ] Open Clock → tap existing alarm → edit modal opens pre-populated
- [ ] Open Clock → add alarm modal → Save and Cancel buttons respond to tap
- [ ] Long-press a message bubble → Copy and Delete options appear
- [ ] Reminders → "+" → create custom list with name + color
- [ ] Reminders → tap existing reminder → edit modal opens

https://claude.ai/code/session_01LmsR4yM6sov8jFt6wFAJQc