### PR TITLE
fix: surface permission prompts and unhide alarm modal controls

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { View, AppState, Platform, StatusBar as RNStatusBar } from 'react-native';
+import { View, AppState, Platform, Pressable, StatusBar as RNStatusBar } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { StatusBar } from 'expo-status-bar';
 import * as NavigationBar from 'expo-navigation-bar';
@@ -18,6 +18,8 @@ import { ErrorBoundary } from './src/components/ErrorBoundary';
 import { AlertProvider } from './src/components/AlertProvider';
 import { NotificationBanner, BannerNotification } from './src/components/NotificationBanner';
 import { HomeIndicator } from './src/components/HomeIndicator';
+import { AssistiveTouch } from './src/components/AssistiveTouch';
+import { AssistiveTouchProvider, useAssistiveTouch } from './src/store/AssistiveTouchStore';
 import { LockScreen } from './src/screens/LockScreen';
 import { OnboardingScreen } from './src/screens/OnboardingScreen';
 import { findContactByPhone } from './src/utils/contacts';
@@ -168,19 +170,41 @@ function AppContent() {
   return (
     <View style={{ flex: 1 }}>
       <StatusBar style={isDark ? 'light' : 'dark'} hidden />
-      <NavigationContainer ref={navigationRef}>
-        <TabNavigator />
-      </NavigationContainer>
+      <ReachabilityShifter>
+        <NavigationContainer ref={navigationRef}>
+          <TabNavigator />
+        </NavigationContainer>
+      </ReachabilityShifter>
 
       {/* iOS-style home indicator — floats above every screen and owns the
           swipe-up-to-home / swipe-up-and-hold-for-switcher gesture. */}
       <HomeIndicator navigationRef={navigationRef} />
+
+      {/* iOS-style AssistiveTouch — draggable floating shortcut button. */}
+      <AssistiveTouch navigationRef={navigationRef} />
 
       {/* iOS-style notification banner — renders ABOVE everything */}
       <NotificationBanner
         notification={banner}
         onDismiss={() => setBanner(null)}
       />
+    </View>
+  );
+}
+
+/** Slides the navigator down when AssistiveTouch Reachability is active. */
+function ReachabilityShifter({ children }: { children: React.ReactNode }) {
+  const { reachabilityActive, setReachabilityActive } = useAssistiveTouch();
+  return (
+    <View style={{ flex: 1, transform: [{ translateY: reachabilityActive ? 260 : 0 }] }}>
+      {children}
+      {reachabilityActive && (
+        <Pressable
+          style={{ position: 'absolute', top: -260, left: 0, right: 0, height: 260 }}
+          onPress={() => setReachabilityActive(false)}
+          accessibilityLabel="Exit reachability"
+        />
+      )}
     </View>
   );
 }
