### PR TITLE
fix(MessagesScreen): give conversation row an opaque background

### DIFF
--- a/src/screens/MessagesScreen.tsx
+++ b/src/screens/MessagesScreen.tsx
@@ -134,7 +134,7 @@ const ConversationRow = React.memo(function ConversationRow({
     <Pressable
       style={({ pressed }) => [
         styles.row,
-        { backgroundColor: pressed ? colors.systemGray5 : 'transparent' },
+        { backgroundColor: pressed ? colors.systemGray5 : colors.systemBackground },
       ]}
       onPress={editMode ? onSelect : onPress}
       accessibilityRole="button"


### PR DESCRIPTION
The row's Pressable used a transparent background when unpressed, so
the absolutely-positioned leading/trailing swipe actions behind each
row bled through on every row simultaneously (blue "Unread" on the
left, red "Delete" on the right, visible at rest). Using
systemBackground ensures the content fully covers the actions until
the user swipes.

https://claude.ai/code/session_01GB7EZkr6SXUeHwhoFLQhPU