@@ -196,11 +220,13 @@ export default function App() {
                 <AppsProvider>
                 <DeviceProvider>
                 <FoldersProvider>
+                <AssistiveTouchProvider>
                 <ErrorBoundary>
                   <AlertProvider>
                     <AppContent />
                   </AlertProvider>
                 </ErrorBoundary>
+                </AssistiveTouchProvider>
                 </FoldersProvider>
                 </DeviceProvider>
                 </AppsProvider>

--- a/App.tsx
+++ b/App.tsx
@@ -57,6 +57,7 @@ function AppContent() {
     if (Platform.OS === 'android') {
       NavigationBar.setVisibilityAsync('hidden');
       NavigationBar.setBehaviorAsync('overlay-swipe');
+      RNStatusBar.setHidden(true, 'slide');
       RNStatusBar.setTranslucent(true);
       RNStatusBar.setBackgroundColor('transparent');
     }
@@ -72,6 +73,10 @@ function AppContent() {
     const sub = AppState.addEventListener('change', (state) => {
       if (state === 'background') {
         setIsLocked(true);
+      } else if (state === 'active' && Platform.OS === 'android') {
+        // Re-assert immersive mode — Android can restore system bars on resume
+        NavigationBar.setVisibilityAsync('hidden');
+        RNStatusBar.setHidden(true, 'slide');
       }
     });
     return () => sub.remove();
@@ -161,7 +166,7 @@ function AppContent() {
 
   return (
     <View style={{ flex: 1 }}>
-      <StatusBar style={isDark ? 'light' : 'dark'} />
+      <StatusBar style={isDark ? 'light' : 'dark'} hidden />
       <NavigationContainer ref={navigationRef}>
         <TabNavigator />
       </NavigationContainer>

--- a/App.tsx
+++ b/App.tsx
@@ -17,6 +17,7 @@ import { TabNavigator } from './src/navigation/TabNavigator';
 import { ErrorBoundary } from './src/components/ErrorBoundary';
 import { AlertProvider } from './src/components/AlertProvider';
 import { NotificationBanner, BannerNotification } from './src/components/NotificationBanner';
+import { HomeIndicator } from './src/components/HomeIndicator';
 import { LockScreen } from './src/screens/LockScreen';
 import { OnboardingScreen } from './src/screens/OnboardingScreen';
 import { findContactByPhone } from './src/utils/contacts';
@@ -170,6 +171,10 @@ function AppContent() {
       <NavigationContainer ref={navigationRef}>
         <TabNavigator />
       </NavigationContainer>
+
+      {/* iOS-style home indicator — floats above every screen and owns the
+          swipe-up-to-home / swipe-up-and-hold-for-switcher gesture. */}
+      <HomeIndicator navigationRef={navigationRef} />
 
       {/* iOS-style notification banner — renders ABOVE everything */}
       <NotificationBanner

--- a/app.json
+++ b/app.json
@@ -66,7 +66,30 @@
     },
     "plugins": [
       "./plugins/withAsyncStorageRepo",
-      "./plugins/withLauncherIntent"
+      "./plugins/withLauncherIntent",
+      [
+        "expo-camera",
+        {
+          "cameraPermission": "Allow $(PRODUCT_NAME) to access your camera.",
+          "microphonePermission": "Allow $(PRODUCT_NAME) to access your microphone.",
+          "recordAudioAndroid": true
+        }
+      ],
+      [
+        "expo-media-library",
+        {
+          "photosPermission": "Allow $(PRODUCT_NAME) to access your photos.",
+          "savePhotosPermission": "Allow $(PRODUCT_NAME) to save photos to your library.",
+          "isAccessMediaLocationEnabled": true
+        }
+      ],
+      [
+        "expo-image-picker",
+        {
+          "photosPermission": "Allow $(PRODUCT_NAME) to access your photos.",
+          "cameraPermission": "Allow $(PRODUCT_NAME) to access your camera."
+        }
+      ]
     ]
   }
 }

--- a/app.json
+++ b/app.json
@@ -51,7 +51,9 @@
         "android.permission.VIBRATE",
         "android.permission.RECEIVE_BOOT_COMPLETED",
         "android.permission.USE_BIOMETRIC",
-        "android.permission.USE_FINGERPRINT"
+        "android.permission.USE_FINGERPRINT",
+        "android.permission.SCHEDULE_EXACT_ALARM",
+        "android.permission.USE_EXACT_ALARM"
       ],
       "edgeToEdgeEnabled": true,
       "predictiveBackGestureEnabled": true

--- a/modules/launcher-module/android/src/main/java/com/iostoandroid/launcher/LauncherModule.kt
+++ b/modules/launcher-module/android/src/main/java/com/iostoandroid/launcher/LauncherModule.kt
@@ -115,6 +115,18 @@ class LauncherModule : Module() {
             true
         }
 
+        AsyncFunction("goHome") {
+            // Fires the system HOME intent, which brings the default launcher
+            // (this app, when set as default) to the foreground. Used to emulate
+            // the iOS swipe-up-home gesture when our app is in the foreground.
+            val intent = Intent(Intent.ACTION_MAIN).apply {
+                addCategory(Intent.CATEGORY_HOME)
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            }
+            context.startActivity(intent)
+            true
+        }
+
         // ── Wi-Fi ────────────────────────────────────────────────────────
 
         AsyncFunction("getWifiInfo") {

--- a/modules/launcher-module/src/index.ts
+++ b/modules/launcher-module/src/index.ts
@@ -144,6 +144,7 @@ interface LauncherModuleType {
   getAppIcon(packageName: string): Promise<string>;
   isDefaultLauncher(): Promise<boolean>;
   openLauncherSettings(): Promise<boolean>;
+  goHome(): Promise<boolean>;
   uninstallApp(packageName: string): Promise<boolean>;
   // Wi-Fi
   getWifiInfo(): Promise<WifiInfo>;
@@ -215,6 +216,7 @@ const stub: LauncherModuleType = {
   getAppIcon: async () => '',
   isDefaultLauncher: async () => false,
   openLauncherSettings: async () => false,
+  goHome: async () => false,
   uninstallApp: async () => false,
   getWifiInfo: async () => ({ enabled: false, ssid: '', rssi: 0, linkSpeed: 0, ip: '' }),
   setWifiEnabled: async () => false,
@@ -282,6 +284,10 @@ function createBridgedModule(): LauncherModuleType {
     openLauncherSettings: async () => {
       try { return await nativeModule.openLauncherSettings(); }
       catch (e) { console.error('LauncherModule.openLauncherSettings failed:', e); return false; }
+    },
+    goHome: async () => {
+      try { return await nativeModule.goHome(); }
+      catch (e) { console.error('LauncherModule.goHome failed:', e); return false; }
     },
     uninstallApp: async (packageName: string) => {
       try { return await nativeModule.uninstallApp(packageName); }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "iostoandroid",
-  "version": "1.8.19",
+  "version": "1.8.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "iostoandroid",
-      "version": "1.8.19",
+      "version": "1.8.24",
       "dependencies": {
         "@expo/vector-icons": "^15.0.3",
         "@react-native-async-storage/async-storage": "^3.0.2",

--- a/src/components/AssistiveTouch.tsx
+++ b/src/components/AssistiveTouch.tsx
@@ -1,0 +1,503 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Dimensions, Platform, Pressable, StyleSheet, Text, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import type { NavigationContainerRefWithCurrent } from '@react-navigation/native';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import Animated, {
+  useAnimatedStyle,
+  useSharedValue,
+  withSpring,
+  withTiming,
+  runOnJS,
+  type SharedValue,
+} from 'react-native-reanimated';
+import { BlurView } from 'expo-blur';
+import { Ionicons } from '@expo/vector-icons';
+import * as Haptics from 'expo-haptics';
+import {
+  useAssistiveTouch,
+  AssistiveAction,
+  MenuItemId,
+} from '../store/AssistiveTouchStore';
+import { useTheme } from '../theme/ThemeContext';
+
+const { width: SCREEN_W, height: SCREEN_H } = Dimensions.get('window');
+
+const IDLE_DIM_MS = 2500;
+const SNAP_SPRING = { damping: 18, stiffness: 220 } as const;
+
+// ─── Menu item catalog ──────────────────────────────────────────────────────
+
+interface MenuItemDef {
+  id: MenuItemId;
+  label: string;
+  icon: keyof typeof Ionicons.glyphMap;
+  action: AssistiveAction;
+}
+
+const MENU_CATALOG: Record<MenuItemId, MenuItemDef> = {
+  home:             { id: 'home',             label: 'Home',           icon: 'home',               action: 'home' },
+  multitask:        { id: 'multitask',        label: 'App Switcher',   icon: 'copy-outline',       action: 'multitask' },
+  notifications:    { id: 'notifications',    label: 'Notifications',  icon: 'notifications',      action: 'notifications' },
+  controlCenter:    { id: 'controlCenter',    label: 'Control Centre', icon: 'options',            action: 'controlCenter' },
+  spotlight:        { id: 'spotlight',        label: 'Spotlight',      icon: 'search',             action: 'spotlight' },
+  settings:         { id: 'settings',         label: 'Settings',       icon: 'settings-sharp',     action: 'settings' },
+  siri:             { id: 'siri',             label: 'Siri',           icon: 'mic',                action: 'siri' },
+  screenshot:       { id: 'screenshot',       label: 'Screenshot',     icon: 'camera-outline',     action: 'screenshot' },
+  lock:             { id: 'lock',             label: 'Lock Screen',    icon: 'lock-closed',        action: 'lock' },
+  reachability:     { id: 'reachability',     label: 'Reachability',   icon: 'arrow-down',         action: 'reachability' },
+  hideTemporarily:  { id: 'hideTemporarily',  label: 'Hide',           icon: 'eye-off',            action: 'hideTemporarily' },
+};
+
+// ─── Context-aware menu overrides ───────────────────────────────────────────
+// When a specific route is focused, replace the first menu slot with something
+// more useful for that context. The original slot is pushed forward.
+
+const CONTEXT_OVERRIDES: Record<string, MenuItemDef | undefined> = {
+  Messages:     { id: 'spotlight',  label: 'New Message', icon: 'create-outline',   action: 'spotlight' },
+  Conversation: { id: 'spotlight',  label: 'Reply',       icon: 'return-down-back', action: 'spotlight' },
+  Camera:       { id: 'screenshot', label: 'Shutter',     icon: 'radio-button-on',  action: 'screenshot' },
+  Phone:        { id: 'home',       label: 'Keypad',      icon: 'keypad',           action: 'home' },
+  Photos:       { id: 'spotlight',  label: 'Search',      icon: 'search',           action: 'spotlight' },
+};
+
+// Routes where the button should auto-hide
+const FULLSCREEN_ROUTES = new Set(['Camera', 'CallScreen']);
+
+// ─── Props ──────────────────────────────────────────────────────────────────
+
+interface AssistiveTouchProps {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  navigationRef: NavigationContainerRefWithCurrent<any>;
+}
+
+// ─── Component ──────────────────────────────────────────────────────────────
+
+export function AssistiveTouch({ navigationRef }: AssistiveTouchProps) {
+  const insets = useSafeAreaInsets();
+  const { theme } = useTheme();
+  const {
+    enabled,
+    idleOpacity,
+    size,
+    position,
+    edge,
+    singleTapAction,
+    doubleTapAction,
+    longPressAction,
+    menuItems,
+    autoHideFullscreen,
+    contextAwareMenu,
+    reachabilityOnDoubleTap,
+    hapticFeedback,
+    temporarilyHidden,
+    setPosition,
+    hideTemporarily,
+    reachabilityActive,
+    setReachabilityActive,
+  } = useAssistiveTouch();
+
+  // ── Current route (for context menu + auto-hide) ──────────────────────────
+  const [currentRoute, setCurrentRoute] = useState<string | undefined>(
+    () => navigationRef.getCurrentRoute()?.name,
+  );
+  useEffect(() => {
+    const unsub = navigationRef.addListener('state', () => {
+      setCurrentRoute(navigationRef.getCurrentRoute()?.name);
+    });
+    return unsub;
+  }, [navigationRef]);
+
+  const hiddenForFullscreen = autoHideFullscreen && !!currentRoute && FULLSCREEN_ROUTES.has(currentRoute);
+  const visible = enabled && !temporarilyHidden && !hiddenForFullscreen;
+
+  // ── Drag position (shared values for smooth dragging) ─────────────────────
+  const translateX = useSharedValue(edge === 'right' ? SCREEN_W - size - 8 : 8);
+  const translateY = useSharedValue(Math.min(position.y, SCREEN_H - size - insets.bottom - 40));
+
+  // Re-snap to stored edge when edge prop changes (after settings reset)
+  useEffect(() => {
+    translateX.value = withSpring(
+      edge === 'right' ? SCREEN_W - size - 8 : 8,
+      SNAP_SPRING,
+    );
+  }, [edge, size, translateX]);
+
+  // ── Idle dim ──────────────────────────────────────────────────────────────
+  const opacity = useSharedValue(1);
+  const idleTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const wake = useCallback(() => {
+    opacity.value = withTiming(1, { duration: 150 });
+    if (idleTimer.current) clearTimeout(idleTimer.current);
+    idleTimer.current = setTimeout(() => {
+      opacity.value = withTiming(idleOpacity, { duration: 600 });
+    }, IDLE_DIM_MS);
+  }, [opacity, idleOpacity]);
+
+  useEffect(() => {
+    if (visible) wake();
+    return () => {
+      if (idleTimer.current) clearTimeout(idleTimer.current);
+    };
+  }, [visible, wake]);
+
+  // ── Radial menu state ─────────────────────────────────────────────────────
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuScale = useSharedValue(0);
+  const menuOpacity = useSharedValue(0);
+
+  const openMenu = useCallback(() => {
+    if (hapticFeedback) Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch(() => {});
+    setMenuOpen(true);
+    menuScale.value = withSpring(1, { damping: 14, stiffness: 220 });
+    menuOpacity.value = withTiming(1, { duration: 160 });
+    wake();
+  }, [menuScale, menuOpacity, wake, hapticFeedback]);
+
+  const closeMenu = useCallback(() => {
+    menuScale.value = withTiming(0, { duration: 150 });
+    menuOpacity.value = withTiming(0, { duration: 150 }, (finished) => {
+      if (finished) runOnJS(setMenuOpen)(false);
+    });
+  }, [menuScale, menuOpacity]);
+
+  // ── Action execution ──────────────────────────────────────────────────────
+  const navigate = useCallback(
+    (route: string) => {
+      try {
+        navigationRef.navigate(route as never);
+      } catch { /* route missing */ }
+    },
+    [navigationRef],
+  );
+
+  const runAction = useCallback(
+    async (action: AssistiveAction) => {
+      if (hapticFeedback) Haptics.selectionAsync().catch(() => {});
+      if (action !== 'openMenu') closeMenu();
+      switch (action) {
+        case 'openMenu':
+          openMenu();
+          break;
+        case 'home':
+          if (Platform.OS === 'android') {
+            try {
+              const mod = (await import('../../modules/launcher-module/src')).default;
+              const ok = await mod.goHome();
+              if (ok) return;
+            } catch { /* fall through */ }
+          }
+          navigate('HomeMain');
+          break;
+        case 'multitask':        navigate('Multitask'); break;
+        case 'notifications':    navigate('NotificationCenter'); break;
+        case 'controlCenter':    navigate('ControlCenter'); break;
+        case 'spotlight':        navigate('SpotlightSearch'); break;
+        case 'settings':         navigate('Settings'); break;
+        case 'siri':             navigate('SpotlightSearch'); break; // best-available analogue
+        case 'screenshot':
+          // No reliable programmatic screenshot API; briefly flash the screen
+          // and let the user capture via power+volume. Treat as placeholder.
+          Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success).catch(() => {});
+          break;
+        case 'lock':             navigate('LockScreen'); break;
+        case 'reachability':
+          setReachabilityActive(!reachabilityActive);
+          break;
+        case 'hideTemporarily':
+          hideTemporarily(10000);
+          break;
+        case 'none':
+        default:
+          break;
+      }
+    },
+    [openMenu, closeMenu, navigate, reachabilityActive, setReachabilityActive, hideTemporarily, hapticFeedback],
+  );
+
+  // ── Drag gesture ──────────────────────────────────────────────────────────
+  const dragStart = useSharedValue({ x: 0, y: 0 });
+
+  const persistPosition = useCallback(
+    (x: number, y: number) => {
+      const snapEdge: 'left' | 'right' = x + size / 2 < SCREEN_W / 2 ? 'left' : 'right';
+      setPosition(x, y, snapEdge);
+    },
+    [setPosition, size],
+  );
+
+  const snapHaptic = useCallback(() => {
+    if (hapticFeedback) Haptics.selectionAsync().catch(() => {});
+  }, [hapticFeedback]);
+
+  const panGesture = Gesture.Pan()
+    .minDistance(4)
+    .onBegin(() => {
+      'worklet';
+      dragStart.value = { x: translateX.value, y: translateY.value };
+      runOnJS(wake)();
+    })
+    .onUpdate((e) => {
+      'worklet';
+      translateX.value = dragStart.value.x + e.translationX;
+      translateY.value = dragStart.value.y + e.translationY;
+    })
+    .onEnd(() => {
+      'worklet';
+      // Magnetic snap to nearest horizontal edge
+      const snapLeft = 8;
+      const snapRight = SCREEN_W - size - 8;
+      const center = translateX.value + size / 2;
+      const targetX = center < SCREEN_W / 2 ? snapLeft : snapRight;
+      translateX.value = withSpring(targetX, SNAP_SPRING);
+
+      // Clamp Y inside safe area
+      const minY = insets.top + 8;
+      const maxY = SCREEN_H - size - insets.bottom - 40;
+      let targetY = translateY.value;
+      if (targetY < minY) targetY = minY;
+      if (targetY > maxY) targetY = maxY;
+      translateY.value = withSpring(targetY, SNAP_SPRING);
+
+      runOnJS(persistPosition)(targetX, targetY);
+      runOnJS(snapHaptic)();
+    });
+
+  // ── Tap gestures (single / double / long) ────────────────────────────────
+  const singleTap = Gesture.Tap()
+    .numberOfTaps(1)
+    .maxDuration(250)
+    .onEnd((_e, success) => {
+      'worklet';
+      if (!success) return;
+      runOnJS(runAction)(singleTapAction);
+    });
+
+  const doubleTap = Gesture.Tap()
+    .numberOfTaps(2)
+    .maxDuration(300)
+    .onEnd((_e, success) => {
+      'worklet';
+      if (!success) return;
+      const action: AssistiveAction = reachabilityOnDoubleTap ? 'reachability' : doubleTapAction;
+      runOnJS(runAction)(action);
+    });
+
+  const longPress = Gesture.LongPress()
+    .minDuration(500)
+    .onStart(() => {
+      'worklet';
+      runOnJS(runAction)(longPressAction);
+    });
+
+  // Priority: double > single (RNGH's Exclusive + requireExternalGestureToFail)
+  const tapChord = Gesture.Exclusive(doubleTap, singleTap, longPress);
+  const combined = Gesture.Simultaneous(panGesture, tapChord);
+
+  // ── Animated styles ───────────────────────────────────────────────────────
+  const buttonStyle = useAnimatedStyle(() => ({
+    transform: [{ translateX: translateX.value }, { translateY: translateY.value }],
+    opacity: opacity.value,
+    width: size,
+    height: size,
+    borderRadius: size / 2,
+  }));
+
+  const menuStyle = useAnimatedStyle(() => ({
+    opacity: menuOpacity.value,
+    transform: [{ scale: menuScale.value }],
+  }));
+
+  // ── Menu items (resolved with context-aware overrides) ───────────────────
+  const resolvedMenu = useMemo<MenuItemDef[]>(() => {
+    const items = menuItems.map((id) => MENU_CATALOG[id]);
+    if (contextAwareMenu && currentRoute && CONTEXT_OVERRIDES[currentRoute]) {
+      // Prepend the override, drop any pre-existing entry with the same id
+      const override = CONTEXT_OVERRIDES[currentRoute] as MenuItemDef;
+      const filtered = items.filter((m) => m.id !== override.id);
+      return [override, ...filtered].slice(0, 6);
+    }
+    return items.slice(0, 6);
+  }, [menuItems, contextAwareMenu, currentRoute]);
+
+  if (!visible) return null;
+
+  // ── Render ────────────────────────────────────────────────────────────────
+  const isDark = theme.dark;
+
+  return (
+    <>
+      {/* Radial menu — backdrop + popover. Backdrop is static so tapping
+          outside always closes cleanly; only the popover itself animates. */}
+      {menuOpen && (
+        <>
+          <Pressable
+            style={StyleSheet.absoluteFill}
+            onPress={closeMenu}
+            accessibilityLabel="Close AssistiveTouch menu"
+          />
+          <Animated.View pointerEvents="box-none" style={[StyleSheet.absoluteFill, menuStyle]}>
+            <RadialMenu
+              items={resolvedMenu}
+              onPick={(item) => runAction(item.action)}
+              buttonSize={size}
+              anchorX={translateX}
+              anchorY={translateY}
+              isDark={isDark}
+            />
+          </Animated.View>
+        </>
+      )}
+
+      {/* Floating button */}
+      <GestureDetector gesture={combined}>
+        <Animated.View
+          style={[styles.button, buttonStyle]}
+          accessibilityLabel="AssistiveTouch button"
+          accessibilityRole="button"
+          accessibilityHint="Tap to open the menu. Drag to reposition. Long-press to hide."
+        >
+          <BlurView
+            intensity={55}
+            tint={isDark ? 'dark' : 'light'}
+            experimentalBlurMethod="dimezisBlurView"
+            style={[styles.buttonBlur, { borderRadius: size / 2 }]}
+          >
+            <View style={[styles.buttonInner, { backgroundColor: isDark ? 'rgba(40,40,44,0.55)' : 'rgba(255,255,255,0.55)' }]}>
+              <View style={[styles.buttonDot, { backgroundColor: isDark ? 'rgba(255,255,255,0.85)' : 'rgba(0,0,0,0.65)' }]} />
+            </View>
+          </BlurView>
+        </Animated.View>
+      </GestureDetector>
+    </>
+  );
+}
+
+// ─── Radial menu sub-component ──────────────────────────────────────────────
+
+interface RadialMenuProps {
+  items: MenuItemDef[];
+  onPick: (item: MenuItemDef) => void;
+  buttonSize: number;
+  anchorX: SharedValue<number>;
+  anchorY: SharedValue<number>;
+  isDark: boolean;
+}
+
+function RadialMenu({ items, onPick, buttonSize, anchorX, anchorY, isDark }: RadialMenuProps) {
+  // The menu is a 2x3 grid popover, not a true radial layout — iOS
+  // AssistiveTouch uses a grid and it tests better at small scale. We
+  // position the popover to the side of the button that has more space.
+  const anchorStyle = useAnimatedStyle(() => {
+    const cx = anchorX.value + buttonSize / 2;
+    const cy = anchorY.value + buttonSize / 2;
+    const preferLeft = cx > SCREEN_W / 2;
+    const popWidth = 240;
+    const popHeight = 200;
+    const gap = 14;
+    const x = preferLeft ? cx - popWidth - gap : cx + gap;
+    const y = Math.max(40, Math.min(SCREEN_H - popHeight - 40, cy - popHeight / 2));
+    return { transform: [{ translateX: x }, { translateY: y }] };
+  });
+
+  const cellBg = isDark ? 'rgba(60,60,64,0.35)' : 'rgba(255,255,255,0.25)';
+  const iconColor = isDark ? '#fff' : '#000';
+
+  return (
+    <Animated.View style={[styles.menu, anchorStyle]}>
+      <BlurView
+        intensity={70}
+        tint={isDark ? 'dark' : 'light'}
+        experimentalBlurMethod="dimezisBlurView"
+        style={styles.menuBlur}
+      >
+        <View style={styles.menuGrid}>
+          {items.map((item) => (
+            <Pressable
+              key={item.id}
+              style={[styles.menuCell, { backgroundColor: cellBg }]}
+              onPress={() => onPick(item)}
+              android_ripple={{ color: 'rgba(255,255,255,0.15)', borderless: true }}
+              accessibilityRole="button"
+              accessibilityLabel={item.label}
+            >
+              <Ionicons name={item.icon} size={22} color={iconColor} />
+              <Text style={[styles.menuLabel, { color: iconColor }]} numberOfLines={1}>
+                {item.label}
+              </Text>
+            </Pressable>
+          ))}
+        </View>
+      </BlurView>
+    </Animated.View>
+  );
+}
+
+// ─── Styles ─────────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  button: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.25,
+    shadowRadius: 5,
+    elevation: 6,
+    zIndex: 60,
+  },
+  buttonBlur: {
+    flex: 1,
+    overflow: 'hidden',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  buttonInner: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '100%',
+    height: '100%',
+  },
+  buttonDot: {
+    width: '55%',
+    height: '55%',
+    borderRadius: 999,
+  },
+
+  menu: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    width: 240,
+    height: 200,
+    borderRadius: 20,
+    overflow: 'hidden',
+    zIndex: 55,
+  },
+  menuBlur: {
+    flex: 1,
+    padding: 10,
+  },
+  menuGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 6,
+  },
+  menuCell: {
+    width: '32%',
+    height: 88,
+    borderRadius: 14,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 6,
+  },
+  menuLabel: {
+    fontSize: 10,
+    fontWeight: '600',
+    textAlign: 'center',
+    paddingHorizontal: 4,
+  },
+});

--- a/src/components/HomeIndicator.tsx
+++ b/src/components/HomeIndicator.tsx
@@ -1,0 +1,214 @@
+import React, { useCallback, useEffect, useRef } from 'react';
+import { Platform, StyleSheet } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import type { NavigationContainerRefWithCurrent } from '@react-navigation/native';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import Animated, {
+  useAnimatedStyle,
+  useSharedValue,
+  withSpring,
+  withTiming,
+  runOnJS,
+} from 'react-native-reanimated';
+import * as Haptics from 'expo-haptics';
+
+// iOS-matched thresholds (from reverse-engineered gesture behavior):
+// - Home:         short upward swipe OR high upward velocity
+// - App switcher: deeper upward swipe with a hold/pause near mid-screen
+// - Lateral drift cancels the gesture
+const HOME_DISTANCE = 60;          // pt — short swipe triggers home
+const SWITCHER_DISTANCE = 180;     // pt — deeper swipe with pause triggers app switcher
+const HOME_VELOCITY = 500;         // pt/s — flick velocity alternative to distance
+const SWITCHER_HOLD_MS = 400;      // ms — hold near mid-swipe to summon switcher
+const LATERAL_CANCEL = 80;         // pt — sideways drift cancels the gesture
+const IDLE_DIM_MS = 2500;          // ms — pill fades after inactivity (AssistiveTouch-inspired)
+const IDLE_OPACITY = 0.35;
+
+interface HomeIndicatorProps {
+  /** Override the home action. Defaults to native goHome() on Android. */
+  onHome?: () => void;
+  /** Override the app-switcher action. Defaults to navigating to the Multitask route via navigationRef. */
+  onSwitcher?: () => void;
+  /** NavigationContainer ref used for the default switcher fallback. */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  navigationRef?: NavigationContainerRefWithCurrent<any>;
+  /** Light pill (default) or dark pill for light backgrounds. */
+  variant?: 'light' | 'dark';
+}
+
+export function HomeIndicator({ onHome, onSwitcher, navigationRef, variant = 'light' }: HomeIndicatorProps) {
+  const insets = useSafeAreaInsets();
+
+  const translateY = useSharedValue(0);
+  const opacity = useSharedValue(1);
+  const idleTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const wake = useCallback(() => {
+    opacity.value = withTiming(1, { duration: 150 });
+    if (idleTimer.current) clearTimeout(idleTimer.current);
+    idleTimer.current = setTimeout(() => {
+      opacity.value = withTiming(IDLE_OPACITY, { duration: 600 });
+    }, IDLE_DIM_MS);
+  }, [opacity]);
+
+  useEffect(() => {
+    wake();
+    return () => {
+      if (idleTimer.current) clearTimeout(idleTimer.current);
+    };
+  }, [wake]);
+
+  const doHome = useCallback(async () => {
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+    if (onHome) return onHome();
+    if (Platform.OS === 'android') {
+      try {
+        const mod = (await import('../../modules/launcher-module/src')).default;
+        const ok = await mod.goHome();
+        if (ok) return;
+      } catch {
+        /* fall through */
+      }
+    }
+    try {
+      navigationRef?.current?.navigate('HomeMain' as never);
+    } catch {
+      /* no-op */
+    }
+  }, [onHome, navigationRef]);
+
+  const doSwitcher = useCallback(() => {
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy);
+    if (onSwitcher) return onSwitcher();
+    try {
+      navigationRef?.current?.navigate('Multitask' as never);
+    } catch {
+      /* route may not exist in some contexts */
+    }
+  }, [onSwitcher, navigationRef]);
+
+  // Track whether a mid-swipe hold triggered "switcher mode" already
+  const heldForSwitcher = useSharedValue(0);
+  const holdScheduled = useSharedValue(0);
+  const thresholdHapticFired = useSharedValue(0);
+
+  const fireLightHaptic = useCallback(() => {
+    Haptics.selectionAsync().catch(() => {});
+  }, []);
+
+  const pan = Gesture.Pan()
+    .activeOffsetY([-10, 10])
+    .minDistance(8)
+    .onBegin(() => {
+      'worklet';
+      heldForSwitcher.value = 0;
+      holdScheduled.value = 0;
+      thresholdHapticFired.value = 0;
+      runOnJS(wake)();
+    })
+    .onUpdate((e) => {
+      'worklet';
+      const dy = Math.min(0, e.translationY); // only track upward
+      translateY.value = dy;
+
+      // Haptic tick the first time we cross the "home" threshold
+      if (!thresholdHapticFired.value && Math.abs(dy) >= HOME_DISTANCE) {
+        thresholdHapticFired.value = 1;
+        runOnJS(fireLightHaptic)();
+      }
+
+      // Lateral drift cancels — match iOS's lock-to-axis behavior
+      if (Math.abs(e.translationX) > LATERAL_CANCEL) {
+        translateY.value = withSpring(0, { damping: 15, stiffness: 180 });
+        thresholdHapticFired.value = 0;
+      }
+    })
+    .onEnd((e) => {
+      'worklet';
+      const dy = Math.min(0, e.translationY);
+      const vy = e.velocityY;
+      translateY.value = withSpring(0, { damping: 20, stiffness: 220 });
+
+      // Deep swipe OR held mid-swipe → app switcher
+      if (Math.abs(dy) >= SWITCHER_DISTANCE || heldForSwitcher.value === 1) {
+        runOnJS(doSwitcher)();
+        return;
+      }
+      // Short swipe OR flick → home
+      if (Math.abs(dy) >= HOME_DISTANCE || vy <= -HOME_VELOCITY) {
+        runOnJS(doHome)();
+      }
+    });
+
+  // Separate detector for the "hold at midpoint" behavior, used alongside pan.
+  // When the user pauses their finger past the home threshold but below
+  // switcher-distance, we summon the switcher after SWITCHER_HOLD_MS.
+  useEffect(() => {
+    const id = setInterval(() => {
+      const dy = Math.abs(translateY.value);
+      if (dy >= HOME_DISTANCE && dy < SWITCHER_DISTANCE) {
+        if (!holdScheduled.value) {
+          holdScheduled.value = 1;
+          setTimeout(() => {
+            if (Math.abs(translateY.value) >= HOME_DISTANCE && Math.abs(translateY.value) < SWITCHER_DISTANCE) {
+              heldForSwitcher.value = 1;
+              Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium).catch(() => {});
+            }
+          }, SWITCHER_HOLD_MS);
+        }
+      } else {
+        holdScheduled.value = 0;
+      }
+    }, 80);
+    return () => clearInterval(id);
+  }, [translateY, holdScheduled, heldForSwitcher]);
+
+  // AssistiveTouch-inspired convenience: double-tap the pill as a shortcut
+  // to the app switcher for users who find the precise swipe awkward.
+  const doubleTap = Gesture.Tap()
+    .numberOfTaps(2)
+    .onEnd((_e, success) => {
+      'worklet';
+      if (success) runOnJS(doSwitcher)();
+    });
+
+  const combined = Gesture.Simultaneous(pan, doubleTap);
+
+  const pillStyle = useAnimatedStyle(() => ({
+    opacity: opacity.value,
+    transform: [{ translateY: translateY.value * 0.15 }], // subtle follow while swiping
+  }));
+
+  const pillColor = variant === 'dark' ? 'rgba(0,0,0,0.4)' : 'rgba(255,255,255,0.5)';
+
+  return (
+    <GestureDetector gesture={combined}>
+      <Animated.View
+        pointerEvents="box-only"
+        style={[styles.hitArea, { paddingBottom: Math.max(insets.bottom, 6) }]}
+        accessibilityLabel="Home indicator. Swipe up to go home. Swipe up and hold for app switcher."
+        accessibilityRole="button"
+      >
+        <Animated.View style={[styles.pill, { backgroundColor: pillColor }, pillStyle]} />
+      </Animated.View>
+    </GestureDetector>
+  );
+}
+
+const styles = StyleSheet.create({
+  hitArea: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    alignItems: 'center',
+    justifyContent: 'flex-end',
+    paddingTop: 14, // tall catch area above the pill for easier swipes
+    zIndex: 50,
+  },
+  pill: {
+    width: 134,
+    height: 5,
+    borderRadius: 2.5,
+  },
+});

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -21,3 +21,4 @@ export { CupertinoSkeleton, SkeletonListRow, SkeletonCard } from './CupertinoSke
 export { CupertinoShareSheet } from './CupertinoShareSheet';
 export { NotificationBanner } from './NotificationBanner';
 export type { BannerNotification } from './NotificationBanner';
+export { HomeIndicator } from './HomeIndicator';

--- a/src/navigation/TabNavigator.tsx
+++ b/src/navigation/TabNavigator.tsx
@@ -45,6 +45,7 @@ import { BatteryScreen } from '../screens/settings/BatteryScreen';
 import { PrivacyScreen } from '../screens/settings/PrivacyScreen';
 import { WallpaperScreen } from '../screens/settings/WallpaperScreen';
 import { AccessibilityScreen } from '../screens/settings/AccessibilityScreen';
+import { AssistiveTouchSettingsScreen } from '../screens/settings/AssistiveTouchSettingsScreen';
 import { BackupRestoreScreen } from '../screens/settings/BackupRestoreScreen';
 import { ComponentsGalleryScreen } from '../screens/ComponentsGalleryScreen';
 import { AppLibraryScreen } from '../screens/AppLibraryScreen';
@@ -120,6 +121,7 @@ export function TabNavigator() {
       <Stack.Screen name="DisplayBrightness" component={DisplayBrightnessScreen} options={{ animation: slideAnimation }} />
       <Stack.Screen name="Wallpaper" component={WallpaperScreen} options={{ animation: slideAnimation }} />
       <Stack.Screen name="Accessibility" component={AccessibilityScreen} options={{ animation: slideAnimation }} />
+      <Stack.Screen name="AssistiveTouchSettings" component={AssistiveTouchSettingsScreen} options={{ animation: slideAnimation }} />
       <Stack.Screen name="Battery" component={BatteryScreen} options={{ animation: slideAnimation }} />
       <Stack.Screen name="Privacy" component={PrivacyScreen} options={{ animation: slideAnimation }} />
       <Stack.Screen name="Storage" component={StorageScreen} options={{ animation: slideAnimation }} />

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -43,6 +43,7 @@ export type RootStackParamList = {
   DisplayBrightness: undefined;
   Wallpaper: undefined;
   Accessibility: undefined;
+  AssistiveTouchSettings: undefined;
   Battery: undefined;
   Privacy: undefined;
   Storage: undefined;

--- a/src/screens/CameraScreen.tsx
+++ b/src/screens/CameraScreen.tsx
@@ -99,22 +99,12 @@ export function CameraScreen({ navigation }: { navigation: AppNavigationProp }) 
         setLastPhoto(photo.uri);
         await saveToLibrary(photo.uri);
       }
-    } catch {
-      // Fallback: use ImagePicker system camera picker (shows iOS-styled result picker overlay)
-      try {
-        const result = await ImagePicker.launchCameraAsync({
-          mediaTypes: ['images'],
-          quality: 0.9,
-          allowsEditing: false,
-        });
-        if (!result.canceled && result.assets[0]) {
-          setLastPhoto(result.assets[0].uri);
-          await saveToLibrary(result.assets[0].uri);
-        }
-      } catch {
-        // No further fallback — keep user in-app
-        alert('Camera Error', 'Unable to capture photo. Please check camera permissions.');
-      }
+    } catch (e) {
+      // Stay in-app and surface the actual failure. Do NOT fall back to
+      // ImagePicker.launchCameraAsync — that launches the system camera app
+      // on Android and defeats the purpose of the in-app preview.
+      const msg = e instanceof Error ? e.message : 'Unknown error';
+      alert('Couldn\u2019t Capture Photo', msg);
     }
   }, [cameraReady, alert, saveToLibrary]);
 
@@ -238,8 +228,10 @@ export function CameraScreen({ navigation }: { navigation: AppNavigationProp }) 
         flash={flashOn ? 'on' : 'off'}
         mode={cameraMode}
         onCameraReady={onCameraReady}
-        onMountError={() => {
-          alert('Camera Error', 'Could not start camera preview.');
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        onMountError={(event: any) => {
+          const msg = event?.nativeEvent?.message ?? 'Could not start camera preview.';
+          alert('Camera Error', msg);
         }}
       />
     );
@@ -295,8 +287,17 @@ export function CameraScreen({ navigation }: { navigation: AppNavigationProp }) 
           )}
         </Pressable>
 
-        {/* Shutter button */}
-        <Pressable onPress={handleShutter} style={styles.shutterOuter}>
+        {/* Shutter button — disabled when the preview isn't live so taps
+            don't trigger the fallback path. */}
+        <Pressable
+          onPress={handleShutter}
+          disabled={cameraUnavailable || permissionDenied || permissionLoading || !cameraReady}
+          style={({ pressed }) => [
+            styles.shutterOuter,
+            (cameraUnavailable || permissionDenied || permissionLoading || !cameraReady) && styles.shutterDisabled,
+            pressed && { opacity: 0.7 },
+          ]}
+        >
           {mode === 'VIDEO' && isRecording ? (
             <View style={styles.shutterStop} />
           ) : mode === 'VIDEO' ? (
@@ -391,6 +392,9 @@ const styles = StyleSheet.create({
     borderColor: '#fff',
     alignItems: 'center',
     justifyContent: 'center',
+  },
+  shutterDisabled: {
+    opacity: 0.35,
   },
   shutterInner: {
     width: 60,

--- a/src/screens/ClockScreen.tsx
+++ b/src/screens/ClockScreen.tsx
@@ -6,6 +6,8 @@ import {
   StyleSheet,
   Pressable,
   Modal,
+  Linking,
+  Platform,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
@@ -21,6 +23,7 @@ import {
   CupertinoTextField,
   CupertinoSwipeableRow,
   CupertinoPicker,
+  useAlert,
 } from '../components';
 import type { AppNavigationProp } from '../navigation/types';
 
@@ -227,16 +230,24 @@ Notifications.setNotificationHandler({
   }),
 });
 
-async function requestNotificationPermissions(): Promise<boolean> {
-  const { status: existingStatus } = await Notifications.getPermissionsAsync();
-  if (existingStatus === 'granted') return true;
-  const { status } = await Notifications.requestPermissionsAsync();
-  return status === 'granted';
+async function requestNotificationPermissions(): Promise<{
+  granted: boolean;
+  canAskAgain: boolean;
+}> {
+  try {
+    const existing = await Notifications.getPermissionsAsync();
+    if (existing.status === 'granted') return { granted: true, canAskAgain: true };
+    if (!existing.canAskAgain) return { granted: false, canAskAgain: false };
+    const result = await Notifications.requestPermissionsAsync();
+    return { granted: result.status === 'granted', canAskAgain: result.canAskAgain };
+  } catch {
+    return { granted: false, canAskAgain: false };
+  }
 }
 
 async function scheduleAlarmNotifications(alarm: Alarm): Promise<string[]> {
-  const hasPermission = await requestNotificationPermissions();
-  if (!hasPermission) return [];
+  const perm = await requestNotificationPermissions();
+  if (!perm.granted) return [];
 
   const ids: string[] = [];
 
@@ -328,6 +339,7 @@ async function saveWorldClocks(clocks: WorldClock[]): Promise<void> {
 function WorldClockTab() {
   const { theme, typography } = useTheme();
   const { colors } = theme;
+  const insets = useSafeAreaInsets();
   const [, setTick] = useState(0);
   const [cities, setCities] = useState<WorldClock[]>([]);
   const [showAddModal, setShowAddModal] = useState(false);
@@ -423,7 +435,7 @@ function WorldClockTab() {
 
       {/* Add City Modal */}
       <Modal visible={showAddModal} animationType="slide" presentationStyle="pageSheet">
-        <View style={[styles.modalContainer, { backgroundColor: colors.systemBackground }]}>
+        <View style={[styles.modalContainer, { backgroundColor: colors.systemBackground, paddingTop: Platform.OS === 'android' ? insets.top : 0 }]}>
           <View style={styles.modalHeader}>
             <Pressable
               onPress={() => { setShowAddModal(false); setSearchQuery(''); }}
@@ -481,6 +493,8 @@ function WorldClockTab() {
 function AlarmTab() {
   const { theme, typography } = useTheme();
   const { colors } = theme;
+  const insets = useSafeAreaInsets();
+  const alert = useAlert();
   const [alarms, setAlarms] = useState<Alarm[]>([]);
   const [alarmsLoaded, setAlarmsLoaded] = useState(false);
   const [showAddModal, setShowAddModal] = useState(false);
@@ -629,6 +643,26 @@ function AlarmTab() {
   }, []);
 
   const handleSaveAlarm = useCallback(async () => {
+    // Request notification permission up front so the system dialog appears
+    // before we try to schedule. If denied, save the alarm in a disabled state
+    // and tell the user why it won't ring.
+    const perm = await requestNotificationPermissions();
+    if (!perm.granted) {
+      alert(
+        'Notifications Disabled',
+        perm.canAskAgain
+          ? 'Alarms need notification permission to ring. Please allow notifications and try again.'
+          : 'Alarms need notification permission to ring. Enable notifications for this app in system settings.',
+        [
+          ...(perm.canAskAgain
+            ? []
+            : [{ text: 'Open Settings', onPress: () => { Linking.openSettings().catch(() => {}); } }]),
+          { text: 'OK' },
+        ],
+      );
+      return;
+    }
+
     if (editingAlarmId) {
       // Edit existing alarm
       const existing = alarms.find((a) => a.id === editingAlarmId);
@@ -663,7 +697,7 @@ function AlarmTab() {
     }
     setShowAddModal(false);
     setEditingAlarmId(null);
-  }, [editingAlarmId, editHour, editMinute, editLabel, editDays, alarms, persistAlarms]);
+  }, [editingAlarmId, editHour, editMinute, editLabel, editDays, alarms, persistAlarms, alert]);
 
   const toggleDay = useCallback(
     (day: number) => {
@@ -746,7 +780,7 @@ function AlarmTab() {
 
       {/* Add Alarm Modal */}
       <Modal visible={showAddModal} animationType="slide" presentationStyle="pageSheet">
-        <View style={[styles.modalContainer, { backgroundColor: colors.systemBackground }]}>
+        <View style={[styles.modalContainer, { backgroundColor: colors.systemBackground, paddingTop: Platform.OS === 'android' ? insets.top : 0 }]}>
           <View style={styles.modalHeader}>
             <Pressable
               onPress={() => { setShowAddModal(false); setEditingAlarmId(null); }}

--- a/src/screens/ConversationScreen.tsx
+++ b/src/screens/ConversationScreen.tsx
@@ -8,6 +8,7 @@ import {
   Linking,
   KeyboardAvoidingView,
   Platform,
+  PermissionsAndroid,
   Dimensions,
   ActivityIndicator,
   Image,
@@ -454,6 +455,45 @@ export function ConversationScreen({ navigation, route }: ConversationScreenProp
   const handleSend = useCallback(async () => {
     const text = inputText.trim();
     if (!text || isSending) return;
+
+    // Ensure SEND_SMS permission is granted BEFORE hitting the native module
+    // so the user gets a system prompt instead of a silent failure.
+    if (Platform.OS === 'android') {
+      try {
+        const already = await PermissionsAndroid.check(
+          PermissionsAndroid.PERMISSIONS.SEND_SMS,
+        );
+        if (!already) {
+          const result = await PermissionsAndroid.request(
+            PermissionsAndroid.PERMISSIONS.SEND_SMS,
+            {
+              title: 'Send Messages',
+              message: 'Allow this app to send SMS messages on your behalf?',
+              buttonPositive: 'Allow',
+              buttonNegative: 'Deny',
+            },
+          );
+          if (result !== PermissionsAndroid.RESULTS.GRANTED) {
+            alert(
+              'Permission Needed',
+              result === PermissionsAndroid.RESULTS.NEVER_ASK_AGAIN
+                ? 'SMS permission is disabled. Enable it in system settings to send messages.'
+                : 'SMS permission was denied. Messages can\u2019t be sent without it.',
+              [
+                ...(result === PermissionsAndroid.RESULTS.NEVER_ASK_AGAIN
+                  ? [{ text: 'Open Settings', onPress: () => { Linking.openSettings().catch(() => {}); } }]
+                  : []),
+                { text: 'OK' },
+              ],
+            );
+            return;
+          }
+        }
+      } catch {
+        // Fall through — native module call below will surface the real failure.
+      }
+    }
+
     const mod = await getLauncher();
     if (mod) {
       setIsSending(true);

--- a/src/screens/LauncherHomeScreen.tsx
+++ b/src/screens/LauncherHomeScreen.tsx
@@ -1153,12 +1153,7 @@ export function LauncherHomeScreen() {
         options={actionSheetOptions}
       />
 
-      {/* ---------------------------------------------------------------- */}
-      {/* Home indicator bar (iOS-style)                                     */}
-      {/* ---------------------------------------------------------------- */}
-      <View style={[styles.homeIndicator, { bottom: insets.bottom + 2 }]}>
-        <View style={styles.homeIndicatorBar} />
-      </View>
+      {/* Home indicator is rendered globally from App.tsx (HomeIndicator). */}
 
       {/* ---------------------------------------------------------------- */}
       {/* Incoming notification banner                                       */}
@@ -1488,17 +1483,4 @@ const styles = StyleSheet.create({
     fontWeight: '600',
   },
 
-  // Home indicator bar (iOS-style)
-  homeIndicator: {
-    position: 'absolute',
-    left: 0,
-    right: 0,
-    alignItems: 'center',
-  },
-  homeIndicatorBar: {
-    width: 134,
-    height: 5,
-    borderRadius: 2.5,
-    backgroundColor: 'rgba(255,255,255,0.4)',
-  },
 });

--- a/src/screens/LockScreen.tsx
+++ b/src/screens/LockScreen.tsx
@@ -613,7 +613,7 @@ export function LockScreen({ navigation, onUnlock }: { navigation?: any; route?:
         accessibilityLabel="Swipe up to unlock"
         accessibilityRole="button"
       >
-        <StatusBar translucent backgroundColor="transparent" barStyle="light-content" />
+        <StatusBar hidden translucent backgroundColor="transparent" barStyle="light-content" />
         <LinearGradient
           colors={[wallpaperColor, wallpaperDark, '#000000']}
           locations={[0, 0.6, 1]}

--- a/src/screens/PhotosScreen.tsx
+++ b/src/screens/PhotosScreen.tsx
@@ -12,6 +12,7 @@ import {
   Platform,
   TextInput,
   Modal,
+  Linking,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
@@ -76,6 +77,7 @@ export function PhotosScreen({ navigation }: { navigation: AppNavigationProp }) 
   // ---- shared state ----
   const [tabIndex, setTabIndex] = useState(0);
   const [permissionStatus, setPermissionStatus] = useState<'undetermined' | 'granted' | 'denied'>('undetermined');
+  const [canAskAgain, setCanAskAgain] = useState(true);
   const [loading, setLoading] = useState(true);
   const [skeletonLoading, setSkeletonLoading] = useState(true);
   const [selectedMemory, setSelectedMemory] = useState<{ title: string } | null>(null);
@@ -124,33 +126,49 @@ export function PhotosScreen({ navigation }: { navigation: AppNavigationProp }) 
   // ------------------------------------------------------------------
   // Permissions
   // ------------------------------------------------------------------
+  const requestMediaPermission = useCallback(async () => {
+    if (Platform.OS !== 'android' && Platform.OS !== 'ios') {
+      setPermissionStatus('denied');
+      setCanAskAgain(false);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    try {
+      // Check first so we know whether we can still prompt.
+      const existing = await MediaLibrary.getPermissionsAsync();
+      if (existing.status === 'granted') {
+        setPermissionStatus('granted');
+        setCanAskAgain(true);
+        setLoading(false);
+        return;
+      }
+      if (!existing.canAskAgain) {
+        setPermissionStatus('denied');
+        setCanAskAgain(false);
+        setLoading(false);
+        return;
+      }
+      const result = await MediaLibrary.requestPermissionsAsync();
+      setPermissionStatus(result.status === 'granted' ? 'granted' : 'denied');
+      setCanAskAgain(result.canAskAgain);
+    } catch {
+      setPermissionStatus('denied');
+      setCanAskAgain(false);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
   useEffect(() => {
     let cancelled = false;
     (async () => {
-      if (Platform.OS !== 'android' && Platform.OS !== 'ios') {
-        if (!cancelled) {
-          setPermissionStatus('denied');
-          setLoading(false);
-        }
-        return;
-      }
-      try {
-        const { status } = await MediaLibrary.requestPermissionsAsync();
-        if (!cancelled) {
-          setPermissionStatus(status === 'granted' ? 'granted' : 'denied');
-          setLoading(false);
-        }
-      } catch {
-        if (!cancelled) {
-          setPermissionStatus('denied');
-          setLoading(false);
-        }
-      }
+      if (!cancelled) await requestMediaPermission();
     })();
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [requestMediaPermission]);
 
   // ------------------------------------------------------------------
   // Library: load initial page of photos
@@ -471,8 +489,24 @@ export function PhotosScreen({ navigation }: { navigation: AppNavigationProp }) 
               { color: colors.secondaryLabel, textAlign: 'center', marginTop: 8, marginHorizontal: 32 },
             ]}
           >
-            Grant photo library access to browse your photos.
+            {canAskAgain
+              ? 'Grant photo library access to browse your photos.'
+              : 'Photo access was denied. Enable it for this app in system settings.'}
           </Text>
+          <Pressable
+            style={[styles.browseBtn, { backgroundColor: colors.systemBlue }]}
+            onPress={() => {
+              if (canAskAgain) {
+                requestMediaPermission();
+              } else {
+                Linking.openSettings().catch(() => {});
+              }
+            }}
+          >
+            <Text style={{ color: '#fff', fontWeight: '600' }}>
+              {canAskAgain ? 'Grant Access' : 'Open Settings'}
+            </Text>
+          </Pressable>
         </View>
       ) : tabIndex === 0 ? (
         // ============================================================

--- a/src/screens/WeatherScreen.tsx
+++ b/src/screens/WeatherScreen.tsx
@@ -55,6 +55,13 @@ export function WeatherScreen({ navigation }: WeatherScreenProps) {
   const [currentCity, setCurrentCity] = useState('');
 
   useEffect(() => {
+    let cancelled = false;
+    // Hard timeout so the loading spinner can never hang forever if the
+    // permission dialog or network request stalls.
+    const timeoutId = setTimeout(() => {
+      if (!cancelled) setLoading(false);
+    }, 10000);
+
     (async () => {
       try {
         // Request location permission here (non-blocking for the rest of the app)
@@ -70,7 +77,10 @@ export function WeatherScreen({ navigation }: WeatherScreenProps) {
         const url = locationQuery
           ? `https://wttr.in/${locationQuery}?format=j1`
           : 'https://wttr.in/?format=j1';
-        const res = await fetch(url);
+        const controller = new AbortController();
+        const fetchTimeout = setTimeout(() => controller.abort(), 8000);
+        const res = await fetch(url, { signal: controller.signal });
+        clearTimeout(fetchTimeout);
         const data = await res.json();
         const current = data.current_condition[0];
         const area = data.nearest_area?.[0];
@@ -125,14 +135,28 @@ export function WeatherScreen({ navigation }: WeatherScreenProps) {
         });
         setForecast(days);
       } catch { /* use device weather fallback */ }
-      setLoading(false);
+      clearTimeout(timeoutId);
+      if (!cancelled) setLoading(false);
     })();
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timeoutId);
+    };
   }, []);
 
   if (loading && currentTemp === null) {
     return (
-      <LinearGradient colors={['#2C5F8A', '#1B3A5C']} style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
-        <ActivityIndicator size="large" color="#fff" />
+      <LinearGradient colors={['#2C5F8A', '#1B3A5C']} style={[styles.root, { paddingTop: insets.top }]}>
+        <CupertinoNavigationBar
+          title=""
+          leftButton={
+            <Ionicons name="chevron-back" size={28} color="#fff" onPress={() => navigation.goBack()} />
+          }
+        />
+        <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+          <ActivityIndicator size="large" color="#fff" />
+        </View>
       </LinearGradient>
     );
   }

--- a/src/screens/settings/AccessibilityScreen.tsx
+++ b/src/screens/settings/AccessibilityScreen.tsx
@@ -12,6 +12,7 @@ import {
   CupertinoSegmentedControl,
   CupertinoSlider,
 } from '../../components';
+import { useAssistiveTouch } from '../../store/AssistiveTouchStore';
 import type { AppNavigationProp } from '../../navigation/types';
 
 const TEXT_SIZE_LABELS = ['Small', 'Default', 'Large', 'XL'];
@@ -29,6 +30,7 @@ export function AccessibilityScreen({ navigation }: { navigation: AppNavigationP
   const { colors } = theme;
   const insets = useSafeAreaInsets();
   const { settings, update } = useSettings();
+  const assistive = useAssistiveTouch();
   const [reduceTransparency, setReduceTransparency] = useState(false);
   const [smartInvert, setSmartInvert] = useState(false);
   const [colorFilters, setColorFilters] = useState(false);
@@ -210,6 +212,20 @@ export function AccessibilityScreen({ navigation }: { navigation: AppNavigationP
                 Current scale: {Math.round(textScale * 100)}%
               </Text>
             </View>
+          </CupertinoListSection>
+        </View>
+
+        {/* Physical and Motor */}
+        <View style={{ paddingHorizontal: spacing.md }}>
+          <CupertinoListSection
+            header="Physical and Motor"
+            footer="AssistiveTouch lets you replace the home swipe with a customisable floating button."
+          >
+            <CupertinoListTile
+              title="AssistiveTouch"
+              subtitle={assistive.enabled ? 'On' : 'Off'}
+              onPress={() => navigation.navigate('AssistiveTouchSettings')}
+            />
           </CupertinoListSection>
         </View>
 

--- a/src/screens/settings/AssistiveTouchSettingsScreen.tsx
+++ b/src/screens/settings/AssistiveTouchSettingsScreen.tsx
@@ -1,0 +1,383 @@
+import React, { useCallback, useMemo } from 'react';
+import { View, Text, ScrollView, StyleSheet, Pressable } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Ionicons } from '@expo/vector-icons';
+import { useTheme } from '../../theme/ThemeContext';
+import {
+  CupertinoNavigationBar,
+  CupertinoListSection,
+  CupertinoListTile,
+  CupertinoSwitch,
+  CupertinoSlider,
+  useAlert,
+} from '../../components';
+import {
+  useAssistiveTouch,
+  AssistiveAction,
+  MenuItemId,
+} from '../../store/AssistiveTouchStore';
+import type { AppNavigationProp } from '../../navigation/types';
+
+// ─── Action catalog (for tap mapping) ────────────────────────────────────────
+const ACTION_OPTIONS: { id: AssistiveAction; label: string }[] = [
+  { id: 'openMenu',         label: 'Open Menu' },
+  { id: 'home',             label: 'Home' },
+  { id: 'multitask',        label: 'App Switcher' },
+  { id: 'notifications',    label: 'Notifications' },
+  { id: 'controlCenter',    label: 'Control Centre' },
+  { id: 'spotlight',        label: 'Spotlight' },
+  { id: 'settings',         label: 'Settings' },
+  { id: 'reachability',     label: 'Reachability' },
+  { id: 'hideTemporarily',  label: 'Hide Temporarily' },
+  { id: 'screenshot',       label: 'Screenshot' },
+  { id: 'lock',             label: 'Lock Screen' },
+  { id: 'siri',             label: 'Siri' },
+  { id: 'none',             label: 'None' },
+];
+
+const ALL_MENU_ITEMS: { id: MenuItemId; label: string }[] = [
+  { id: 'home',             label: 'Home' },
+  { id: 'multitask',        label: 'App Switcher' },
+  { id: 'notifications',    label: 'Notifications' },
+  { id: 'controlCenter',    label: 'Control Centre' },
+  { id: 'spotlight',        label: 'Spotlight' },
+  { id: 'settings',         label: 'Settings' },
+  { id: 'siri',             label: 'Siri' },
+  { id: 'screenshot',       label: 'Screenshot' },
+  { id: 'lock',             label: 'Lock Screen' },
+  { id: 'reachability',     label: 'Reachability' },
+  { id: 'hideTemporarily',  label: 'Hide Temporarily' },
+];
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function AssistiveTouchSettingsScreen({ navigation }: { navigation: AppNavigationProp }) {
+  const { theme, typography, spacing } = useTheme();
+  const { colors } = theme;
+  const insets = useSafeAreaInsets();
+  const alert = useAlert();
+  const assistive = useAssistiveTouch();
+
+  const labelFor = useCallback(
+    (action: AssistiveAction) => ACTION_OPTIONS.find((o) => o.id === action)?.label ?? 'None',
+    [],
+  );
+
+  const pickAction = useCallback(
+    (current: AssistiveAction, apply: (a: AssistiveAction) => void) => {
+      alert(
+        'Choose Action',
+        undefined,
+        ACTION_OPTIONS.map((opt) => ({
+          text: opt.label + (opt.id === current ? '  ✓' : ''),
+          onPress: () => apply(opt.id),
+        })),
+      );
+    },
+    [alert],
+  );
+
+  const moveItem = useCallback(
+    (index: number, direction: -1 | 1) => {
+      const target = index + direction;
+      if (target < 0 || target >= assistive.menuItems.length) return;
+      const next = assistive.menuItems.slice();
+      [next[index], next[target]] = [next[target], next[index]];
+      assistive.update({ menuItems: next });
+    },
+    [assistive],
+  );
+
+  const removeItem = useCallback(
+    (id: MenuItemId) => {
+      if (assistive.menuItems.length <= 1) return;
+      assistive.update({ menuItems: assistive.menuItems.filter((i) => i !== id) });
+    },
+    [assistive],
+  );
+
+  const addItem = useCallback(() => {
+    const missing = ALL_MENU_ITEMS.filter((i) => !assistive.menuItems.includes(i.id));
+    if (missing.length === 0) {
+      alert('Menu Full', 'All available items are already in your menu.');
+      return;
+    }
+    alert(
+      'Add to Menu',
+      undefined,
+      missing.slice(0, 6).map((item) => ({
+        text: item.label,
+        onPress: () => {
+          if (assistive.menuItems.length >= 6) {
+            alert('Limit Reached', 'A menu can hold at most 6 items. Remove one first.');
+            return;
+          }
+          assistive.update({ menuItems: [...assistive.menuItems, item.id] });
+        },
+      })),
+    );
+  }, [assistive, alert]);
+
+  const resetAll = useCallback(() => {
+    alert('Reset AssistiveTouch?', 'This will restore the default layout, actions, and menu.', [
+      { text: 'Cancel', style: 'cancel' },
+      {
+        text: 'Reset',
+        style: 'destructive',
+        onPress: () =>
+          assistive.update({
+            idleOpacity: 0.5,
+            size: 46,
+            singleTapAction: 'openMenu',
+            doubleTapAction: 'multitask',
+            longPressAction: 'hideTemporarily',
+            menuItems: ['home', 'multitask', 'notifications', 'controlCenter', 'spotlight', 'settings'],
+            autoHideFullscreen: true,
+            contextAwareMenu: true,
+            reachabilityOnDoubleTap: false,
+            hapticFeedback: true,
+          }),
+      },
+    ]);
+  }, [alert, assistive]);
+
+  // Pretty label for menu item ids
+  const menuItemLabel = useMemo(() => {
+    const map: Record<MenuItemId, string> = {} as Record<MenuItemId, string>;
+    ALL_MENU_ITEMS.forEach((i) => { map[i.id] = i.label; });
+    return map;
+  }, []);
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.systemGroupedBackground }]}>
+      <CupertinoNavigationBar
+        title="AssistiveTouch"
+        leftButton={
+          <Text
+            style={[typography.body, { color: colors.systemBlue }]}
+            onPress={() => navigation.goBack()}
+          >
+            Accessibility
+          </Text>
+        }
+      />
+      <ScrollView
+        contentContainerStyle={{ paddingBottom: insets.bottom + 90 }}
+        showsVerticalScrollIndicator={false}
+      >
+        {/* Master switch */}
+        <View style={{ paddingHorizontal: spacing.md }}>
+          <CupertinoListSection
+            footer="Shows a floating button that can replace home navigation, open menus, and perform custom actions."
+          >
+            <CupertinoListTile
+              title="AssistiveTouch"
+              trailing={
+                <CupertinoSwitch
+                  value={assistive.enabled}
+                  onValueChange={(v) => assistive.update({ enabled: v })}
+                />
+              }
+              showChevron={false}
+            />
+          </CupertinoListSection>
+        </View>
+
+        {assistive.enabled && (
+          <>
+            {/* Appearance */}
+            <View style={{ paddingHorizontal: spacing.md }}>
+              <CupertinoListSection header="Appearance" footer="Idle opacity dims the button after a few seconds of inactivity.">
+                <View style={styles.sliderBlock}>
+                  <Text style={[typography.caption1, { color: colors.secondaryLabel }]}>
+                    Idle Opacity ({Math.round(assistive.idleOpacity * 100)}%)
+                  </Text>
+                  <CupertinoSlider
+                    value={assistive.idleOpacity}
+                    onValueChange={(v) => assistive.update({ idleOpacity: Math.max(0.15, Math.min(1, v)) })}
+                    minimumValue={0.15}
+                    maximumValue={1}
+                  />
+                </View>
+                <View style={styles.sliderBlock}>
+                  <Text style={[typography.caption1, { color: colors.secondaryLabel }]}>
+                    Button Size ({Math.round(assistive.size)}pt)
+                  </Text>
+                  <CupertinoSlider
+                    value={assistive.size}
+                    onValueChange={(v) => assistive.update({ size: Math.round(Math.max(40, Math.min(60, v))) })}
+                    minimumValue={40}
+                    maximumValue={60}
+                  />
+                </View>
+              </CupertinoListSection>
+            </View>
+
+            {/* Custom actions */}
+            <View style={{ paddingHorizontal: spacing.md }}>
+              <CupertinoListSection
+                header="Custom Actions"
+                footer="Actions run directly without opening the menu."
+              >
+                <CupertinoListTile
+                  title="Single-Tap"
+                  trailing={
+                    <Text style={[typography.body, { color: colors.secondaryLabel }]}>
+                      {labelFor(assistive.singleTapAction)}
+                    </Text>
+                  }
+                  onPress={() => pickAction(assistive.singleTapAction, (a) => assistive.update({ singleTapAction: a }))}
+                />
+                <CupertinoListTile
+                  title="Double-Tap"
+                  trailing={
+                    <Text style={[typography.body, { color: colors.secondaryLabel }]}>
+                      {labelFor(assistive.doubleTapAction)}
+                    </Text>
+                  }
+                  onPress={() => pickAction(assistive.doubleTapAction, (a) => assistive.update({ doubleTapAction: a }))}
+                />
+                <CupertinoListTile
+                  title="Long Press"
+                  trailing={
+                    <Text style={[typography.body, { color: colors.secondaryLabel }]}>
+                      {labelFor(assistive.longPressAction)}
+                    </Text>
+                  }
+                  onPress={() => pickAction(assistive.longPressAction, (a) => assistive.update({ longPressAction: a }))}
+                />
+              </CupertinoListSection>
+            </View>
+
+            {/* Top-Level Menu */}
+            <View style={{ paddingHorizontal: spacing.md }}>
+              <CupertinoListSection
+                header="Customise Top Level Menu"
+                footer="Up to 6 items. Reorder with the arrows, tap the minus to remove."
+              >
+                {assistive.menuItems.map((id, i) => (
+                  <View
+                    key={id}
+                    style={[styles.menuRow, { borderBottomColor: colors.separator }]}
+                  >
+                    <Pressable
+                      onPress={() => removeItem(id)}
+                      hitSlop={8}
+                      disabled={assistive.menuItems.length <= 1}
+                      style={{ opacity: assistive.menuItems.length <= 1 ? 0.3 : 1 }}
+                    >
+                      <Ionicons name="remove-circle" size={22} color={colors.systemRed} />
+                    </Pressable>
+                    <Text style={[typography.body, { color: colors.label, flex: 1, marginLeft: 10 }]}>
+                      {menuItemLabel[id]}
+                    </Text>
+                    <Pressable onPress={() => moveItem(i, -1)} hitSlop={8} disabled={i === 0}>
+                      <Ionicons name="chevron-up" size={20} color={i === 0 ? colors.tertiaryLabel : colors.systemBlue} />
+                    </Pressable>
+                    <View style={{ width: 10 }} />
+                    <Pressable
+                      onPress={() => moveItem(i, 1)}
+                      hitSlop={8}
+                      disabled={i === assistive.menuItems.length - 1}
+                    >
+                      <Ionicons
+                        name="chevron-down"
+                        size={20}
+                        color={i === assistive.menuItems.length - 1 ? colors.tertiaryLabel : colors.systemBlue}
+                      />
+                    </Pressable>
+                  </View>
+                ))}
+                <CupertinoListTile
+                  title="Add Item"
+                  trailing={<Ionicons name="add-circle" size={22} color={colors.systemGreen} />}
+                  showChevron={false}
+                  onPress={addItem}
+                />
+              </CupertinoListSection>
+            </View>
+
+            {/* Enhancements beyond iOS */}
+            <View style={{ paddingHorizontal: spacing.md }}>
+              <CupertinoListSection
+                header="Enhancements"
+                footer="Improvements beyond what AssistiveTouch offers on iOS."
+              >
+                <CupertinoListTile
+                  title="Auto-hide in Full-Screen"
+                  subtitle="Hides the button in Camera and Call screens"
+                  trailing={
+                    <CupertinoSwitch
+                      value={assistive.autoHideFullscreen}
+                      onValueChange={(v) => assistive.update({ autoHideFullscreen: v })}
+                    />
+                  }
+                  showChevron={false}
+                />
+                <CupertinoListTile
+                  title="Context-Aware Menu"
+                  subtitle="First menu slot adapts to the current screen"
+                  trailing={
+                    <CupertinoSwitch
+                      value={assistive.contextAwareMenu}
+                      onValueChange={(v) => assistive.update({ contextAwareMenu: v })}
+                    />
+                  }
+                  showChevron={false}
+                />
+                <CupertinoListTile
+                  title="Reachability on Double-Tap"
+                  subtitle="Slides the screen down for one-handed use"
+                  trailing={
+                    <CupertinoSwitch
+                      value={assistive.reachabilityOnDoubleTap}
+                      onValueChange={(v) => assistive.update({ reachabilityOnDoubleTap: v })}
+                    />
+                  }
+                  showChevron={false}
+                />
+                <CupertinoListTile
+                  title="Haptic Feedback"
+                  trailing={
+                    <CupertinoSwitch
+                      value={assistive.hapticFeedback}
+                      onValueChange={(v) => assistive.update({ hapticFeedback: v })}
+                    />
+                  }
+                  showChevron={false}
+                />
+              </CupertinoListSection>
+            </View>
+
+            {/* Reset */}
+            <View style={{ paddingHorizontal: spacing.md }}>
+              <CupertinoListSection>
+                <CupertinoListTile
+                  title="Reset to Defaults"
+                  onPress={resetAll}
+                  showChevron={false}
+                  trailing={<Ionicons name="refresh" size={18} color={colors.systemRed} />}
+                />
+              </CupertinoListSection>
+            </View>
+          </>
+        )}
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  sliderBlock: {
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    gap: 4,
+  },
+  menuRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+});

--- a/src/store/AssistiveTouchStore.tsx
+++ b/src/store/AssistiveTouchStore.tsx
@@ -1,0 +1,151 @@
+import React, { createContext, useContext, useState, useCallback, useEffect, useMemo } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const STORAGE_KEY = '@iostoandroid/assistive_touch';
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export type AssistiveAction =
+  | 'openMenu'
+  | 'home'
+  | 'multitask'
+  | 'notifications'
+  | 'controlCenter'
+  | 'spotlight'
+  | 'settings'
+  | 'reachability'
+  | 'hideTemporarily'
+  | 'screenshot'
+  | 'lock'
+  | 'siri'
+  | 'none';
+
+export type MenuItemId =
+  | 'home'
+  | 'multitask'
+  | 'notifications'
+  | 'controlCenter'
+  | 'spotlight'
+  | 'settings'
+  | 'siri'
+  | 'screenshot'
+  | 'lock'
+  | 'reachability'
+  | 'hideTemporarily';
+
+export interface AssistiveTouchState {
+  /** Master on/off switch */
+  enabled: boolean;
+  /** Opacity when idle (0.15 – 1.0) */
+  idleOpacity: number;
+  /** Button diameter in pt (40 – 60) */
+  size: number;
+  /** Persisted position — x/y in pt, snapped edge */
+  position: { x: number; y: number };
+  /** Edge the button snaps to after drag */
+  edge: 'left' | 'right';
+  /** Action mappings */
+  singleTapAction: AssistiveAction;
+  doubleTapAction: AssistiveAction;
+  longPressAction: AssistiveAction;
+  /** Ordered list of menu items shown when openMenu fires */
+  menuItems: MenuItemId[];
+  /** Improvement toggles */
+  autoHideFullscreen: boolean;
+  contextAwareMenu: boolean;
+  reachabilityOnDoubleTap: boolean;
+  hapticFeedback: boolean;
+}
+
+const DEFAULT_STATE: AssistiveTouchState = {
+  enabled: false,
+  idleOpacity: 0.5,
+  size: 46,
+  position: { x: 0, y: 300 },
+  edge: 'right',
+  singleTapAction: 'openMenu',
+  doubleTapAction: 'multitask',
+  longPressAction: 'hideTemporarily',
+  menuItems: ['home', 'multitask', 'notifications', 'controlCenter', 'spotlight', 'settings'],
+  autoHideFullscreen: true,
+  contextAwareMenu: true,
+  reachabilityOnDoubleTap: false,
+  hapticFeedback: true,
+};
+
+// ─── Context ────────────────────────────────────────────────────────────────
+
+interface AssistiveTouchContextValue extends AssistiveTouchState {
+  update: (patch: Partial<AssistiveTouchState>) => void;
+  setPosition: (x: number, y: number, edge: 'left' | 'right') => void;
+  /** Triggered by long-press action — hides for `ms` then reveals again. */
+  hideTemporarily: (ms?: number) => void;
+  /** True while a temporary hide is active. */
+  temporarilyHidden: boolean;
+  /** Runtime-only: reachability shifts app content down when true. */
+  reachabilityActive: boolean;
+  setReachabilityActive: (v: boolean) => void;
+}
+
+const AssistiveTouchContext = createContext<AssistiveTouchContextValue | null>(null);
+
+export function useAssistiveTouch(): AssistiveTouchContextValue {
+  const ctx = useContext(AssistiveTouchContext);
+  if (!ctx) throw new Error('useAssistiveTouch must be used inside AssistiveTouchProvider');
+  return ctx;
+}
+
+// ─── Provider ───────────────────────────────────────────────────────────────
+
+export function AssistiveTouchProvider({ children }: { children: React.ReactNode }) {
+  const [state, setState] = useState<AssistiveTouchState>(DEFAULT_STATE);
+  const [isReady, setIsReady] = useState(false);
+  const [temporarilyHidden, setTemporarilyHidden] = useState(false);
+  const [reachabilityActive, setReachabilityActive] = useState(false);
+
+  // Load persisted state
+  useEffect(() => {
+    AsyncStorage.getItem(STORAGE_KEY).then((stored) => {
+      if (stored) {
+        try {
+          const parsed = JSON.parse(stored) as Partial<AssistiveTouchState>;
+          setState((prev) => ({ ...prev, ...parsed }));
+        } catch { /* ignore malformed */ }
+      }
+      setIsReady(true);
+    });
+  }, []);
+
+  // Persist on every change (skip initial load)
+  useEffect(() => {
+    if (isReady) AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(state)).catch(() => {});
+  }, [state, isReady]);
+
+  const update = useCallback((patch: Partial<AssistiveTouchState>) => {
+    setState((prev) => ({ ...prev, ...patch }));
+  }, []);
+
+  const setPosition = useCallback((x: number, y: number, edge: 'left' | 'right') => {
+    setState((prev) => ({ ...prev, position: { x, y }, edge }));
+  }, []);
+
+  const hideTemporarily = useCallback((ms: number = 10000) => {
+    setTemporarilyHidden(true);
+    setTimeout(() => setTemporarilyHidden(false), ms);
+  }, []);
+
+  const value = useMemo<AssistiveTouchContextValue>(
+    () => ({
+      ...state,
+      update,
+      setPosition,
+      hideTemporarily,
+      temporarilyHidden,
+      reachabilityActive,
+      setReachabilityActive,
+    }),
+    [state, update, setPosition, hideTemporarily, temporarilyHidden, reachabilityActive],
+  );
+
+  return <AssistiveTouchContext.Provider value={value}>{children}</AssistiveTouchContext.Provider>;
+}


### PR DESCRIPTION
The Clock alarm modal's Cancel/Save buttons were hidden behind the
Android status bar because `edgeToEdgeEnabled: true` draws full-screen
modals under the system UI. Apply top safe-area padding so the header is
tappable. Same fix applied to the World Clock "Add City" modal.

Permission prompts were failing silently in three places:

- ConversationScreen: sendSms was invoked without requesting SEND_SMS
  first, so Android rejected the call and only "Could not send message"
  appeared. Now PermissionsAndroid.check/request runs up front, with
  an Open Settings escape hatch when NEVER_ASK_AGAIN is returned.
- ClockScreen: notification permission denials were swallowed, so
  saving an alarm just closed the modal. Now the dialog is raised up
  front and denial surfaces a user-facing alert with Open Settings.
- PhotosScreen: a denied MediaLibrary permission left the user on a
  dead empty state. Added a Grant Access / Open Settings button and
  tracked canAskAgain so the correct affordance shows.

Also fix the Weather loading state, which could trap the user on an
infinite spinner with no back button if the location prompt or network
call stalled. Added a back button, an 8s fetch abort, and a 10s overall
safety timeout. Declared SCHEDULE_EXACT_ALARM and USE_EXACT_ALARM in
app.json so alarm scheduling works on Android 12+.