### PR TITLE
feat(gestures): foundation — gestureConfig + multi-sample velocity + state machine (#226, #227)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-legacy-peer-deps=true
+legacy-peer-deps=false

--- a/App.tsx
+++ b/App.tsx
@@ -18,6 +18,7 @@ import { ErrorBoundary } from './src/components/ErrorBoundary';
 import { AlertProvider } from './src/components/AlertProvider';
 import { NotificationBanner, BannerNotification } from './src/components/NotificationBanner';
 import { HomeIndicator } from './src/components/HomeIndicator';
+import { GestureHost } from './src/components/GestureHost';
 import { AssistiveTouch } from './src/components/AssistiveTouch';
 import { AssistiveTouchProvider, useAssistiveTouch } from './src/store/AssistiveTouchStore';
 import { LockScreen } from './src/screens/LockScreen';
@@ -200,9 +201,11 @@ function AppContent() {
     <View style={{ flex: 1 }}>
       <StatusBar style={isDark ? 'light' : 'dark'} hidden />
       <ReachabilityShifter>
-        <NavigationContainer ref={navigationRef}>
-          <TabNavigator />
-        </NavigationContainer>
+        <GestureHost>
+          <NavigationContainer ref={navigationRef}>
+            <TabNavigator />
+          </NavigationContainer>
+        </GestureHost>
       </ReachabilityShifter>
 
       {/* iOS-style home indicator — floats above every screen and owns the

--- a/App.tsx
+++ b/App.tsx
@@ -18,6 +18,7 @@ import { ErrorBoundary } from './src/components/ErrorBoundary';
 import { AlertProvider } from './src/components/AlertProvider';
 import { NotificationBanner, BannerNotification } from './src/components/NotificationBanner';
 import { HomeIndicator } from './src/components/HomeIndicator';
+import { QuickSwitchHomeBar } from './src/components/QuickSwitchHomeBar';
 import { GestureHost } from './src/components/GestureHost';
 import { AssistiveTouch } from './src/components/AssistiveTouch';
 import { AssistiveTouchProvider, useAssistiveTouch } from './src/store/AssistiveTouchStore';
@@ -207,6 +208,11 @@ function AppContent() {
           </NavigationContainer>
         </GestureHost>
       </ReachabilityShifter>
+
+      {/* Horizontal quick-switch strip — sits one z-level below the pill so
+          vertical gestures on the pill still win. Handles leftward/rightward
+          swipes on the home-bar zone to switch to recent apps. */}
+      <QuickSwitchHomeBar />
 
       {/* iOS-style home indicator — floats above every screen and owns the
           swipe-up-to-home / swipe-up-and-hold-for-switcher gesture. */}

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -201,7 +201,7 @@ jest.mock('react-native-gesture-handler', () => {
     GestureDetector: 'View',
     Gesture: {
       Pan: () => {
-        const g = { onUpdate: () => g, onEnd: () => g, onBegin: () => g, onFinalize: () => g, minDistance: () => g, enabled: () => g, activeOffsetX: () => g, activeOffsetY: () => g, failOffsetX: () => g, failOffsetY: () => g, simultaneousWithExternalGesture: () => g, withRef: () => g, onChange: () => g, onStart: () => g, onTouchesBegan: () => g, onTouchesMove: () => g, onTouchesUp: () => g, onTouchesCancelled: () => g };
+        const g = { onUpdate: () => g, onEnd: () => g, onBegin: () => g, onFinalize: () => g, minDistance: () => g, enabled: () => g, activeOffsetX: () => g, activeOffsetY: () => g, failOffsetX: () => g, failOffsetY: () => g, simultaneousWithExternalGesture: () => g, withRef: () => g, onChange: () => g, onStart: () => g, onTouchesBegan: () => g, onTouchesMove: () => g, onTouchesUp: () => g, onTouchesCancelled: () => g, hitSlop: () => g, maxPointers: () => g, minPointers: () => g, averageTouches: () => g };
         return g;
       },
       Tap: () => {
@@ -240,7 +240,12 @@ jest.mock('react-native-safe-area-context', () => {
 });
 
 jest.mock('@react-navigation/native', () => ({
-  useNavigation: () => ({ navigate: jest.fn(), goBack: jest.fn(), getParent: () => ({ navigate: jest.fn() }) }),
+  useNavigation: () => ({
+    navigate: jest.fn(),
+    goBack: jest.fn(),
+    canGoBack: jest.fn(() => false),
+    getParent: () => ({ navigate: jest.fn() }),
+  }),
   useRoute: () => ({ params: {} }),
   NavigationContainer: ({ children }) => children,
 }));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "iostoandroid",
-  "version": "1.8.24",
+  "version": "1.8.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "iostoandroid",
-      "version": "1.8.24",
+      "version": "1.8.26",
       "dependencies": {
         "@expo/vector-icons": "^15.0.3",
         "@react-native-async-storage/async-storage": "^3.0.2",
@@ -17,7 +17,7 @@
         "expo-battery": "~10.0.8",
         "expo-blur": "~15.0.8",
         "expo-brightness": "~14.0.8",
-        "expo-camera": "^55.0.15",
+        "expo-camera": "~17.0.8",
         "expo-clipboard": "~8.0.8",
         "expo-contacts": "~15.0.11",
         "expo-haptics": "~15.0.8",
@@ -26,11 +26,11 @@
         "expo-linking": "~8.0.11",
         "expo-local-authentication": "~17.0.8",
         "expo-location": "~19.0.8",
-        "expo-media-library": "^55.0.14",
+        "expo-media-library": "~18.2.0",
         "expo-navigation-bar": "~5.0.10",
         "expo-network": "~8.0.8",
-        "expo-notifications": "^55.0.18",
-        "expo-secure-store": "^55.0.13",
+        "expo-notifications": "~0.32.11",
+        "expo-secure-store": "~15.0.7",
         "expo-sharing": "^55.0.18",
         "expo-status-bar": "~3.0.9",
         "react": "19.1.0",
@@ -53,7 +53,7 @@
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^7.0.1",
         "jest": "^29.7.0",
-        "jest-expo": "^55.0.13",
+        "jest-expo": "~54.0.12",
         "prettier": "^3.8.1",
         "react-native-worklets": "^0.8.1",
         "react-test-renderer": "19.1.0",
@@ -2516,6 +2516,12 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/@ide/backoff": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@ide/backoff/-/backoff-1.0.0.tgz",
+      "integrity": "sha512-F0YfUDjvT+Mtt/R4xdl2X0EYCHMMiJqNLdxHD++jDT5ydEFIyqbCHh51Qx2E211dgZprPKhV7sHmnXKpLuvc5g==",
+      "license": "MIT"
+    },
     "node_modules/@isaacs/fs-minipass": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
@@ -3523,12 +3529,6 @@
         "@babel/types": "^7.28.2"
       }
     },
-    "node_modules/@types/emscripten": {
-      "version": "1.41.5",
-      "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.41.5.tgz",
-      "integrity": "sha512-cMQm7pxu6BxtHyqJ7mQZ2kXWV5SLmugybFdHCBbJ5eHzOo6VhBckEgAT3//rP5FwPHNPeEiq4SmQ5ucBwsOo4Q==",
-      "license": "MIT"
-    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
@@ -4297,6 +4297,19 @@
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "license": "MIT"
     },
+    "node_modules/assert": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
+      "integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "is-nan": "^1.3.2",
+        "object-is": "^1.1.5",
+        "object.assign": "^4.1.4",
+        "util": "^0.12.5"
+      }
+    },
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -4324,7 +4337,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
       "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "possible-typed-array-names": "^1.0.0"
@@ -4461,15 +4473,6 @@
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
       }
     },
-    "node_modules/babel-plugin-react-compiler": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-react-compiler/-/babel-plugin-react-compiler-1.0.0.tgz",
-      "integrity": "sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.26.0"
-      }
-    },
     "node_modules/babel-plugin-react-native-web": {
       "version": "0.19.13",
       "resolved": "https://registry.npmjs.org/babel-plugin-react-native-web/-/babel-plugin-react-native-web-0.19.13.tgz",
@@ -4600,15 +4603,6 @@
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/barcode-detector": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/barcode-detector/-/barcode-detector-3.1.2.tgz",
-      "integrity": "sha512-Q5kjXpVH5I3ItykNzbWmfWnNryFN1ZTWp10k9/PKJuS0RnoKR7jTrHEJODR4fn04bRomq7TJwie/Dr9fj/GoGQ==",
-      "license": "MIT",
-      "dependencies": {
-        "zxing-wasm": "3.0.2"
       }
     },
     "node_modules/base64-js": {
@@ -4811,7 +4805,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
       "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.0",
@@ -4830,7 +4823,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -4844,7 +4836,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -5450,7 +5441,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0",
@@ -5477,7 +5467,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.0.1",
@@ -5607,7 +5596,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -5772,7 +5760,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5782,7 +5769,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5821,7 +5807,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -6466,9 +6451,9 @@
       }
     },
     "node_modules/expo-application": {
-      "version": "55.0.14",
-      "resolved": "https://registry.npmjs.org/expo-application/-/expo-application-55.0.14.tgz",
-      "integrity": "sha512-NgqDIt3eCf4aVLp1L6AcEanCYoyJeuBsGrgGSzOIvxAsOvp5X3SYKW3ROgpKUnLQEKMWlzwETpjsUGszcqkk8g==",
+      "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/expo-application/-/expo-application-7.0.8.tgz",
+      "integrity": "sha512-qFGyxk7VJbrNOQWBbE09XUuGuvkOgFS9QfToaK2FdagM2aQ+x3CvGV2DuVgl/l4ZxPgIf3b/MNh9xHpwSwn74Q==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*"
@@ -6521,12 +6506,12 @@
       }
     },
     "node_modules/expo-camera": {
-      "version": "55.0.15",
-      "resolved": "https://registry.npmjs.org/expo-camera/-/expo-camera-55.0.15.tgz",
-      "integrity": "sha512-WRVsZf+2p7EsxudwyiUMYijJS8M98t/BVP6yG7N+08JSUotkGjmZcemom1gM36uy27P8QsSVP0hD+FravmQiBA==",
+      "version": "17.0.10",
+      "resolved": "https://registry.npmjs.org/expo-camera/-/expo-camera-17.0.10.tgz",
+      "integrity": "sha512-w1RBw83mAGVk4BPPwNrCZyFop0VLiVSRE3c2V9onWbdFwonpRhzmB4drygG8YOUTl1H3wQvALJHyMPTbgsK1Jg==",
       "license": "MIT",
       "dependencies": {
-        "barcode-detector": "^3.0.0"
+        "invariant": "^2.2.4"
       },
       "peerDependencies": {
         "expo": "*",
@@ -6687,9 +6672,9 @@
       }
     },
     "node_modules/expo-media-library": {
-      "version": "55.0.14",
-      "resolved": "https://registry.npmjs.org/expo-media-library/-/expo-media-library-55.0.14.tgz",
-      "integrity": "sha512-S84myNFYinf6Yu492/hA7BV+mRURUmSkLR9GpZOgJ0SunmG3/7S/R6Bj0yx8TcbLToObciya+BejC8juPuyoBg==",
+      "version": "18.2.1",
+      "resolved": "https://registry.npmjs.org/expo-media-library/-/expo-media-library-18.2.1.tgz",
+      "integrity": "sha512-dV1acx6Aseu+I5hmF61wY8UkD4vdt8d7YXHDfgNp6ZSs06qxayUxgrBsiG2eigLe54VLm3ycbFBbWi31lhfsCA==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*",
@@ -6752,16 +6737,18 @@
       }
     },
     "node_modules/expo-notifications": {
-      "version": "55.0.18",
-      "resolved": "https://registry.npmjs.org/expo-notifications/-/expo-notifications-55.0.18.tgz",
-      "integrity": "sha512-NxA9zdADnsQ5g66cznpu3m+bFMyoi7XKN+GkKZCRQ0RJAi4NXwB+1mljzdCAt5TGlcnAwwVBw+3zC1B9qORfcQ==",
+      "version": "0.32.16",
+      "resolved": "https://registry.npmjs.org/expo-notifications/-/expo-notifications-0.32.16.tgz",
+      "integrity": "sha512-QQD/UA6v7LgvwIJ+tS7tSvqJZkdp0nCSj9MxsDk/jU1GttYdK49/5L2LvE/4U0H7sNBz1NZAyhDZozg8xgBLXw==",
       "license": "MIT",
       "dependencies": {
-        "@expo/image-utils": "^0.8.13",
+        "@expo/image-utils": "^0.8.8",
+        "@ide/backoff": "^1.0.0",
         "abort-controller": "^3.0.0",
+        "assert": "^2.0.0",
         "badgin": "^1.1.5",
-        "expo-application": "~55.0.14",
-        "expo-constants": "~55.0.13"
+        "expo-application": "~7.0.8",
+        "expo-constants": "~18.0.13"
       },
       "peerDependencies": {
         "expo": "*",
@@ -6769,111 +6756,10 @@
         "react-native": "*"
       }
     },
-    "node_modules/expo-notifications/node_modules/@expo/config": {
-      "version": "55.0.14",
-      "resolved": "https://registry.npmjs.org/@expo/config/-/config-55.0.14.tgz",
-      "integrity": "sha512-CCIe6Suuy0DjC58PI6jBpK8Y3pW0BimXGP8tZrVKPqS5ECqVTei0Xp78nbC/fbO+79r6ak5Su6Os71U459j4dw==",
-      "license": "MIT",
-      "dependencies": {
-        "@expo/config-plugins": "~55.0.8",
-        "@expo/config-types": "^55.0.5",
-        "@expo/json-file": "^10.0.13",
-        "@expo/require-utils": "^55.0.4",
-        "deepmerge": "^4.3.1",
-        "getenv": "^2.0.0",
-        "glob": "^13.0.0",
-        "resolve-workspace-root": "^2.0.0",
-        "semver": "^7.6.0",
-        "slugify": "^1.3.4"
-      }
-    },
-    "node_modules/expo-notifications/node_modules/@expo/config-plugins": {
-      "version": "55.0.8",
-      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-55.0.8.tgz",
-      "integrity": "sha512-8WfWTRntTCcowfOS+tHdB0z98gKetTwktg4G5TWkCkXVa8Jt1NUnvzaaU4UHk2vbR2U4N84RyZJFizSwfF6C9g==",
-      "license": "MIT",
-      "dependencies": {
-        "@expo/config-types": "^55.0.5",
-        "@expo/json-file": "~10.0.13",
-        "@expo/plist": "^0.5.2",
-        "@expo/sdk-runtime-versions": "^1.0.0",
-        "chalk": "^4.1.2",
-        "debug": "^4.3.5",
-        "getenv": "^2.0.0",
-        "glob": "^13.0.0",
-        "resolve-from": "^5.0.0",
-        "semver": "^7.5.4",
-        "slugify": "^1.6.6",
-        "xcode": "^3.0.1",
-        "xml2js": "0.6.0"
-      }
-    },
-    "node_modules/expo-notifications/node_modules/@expo/config-types": {
-      "version": "55.0.5",
-      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-55.0.5.tgz",
-      "integrity": "sha512-sCmSUZG4mZ/ySXvfyyBdhjivz8Q539X1NondwDdYG7s3SBsk+wsgPJzYsqgAG/P9+l0xWjUD2F+kQ1cAJ6NNLg==",
-      "license": "MIT"
-    },
-    "node_modules/expo-notifications/node_modules/@expo/env": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@expo/env/-/env-2.1.1.tgz",
-      "integrity": "sha512-rVvHC4I6xlPcg+mAO09ydUi2Wjv1ZytpLmHOSzvXzBAz9mMrJggqCe4s4dubjJvi/Ino/xQCLhbaLCnTtLpikg==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.0.0",
-        "debug": "^4.3.4",
-        "getenv": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=20.12.0"
-      }
-    },
-    "node_modules/expo-notifications/node_modules/@expo/plist": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.5.2.tgz",
-      "integrity": "sha512-o4xdVdBpe4aTl3sPMZ2u3fJH4iG1I768EIRk1xRZP+GaFI93MaR3JvoFibYqxeTmLQ1p1kNEVqylfUjezxx45g==",
-      "license": "MIT",
-      "dependencies": {
-        "@xmldom/xmldom": "^0.8.8",
-        "base64-js": "^1.5.1",
-        "xmlbuilder": "^15.1.1"
-      }
-    },
-    "node_modules/expo-notifications/node_modules/expo-constants": {
-      "version": "55.0.13",
-      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-55.0.13.tgz",
-      "integrity": "sha512-imSsHm94KWsJbBLvjsUNgubcPQ3H6dXaAm0IZj2Y6+XEdJmjWo2JreriYmeSu/azmpiYUd3Y7K+/Hq9WXQ2Elg==",
-      "license": "MIT",
-      "dependencies": {
-        "@expo/config": "~55.0.14",
-        "@expo/env": "~2.1.1"
-      },
-      "peerDependencies": {
-        "expo": "*",
-        "react-native": "*"
-      }
-    },
-    "node_modules/expo-notifications/node_modules/glob": {
-      "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "minimatch": "^10.2.2",
-        "minipass": "^7.1.3",
-        "path-scurry": "^2.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/expo-secure-store": {
-      "version": "55.0.13",
-      "resolved": "https://registry.npmjs.org/expo-secure-store/-/expo-secure-store-55.0.13.tgz",
-      "integrity": "sha512-I6r0JNO1Fd4o0Gu7Ixiic7s89lqgdUHq17uBH9y1f/AntoyKn71TdtYJH82RgfsBbu5qNVzrwImmvlANyOlITQ==",
+      "version": "15.0.8",
+      "resolved": "https://registry.npmjs.org/expo-secure-store/-/expo-secure-store-15.0.8.tgz",
+      "integrity": "sha512-lHnzvRajBu4u+P99+0GEMijQMFCOYpWRO4dWsXSuMt77+THPIGjzNvVKrGSl6mMrLsfVaKL8BpwYZLGlgA+zAw==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*"
@@ -7075,6 +6961,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/expo/node_modules/babel-plugin-react-compiler": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-react-compiler/-/babel-plugin-react-compiler-1.0.0.tgz",
+      "integrity": "sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.26.0"
       }
     },
     "node_modules/expo/node_modules/babel-plugin-react-native-web": {
@@ -7353,7 +7248,6 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
       "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-callable": "^1.2.7"
@@ -7464,7 +7358,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
       "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7492,7 +7385,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -7526,7 +7418,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -7675,7 +7566,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7723,7 +7613,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0"
@@ -7752,7 +7641,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7765,7 +7653,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -8104,6 +7991,22 @@
         "loose-envify": "^1.0.0"
       }
     },
+    "node_modules/is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-array-buffer": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
@@ -8186,7 +8089,6 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8309,7 +8211,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
       "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.4",
@@ -8344,6 +8245,22 @@
       "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-nan": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
+      "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -8411,7 +8328,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
       "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -8507,7 +8423,6 @@
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
       "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "which-typed-array": "^1.1.16"
@@ -9061,14 +8976,14 @@
       }
     },
     "node_modules/jest-expo": {
-      "version": "55.0.13",
-      "resolved": "https://registry.npmjs.org/jest-expo/-/jest-expo-55.0.13.tgz",
-      "integrity": "sha512-HMI2IDOsnoQnKbUNPPLuM+XDQ8QD+QUVP7ETeQWYeq87SUZWKYV+vMwwtRiZFawGnYEqYx0qj8iL0RzKXlFNWA==",
+      "version": "54.0.17",
+      "resolved": "https://registry.npmjs.org/jest-expo/-/jest-expo-54.0.17.tgz",
+      "integrity": "sha512-LyIhrsP4xvHEEcR1R024u/LBj3uPpAgB+UljgV+YXWkEHjprnr0KpE4tROsMNYCVTM1pPlAnPuoBmn5gnAN9KA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@expo/config": "~55.0.12",
-        "@expo/json-file": "^10.0.13",
+        "@expo/config": "~12.0.13",
+        "@expo/json-file": "^10.0.8",
         "@jest/create-cache-key-function": "^29.2.1",
         "@jest/globals": "^29.2.1",
         "babel-jest": "^29.2.1",
@@ -9078,7 +8993,7 @@
         "jest-watch-typeahead": "2.2.1",
         "json5": "^2.2.3",
         "lodash": "^4.17.19",
-        "react-test-renderer": "19.2.0",
+        "react-test-renderer": "19.1.0",
         "server-only": "^0.0.1",
         "stacktrace-js": "^2.0.2"
       },
@@ -9095,106 +9010,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/jest-expo/node_modules/@expo/config": {
-      "version": "55.0.12",
-      "resolved": "https://registry.npmjs.org/@expo/config/-/config-55.0.12.tgz",
-      "integrity": "sha512-qVih0IrjupykH/yAUilZqW1RCpqm8TKG8XJabji2VHI1LstGqw0NJAsBjX927yns08u/fFJTwOsB4PYOoq1HiA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@expo/config-plugins": "~55.0.7",
-        "@expo/config-types": "^55.0.5",
-        "@expo/json-file": "^10.0.13",
-        "@expo/require-utils": "^55.0.3",
-        "deepmerge": "^4.3.1",
-        "getenv": "^2.0.0",
-        "glob": "^13.0.0",
-        "resolve-from": "^5.0.0",
-        "resolve-workspace-root": "^2.0.0",
-        "semver": "^7.6.0",
-        "slugify": "^1.3.4"
-      }
-    },
-    "node_modules/jest-expo/node_modules/@expo/config-plugins": {
-      "version": "55.0.7",
-      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-55.0.7.tgz",
-      "integrity": "sha512-XZUoDWrsHEkH3yasnDSJABM/UxP5a1ixzRwU/M+BToyn/f0nTrSJJe/Ay/FpxkI4JSNz2n0e06I23b2bleXKVA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@expo/config-types": "^55.0.5",
-        "@expo/json-file": "~10.0.12",
-        "@expo/plist": "^0.5.2",
-        "@expo/sdk-runtime-versions": "^1.0.0",
-        "chalk": "^4.1.2",
-        "debug": "^4.3.5",
-        "getenv": "^2.0.0",
-        "glob": "^13.0.0",
-        "resolve-from": "^5.0.0",
-        "semver": "^7.5.4",
-        "slugify": "^1.6.6",
-        "xcode": "^3.0.1",
-        "xml2js": "0.6.0"
-      }
-    },
-    "node_modules/jest-expo/node_modules/@expo/config-types": {
-      "version": "55.0.5",
-      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-55.0.5.tgz",
-      "integrity": "sha512-sCmSUZG4mZ/ySXvfyyBdhjivz8Q539X1NondwDdYG7s3SBsk+wsgPJzYsqgAG/P9+l0xWjUD2F+kQ1cAJ6NNLg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/jest-expo/node_modules/@expo/plist": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.5.2.tgz",
-      "integrity": "sha512-o4xdVdBpe4aTl3sPMZ2u3fJH4iG1I768EIRk1xRZP+GaFI93MaR3JvoFibYqxeTmLQ1p1kNEVqylfUjezxx45g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@xmldom/xmldom": "^0.8.8",
-        "base64-js": "^1.5.1",
-        "xmlbuilder": "^15.1.1"
-      }
-    },
-    "node_modules/jest-expo/node_modules/glob": {
-      "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "minimatch": "^10.2.2",
-        "minipass": "^7.1.3",
-        "path-scurry": "^2.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/jest-expo/node_modules/react-test-renderer": {
-      "version": "19.2.0",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-19.2.0.tgz",
-      "integrity": "sha512-zLCFMHFE9vy/w3AxO0zNxy6aAupnCuLSVOJYDe/Tp+ayGI1f2PLQsFVPANSD42gdSbmYx5oN+1VWDhcXtq7hAQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "react-is": "^19.2.0",
-        "scheduler": "^0.27.0"
-      },
-      "peerDependencies": {
-        "react": "^19.2.0"
-      }
-    },
-    "node_modules/jest-expo/node_modules/scheduler": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
-      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/jest-get-type": {
       "version": "29.6.3",
@@ -10526,7 +10341,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -11254,11 +11068,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/object-is": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -11268,7 +11097,6 @@
       "version": "4.1.7",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
       "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -11833,7 +11661,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
       "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -12845,7 +12672,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
       "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -13019,7 +12845,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
@@ -13696,18 +13521,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/tagged-tag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
-      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/tar": {
       "version": "7.5.13",
       "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
@@ -14241,6 +14054,19 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
+      }
+    },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -14498,7 +14324,6 @@
       "version": "1.1.20",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
       "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
@@ -14740,34 +14565,6 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
-      }
-    },
-    "node_modules/zxing-wasm": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/zxing-wasm/-/zxing-wasm-3.0.2.tgz",
-      "integrity": "sha512-2YMAriaYHX9wrBY2k7H0epSo+dyCaCZg/vOtt+nEDXM9ul480gkXz/9SkwpOeHcD2H5qqDG8lWDSBwpTcZpa6w==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/emscripten": "^1.41.5",
-        "type-fest": "^5.5.0"
-      },
-      "peerDependencies": {
-        "@types/emscripten": ">=1.39.6"
-      }
-    },
-    "node_modules/zxing-wasm/node_modules/type-fest": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.5.0.tgz",
-      "integrity": "sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g==",
-      "license": "(MIT OR CC0-1.0)",
-      "dependencies": {
-        "tagged-tag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "expo-network": "~8.0.8",
     "expo-notifications": "~0.32.11",
     "expo-secure-store": "~15.0.7",
-    "expo-sharing": "~14.2.0",
+    "expo-sharing": "^55.0.18",
     "expo-status-bar": "~3.0.9",
     "react": "19.1.0",
     "react-native": "0.81.5",

--- a/src/components/BackEdgeSwipe.tsx
+++ b/src/components/BackEdgeSwipe.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import { View, StyleSheet, Dimensions } from 'react-native';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import Animated, {
+  useAnimatedStyle,
+  useSharedValue,
+  useFrameCallback,
+  runOnJS,
+  withTiming,
+} from 'react-native-reanimated';
+import { useNavigation } from '@react-navigation/native';
+
+import { gestureConfig } from '../utils/gestureConfig';
+import { pushSample, sampledVelocity, useVelocityBuffer } from '../utils/gestureVelocity';
+import { commitForBack } from '../utils/gestureMachine';
+import { hapticSelection } from '../utils/haptics';
+
+const { width: SCREEN_W } = Dimensions.get('window');
+
+/**
+ * Thin affordance layer around the native back-swipe gesture. Does NOT drive
+ * navigation — native-stack handles that. Emits:
+ *   - haptic selection when the swipe crosses the hybrid-progress threshold
+ *   - progressive edge-shadow visual as the user drags
+ */
+export function BackEdgeSwipe({ children }: { children: React.ReactNode }) {
+  const navigation = useNavigation();
+  // Don't activate on screens with nothing to go back to.
+  const canGo = navigation.canGoBack();
+
+  const progress = useSharedValue(0);
+  const thresholdFired = useSharedValue(false);
+  const buf = useVelocityBuffer();
+  const currentT = useSharedValue(0);
+  useFrameCallback(({ timestamp }) => {
+    'worklet';
+    currentT.value = timestamp;
+  });
+
+  const fireHaptic = React.useCallback(() => {
+    hapticSelection();
+  }, []);
+
+  const pan = Gesture.Pan()
+    .enabled(canGo)
+    .activeOffsetX([gestureConfig.axisLockDp, 9999])
+    .hitSlop({ left: 0, width: gestureConfig.leftEdgeWidthDp })
+    .onBegin(() => {
+      'worklet';
+      progress.value = 0;
+      thresholdFired.value = false;
+      buf.value = [];
+    })
+    .onUpdate((e) => {
+      'worklet';
+      const dx = Math.max(0, e.translationX);
+      const travel = SCREEN_W * gestureConfig.backTravelRatio;
+      const p = Math.max(0, Math.min(1, dx / travel));
+      progress.value = p;
+      pushSample(buf.value, e.translationX, e.translationY, currentT.value);
+
+      if (!thresholdFired.value && p >= gestureConfig.backHybridProgress) {
+        thresholdFired.value = true;
+        runOnJS(fireHaptic)();
+      }
+    })
+    .onEnd((e) => {
+      'worklet';
+      pushSample(buf.value, e.translationX, e.translationY, currentT.value);
+      const { vx } = sampledVelocity(buf.value, currentT.value);
+      const reason = commitForBack({ progress: progress.value, velocity: vx, holdMs: 0 });
+      // The native gesture owns navigation; we just animate our edge shadow out.
+      if (reason !== 'none') {
+        progress.value = withTiming(1, { duration: 120 });
+      } else {
+        progress.value = withTiming(0, { duration: 160 });
+      }
+    });
+
+  const edgeShadowStyle = useAnimatedStyle(() => ({
+    opacity: progress.value * 0.6,
+    width: 12 + progress.value * 24,
+  }));
+
+  if (!canGo) {
+    return <>{children}</>;
+  }
+
+  return (
+    <View style={{ flex: 1 }}>
+      <GestureDetector gesture={pan}>
+        <View style={styles.edgeCatch} collapsable={false} />
+      </GestureDetector>
+      <View style={{ flex: 1 }}>{children}</View>
+      <Animated.View pointerEvents="none" style={[styles.edgeShadow, edgeShadowStyle]} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  edgeCatch: {
+    position: 'absolute',
+    top: 0,
+    bottom: 0,
+    left: 0,
+    width: gestureConfig.leftEdgeWidthDp,
+    zIndex: 100,
+  },
+  edgeShadow: {
+    position: 'absolute',
+    top: 0,
+    bottom: 0,
+    left: 0,
+    backgroundColor: 'rgba(0,0,0,0.18)',
+    zIndex: 99,
+  },
+});

--- a/src/components/BackEdgeSwipe.tsx
+++ b/src/components/BackEdgeSwipe.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { View, StyleSheet, Dimensions } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
@@ -6,7 +6,6 @@ import Animated, {
   useSharedValue,
   useFrameCallback,
   runOnJS,
-  withTiming,
 } from 'react-native-reanimated';
 import { useNavigation } from '@react-navigation/native';
 
@@ -14,6 +13,7 @@ import { gestureConfig } from '../utils/gestureConfig';
 import { pushSample, sampledVelocity, useVelocityBuffer } from '../utils/gestureVelocity';
 import { commitForBack } from '../utils/gestureMachine';
 import { hapticSelection } from '../utils/haptics';
+import { settle, useGestureReduceMotion } from '../utils/useGestureReduceMotion';
 
 const { width: SCREEN_W } = Dimensions.get('window');
 
@@ -27,6 +27,12 @@ export function BackEdgeSwipe({ children }: { children: React.ReactNode }) {
   const navigation = useNavigation();
   // Don't activate on screens with nothing to go back to.
   const canGo = navigation.canGoBack();
+
+  const reduceMotion = useGestureReduceMotion();
+  const reduceMotionShared = useSharedValue(reduceMotion);
+  useEffect(() => {
+    reduceMotionShared.value = reduceMotion;
+  }, [reduceMotion, reduceMotionShared]);
 
   const progress = useSharedValue(0);
   const thresholdFired = useSharedValue(false);
@@ -71,9 +77,9 @@ export function BackEdgeSwipe({ children }: { children: React.ReactNode }) {
       const reason = commitForBack({ progress: progress.value, velocity: vx, holdMs: 0 });
       // The native gesture owns navigation; we just animate our edge shadow out.
       if (reason !== 'none') {
-        progress.value = withTiming(1, { duration: 120 });
+        progress.value = settle(1, 'backSettle', reduceMotionShared.value);
       } else {
-        progress.value = withTiming(0, { duration: 160 });
+        progress.value = settle(0, 'backSettle', reduceMotionShared.value);
       }
     });
 
@@ -89,7 +95,12 @@ export function BackEdgeSwipe({ children }: { children: React.ReactNode }) {
   return (
     <View style={{ flex: 1 }}>
       <GestureDetector gesture={pan}>
-        <View style={styles.edgeCatch} collapsable={false} />
+        <View
+          style={styles.edgeCatch}
+          collapsable={false}
+          accessible={false}
+          importantForAccessibility="no-hide-descendants"
+        />
       </GestureDetector>
       <View style={{ flex: 1 }}>{children}</View>
       <Animated.View pointerEvents="none" style={[styles.edgeShadow, edgeShadowStyle]} />

--- a/src/components/ControlCenterOverlay.tsx
+++ b/src/components/ControlCenterOverlay.tsx
@@ -1,15 +1,15 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { View, Text, StyleSheet, Dimensions } from 'react-native';
 import Animated, {
   useSharedValue,
   useAnimatedStyle,
-  withSpring,
   runOnJS,
 } from 'react-native-reanimated';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import { gestureConfig } from '../utils/gestureConfig';
 import { useVelocityBuffer, pushSample, sampledVelocity } from '../utils/gestureVelocity';
 import { commitForPanel } from '../utils/gestureMachine';
+import { settle, useGestureReduceMotion } from '../utils/useGestureReduceMotion';
 
 const { height: SCREEN_HEIGHT } = Dimensions.get('window');
 
@@ -26,6 +26,12 @@ interface Props {
 }
 
 export function ControlCenterOverlay({ zone, onCommit }: Props) {
+  const reduceMotion = useGestureReduceMotion();
+  const reduceMotionShared = useSharedValue(reduceMotion);
+  useEffect(() => {
+    reduceMotionShared.value = reduceMotion;
+  }, [reduceMotion, reduceMotionShared]);
+
   const panelProgress = useSharedValue(0);
   const buf = useVelocityBuffer();
   const startedInZone = useSharedValue(false);
@@ -54,7 +60,7 @@ export function ControlCenterOverlay({ zone, onCommit }: Props) {
     .onEnd((e) => {
       'worklet';
       if (!startedInZone.value) {
-        panelProgress.value = withSpring(0, gestureConfig.spring.fastSettle);
+        panelProgress.value = settle(0, 'fastSettle', reduceMotionShared.value);
         return;
       }
       currentT.value = Date.now();
@@ -63,10 +69,10 @@ export function ControlCenterOverlay({ zone, onCommit }: Props) {
       const progress = panelProgress.value;
       const reason = commitForPanel({ progress, velocity: vy, holdMs: 0 });
       if (reason !== 'none') {
-        panelProgress.value = withSpring(1, gestureConfig.spring.mediumSettle);
+        panelProgress.value = settle(1, 'mediumSettle', reduceMotionShared.value);
         runOnJS(onCommit)();
       } else {
-        panelProgress.value = withSpring(0, gestureConfig.spring.fastSettle);
+        panelProgress.value = settle(0, 'fastSettle', reduceMotionShared.value);
       }
     });
 
@@ -96,8 +102,13 @@ export function ControlCenterOverlay({ zone, onCommit }: Props) {
         pointerEvents="none"
       />
 
-      {/* Sliding preview sheet */}
-      <Animated.View style={[styles.sheet, sheetStyle]} pointerEvents="none">
+      {/* Sliding preview sheet — visual only, hidden from screen readers */}
+      <Animated.View
+        style={[styles.sheet, sheetStyle]}
+        pointerEvents="none"
+        accessible={false}
+        importantForAccessibility="no-hide-descendants"
+      >
         <View style={styles.handle} />
         <Text style={styles.title}>Control Center</Text>
         <View style={styles.tileRow}>
@@ -108,7 +119,7 @@ export function ControlCenterOverlay({ zone, onCommit }: Props) {
         </View>
       </Animated.View>
 
-      {/* Activation zone — intercepts touches in the top-right corner */}
+      {/* Activation zone — intercepts touches in the top-right corner; hidden from TalkBack */}
       <View
         style={[
           styles.activationZone,
@@ -120,6 +131,8 @@ export function ControlCenterOverlay({ zone, onCommit }: Props) {
           },
         ]}
         pointerEvents="auto"
+        accessible={false}
+        importantForAccessibility="no-hide-descendants"
       >
         <GestureDetector gesture={pan}>
           <View style={StyleSheet.absoluteFill} />

--- a/src/components/ControlCenterOverlay.tsx
+++ b/src/components/ControlCenterOverlay.tsx
@@ -1,0 +1,174 @@
+import React from 'react';
+import { View, Text, StyleSheet, Dimensions } from 'react-native';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withSpring,
+  runOnJS,
+} from 'react-native-reanimated';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import { gestureConfig } from '../utils/gestureConfig';
+import { useVelocityBuffer, pushSample, sampledVelocity } from '../utils/gestureVelocity';
+import { commitForPanel } from '../utils/gestureMachine';
+
+const { height: SCREEN_HEIGHT } = Dimensions.get('window');
+
+interface Zone {
+  top: number;
+  bottom: number;
+  left: number;
+  right: number;
+}
+
+interface Props {
+  zone: Zone;
+  onCommit: () => void;
+}
+
+export function ControlCenterOverlay({ zone, onCommit }: Props) {
+  const panelProgress = useSharedValue(0);
+  const buf = useVelocityBuffer();
+  const startedInZone = useSharedValue(false);
+  // Wall-clock timestamp updated per gesture event
+  const currentT = useSharedValue(0);
+
+  const pan = Gesture.Pan()
+    .onBegin((e) => {
+      'worklet';
+      buf.value = [];
+      startedInZone.value =
+        e.absoluteX >= zone.left &&
+        e.absoluteX <= zone.right &&
+        e.absoluteY >= zone.top &&
+        e.absoluteY <= zone.bottom;
+      currentT.value = e.absoluteY; // approximate; overwritten in onUpdate
+    })
+    .onUpdate((e) => {
+      'worklet';
+      if (!startedInZone.value) return;
+      currentT.value = Date.now();
+      pushSample(buf.value, e.translationX, e.translationY, currentT.value);
+      const dy = Math.max(0, e.translationY);
+      panelProgress.value = Math.max(0, Math.min(1, dy / gestureConfig.panelTravelDp));
+    })
+    .onEnd((e) => {
+      'worklet';
+      if (!startedInZone.value) {
+        panelProgress.value = withSpring(0, gestureConfig.spring.fastSettle);
+        return;
+      }
+      currentT.value = Date.now();
+      pushSample(buf.value, e.translationX, e.translationY, currentT.value);
+      const { vy } = sampledVelocity(buf.value, currentT.value);
+      const progress = panelProgress.value;
+      const reason = commitForPanel({ progress, velocity: vy, holdMs: 0 });
+      if (reason !== 'none') {
+        panelProgress.value = withSpring(1, gestureConfig.spring.mediumSettle);
+        runOnJS(onCommit)();
+      } else {
+        panelProgress.value = withSpring(0, gestureConfig.spring.fastSettle);
+      }
+    });
+
+  const sheetStyle = useAnimatedStyle(() => {
+    'worklet';
+    const translateY = -SCREEN_HEIGHT * (1 - panelProgress.value);
+    return {
+      transform: [{ translateY }],
+    };
+  });
+
+  const backdropStyle = useAnimatedStyle(() => {
+    'worklet';
+    return {
+      opacity: panelProgress.value * 0.5,
+    };
+  });
+
+  const zoneWidth = zone.right - zone.left;
+  const zoneHeight = zone.bottom - zone.top;
+
+  return (
+    <>
+      {/* Dark backdrop */}
+      <Animated.View
+        style={[StyleSheet.absoluteFill, styles.backdrop, backdropStyle]}
+        pointerEvents="none"
+      />
+
+      {/* Sliding preview sheet */}
+      <Animated.View style={[styles.sheet, sheetStyle]} pointerEvents="none">
+        <View style={styles.handle} />
+        <Text style={styles.title}>Control Center</Text>
+        <View style={styles.tileRow}>
+          <View style={styles.tile} />
+          <View style={styles.tile} />
+          <View style={styles.tile} />
+          <View style={styles.tile} />
+        </View>
+      </Animated.View>
+
+      {/* Activation zone — intercepts touches in the top-right corner */}
+      <View
+        style={[
+          styles.activationZone,
+          {
+            top: zone.top,
+            left: zone.left,
+            width: zoneWidth,
+            height: zoneHeight,
+          },
+        ]}
+        pointerEvents="auto"
+      >
+        <GestureDetector gesture={pan}>
+          <View style={StyleSheet.absoluteFill} />
+        </GestureDetector>
+      </View>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    backgroundColor: '#000',
+  },
+  sheet: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    height: SCREEN_HEIGHT * 0.55,
+    backgroundColor: 'rgba(28,28,30,0.92)',
+    borderBottomLeftRadius: 20,
+    borderBottomRightRadius: 20,
+    alignItems: 'center',
+    paddingTop: 12,
+  },
+  handle: {
+    width: 36,
+    height: 4,
+    borderRadius: 2,
+    backgroundColor: 'rgba(255,255,255,0.35)',
+    marginBottom: 16,
+  },
+  title: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: '600',
+    marginBottom: 24,
+  },
+  tileRow: {
+    flexDirection: 'row',
+    gap: 12,
+  },
+  tile: {
+    width: 56,
+    height: 56,
+    borderRadius: 14,
+    backgroundColor: 'rgba(255,255,255,0.12)',
+  },
+  activationZone: {
+    position: 'absolute',
+  },
+});

--- a/src/components/GestureHost.tsx
+++ b/src/components/GestureHost.tsx
@@ -1,0 +1,76 @@
+import React, { createContext, useContext, useMemo } from 'react';
+import { StyleSheet } from 'react-native';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  SharedValue,
+} from 'react-native-reanimated';
+
+export type GestureHostMode = 'none' | 'home' | 'switcher';
+
+interface GestureHostContextValue {
+  scale: SharedValue<number>;
+  radius: SharedValue<number>;
+  shadow: SharedValue<number>;       // 0..1
+  wallpaperDim: SharedValue<number>; // 0..1, reserved for future switcher visuals
+  mode: SharedValue<GestureHostMode>;
+}
+
+const GestureHostContext = createContext<GestureHostContextValue | null>(null);
+
+export function useGestureHost(): GestureHostContextValue {
+  const ctx = useContext(GestureHostContext);
+  if (!ctx) throw new Error('useGestureHost must be used inside <GestureHost>');
+  return ctx;
+}
+
+/** Returns null outside a provider — HomeIndicator uses this so it is safe
+ *  to render in tests/stories without a host wrapping it. */
+export function useOptionalGestureHost(): GestureHostContextValue | null {
+  return useContext(GestureHostContext);
+}
+
+export function GestureHost({ children }: { children: React.ReactNode }) {
+  const scale = useSharedValue(1);
+  const radius = useSharedValue(0);
+  const shadow = useSharedValue(0);
+  const wallpaperDim = useSharedValue(0);
+  const mode = useSharedValue<GestureHostMode>('none');
+
+  const value = useMemo(
+    () => ({ scale, radius, shadow, wallpaperDim, mode }),
+    // shared values are stable refs — deps array intentionally empty
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
+
+  const hostStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: scale.value }],
+    borderRadius: radius.value,
+    // iOS-style shadow — soft and large
+    shadowOpacity: shadow.value * 0.35,
+    shadowRadius: shadow.value * 28,
+    shadowOffset: { width: 0, height: shadow.value * 16 },
+    shadowColor: '#000',
+    // Android elevation — overflow hidden so rounded corners clip children
+    overflow: 'hidden',
+    elevation: shadow.value * 24,
+  }));
+
+  // TODO: wallpaperDim could drive a full-screen overlay here for deeper
+  // switcher-mode visuals (e.g. dimming what's visible through the gap at
+  // the edges as the host scales down). Skipped for now — wallpaperDim is
+  // already written by HomeIndicator and ready to wire up.
+
+  return (
+    <GestureHostContext.Provider value={value}>
+      <Animated.View style={[styles.host, hostStyle]}>
+        {children}
+      </Animated.View>
+    </GestureHostContext.Provider>
+  );
+}
+
+const styles = StyleSheet.create({
+  host: { flex: 1, backgroundColor: 'transparent' },
+});

--- a/src/components/HomeIndicator.tsx
+++ b/src/components/HomeIndicator.tsx
@@ -6,22 +6,20 @@ import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
   useAnimatedStyle,
   useSharedValue,
+  useFrameCallback,
   withSpring,
   withTiming,
   runOnJS,
 } from 'react-native-reanimated';
 import * as Haptics from 'expo-haptics';
 
-// iOS-matched thresholds (from reverse-engineered gesture behavior):
-// - Home:         short upward swipe OR high upward velocity
-// - App switcher: deeper upward swipe with a hold/pause near mid-screen
-// - Lateral drift cancels the gesture
-const HOME_DISTANCE = 60;          // pt — short swipe triggers home
-const SWITCHER_DISTANCE = 180;     // pt — deeper swipe with pause triggers app switcher
-const HOME_VELOCITY = 500;         // pt/s — flick velocity alternative to distance
-const SWITCHER_HOLD_MS = 400;      // ms — hold near mid-swipe to summon switcher
-const LATERAL_CANCEL = 80;         // pt — sideways drift cancels the gesture
-const IDLE_DIM_MS = 2500;          // ms — pill fades after inactivity (AssistiveTouch-inspired)
+import { gestureConfig } from '../utils/gestureConfig';
+import { pushSample, sampledVelocity, useVelocityBuffer } from '../utils/gestureVelocity';
+import { useGestureMachine, commitForHome, commitForSwitcher } from '../utils/gestureMachine';
+import { hapticImpact, hapticSelection } from '../utils/haptics';
+
+// Keep idle-dim constants local (not gesture thresholds — these are UI-only)
+const IDLE_DIM_MS = 2500; // ms — pill fades after inactivity
 const IDLE_OPACITY = 0.35;
 
 interface HomeIndicatorProps {
@@ -43,6 +41,20 @@ export function HomeIndicator({ onHome, onSwitcher, navigationRef, variant = 'li
   const opacity = useSharedValue(1);
   const idleTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  // Frame-callback timestamp — updated every frame on the UI thread, safe to
+  // read from inside Pan worklets without JS round-trips.
+  const currentT = useSharedValue(0);
+  useFrameCallback(({ timestamp }) => {
+    'worklet';
+    currentT.value = timestamp;
+  });
+
+  // Multi-sample velocity buffer
+  const buf = useVelocityBuffer();
+
+  // Shared state machine (home commit predicate)
+  const machine = useGestureMachine({ shouldCommit: commitForHome });
+
   const wake = useCallback(() => {
     opacity.value = withTiming(1, { duration: 150 });
     if (idleTimer.current) clearTimeout(idleTimer.current);
@@ -59,7 +71,7 @@ export function HomeIndicator({ onHome, onSwitcher, navigationRef, variant = 'li
   }, [wake]);
 
   const doHome = useCallback(async () => {
-    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+    hapticImpact(Haptics.ImpactFeedbackStyle.Medium);
     if (onHome) return onHome();
     if (Platform.OS === 'android') {
       try {
@@ -78,7 +90,7 @@ export function HomeIndicator({ onHome, onSwitcher, navigationRef, variant = 'li
   }, [onHome, navigationRef]);
 
   const doSwitcher = useCallback(() => {
-    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy);
+    hapticImpact(Haptics.ImpactFeedbackStyle.Heavy);
     if (onSwitcher) return onSwitcher();
     try {
       navigationRef?.current?.navigate('Multitask' as never);
@@ -87,13 +99,12 @@ export function HomeIndicator({ onHome, onSwitcher, navigationRef, variant = 'li
     }
   }, [onSwitcher, navigationRef]);
 
-  // Track whether a mid-swipe hold triggered "switcher mode" already
-  const heldForSwitcher = useSharedValue(0);
-  const holdScheduled = useSharedValue(0);
-  const thresholdHapticFired = useSharedValue(0);
+  const fireHapticThreshold = useCallback(() => {
+    hapticSelection();
+  }, []);
 
-  const fireLightHaptic = useCallback(() => {
-    Haptics.selectionAsync().catch(() => {});
+  const fireHapticHoldConfirm = useCallback(() => {
+    hapticImpact(Haptics.ImpactFeedbackStyle.Light);
   }, []);
 
   const pan = Gesture.Pan()
@@ -101,67 +112,79 @@ export function HomeIndicator({ onHome, onSwitcher, navigationRef, variant = 'li
     .minDistance(8)
     .onBegin(() => {
       'worklet';
-      heldForSwitcher.value = 0;
-      holdScheduled.value = 0;
-      thresholdHapticFired.value = 0;
+      machine.reset();
+      machine.startT.value = currentT.value;
+      machine.phase.value = 'possible';
+      buf.value = [];
       runOnJS(wake)();
     })
     .onUpdate((e) => {
       'worklet';
+      machine.phase.value = 'tracking';
+
       const dy = Math.min(0, e.translationY); // only track upward
       translateY.value = dy;
 
-      // Haptic tick the first time we cross the "home" threshold
-      if (!thresholdHapticFired.value && Math.abs(dy) >= HOME_DISTANCE) {
-        thresholdHapticFired.value = 1;
-        runOnJS(fireLightHaptic)();
+      // Clamp progress [0,1] based on upward travel vs full homeTravelDp
+      const progress = Math.max(0, Math.min(1, -dy / gestureConfig.homeTravelDp));
+      machine.progress.value = progress;
+
+      // Push sample into velocity buffer
+      pushSample(buf.value, e.translationX, e.translationY, currentT.value);
+      const { vy } = sampledVelocity(buf.value, currentT.value);
+
+      // Axis-lock: cancel if lateral drift exceeds threshold
+      if (Math.abs(e.translationX) > gestureConfig.axisLockDp * 8) {
+        translateY.value = withSpring(0, gestureConfig.spring.homeSettle);
+        machine.phase.value = 'cancelled';
+        return;
       }
 
-      // Lateral drift cancels — match iOS's lock-to-axis behavior
-      if (Math.abs(e.translationX) > LATERAL_CANCEL) {
-        translateY.value = withSpring(0, { damping: 15, stiffness: 180 });
-        thresholdHapticFired.value = 0;
+      // Haptic tick at hybrid-progress threshold crossing
+      if (!machine.thresholdFired.value && progress >= gestureConfig.homeHybridProgress) {
+        machine.thresholdFired.value = true;
+        runOnJS(fireHapticThreshold)();
+      }
+
+      // Switcher hold predicate check (in-worklet — no setInterval)
+      if (!machine.holdFired.value) {
+        const holdMs = currentT.value - machine.startT.value;
+        const switcherResult = commitForSwitcher({ progress, velocity: vy, holdMs });
+        if (switcherResult === 'hold') {
+          machine.holdFired.value = true;
+          runOnJS(fireHapticHoldConfirm)();
+        }
       }
     })
     .onEnd((e) => {
       'worklet';
-      const dy = Math.min(0, e.translationY);
-      const vy = e.velocityY;
-      translateY.value = withSpring(0, { damping: 20, stiffness: 220 });
+      translateY.value = withSpring(0, gestureConfig.spring.homeSettle);
 
-      // Deep swipe OR held mid-swipe → app switcher
-      if (Math.abs(dy) >= SWITCHER_DISTANCE || heldForSwitcher.value === 1) {
+      const dy = Math.min(0, e.translationY);
+      const progress = Math.max(0, Math.min(1, -dy / gestureConfig.homeTravelDp));
+
+      // Final velocity from multi-sample buffer
+      pushSample(buf.value, e.translationX, e.translationY, currentT.value);
+      const { vy } = sampledVelocity(buf.value, currentT.value);
+
+      const holdMs = currentT.value - machine.startT.value;
+
+      if (machine.phase.value === 'cancelled') {
+        return;
+      }
+
+      // Switcher: hold was confirmed during drag
+      if (machine.holdFired.value) {
         runOnJS(doSwitcher)();
         return;
       }
-      // Short swipe OR flick → home
-      if (Math.abs(dy) >= HOME_DISTANCE || vy <= -HOME_VELOCITY) {
+
+      // Home: evaluate three-path commit predicate
+      const homeResult = commitForHome({ progress, velocity: vy, holdMs });
+      if (homeResult !== 'none') {
         runOnJS(doHome)();
       }
     });
-
-  // Separate detector for the "hold at midpoint" behavior, used alongside pan.
-  // When the user pauses their finger past the home threshold but below
-  // switcher-distance, we summon the switcher after SWITCHER_HOLD_MS.
-  useEffect(() => {
-    const id = setInterval(() => {
-      const dy = Math.abs(translateY.value);
-      if (dy >= HOME_DISTANCE && dy < SWITCHER_DISTANCE) {
-        if (!holdScheduled.value) {
-          holdScheduled.value = 1;
-          setTimeout(() => {
-            if (Math.abs(translateY.value) >= HOME_DISTANCE && Math.abs(translateY.value) < SWITCHER_DISTANCE) {
-              heldForSwitcher.value = 1;
-              Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium).catch(() => {});
-            }
-          }, SWITCHER_HOLD_MS);
-        }
-      } else {
-        holdScheduled.value = 0;
-      }
-    }, 80);
-    return () => clearInterval(id);
-  }, [translateY, holdScheduled, heldForSwitcher]);
 
   // AssistiveTouch-inspired convenience: double-tap the pill as a shortcut
   // to the app switcher for users who find the precise swipe awkward.
@@ -176,7 +199,8 @@ export function HomeIndicator({ onHome, onSwitcher, navigationRef, variant = 'li
 
   const pillStyle = useAnimatedStyle(() => ({
     opacity: opacity.value,
-    transform: [{ translateY: translateY.value * 0.15 }], // subtle follow while swiping
+    // Pill rises ~10dp at full progress (machine.progress.value = 1)
+    transform: [{ translateY: machine.progress.value * -10 }],
   }));
 
   const pillColor = variant === 'dark' ? 'rgba(0,0,0,0.4)' : 'rgba(255,255,255,0.5)';

--- a/src/components/HomeIndicator.tsx
+++ b/src/components/HomeIndicator.tsx
@@ -7,7 +7,6 @@ import Animated, {
   useAnimatedStyle,
   useSharedValue,
   useFrameCallback,
-  withSpring,
   withTiming,
   runOnJS,
 } from 'react-native-reanimated';
@@ -17,6 +16,7 @@ import { gestureConfig } from '../utils/gestureConfig';
 import { pushSample, sampledVelocity, useVelocityBuffer } from '../utils/gestureVelocity';
 import { useGestureMachine, commitForHome, commitForSwitcher } from '../utils/gestureMachine';
 import { hapticImpact, hapticSelection } from '../utils/haptics';
+import { useGestureReduceMotion, settle } from '../utils/useGestureReduceMotion';
 import { useOptionalGestureHost } from './GestureHost';
 
 // Keep idle-dim constants local (not gesture thresholds — these are UI-only)
@@ -38,10 +38,15 @@ interface HomeIndicatorProps {
 export function HomeIndicator({ onHome, onSwitcher, navigationRef, variant = 'light' }: HomeIndicatorProps) {
   const insets = useSafeAreaInsets();
   const host = useOptionalGestureHost();
+  const reduceMotion = useGestureReduceMotion();
 
   const translateY = useSharedValue(0);
   const opacity = useSharedValue(1);
   const idleTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const reduceMotionShared = useSharedValue(reduceMotion);
+  useEffect(() => {
+    reduceMotionShared.value = reduceMotion;
+  }, [reduceMotion, reduceMotionShared]);
 
   // Frame-callback timestamp — updated every frame on the UI thread, safe to
   // read from inside Pan worklets without JS round-trips.
@@ -165,7 +170,7 @@ export function HomeIndicator({ onHome, onSwitcher, navigationRef, variant = 'li
 
       // Axis-lock: cancel if lateral drift exceeds threshold
       if (Math.abs(e.translationX) > gestureConfig.axisLockDp * 8) {
-        translateY.value = withSpring(0, gestureConfig.spring.homeSettle);
+        translateY.value = settle(0, 'homeSettle', reduceMotionShared.value);
         machine.phase.value = 'cancelled';
         return;
       }
@@ -188,7 +193,7 @@ export function HomeIndicator({ onHome, onSwitcher, navigationRef, variant = 'li
     })
     .onEnd((e) => {
       'worklet';
-      translateY.value = withSpring(0, gestureConfig.spring.homeSettle);
+      translateY.value = settle(0, 'homeSettle', reduceMotionShared.value);
 
       const dy = Math.min(0, e.translationY);
       const progress = Math.max(0, Math.min(1, -dy / gestureConfig.homeTravelDp));
@@ -201,9 +206,9 @@ export function HomeIndicator({ onHome, onSwitcher, navigationRef, variant = 'li
 
       if (machine.phase.value === 'cancelled') {
         if (host) {
-          host.scale.value = withSpring(1, gestureConfig.spring.homeSettle);
-          host.radius.value = withSpring(0, gestureConfig.spring.homeSettle);
-          host.shadow.value = withSpring(0, gestureConfig.spring.homeSettle);
+          host.scale.value = settle(1, 'homeSettle', reduceMotionShared.value);
+          host.radius.value = settle(0, 'homeSettle', reduceMotionShared.value);
+          host.shadow.value = settle(0, 'homeSettle', reduceMotionShared.value);
           host.mode.value = 'none';
         }
         return;
@@ -212,9 +217,9 @@ export function HomeIndicator({ onHome, onSwitcher, navigationRef, variant = 'li
       // Switcher: hold was confirmed during drag
       if (machine.holdFired.value) {
         if (host) {
-          host.scale.value = withSpring(1, gestureConfig.spring.switcherSettle);
-          host.radius.value = withSpring(0, gestureConfig.spring.switcherSettle);
-          host.shadow.value = withSpring(0, gestureConfig.spring.switcherSettle);
+          host.scale.value = settle(1, 'switcherSettle', reduceMotionShared.value);
+          host.radius.value = settle(0, 'switcherSettle', reduceMotionShared.value);
+          host.shadow.value = settle(0, 'switcherSettle', reduceMotionShared.value);
           host.mode.value = 'none';
         }
         runOnJS(doSwitcher)();
@@ -225,18 +230,18 @@ export function HomeIndicator({ onHome, onSwitcher, navigationRef, variant = 'li
       const homeResult = commitForHome({ progress, velocity: vy, holdMs });
       if (homeResult !== 'none') {
         if (host) {
-          host.scale.value = withSpring(1, gestureConfig.spring.homeSettle);
-          host.radius.value = withSpring(0, gestureConfig.spring.homeSettle);
-          host.shadow.value = withSpring(0, gestureConfig.spring.homeSettle);
+          host.scale.value = settle(1, 'homeSettle', reduceMotionShared.value);
+          host.radius.value = settle(0, 'homeSettle', reduceMotionShared.value);
+          host.shadow.value = settle(0, 'homeSettle', reduceMotionShared.value);
           host.mode.value = 'none';
         }
         runOnJS(doHome)();
       } else {
         // Cancelled by insufficient gesture — spring back to identity
         if (host) {
-          host.scale.value = withSpring(1, gestureConfig.spring.homeSettle);
-          host.radius.value = withSpring(0, gestureConfig.spring.homeSettle);
-          host.shadow.value = withSpring(0, gestureConfig.spring.homeSettle);
+          host.scale.value = settle(1, 'homeSettle', reduceMotionShared.value);
+          host.radius.value = settle(0, 'homeSettle', reduceMotionShared.value);
+          host.shadow.value = settle(0, 'homeSettle', reduceMotionShared.value);
           host.mode.value = 'none';
         }
       }

--- a/src/components/HomeIndicator.tsx
+++ b/src/components/HomeIndicator.tsx
@@ -17,6 +17,7 @@ import { gestureConfig } from '../utils/gestureConfig';
 import { pushSample, sampledVelocity, useVelocityBuffer } from '../utils/gestureVelocity';
 import { useGestureMachine, commitForHome, commitForSwitcher } from '../utils/gestureMachine';
 import { hapticImpact, hapticSelection } from '../utils/haptics';
+import { useOptionalGestureHost } from './GestureHost';
 
 // Keep idle-dim constants local (not gesture thresholds — these are UI-only)
 const IDLE_DIM_MS = 2500; // ms — pill fades after inactivity
@@ -36,6 +37,7 @@ interface HomeIndicatorProps {
 
 export function HomeIndicator({ onHome, onSwitcher, navigationRef, variant = 'light' }: HomeIndicatorProps) {
   const insets = useSafeAreaInsets();
+  const host = useOptionalGestureHost();
 
   const translateY = useSharedValue(0);
   const opacity = useSharedValue(1);
@@ -117,6 +119,13 @@ export function HomeIndicator({ onHome, onSwitcher, navigationRef, variant = 'li
       machine.phase.value = 'possible';
       buf.value = [];
       runOnJS(wake)();
+      if (host) {
+        host.scale.value = 1;
+        host.radius.value = 0;
+        host.shadow.value = 0;
+        host.wallpaperDim.value = 0;
+        host.mode.value = 'none';
+      }
     })
     .onUpdate((e) => {
       'worklet';
@@ -128,6 +137,27 @@ export function HomeIndicator({ onHome, onSwitcher, navigationRef, variant = 'li
       // Clamp progress [0,1] based on upward travel vs full homeTravelDp
       const progress = Math.max(0, Math.min(1, -dy / gestureConfig.homeTravelDp));
       machine.progress.value = progress;
+
+      if (host) {
+        if (machine.holdFired.value) {
+          host.mode.value = 'switcher';
+          host.scale.value = 1 - progress * 0.14; // 1.0 -> 0.86
+        } else {
+          host.mode.value = 'home';
+          host.scale.value = 1 - progress * 0.08; // 1.0 -> 0.92
+        }
+        host.radius.value = progress * 22;
+        // Shadow ramps quickly then levels off
+        host.shadow.value =
+          progress < 0.15
+            ? (progress / 0.15) * 0.35
+            : 0.35 + (progress - 0.15) * (0.65 / 0.85);
+        // Wallpaper dim only in switcher mode and only after progress > 0.22
+        host.wallpaperDim.value =
+          machine.holdFired.value && progress >= 0.22
+            ? Math.min(1, (progress - 0.22) / 0.4) * 0.2
+            : 0;
+      }
 
       // Push sample into velocity buffer
       pushSample(buf.value, e.translationX, e.translationY, currentT.value);
@@ -170,11 +200,23 @@ export function HomeIndicator({ onHome, onSwitcher, navigationRef, variant = 'li
       const holdMs = currentT.value - machine.startT.value;
 
       if (machine.phase.value === 'cancelled') {
+        if (host) {
+          host.scale.value = withSpring(1, gestureConfig.spring.homeSettle);
+          host.radius.value = withSpring(0, gestureConfig.spring.homeSettle);
+          host.shadow.value = withSpring(0, gestureConfig.spring.homeSettle);
+          host.mode.value = 'none';
+        }
         return;
       }
 
       // Switcher: hold was confirmed during drag
       if (machine.holdFired.value) {
+        if (host) {
+          host.scale.value = withSpring(1, gestureConfig.spring.switcherSettle);
+          host.radius.value = withSpring(0, gestureConfig.spring.switcherSettle);
+          host.shadow.value = withSpring(0, gestureConfig.spring.switcherSettle);
+          host.mode.value = 'none';
+        }
         runOnJS(doSwitcher)();
         return;
       }
@@ -182,7 +224,21 @@ export function HomeIndicator({ onHome, onSwitcher, navigationRef, variant = 'li
       // Home: evaluate three-path commit predicate
       const homeResult = commitForHome({ progress, velocity: vy, holdMs });
       if (homeResult !== 'none') {
+        if (host) {
+          host.scale.value = withSpring(1, gestureConfig.spring.homeSettle);
+          host.radius.value = withSpring(0, gestureConfig.spring.homeSettle);
+          host.shadow.value = withSpring(0, gestureConfig.spring.homeSettle);
+          host.mode.value = 'none';
+        }
         runOnJS(doHome)();
+      } else {
+        // Cancelled by insufficient gesture — spring back to identity
+        if (host) {
+          host.scale.value = withSpring(1, gestureConfig.spring.homeSettle);
+          host.radius.value = withSpring(0, gestureConfig.spring.homeSettle);
+          host.shadow.value = withSpring(0, gestureConfig.spring.homeSettle);
+          host.mode.value = 'none';
+        }
       }
     });
 

--- a/src/components/NotificationCenterOverlay.tsx
+++ b/src/components/NotificationCenterOverlay.tsx
@@ -1,0 +1,171 @@
+import React from 'react';
+import { View, Text, StyleSheet, Dimensions } from 'react-native';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withSpring,
+  runOnJS,
+} from 'react-native-reanimated';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import { gestureConfig } from '../utils/gestureConfig';
+import { useVelocityBuffer, pushSample, sampledVelocity } from '../utils/gestureVelocity';
+import { commitForNC } from '../utils/gestureMachine';
+
+const { height: SCREEN_HEIGHT } = Dimensions.get('window');
+
+interface Zone {
+  top: number;
+  bottom: number;
+  left: number;
+  right: number;
+}
+
+interface Props {
+  zone: Zone;
+  onCommit: () => void;
+}
+
+export function NotificationCenterOverlay({ zone, onCommit }: Props) {
+  const panelProgress = useSharedValue(0);
+  const buf = useVelocityBuffer();
+  const startedInZone = useSharedValue(false);
+  const currentT = useSharedValue(0);
+
+  const pan = Gesture.Pan()
+    .onBegin((e) => {
+      'worklet';
+      buf.value = [];
+      startedInZone.value =
+        e.absoluteX >= zone.left &&
+        e.absoluteX <= zone.right &&
+        e.absoluteY >= zone.top &&
+        e.absoluteY <= zone.bottom;
+      currentT.value = 0;
+    })
+    .onUpdate((e) => {
+      'worklet';
+      if (!startedInZone.value) return;
+      currentT.value = Date.now();
+      pushSample(buf.value, e.translationX, e.translationY, currentT.value);
+      const dy = Math.max(0, e.translationY);
+      panelProgress.value = Math.max(0, Math.min(1, dy / gestureConfig.panelTravelDp));
+    })
+    .onEnd((e) => {
+      'worklet';
+      if (!startedInZone.value) {
+        panelProgress.value = withSpring(0, gestureConfig.spring.fastSettle);
+        return;
+      }
+      currentT.value = Date.now();
+      pushSample(buf.value, e.translationX, e.translationY, currentT.value);
+      const { vy } = sampledVelocity(buf.value, currentT.value);
+      const progress = panelProgress.value;
+      const reason = commitForNC({ progress, velocity: vy, holdMs: 0 });
+      if (reason !== 'none') {
+        panelProgress.value = withSpring(1, gestureConfig.spring.mediumSettle);
+        runOnJS(onCommit)();
+      } else {
+        panelProgress.value = withSpring(0, gestureConfig.spring.fastSettle);
+      }
+    });
+
+  const sheetStyle = useAnimatedStyle(() => {
+    'worklet';
+    const translateY = -SCREEN_HEIGHT * (1 - panelProgress.value);
+    return {
+      transform: [{ translateY }],
+    };
+  });
+
+  const backdropStyle = useAnimatedStyle(() => {
+    'worklet';
+    return {
+      opacity: panelProgress.value * 0.5,
+    };
+  });
+
+  const zoneWidth = zone.right - zone.left;
+  const zoneHeight = zone.bottom - zone.top;
+
+  return (
+    <>
+      {/* Dark backdrop */}
+      <Animated.View
+        style={[StyleSheet.absoluteFill, styles.backdrop, backdropStyle]}
+        pointerEvents="none"
+      />
+
+      {/* Sliding preview sheet */}
+      <Animated.View style={[styles.sheet, sheetStyle]} pointerEvents="none">
+        <View style={styles.handle} />
+        <Text style={styles.title}>Notification Center</Text>
+        <View style={styles.notifRow}>
+          <View style={styles.notifBar} />
+          <View style={[styles.notifBar, { opacity: 0.6 }]} />
+          <View style={[styles.notifBar, { opacity: 0.4 }]} />
+        </View>
+      </Animated.View>
+
+      {/* Activation zone — intercepts touches in the top-left strip */}
+      <View
+        style={[
+          styles.activationZone,
+          {
+            top: zone.top,
+            left: zone.left,
+            width: zoneWidth,
+            height: zoneHeight,
+          },
+        ]}
+        pointerEvents="auto"
+      >
+        <GestureDetector gesture={pan}>
+          <View style={StyleSheet.absoluteFill} />
+        </GestureDetector>
+      </View>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    backgroundColor: '#000',
+  },
+  sheet: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    height: SCREEN_HEIGHT * 0.65,
+    backgroundColor: 'rgba(28,28,30,0.92)',
+    borderBottomLeftRadius: 20,
+    borderBottomRightRadius: 20,
+    alignItems: 'center',
+    paddingTop: 12,
+  },
+  handle: {
+    width: 36,
+    height: 4,
+    borderRadius: 2,
+    backgroundColor: 'rgba(255,255,255,0.35)',
+    marginBottom: 16,
+  },
+  title: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: '600',
+    marginBottom: 24,
+  },
+  notifRow: {
+    width: '85%',
+    gap: 10,
+  },
+  notifBar: {
+    height: 52,
+    borderRadius: 14,
+    backgroundColor: 'rgba(255,255,255,0.10)',
+  },
+  activationZone: {
+    position: 'absolute',
+  },
+});

--- a/src/components/NotificationCenterOverlay.tsx
+++ b/src/components/NotificationCenterOverlay.tsx
@@ -1,15 +1,15 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { View, Text, StyleSheet, Dimensions } from 'react-native';
 import Animated, {
   useSharedValue,
   useAnimatedStyle,
-  withSpring,
   runOnJS,
 } from 'react-native-reanimated';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import { gestureConfig } from '../utils/gestureConfig';
 import { useVelocityBuffer, pushSample, sampledVelocity } from '../utils/gestureVelocity';
 import { commitForNC } from '../utils/gestureMachine';
+import { settle, useGestureReduceMotion } from '../utils/useGestureReduceMotion';
 
 const { height: SCREEN_HEIGHT } = Dimensions.get('window');
 
@@ -26,6 +26,12 @@ interface Props {
 }
 
 export function NotificationCenterOverlay({ zone, onCommit }: Props) {
+  const reduceMotion = useGestureReduceMotion();
+  const reduceMotionShared = useSharedValue(reduceMotion);
+  useEffect(() => {
+    reduceMotionShared.value = reduceMotion;
+  }, [reduceMotion, reduceMotionShared]);
+
   const panelProgress = useSharedValue(0);
   const buf = useVelocityBuffer();
   const startedInZone = useSharedValue(false);
@@ -53,7 +59,7 @@ export function NotificationCenterOverlay({ zone, onCommit }: Props) {
     .onEnd((e) => {
       'worklet';
       if (!startedInZone.value) {
-        panelProgress.value = withSpring(0, gestureConfig.spring.fastSettle);
+        panelProgress.value = settle(0, 'fastSettle', reduceMotionShared.value);
         return;
       }
       currentT.value = Date.now();
@@ -62,10 +68,10 @@ export function NotificationCenterOverlay({ zone, onCommit }: Props) {
       const progress = panelProgress.value;
       const reason = commitForNC({ progress, velocity: vy, holdMs: 0 });
       if (reason !== 'none') {
-        panelProgress.value = withSpring(1, gestureConfig.spring.mediumSettle);
+        panelProgress.value = settle(1, 'mediumSettle', reduceMotionShared.value);
         runOnJS(onCommit)();
       } else {
-        panelProgress.value = withSpring(0, gestureConfig.spring.fastSettle);
+        panelProgress.value = settle(0, 'fastSettle', reduceMotionShared.value);
       }
     });
 
@@ -95,8 +101,13 @@ export function NotificationCenterOverlay({ zone, onCommit }: Props) {
         pointerEvents="none"
       />
 
-      {/* Sliding preview sheet */}
-      <Animated.View style={[styles.sheet, sheetStyle]} pointerEvents="none">
+      {/* Sliding preview sheet — visual only, hidden from screen readers */}
+      <Animated.View
+        style={[styles.sheet, sheetStyle]}
+        pointerEvents="none"
+        accessible={false}
+        importantForAccessibility="no-hide-descendants"
+      >
         <View style={styles.handle} />
         <Text style={styles.title}>Notification Center</Text>
         <View style={styles.notifRow}>
@@ -106,7 +117,7 @@ export function NotificationCenterOverlay({ zone, onCommit }: Props) {
         </View>
       </Animated.View>
 
-      {/* Activation zone — intercepts touches in the top-left strip */}
+      {/* Activation zone — intercepts touches in the top-left strip; hidden from TalkBack */}
       <View
         style={[
           styles.activationZone,
@@ -118,6 +129,8 @@ export function NotificationCenterOverlay({ zone, onCommit }: Props) {
           },
         ]}
         pointerEvents="auto"
+        accessible={false}
+        importantForAccessibility="no-hide-descendants"
       >
         <GestureDetector gesture={pan}>
           <View style={StyleSheet.absoluteFill} />

--- a/src/components/QuickSwitchHomeBar.tsx
+++ b/src/components/QuickSwitchHomeBar.tsx
@@ -6,7 +6,6 @@ import Animated, {
   useAnimatedStyle,
   useFrameCallback,
   useSharedValue,
-  withSpring,
 } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
@@ -14,6 +13,7 @@ import { gestureConfig } from '../utils/gestureConfig';
 import { GestureHaptics } from '../utils/gestureHaptics';
 import { commitForQuickSwitch } from '../utils/gestureMachine';
 import { pushSample, sampledVelocity, useVelocityBuffer } from '../utils/gestureVelocity';
+import { settle, useGestureReduceMotion } from '../utils/useGestureReduceMotion';
 import { useApps } from '../store/AppsStore';
 
 const { width: SCREEN_W } = Dimensions.get('window');
@@ -25,6 +25,11 @@ export function QuickSwitchHomeBar() {
   const { recentApps, apps, launchApp } = useApps();
 
   const insets = useSafeAreaInsets();
+  const reduceMotion = useGestureReduceMotion();
+  const reduceMotionShared = useSharedValue(reduceMotion);
+  useEffect(() => {
+    reduceMotionShared.value = reduceMotion;
+  }, [reduceMotion, reduceMotionShared]);
 
   // Shared values
   const currentT = useSharedValue(0);
@@ -91,18 +96,19 @@ export function QuickSwitchHomeBar() {
 
         if (canGo) {
           runOnJS(onCommitSwitch)(direction);
-          swipeOffset.value = withSpring(
+          swipeOffset.value = settle(
             dx < 0 ? -SCREEN_W : SCREEN_W,
-            gestureConfig.spring.softCarousel,
+            'softCarousel',
+            reduceMotionShared.value,
           );
         } else {
           // No destination — snap back
-          swipeOffset.value = withSpring(0, gestureConfig.spring.fastSettle);
+          swipeOffset.value = settle(0, 'fastSettle', reduceMotionShared.value);
         }
       } else {
-        swipeOffset.value = withSpring(0, gestureConfig.spring.fastSettle);
+        swipeOffset.value = settle(0, 'fastSettle', reduceMotionShared.value);
       }
-      previewOpacity.value = withSpring(0, gestureConfig.spring.fastSettle);
+      previewOpacity.value = settle(0, 'fastSettle', reduceMotionShared.value);
     });
 
   // Resolve display apps: [prev (index 2), current (index 0), next (index 1)]
@@ -125,9 +131,15 @@ export function QuickSwitchHomeBar() {
       <View
         style={[styles.strip, { paddingBottom: bottomPad }]}
         pointerEvents="auto"
+        accessible={false}
+        importantForAccessibility="no-hide-descendants"
       >
-        {/* Preview row — only visible during drag */}
-        <Animated.View style={[styles.previewRow, rowStyle]}>
+        {/* Preview row — only visible during drag; hidden from screen readers */}
+        <Animated.View
+          style={[styles.previewRow, rowStyle]}
+          accessible={false}
+          importantForAccessibility="no-hide-descendants"
+        >
           {/* Previous app slot (rightward swipe target) */}
           <View style={styles.appSlot}>
             {prevApp ? (

--- a/src/components/QuickSwitchHomeBar.tsx
+++ b/src/components/QuickSwitchHomeBar.tsx
@@ -1,0 +1,225 @@
+import React, { useCallback, useEffect } from 'react';
+import { Dimensions, Image, StyleSheet, Text, View } from 'react-native';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import Animated, {
+  runOnJS,
+  useAnimatedStyle,
+  useFrameCallback,
+  useSharedValue,
+  withSpring,
+} from 'react-native-reanimated';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { gestureConfig } from '../utils/gestureConfig';
+import { GestureHaptics } from '../utils/gestureHaptics';
+import { commitForQuickSwitch } from '../utils/gestureMachine';
+import { pushSample, sampledVelocity, useVelocityBuffer } from '../utils/gestureVelocity';
+import { useApps } from '../store/AppsStore';
+
+const { width: SCREEN_W } = Dimensions.get('window');
+
+const ICON_SIZE = 48;
+const ICON_SLOT_W = 80; // icon + horizontal padding per slot
+
+export function QuickSwitchHomeBar() {
+  const { recentApps, apps, launchApp } = useApps();
+
+  const insets = useSafeAreaInsets();
+
+  // Shared values
+  const currentT = useSharedValue(0);
+  useFrameCallback(({ timestamp }) => {
+    'worklet';
+    currentT.value = timestamp;
+  });
+
+  const buf = useVelocityBuffer();
+  const swipeOffset = useSharedValue(0);
+  const previewOpacity = useSharedValue(0);
+
+  // Availability flags on the JS side, mirrored to shared values for worklet access
+  const canSwipeLeft = recentApps.length >= 2;
+  const canSwipeRight = recentApps.length >= 3;
+  const canSwipeLeftShared = useSharedValue(canSwipeLeft);
+  const canSwipeRightShared = useSharedValue(canSwipeRight);
+
+  useEffect(() => {
+    canSwipeLeftShared.value = recentApps.length >= 2;
+    canSwipeRightShared.value = recentApps.length >= 3;
+  }, [recentApps, canSwipeLeftShared, canSwipeRightShared]);
+
+  const onCommitSwitch = useCallback(
+    (dir: 'left' | 'right') => {
+      GestureHaptics.commit('light');
+      const idx = dir === 'left' ? 1 : 2;
+      const target = recentApps[idx];
+      if (!target) return;
+      launchApp(target.packageName);
+    },
+    [recentApps, launchApp],
+  );
+
+  const pan = Gesture.Pan()
+    .enabled(recentApps.length > 0)
+    .activeOffsetX([-gestureConfig.axisLockDp, gestureConfig.axisLockDp])
+    .failOffsetY([-gestureConfig.axisLockDp * 2, gestureConfig.axisLockDp * 2])
+    .onBegin(() => {
+      'worklet';
+      buf.value = [];
+      swipeOffset.value = 0;
+      previewOpacity.value = 0;
+    })
+    .onUpdate((e) => {
+      'worklet';
+      pushSample(buf.value, e.translationX, e.translationY, currentT.value);
+      swipeOffset.value = e.translationX;
+      // Ramp opacity in from 0 once the user has dragged 10dp
+      const drag = Math.abs(e.translationX);
+      previewOpacity.value = Math.min(1, Math.max(0, (drag - 10) / 20));
+    })
+    .onEnd((e) => {
+      'worklet';
+      pushSample(buf.value, e.translationX, e.translationY, currentT.value);
+      const { vx } = sampledVelocity(buf.value, currentT.value);
+      const dx = e.translationX;
+      const progress = Math.abs(dx) / gestureConfig.quickSwitchDistanceDp;
+      const reason = commitForQuickSwitch({ progress, velocity: vx, holdMs: 0 });
+
+      if (reason !== 'none') {
+        const direction: 'left' | 'right' = dx < 0 ? 'left' : 'right';
+        const canGo = direction === 'left' ? canSwipeLeftShared.value : canSwipeRightShared.value;
+
+        if (canGo) {
+          runOnJS(onCommitSwitch)(direction);
+          swipeOffset.value = withSpring(
+            dx < 0 ? -SCREEN_W : SCREEN_W,
+            gestureConfig.spring.softCarousel,
+          );
+        } else {
+          // No destination — snap back
+          swipeOffset.value = withSpring(0, gestureConfig.spring.fastSettle);
+        }
+      } else {
+        swipeOffset.value = withSpring(0, gestureConfig.spring.fastSettle);
+      }
+      previewOpacity.value = withSpring(0, gestureConfig.spring.fastSettle);
+    });
+
+  // Resolve display apps: [prev (index 2), current (index 0), next (index 1)]
+  const resolveApp = (packageName: string) =>
+    apps.find((a) => a.packageName === packageName) ?? null;
+
+  const currentApp = recentApps[0] ? resolveApp(recentApps[0].packageName) : null;
+  const nextApp = recentApps[1] ? resolveApp(recentApps[1].packageName) : null;
+  const prevApp = recentApps[2] ? resolveApp(recentApps[2].packageName) : null;
+
+  const rowStyle = useAnimatedStyle(() => ({
+    transform: [{ translateX: swipeOffset.value }],
+    opacity: previewOpacity.value,
+  }));
+
+  const bottomPad = Math.max(insets.bottom, 6);
+
+  return (
+    <GestureDetector gesture={pan}>
+      <View
+        style={[styles.strip, { paddingBottom: bottomPad }]}
+        pointerEvents="auto"
+      >
+        {/* Preview row — only visible during drag */}
+        <Animated.View style={[styles.previewRow, rowStyle]}>
+          {/* Previous app slot (rightward swipe target) */}
+          <View style={styles.appSlot}>
+            {prevApp ? (
+              <>
+                {prevApp.icon ? (
+                  <Image source={{ uri: prevApp.icon }} style={styles.appIcon} />
+                ) : (
+                  <View style={[styles.appIcon, styles.appIconFallback]} />
+                )}
+                <Text style={styles.appLabel} numberOfLines={1}>
+                  {prevApp.name}
+                </Text>
+              </>
+            ) : null}
+          </View>
+
+          {/* Current app slot (center) */}
+          <View style={styles.appSlot}>
+            {currentApp ? (
+              <>
+                {currentApp.icon ? (
+                  <Image source={{ uri: currentApp.icon }} style={styles.appIcon} />
+                ) : (
+                  <View style={[styles.appIcon, styles.appIconFallback]} />
+                )}
+                <Text style={styles.appLabel} numberOfLines={1}>
+                  {currentApp.name}
+                </Text>
+              </>
+            ) : null}
+          </View>
+
+          {/* Next app slot (leftward swipe target) */}
+          <View style={styles.appSlot}>
+            {nextApp ? (
+              <>
+                {nextApp.icon ? (
+                  <Image source={{ uri: nextApp.icon }} style={styles.appIcon} />
+                ) : (
+                  <View style={[styles.appIcon, styles.appIconFallback]} />
+                )}
+                <Text style={styles.appLabel} numberOfLines={1}>
+                  {nextApp.name}
+                </Text>
+              </>
+            ) : null}
+          </View>
+        </Animated.View>
+      </View>
+    </GestureDetector>
+  );
+}
+
+const styles = StyleSheet.create({
+  strip: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    height: gestureConfig.bottomZoneHeightDp + 14, // match HomeIndicator's paddingTop catch area
+    zIndex: 49,
+    alignItems: 'center',
+    justifyContent: 'flex-end',
+    overflow: 'hidden',
+  },
+  previewRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: ICON_SLOT_W * 3,
+    marginBottom: 6,
+  },
+  appSlot: {
+    width: ICON_SLOT_W,
+    alignItems: 'center',
+    justifyContent: 'flex-end',
+  },
+  appIcon: {
+    width: ICON_SIZE,
+    height: ICON_SIZE,
+    borderRadius: 12,
+  },
+  appIconFallback: {
+    backgroundColor: 'rgba(120,120,120,0.5)',
+  },
+  appLabel: {
+    marginTop: 4,
+    fontSize: 10,
+    color: '#ffffff',
+    textAlign: 'center',
+    textShadowColor: 'rgba(0,0,0,0.6)',
+    textShadowOffset: { width: 0, height: 1 },
+    textShadowRadius: 2,
+  },
+});

--- a/src/components/SpotlightReveal.tsx
+++ b/src/components/SpotlightReveal.tsx
@@ -1,0 +1,138 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withSpring,
+  runOnJS,
+  useFrameCallback,
+} from 'react-native-reanimated';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import { gestureConfig } from '../utils/gestureConfig';
+import { useVelocityBuffer, pushSample, sampledVelocity } from '../utils/gestureVelocity';
+import { commitForSpotlight } from '../utils/gestureMachine';
+
+interface SpotlightRevealProps {
+  enabled: boolean;   // false when folder open / jiggling / anything that should suppress
+  onCommit: () => void; // called at settling — navigates to SpotlightSearch
+}
+
+export function SpotlightReveal({ enabled, onCommit }: SpotlightRevealProps) {
+  const progress = useSharedValue(0);   // 0..1 relative to spotlightCommitDp
+  const thresholdFired = useSharedValue(false);
+  const buf = useVelocityBuffer();
+  const currentT = useSharedValue(0);
+
+  useFrameCallback(({ timestamp }) => {
+    'worklet';
+    currentT.value = timestamp;
+  });
+
+  const pan = Gesture.Pan()
+    .enabled(enabled)
+    .activeOffsetY([gestureConfig.axisLockDp, 9999])
+    .onBegin(() => {
+      'worklet';
+      progress.value = 0;
+      thresholdFired.value = false;
+      buf.value = [];
+    })
+    .onUpdate((e) => {
+      'worklet';
+      const dy = Math.max(0, e.translationY);
+      pushSample(buf.value, e.translationX, e.translationY, currentT.value);
+      // Below reveal start, stay at 0 — spec §11.2 says don't interpolate noise
+      if (dy < gestureConfig.spotlightRevealDp) {
+        progress.value = 0;
+        return;
+      }
+      // Map dy to 0..1 over spotlightCommitDp so progress >= 1 means committed-by-distance
+      progress.value = Math.min(1.5, (dy - gestureConfig.spotlightRevealDp) / gestureConfig.spotlightCommitDp);
+    })
+    .onEnd((e) => {
+      'worklet';
+      pushSample(buf.value, e.translationX, e.translationY, currentT.value);
+      const { vy } = sampledVelocity(buf.value, currentT.value);
+      // Pass the distance-normalised progress (clamped) to commitForSpotlight
+      const p = Math.min(1, Math.max(0, progress.value));
+      const reason = commitForSpotlight({ progress: p, velocity: vy, holdMs: 0 });
+      if (reason !== 'none') {
+        progress.value = withSpring(1.5, gestureConfig.spring.mediumSettle);
+        runOnJS(onCommit)();
+      } else {
+        progress.value = withSpring(0, gestureConfig.spring.fastSettle);
+      }
+    });
+
+  // Animated affordance: search field that slides in from above
+  const fieldStyle = useAnimatedStyle(() => {
+    'worklet';
+    const p = Math.min(1, progress.value);
+    return {
+      opacity: p,
+      transform: [{ translateY: (p - 1) * 30 }], // slides from -30 to 0
+    };
+  });
+
+  const dimStyle = useAnimatedStyle(() => {
+    'worklet';
+    const p = Math.min(1, progress.value);
+    return { opacity: p * 0.4 };
+  });
+
+  return (
+    <>
+      {/* Full-screen dim overlay behind the content */}
+      <Animated.View
+        pointerEvents="none"
+        style={[StyleSheet.absoluteFill, styles.dim, dimStyle]}
+      />
+      {/* Search field affordance */}
+      <Animated.View pointerEvents="none" style={[styles.fieldHolder, fieldStyle]}>
+        <View style={styles.field}>
+          <Text style={styles.fieldLabel}>Search</Text>
+        </View>
+      </Animated.View>
+      {/* Invisible activation region below the status bar, above the bottom strip */}
+      <GestureDetector gesture={pan}>
+        <View style={styles.hitArea} collapsable={false} />
+      </GestureDetector>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  dim: {
+    backgroundColor: '#000',
+    zIndex: 19,
+  },
+  fieldHolder: {
+    position: 'absolute',
+    left: '10%',
+    right: '10%',
+    top: 80,
+    zIndex: 21,
+    alignItems: 'center',
+  },
+  field: {
+    width: '100%',
+    height: 36,
+    borderRadius: 10,
+    backgroundColor: 'rgba(255,255,255,0.25)',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  fieldLabel: {
+    color: 'rgba(255,255,255,0.7)',
+    fontSize: 15,
+    fontWeight: '400',
+  },
+  hitArea: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    top: 60,
+    bottom: 60,
+    zIndex: 20,
+  },
+});

--- a/src/components/SpotlightReveal.tsx
+++ b/src/components/SpotlightReveal.tsx
@@ -1,9 +1,8 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import Animated, {
   useSharedValue,
   useAnimatedStyle,
-  withSpring,
   runOnJS,
   useFrameCallback,
 } from 'react-native-reanimated';
@@ -11,6 +10,7 @@ import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import { gestureConfig } from '../utils/gestureConfig';
 import { useVelocityBuffer, pushSample, sampledVelocity } from '../utils/gestureVelocity';
 import { commitForSpotlight } from '../utils/gestureMachine';
+import { settle, useGestureReduceMotion } from '../utils/useGestureReduceMotion';
 
 interface SpotlightRevealProps {
   enabled: boolean;   // false when folder open / jiggling / anything that should suppress
@@ -18,6 +18,12 @@ interface SpotlightRevealProps {
 }
 
 export function SpotlightReveal({ enabled, onCommit }: SpotlightRevealProps) {
+  const reduceMotion = useGestureReduceMotion();
+  const reduceMotionShared = useSharedValue(reduceMotion);
+  useEffect(() => {
+    reduceMotionShared.value = reduceMotion;
+  }, [reduceMotion, reduceMotionShared]);
+
   const progress = useSharedValue(0);   // 0..1 relative to spotlightCommitDp
   const thresholdFired = useSharedValue(false);
   const buf = useVelocityBuffer();
@@ -57,10 +63,10 @@ export function SpotlightReveal({ enabled, onCommit }: SpotlightRevealProps) {
       const p = Math.min(1, Math.max(0, progress.value));
       const reason = commitForSpotlight({ progress: p, velocity: vy, holdMs: 0 });
       if (reason !== 'none') {
-        progress.value = withSpring(1.5, gestureConfig.spring.mediumSettle);
+        progress.value = settle(1.5, 'mediumSettle', reduceMotionShared.value);
         runOnJS(onCommit)();
       } else {
-        progress.value = withSpring(0, gestureConfig.spring.fastSettle);
+        progress.value = settle(0, 'fastSettle', reduceMotionShared.value);
       }
     });
 
@@ -87,15 +93,25 @@ export function SpotlightReveal({ enabled, onCommit }: SpotlightRevealProps) {
         pointerEvents="none"
         style={[StyleSheet.absoluteFill, styles.dim, dimStyle]}
       />
-      {/* Search field affordance */}
-      <Animated.View pointerEvents="none" style={[styles.fieldHolder, fieldStyle]}>
+      {/* Search field affordance — preview only, real field is on SpotlightSearchScreen */}
+      <Animated.View
+        pointerEvents="none"
+        style={[styles.fieldHolder, fieldStyle]}
+        accessibilityLabel="Spotlight Search"
+        importantForAccessibility="no-hide-descendants"
+      >
         <View style={styles.field}>
           <Text style={styles.fieldLabel}>Search</Text>
         </View>
       </Animated.View>
-      {/* Invisible activation region below the status bar, above the bottom strip */}
+      {/* Invisible activation region — hidden from TalkBack */}
       <GestureDetector gesture={pan}>
-        <View style={styles.hitArea} collapsable={false} />
+        <View
+          style={styles.hitArea}
+          collapsable={false}
+          accessible={false}
+          importantForAccessibility="no-hide-descendants"
+        />
       </GestureDetector>
     </>
   );

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -22,3 +22,6 @@ export { CupertinoShareSheet } from './CupertinoShareSheet';
 export { NotificationBanner } from './NotificationBanner';
 export type { BannerNotification } from './NotificationBanner';
 export { HomeIndicator } from './HomeIndicator';
+export { GestureHost, useGestureHost, useOptionalGestureHost } from './GestureHost';
+export type { GestureHostMode } from './GestureHost';
+export { BackEdgeSwipe } from './BackEdgeSwipe';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -25,3 +25,4 @@ export { HomeIndicator } from './HomeIndicator';
 export { GestureHost, useGestureHost, useOptionalGestureHost } from './GestureHost';
 export type { GestureHostMode } from './GestureHost';
 export { BackEdgeSwipe } from './BackEdgeSwipe';
+export { QuickSwitchHomeBar } from './QuickSwitchHomeBar';

--- a/src/screens/ContactsScreen.tsx
+++ b/src/screens/ContactsScreen.tsx
@@ -7,7 +7,7 @@ import { StatusBar } from 'expo-status-bar';
 import { useTheme } from '../theme/ThemeContext';
 import { useContacts } from '../store/ContactsStore';
 import { useDevice, DeviceContact } from '../store/DeviceStore';
-import { CupertinoNavigationBar, CupertinoSearchBar, CupertinoActionSheet, CupertinoButton, SkeletonListRow } from '../components';
+import { CupertinoNavigationBar, CupertinoSearchBar, CupertinoActionSheet, CupertinoButton, SkeletonListRow, BackEdgeSwipe } from '../components';
 
 function groupByLetter(contacts: DeviceContact[]) {
   const groups: Record<string, DeviceContact[]> = {};
@@ -161,6 +161,7 @@ export function ContactsScreen() {
   );
 
   return (
+    <BackEdgeSwipe>
     <View style={[styles.container, { backgroundColor: colors.systemGroupedBackground }]}>
       <StatusBar style={theme.dark ? 'light' : 'dark'} />
       <CupertinoNavigationBar
@@ -265,6 +266,7 @@ export function ContactsScreen() {
         cancelLabel="Cancel"
       />
     </View>
+    </BackEdgeSwipe>
   );
 }
 

--- a/src/screens/ControlCenterScreen.tsx
+++ b/src/screens/ControlCenterScreen.tsx
@@ -34,6 +34,7 @@ import { SystemColors } from '../theme/CupertinoTheme';
 import { useAlert } from '../components';
 import * as Haptics from 'expo-haptics';
 import type { AppNavigationProp } from '../navigation/types';
+import { hapticSelection } from '../utils/haptics';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -270,11 +271,19 @@ export function ControlCenterScreen({ navigation }: { navigation: AppNavigationP
     device.setVolume(pct);
   }, [device]);
 
+  const prevBrightnessPct = useSharedValue(device.brightness);
+  const prevVolumePct = useSharedValue(device.volume);
+
   const brightnessPanGesture = Gesture.Pan()
     .onUpdate((e) => {
       // e.y is relative to the gesture view; map to fill height
       const fill = Math.max(0, Math.min(SLIDER_HEIGHT, SLIDER_HEIGHT - e.y));
       brightnessFill.value = fill;
+      const pct = fill / SLIDER_HEIGHT;
+      if ((prevBrightnessPct.value > 0 && pct === 0) || (prevBrightnessPct.value < 1 && pct === 1)) {
+        runOnJS(hapticSelection)();
+      }
+      prevBrightnessPct.value = pct;
     })
     .onEnd(() => {
       const pct = Math.max(0, Math.min(1, brightnessFill.value / SLIDER_HEIGHT));
@@ -289,12 +298,17 @@ export function ControlCenterScreen({ navigation }: { navigation: AppNavigationP
       runOnJS(applyBrightness)(pct);
     });
 
-  const brightnessGesture = Gesture.Race(brightnessPanGesture, brightnessTapGesture);
+  const brightnessGesture = Gesture.Exclusive(brightnessTapGesture, brightnessPanGesture);
 
   const volumePanGesture = Gesture.Pan()
     .onUpdate((e) => {
       const fill = Math.max(0, Math.min(SLIDER_HEIGHT, SLIDER_HEIGHT - e.y));
       volumeFill.value = fill;
+      const pct = fill / SLIDER_HEIGHT;
+      if ((prevVolumePct.value > 0 && pct === 0) || (prevVolumePct.value < 1 && pct === 1)) {
+        runOnJS(hapticSelection)();
+      }
+      prevVolumePct.value = pct;
     })
     .onEnd(() => {
       const pct = Math.max(0, Math.min(1, volumeFill.value / SLIDER_HEIGHT));
@@ -309,7 +323,7 @@ export function ControlCenterScreen({ navigation }: { navigation: AppNavigationP
       runOnJS(applyVolume)(pct);
     });
 
-  const volumeGesture = Gesture.Race(volumePanGesture, volumeTapGesture);
+  const volumeGesture = Gesture.Exclusive(volumeTapGesture, volumePanGesture);
 
   const brightnessFillStyle = useAnimatedStyle(() => ({
     height: brightnessFill.value,

--- a/src/screens/LauncherHomeScreen.tsx
+++ b/src/screens/LauncherHomeScreen.tsx
@@ -49,6 +49,7 @@ import type { BannerNotification } from '../components';
 import { WALLPAPERS, darkenHex } from '../utils/wallpapers';
 import { ControlCenterOverlay } from '../components/ControlCenterOverlay';
 import { NotificationCenterOverlay } from '../components/NotificationCenterOverlay';
+import { SpotlightReveal } from '../components/SpotlightReveal';
 import { zones } from '../utils/gestureConfig';
 
 // ---------------------------------------------------------------------------
@@ -558,18 +559,17 @@ export function LauncherHomeScreen() {
     navigation.navigate(screen);
   }, [navigation]);
 
-  // Vertical swipe gesture: up → App Drawer, down-mid → Spotlight
+  // Vertical swipe gesture: up → App Drawer only.
+  // Downward → Spotlight is handled by SpotlightReveal below.
   // CC and NC top-zone swipes are handled by ControlCenterOverlay / NotificationCenterOverlay.
   const panGesture = Gesture.Pan()
     .activeOffsetY([-20, 20])
     .onEnd((event) => {
       'worklet';
-      const { translationY, absoluteY, velocityY } = event;
+      const { translationY, velocityY } = event;
 
       if (translationY < -60 && velocityY < -200) {
         runOnJS(navigateTo)('AppLibrary');
-      } else if (translationY > 60 && velocityY > 200 && absoluteY >= 350) {
-        runOnJS(navigateTo)('SpotlightSearch');
       }
     });
 
@@ -740,6 +740,9 @@ export function LauncherHomeScreen() {
 
   // +1 for the App Library page appended at the end
   const totalPages = pages.length + 1;
+
+  // Spotlight reveal is suppressed when jiggling, folder is open, or action sheet is up
+  const canSpotlight = !isJiggling && !actionSheet.visible && openFolder === null;
 
   const handleScroll = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
     const offsetX = event.nativeEvent.contentOffset.x;
@@ -1157,6 +1160,14 @@ export function LauncherHomeScreen() {
       />
 
       {/* Home indicator is rendered globally from App.tsx (HomeIndicator). */}
+
+      {/* ---------------------------------------------------------------- */}
+      {/* Spotlight progressive reveal (downward swipe on home)             */}
+      {/* ---------------------------------------------------------------- */}
+      <SpotlightReveal
+        enabled={canSpotlight}
+        onCommit={() => navigation.navigate('SpotlightSearch')}
+      />
 
       {/* ---------------------------------------------------------------- */}
       {/* Top-zone progressive reveal overlays (CC + NC)                    */}

--- a/src/screens/LauncherHomeScreen.tsx
+++ b/src/screens/LauncherHomeScreen.tsx
@@ -47,12 +47,16 @@ import {
 } from '../components';
 import type { BannerNotification } from '../components';
 import { WALLPAPERS, darkenHex } from '../utils/wallpapers';
+import { ControlCenterOverlay } from '../components/ControlCenterOverlay';
+import { NotificationCenterOverlay } from '../components/NotificationCenterOverlay';
+import { zones } from '../utils/gestureConfig';
 
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
 
 const SCREEN_WIDTH = Dimensions.get('window').width;
+const SCREEN_HEIGHT = Dimensions.get('window').height;
 const COLS = Math.min(4, Math.floor(SCREEN_WIDTH / 90));
 const ROWS = 6;
 const APPS_PER_PAGE = COLS * ROWS; // 24
@@ -554,21 +558,16 @@ export function LauncherHomeScreen() {
     navigation.navigate(screen);
   }, [navigation]);
 
-  // Vertical swipe gesture: up → App Drawer, down-top-left → Notification Center, down-top-right → Control Center, down-mid → Spotlight
+  // Vertical swipe gesture: up → App Drawer, down-mid → Spotlight
+  // CC and NC top-zone swipes are handled by ControlCenterOverlay / NotificationCenterOverlay.
   const panGesture = Gesture.Pan()
     .activeOffsetY([-20, 20])
     .onEnd((event) => {
       'worklet';
-      const { translationY, absoluteY, absoluteX, velocityY } = event;
+      const { translationY, absoluteY, velocityY } = event;
 
       if (translationY < -60 && velocityY < -200) {
         runOnJS(navigateTo)('AppLibrary');
-      } else if (translationY > 60 && velocityY > 200 && absoluteY < 350) {
-        if (absoluteX < SCREEN_WIDTH / 2) {
-          runOnJS(navigateTo)('NotificationCenter');
-        } else {
-          runOnJS(navigateTo)('ControlCenter');
-        }
       } else if (translationY > 60 && velocityY > 200 && absoluteY >= 350) {
         runOnJS(navigateTo)('SpotlightSearch');
       }
@@ -1158,6 +1157,18 @@ export function LauncherHomeScreen() {
       />
 
       {/* Home indicator is rendered globally from App.tsx (HomeIndicator). */}
+
+      {/* ---------------------------------------------------------------- */}
+      {/* Top-zone progressive reveal overlays (CC + NC)                    */}
+      {/* ---------------------------------------------------------------- */}
+      <ControlCenterOverlay
+        zone={zones(SCREEN_WIDTH, SCREEN_HEIGHT).controlCenter}
+        onCommit={() => navigateTo('ControlCenter')}
+      />
+      <NotificationCenterOverlay
+        zone={zones(SCREEN_WIDTH, SCREEN_HEIGHT).notificationCenter}
+        onCommit={() => navigateTo('NotificationCenter')}
+      />
 
       {/* ---------------------------------------------------------------- */}
       {/* Incoming notification banner                                       */}

--- a/src/screens/LockScreen.tsx
+++ b/src/screens/LockScreen.tsx
@@ -15,6 +15,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import Animated, {
   useSharedValue,
   useAnimatedStyle,
+  useFrameCallback,
   withSpring,
   withTiming,
   withSequence,
@@ -25,6 +26,9 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as SecureStore from 'expo-secure-store';
 
 import * as Haptics from 'expo-haptics';
+import { gestureConfig } from '../utils/gestureConfig';
+import { pushSample, sampledVelocity, useVelocityBuffer } from '../utils/gestureVelocity';
+import { GestureHaptics } from '../utils/gestureHaptics';
 import { useDevice } from '../store/DeviceStore';
 import { useSettings } from '../store/SettingsStore';
 import { useApps } from '../store/AppsStore';
@@ -558,6 +562,16 @@ export function LockScreen({ navigation, onUnlock }: { navigation?: any; route?:
   const translateY = useSharedValue(0);
   const opacity = useSharedValue(1);
 
+  // Frame-callback timestamp for velocity sampling
+  const currentT = useSharedValue(0);
+  useFrameCallback(({ timestamp }) => {
+    'worklet';
+    currentT.value = timestamp;
+  });
+
+  // Multi-sample velocity buffer
+  const lockBuf = useVelocityBuffer();
+
   const handleUnlock = () => {
     Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
     if (onUnlock) {
@@ -568,21 +582,38 @@ export function LockScreen({ navigation, onUnlock }: { navigation?: any; route?:
   };
 
   const swipeGesture = Gesture.Pan()
+    .onBegin(() => {
+      'worklet';
+      lockBuf.value = [];
+    })
     .onUpdate((e) => {
+      'worklet';
       if (e.translationY < 0) {
         // Only track upward swipes
         translateY.value = e.translationY;
         opacity.value = 1 + e.translationY / (SCREEN_HEIGHT * 0.4);
+        pushSample(lockBuf.value, e.translationX, e.translationY, currentT.value);
       }
     })
     .onEnd((e) => {
-      if (e.translationY < -SWIPE_THRESHOLD) {
-        translateY.value = withSpring(-SCREEN_HEIGHT, { damping: 20, stiffness: 200 });
+      'worklet';
+      pushSample(lockBuf.value, e.translationX, e.translationY, currentT.value);
+      const { vy } = sampledVelocity(lockBuf.value, currentT.value);
+      const upwardV = -vy; // vy is negative for upward motion
+      const progress = Math.min(1, -e.translationY / (SCREEN_HEIGHT * 0.4));
+      const shouldCommit =
+        e.translationY < -SWIPE_THRESHOLD ||
+        progress >= gestureConfig.panelCommitProgress ||
+        upwardV >= gestureConfig.panelCommitVelocity;
+
+      if (shouldCommit) {
+        runOnJS(GestureHaptics.commit)('light');
+        translateY.value = withSpring(-SCREEN_HEIGHT, gestureConfig.spring.mediumSettle);
         opacity.value = withTiming(0, { duration: 250 }, () => {
           runOnJS(handleUnlock)();
         });
       } else {
-        translateY.value = withSpring(0, { damping: 20, stiffness: 300 });
+        translateY.value = withSpring(0, gestureConfig.spring.fastSettle);
         opacity.value = withTiming(1, { duration: 200 });
       }
     });

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -14,6 +14,7 @@ import {
   CupertinoListTile,
   CupertinoSwitch,
   CupertinoSearchBar,
+  BackEdgeSwipe,
 } from '../components';
 import type { AppNavigationProp, RootStackParamList } from '../navigation/types';
 
@@ -202,6 +203,7 @@ export function SettingsScreen() {
   };
 
   return (
+    <BackEdgeSwipe>
     <View style={[styles.container, { backgroundColor: colors.systemGroupedBackground }]}>
       <StatusBar style={isDark ? 'light' : 'dark'} />
       <CupertinoNavigationBar
@@ -249,6 +251,7 @@ export function SettingsScreen() {
         )}
       </CupertinoNavigationBar>
     </View>
+    </BackEdgeSwipe>
   );
 }
 

--- a/src/screens/TodayViewScreen.tsx
+++ b/src/screens/TodayViewScreen.tsx
@@ -16,11 +16,16 @@ import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
   useSharedValue,
   useAnimatedStyle,
+  useFrameCallback,
+  withSpring,
   withTiming,
   runOnJS,
 } from 'react-native-reanimated';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as Haptics from 'expo-haptics';
+import { gestureConfig } from '../utils/gestureConfig';
+import { pushSample, sampledVelocity, useVelocityBuffer } from '../utils/gestureVelocity';
+import { GestureHaptics } from '../utils/gestureHaptics';
 
 import { useDevice } from '../store/DeviceStore';
 import { useTheme } from '../theme/ThemeContext';
@@ -568,21 +573,49 @@ export function TodayViewScreen({ navigation }: { navigation: AppNavigationProp 
   const translateX = useSharedValue(0);
   const opacity = useSharedValue(1);
 
+  // Frame-callback timestamp for velocity sampling
+  const todayCurrentT = useSharedValue(0);
+  useFrameCallback(({ timestamp }) => {
+    'worklet';
+    todayCurrentT.value = timestamp;
+  });
+
+  // Multi-sample velocity buffer
+  const todayBuf = useVelocityBuffer();
+
   const handleClose = () => navigation.goBack();
 
   const swipeLeftGesture = Gesture.Pan()
+    .onBegin(() => {
+      'worklet';
+      todayBuf.value = [];
+    })
     .onUpdate((e) => {
+      'worklet';
       if (e.translationX < 0) {
         translateX.value = e.translationX;
         opacity.value = Math.max(0, 1 + e.translationX / 300);
+        pushSample(todayBuf.value, e.translationX, e.translationY, todayCurrentT.value);
       }
     })
     .onEnd((e) => {
-      if (e.translationX < -80 || e.velocityX < -600) {
-        translateX.value = withTiming(-400, { duration: 250 });
+      'worklet';
+      pushSample(todayBuf.value, e.translationX, e.translationY, todayCurrentT.value);
+      const { vx } = sampledVelocity(todayBuf.value, todayCurrentT.value);
+      const absX = Math.abs(e.translationX);
+      const absVx = Math.abs(vx);
+      const shouldCommit =
+        absX >= gestureConfig.quickSwitchDistanceDp ||
+        absVx >= gestureConfig.quickSwitchVelocity ||
+        (absX >= gestureConfig.quickSwitchHybridDistanceDp &&
+          absVx >= gestureConfig.quickSwitchHybridVelocity);
+
+      if (shouldCommit && e.translationX < 0) {
+        runOnJS(GestureHaptics.commit)('light');
+        translateX.value = withSpring(-400, gestureConfig.spring.mediumSettle);
         opacity.value = withTiming(0, { duration: 250 }, () => runOnJS(handleClose)());
       } else {
-        translateX.value = withTiming(0, { duration: 200 });
+        translateX.value = withSpring(0, gestureConfig.spring.fastSettle);
         opacity.value = withTiming(1, { duration: 200 });
       }
     });

--- a/src/screens/contacts/ContactDetailScreen.tsx
+++ b/src/screens/contacts/ContactDetailScreen.tsx
@@ -11,6 +11,7 @@ import {
   CupertinoListTile,
   CupertinoButton,
   CupertinoAlertDialog,
+  BackEdgeSwipe,
 } from '../../components';
 import type { AppNavigationProp, AppRouteProp } from '../../navigation/types';
 
@@ -66,6 +67,7 @@ export function ContactDetailScreen({ navigation, route }: ContactDetailScreenPr
 
   if (!contact) {
     return (
+      <BackEdgeSwipe>
       <View style={[styles.container, { backgroundColor: colors.systemGroupedBackground }]}>
         <CupertinoNavigationBar
           title="Contact"
@@ -81,6 +83,7 @@ export function ContactDetailScreen({ navigation, route }: ContactDetailScreenPr
           <Text style={[typography.body, { color: colors.secondaryLabel }]}>Contact not found.</Text>
         </View>
       </View>
+      </BackEdgeSwipe>
     );
   }
 
@@ -115,6 +118,7 @@ export function ContactDetailScreen({ navigation, route }: ContactDetailScreenPr
   ];
 
   return (
+    <BackEdgeSwipe>
     <View style={[styles.container, { backgroundColor: colors.systemGroupedBackground }]}>
       <CupertinoNavigationBar
         title={fullName}
@@ -270,6 +274,7 @@ export function ContactDetailScreen({ navigation, route }: ContactDetailScreenPr
         ]}
       />
     </View>
+    </BackEdgeSwipe>
   );
 }
 

--- a/src/screens/settings/GeneralScreen.tsx
+++ b/src/screens/settings/GeneralScreen.tsx
@@ -9,6 +9,7 @@ import {
   CupertinoListTile,
   CupertinoActionSheet,
   useAlert,
+  BackEdgeSwipe,
 } from '../../components';
 import type { AppNavigationProp } from '../../navigation/types';
 
@@ -26,6 +27,7 @@ export function GeneralScreen({ navigation }: { navigation: AppNavigationProp })
   const bgRefreshLabel = settings.backgroundAppRefresh === 'off' ? 'Off' : settings.backgroundAppRefresh === 'wifi' ? 'Wi-Fi' : 'Wi-Fi & Cellular';
 
   return (
+    <BackEdgeSwipe>
     <View style={[styles.container, { backgroundColor: colors.systemGroupedBackground }]}>
       <CupertinoNavigationBar
         title="General"
@@ -143,6 +145,7 @@ export function GeneralScreen({ navigation }: { navigation: AppNavigationProp })
         cancelLabel="Cancel"
       />
     </View>
+    </BackEdgeSwipe>
   );
 }
 

--- a/src/utils/__tests__/gestureMachine.test.ts
+++ b/src/utils/__tests__/gestureMachine.test.ts
@@ -1,0 +1,199 @@
+import {
+  commitForHome,
+  commitForSwitcher,
+  commitForBack,
+  commitForQuickSwitch,
+  commitForPanel,
+  commitForNC,
+  commitForSpotlight,
+} from '../gestureMachine';
+import type { CommitPredicate } from '../gestureMachine';
+import { gestureConfig } from '../gestureConfig';
+
+function pred(overrides: Partial<CommitPredicate>): CommitPredicate {
+  return { progress: 0, velocity: 0, holdMs: 0, ...overrides };
+}
+
+describe('commitForHome', () => {
+  it('returns distance when progress >= homeCommitProgress', () => {
+    expect(
+      commitForHome(pred({ progress: gestureConfig.homeCommitProgress })),
+    ).toBe('distance');
+  });
+
+  it('returns velocity when upward velocity magnitude >= homeCommitVelocity', () => {
+    // upward velocity is negative; -p.velocity >= threshold means p.velocity <= -threshold
+    expect(
+      commitForHome(pred({ velocity: -gestureConfig.homeCommitVelocity })),
+    ).toBe('velocity');
+  });
+
+  it('returns hybrid when progress and velocity meet hybrid thresholds', () => {
+    expect(
+      commitForHome(
+        pred({
+          progress: gestureConfig.homeHybridProgress,
+          velocity: -gestureConfig.homeHybridVelocity,
+        }),
+      ),
+    ).toBe('hybrid');
+  });
+
+  it('returns none when below all thresholds', () => {
+    expect(commitForHome(pred({ progress: 0, velocity: 0 }))).toBe('none');
+  });
+});
+
+describe('commitForBack', () => {
+  it('returns distance when progress >= backCommitProgress', () => {
+    expect(
+      commitForBack(pred({ progress: gestureConfig.backCommitProgress })),
+    ).toBe('distance');
+  });
+
+  it('returns velocity when rightward velocity >= backCommitVelocity', () => {
+    expect(
+      commitForBack(pred({ velocity: gestureConfig.backCommitVelocity })),
+    ).toBe('velocity');
+  });
+
+  it('returns hybrid when progress and velocity meet hybrid thresholds', () => {
+    expect(
+      commitForBack(
+        pred({
+          progress: gestureConfig.backHybridProgress,
+          velocity: gestureConfig.backHybridVelocity,
+        }),
+      ),
+    ).toBe('hybrid');
+  });
+
+  it('returns none when below all thresholds', () => {
+    expect(commitForBack(pred({ progress: 0, velocity: 0 }))).toBe('none');
+  });
+});
+
+describe('commitForSwitcher', () => {
+  const validPred: CommitPredicate = {
+    progress: gestureConfig.switcherProgressMin,
+    velocity: 0,
+    holdMs: gestureConfig.switcherHoldMinMs,
+  };
+
+  it('returns hold when all switcher conditions are met', () => {
+    expect(commitForSwitcher(validPred)).toBe('hold');
+  });
+
+  it('returns none when holdMs is too short', () => {
+    expect(
+      commitForSwitcher({ ...validPred, holdMs: gestureConfig.switcherHoldMinMs - 1 }),
+    ).toBe('none');
+  });
+
+  it('returns none when progress is below switcherProgressMin', () => {
+    expect(
+      commitForSwitcher({ ...validPred, progress: gestureConfig.switcherProgressMin - 0.01 }),
+    ).toBe('none');
+  });
+
+  it('returns none when progress exceeds switcherProgressMax', () => {
+    expect(
+      commitForSwitcher({ ...validPred, progress: gestureConfig.switcherProgressMax + 0.01 }),
+    ).toBe('none');
+  });
+
+  it('returns none when velocity magnitude exceeds switcherHoldVelocityMax', () => {
+    expect(
+      commitForSwitcher({
+        ...validPred,
+        velocity: gestureConfig.switcherHoldVelocityMax + 0.01,
+      }),
+    ).toBe('none');
+  });
+});
+
+describe('commitForQuickSwitch', () => {
+  it('returns distance when progress >= 1', () => {
+    expect(commitForQuickSwitch(pred({ progress: 1 }))).toBe('distance');
+  });
+
+  it('returns velocity when |velocity| >= quickSwitchVelocity', () => {
+    expect(
+      commitForQuickSwitch(pred({ velocity: gestureConfig.quickSwitchVelocity })),
+    ).toBe('velocity');
+
+    expect(
+      commitForQuickSwitch(pred({ velocity: -gestureConfig.quickSwitchVelocity })),
+    ).toBe('velocity');
+  });
+
+  it('returns hybrid when dist and velocity meet hybrid thresholds', () => {
+    // progress such that progress * quickSwitchDistanceDp >= quickSwitchHybridDistanceDp
+    const hybridProgress =
+      gestureConfig.quickSwitchHybridDistanceDp / gestureConfig.quickSwitchDistanceDp;
+    expect(
+      commitForQuickSwitch(
+        pred({
+          progress: hybridProgress,
+          velocity: gestureConfig.quickSwitchHybridVelocity,
+        }),
+      ),
+    ).toBe('hybrid');
+  });
+
+  it('returns none when below all thresholds', () => {
+    expect(commitForQuickSwitch(pred({ progress: 0, velocity: 0 }))).toBe('none');
+  });
+});
+
+describe('commitForPanel', () => {
+  it('returns distance when progress >= panelCommitProgress', () => {
+    expect(
+      commitForPanel(pred({ progress: gestureConfig.panelCommitProgress })),
+    ).toBe('distance');
+  });
+
+  it('returns velocity when downward velocity >= panelCommitVelocity', () => {
+    expect(
+      commitForPanel(pred({ velocity: gestureConfig.panelCommitVelocity })),
+    ).toBe('velocity');
+  });
+
+  it('returns none when below all thresholds', () => {
+    expect(commitForPanel(pred({ progress: 0, velocity: 0 }))).toBe('none');
+  });
+});
+
+describe('commitForNC', () => {
+  it('returns distance when progress >= ncCommitProgress', () => {
+    expect(
+      commitForNC(pred({ progress: gestureConfig.ncCommitProgress })),
+    ).toBe('distance');
+  });
+
+  it('returns velocity when downward velocity >= ncCommitVelocity', () => {
+    expect(
+      commitForNC(pred({ velocity: gestureConfig.ncCommitVelocity })),
+    ).toBe('velocity');
+  });
+
+  it('returns none when below all thresholds', () => {
+    expect(commitForNC(pred({ progress: 0, velocity: 0 }))).toBe('none');
+  });
+});
+
+describe('commitForSpotlight', () => {
+  it('returns distance when progress >= 1 (dy >= spotlightCommitDp)', () => {
+    expect(commitForSpotlight(pred({ progress: 1 }))).toBe('distance');
+  });
+
+  it('returns velocity when downward velocity >= spotlightCommitVelocity', () => {
+    expect(
+      commitForSpotlight(pred({ velocity: gestureConfig.spotlightCommitVelocity })),
+    ).toBe('velocity');
+  });
+
+  it('returns none when below all thresholds', () => {
+    expect(commitForSpotlight(pred({ progress: 0, velocity: 0 }))).toBe('none');
+  });
+});

--- a/src/utils/__tests__/gestureVelocity.test.ts
+++ b/src/utils/__tests__/gestureVelocity.test.ts
@@ -53,8 +53,8 @@ describe('gestureVelocity', () => {
       for (let t = 0; t <= 180; t += 30) {
         pushSample(buf, t, 0, t);
       }
-      // 2*WINDOW = 120; cutoff from last push (t=180) is 180 - 120 = 60
-      expect(buf[0].t).toBeGreaterThanOrEqual(60);
+      // cutoff from last push (t=180) is 180 - 2*WINDOW
+      expect(buf[0].t).toBeGreaterThanOrEqual(180 - 2 * WINDOW);
     });
 
     it('uses oldest sample within the WINDOW, not outside', () => {

--- a/src/utils/__tests__/gestureVelocity.test.ts
+++ b/src/utils/__tests__/gestureVelocity.test.ts
@@ -1,0 +1,101 @@
+import { pushSample, sampledVelocity } from '../gestureVelocity';
+import type { VelocitySample } from '../gestureVelocity';
+import { gestureConfig } from '../gestureConfig';
+
+const CLAMP = gestureConfig.velocityClampDpPerMs;
+const WINDOW = gestureConfig.velocityWindowMs;
+
+function makeBuf(): VelocitySample[] {
+  return [];
+}
+
+describe('gestureVelocity', () => {
+  describe('sampledVelocity', () => {
+    it('returns zero for empty buffer', () => {
+      const buf = makeBuf();
+      expect(sampledVelocity(buf, 0)).toEqual({ vx: 0, vy: 0 });
+    });
+
+    it('returns zero for single sample', () => {
+      const buf = makeBuf();
+      pushSample(buf, 0, 0, 0);
+      expect(sampledVelocity(buf, 0)).toEqual({ vx: 0, vy: 0 });
+    });
+
+    it('computes correct velocity for two samples 100dp apart, 50ms apart', () => {
+      const buf = makeBuf();
+      pushSample(buf, 0, 0, 0);
+      pushSample(buf, 100, 0, 50);
+      const { vx } = sampledVelocity(buf, 50);
+      // 100 dp / 50 ms = 2.0 dp/ms
+      expect(vx).toBeCloseTo(2.0, 5);
+    });
+
+    it('clamps velocity to +CLAMP', () => {
+      const buf = makeBuf();
+      pushSample(buf, 0, 0, 0);
+      // 1000dp in 10ms = 100 dp/ms — well above 4.0
+      pushSample(buf, 1000, 0, 10);
+      const { vx } = sampledVelocity(buf, 10);
+      expect(vx).toBe(CLAMP);
+    });
+
+    it('clamps velocity to -CLAMP', () => {
+      const buf = makeBuf();
+      pushSample(buf, 0, 0, 0);
+      pushSample(buf, -1000, 0, 10);
+      const { vx } = sampledVelocity(buf, 10);
+      expect(vx).toBe(-CLAMP);
+    });
+
+    it('trims old samples: after pushing t=0..180 step 30, oldest retained t >= 60', () => {
+      const buf = makeBuf();
+      for (let t = 0; t <= 180; t += 30) {
+        pushSample(buf, t, 0, t);
+      }
+      // 2*WINDOW = 120; cutoff from last push (t=180) is 180 - 120 = 60
+      expect(buf[0].t).toBeGreaterThanOrEqual(60);
+    });
+
+    it('uses oldest sample within the WINDOW, not outside', () => {
+      const buf = makeBuf();
+      // t=0 is outside WINDOW relative to last sample t=100 (cutoff = 100-60=40)
+      pushSample(buf, 0, 0, 0);
+      // t=50 is within WINDOW (50 >= 40)
+      pushSample(buf, 50, 0, 50);
+      pushSample(buf, 100, 0, 100);
+
+      // The oldest sample within window is t=50, not t=0
+      // velocity should be (100-50)/(100-50) = 1.0 dp/ms, not (100-0)/100 = 1.0 — both happen to be 1.0
+      // To distinguish, shift x so only t=0 would yield a different result
+      const buf2 = makeBuf();
+      pushSample(buf2, 0, 0, 0);    // far outside window — x=0
+      pushSample(buf2, 200, 0, 50); // within window — x=200
+      pushSample(buf2, 260, 0, 100);
+
+      // oldest-in-window is t=50, x=200; velocity = (260-200)/(100-50) = 1.2
+      // if t=0 were used: (260-0)/100 = 2.6
+      const { vx } = sampledVelocity(buf2, 100);
+      expect(vx).toBeCloseTo(1.2, 5);
+    });
+  });
+
+  describe('pushSample', () => {
+    it('trims samples older than 2*WINDOW from the head', () => {
+      const buf = makeBuf();
+      // push at t=0, well before the 2*WINDOW cutoff at t=180-120=60
+      pushSample(buf, 0, 0, 0);
+      pushSample(buf, 1, 0, 180);
+      // t=0 is older than 180 - 2*60 = 60, so it should be trimmed
+      expect(buf.findIndex(s => s.t === 0)).toBe(-1);
+    });
+
+    it('retains samples within 2*WINDOW', () => {
+      const buf = makeBuf();
+      pushSample(buf, 0, 0, 100);
+      pushSample(buf, 1, 0, 200);
+      // cutoff = 200 - 120 = 80; t=100 >= 80, retained
+      expect(buf.findIndex(s => s.t === 100)).toBeGreaterThanOrEqual(0);
+    });
+  });
+});

--- a/src/utils/gestureConfig.ts
+++ b/src/utils/gestureConfig.ts
@@ -1,0 +1,125 @@
+export const gestureConfig = {
+  // Zones (all dp = React Native px)
+  bottomZoneHeightDp: 28,
+  leftEdgeWidthDp: 20,
+  topZoneHeightDp: 24,
+  controlCenterWidthRatio: 0.34,
+
+  // Travel distances
+  homeTravelDp: 220,
+  switcherTravelDp: 220,
+  backTravelRatio: 0.33,
+  panelTravelDp: 180,
+
+  // Axis lock
+  axisLockDp: 10,
+
+  // Home
+  homeCommitProgress: 0.52,
+  homeCommitVelocity: 1.10,
+  homeHybridProgress: 0.32,
+  homeHybridVelocity: 0.75,
+
+  // Switcher (hold)
+  switcherHoldMinMs: 140,
+  switcherProgressMin: 0.28,
+  switcherProgressMax: 0.58,
+  switcherHoldVelocityMax: 0.35,
+
+  // Quick switch (horizontal on home bar)
+  quickSwitchDistanceDp: 56,
+  quickSwitchVelocity: 0.85,
+  quickSwitchHybridDistanceDp: 32,
+  quickSwitchHybridVelocity: 0.55,
+
+  // Back
+  backCommitProgress: 0.35,
+  backCommitVelocity: 0.75,
+  backHybridProgress: 0.18,
+  backHybridVelocity: 0.55,
+
+  // Top panels (CC)
+  panelCommitProgress: 0.32,
+  panelCommitVelocity: 0.80,
+  // Notification Center
+  ncCommitProgress: 0.28,
+  ncCommitVelocity: 0.75,
+
+  // Spotlight
+  spotlightRevealDp: 8,
+  spotlightCommitDp: 32,
+  spotlightCommitVelocity: 0.55,
+
+  // Swipe row actions
+  swipeActionRevealDp: 10,
+  swipeActionFirstExposedDp: 64,
+  swipeActionFullSwipeDp: 132,
+  swipeActionFullSwipeVelocity: 1.0,
+
+  // Card dismiss (app switcher card)
+  cardDismissDp: 84,
+  cardDismissVelocity: -0.9,
+
+  // Springs — per §13.3 of spec
+  spring: {
+    fastSettle: { stiffness: 760, damping: 58, mass: 1 },
+    mediumSettle: { stiffness: 680, damping: 52, mass: 1 },
+    softCarousel: { stiffness: 560, damping: 44, mass: 1 },
+    homeSettle: { stiffness: 700, damping: 52, mass: 1 },
+    switcherSettle: { stiffness: 620, damping: 48, mass: 1 },
+    backSettle: { stiffness: 760, damping: 56, mass: 1 },
+  },
+
+  // Velocity window
+  velocityWindowMs: 60,
+  velocityClampDpPerMs: 4.0,
+} as const;
+
+export function dpPerMsToPtPerSec(v: number): number {
+  return v * 1000;
+}
+
+export function ptPerSecToDpPerMs(v: number): number {
+  return v / 1000;
+}
+
+export function zones(
+  width: number,
+  height: number,
+): {
+  bottom: { top: number; bottom: number; left: number; right: number };
+  leftEdge: { top: number; bottom: number; left: number; right: number };
+  controlCenter: { top: number; bottom: number; left: number; right: number };
+  notificationCenter: { top: number; bottom: number; left: number; right: number };
+} {
+  'worklet';
+  const topStripHeight = gestureConfig.topZoneHeightDp + 20;
+  const ccWidth = Math.round(width * gestureConfig.controlCenterWidthRatio);
+
+  return {
+    bottom: {
+      top: height - gestureConfig.bottomZoneHeightDp,
+      bottom: height,
+      left: 0,
+      right: width,
+    },
+    leftEdge: {
+      top: 0,
+      bottom: height,
+      left: 0,
+      right: gestureConfig.leftEdgeWidthDp,
+    },
+    controlCenter: {
+      top: 0,
+      bottom: topStripHeight,
+      left: width - ccWidth,
+      right: width,
+    },
+    notificationCenter: {
+      top: 0,
+      bottom: topStripHeight,
+      left: 0,
+      right: width - ccWidth,
+    },
+  };
+}

--- a/src/utils/gestureHaptics.ts
+++ b/src/utils/gestureHaptics.ts
@@ -1,0 +1,18 @@
+import * as Haptics from 'expo-haptics';
+import { hapticImpact, hapticSelection } from './haptics';
+
+export type HapticMoment = 'threshold' | 'hold-confirm' | 'commit';
+export type CommitWeight = 'light' | 'medium' | 'heavy';
+
+const WEIGHT_MAP = {
+  light: Haptics.ImpactFeedbackStyle.Light,
+  medium: Haptics.ImpactFeedbackStyle.Medium,
+  heavy: Haptics.ImpactFeedbackStyle.Heavy,
+} as const;
+
+export const GestureHaptics = {
+  threshold: () => hapticSelection().catch(() => {}),
+  holdConfirm: () => hapticImpact(Haptics.ImpactFeedbackStyle.Light).catch(() => {}),
+  commit: (weight: CommitWeight = 'light') =>
+    hapticImpact(WEIGHT_MAP[weight]).catch(() => {}),
+};

--- a/src/utils/gestureMachine.ts
+++ b/src/utils/gestureMachine.ts
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useRef, useEffect } from 'react';
 import { useSharedValue } from 'react-native-reanimated';
 import type { SharedValue } from 'react-native-reanimated';
 import { gestureConfig } from './gestureConfig';
@@ -47,11 +47,13 @@ export function useGestureMachine(cfg: MachineConfig): GestureMachine {
   // Store callbacks in refs so consumers can runOnJS(ref.current) without
   // stale closures forcing hook re-runs and machine recreation.
   const onPhaseChangeRef = useRef(cfg.onPhaseChange);
-  onPhaseChangeRef.current = cfg.onPhaseChange;
   const onHapticRef = useRef(cfg.onHaptic);
-  onHapticRef.current = cfg.onHaptic;
   const shouldCommitRef = useRef(cfg.shouldCommit);
-  shouldCommitRef.current = cfg.shouldCommit;
+  useEffect(() => {
+    onPhaseChangeRef.current = cfg.onPhaseChange;
+    onHapticRef.current = cfg.onHaptic;
+    shouldCommitRef.current = cfg.shouldCommit;
+  });
 
   function reset() {
     'worklet';

--- a/src/utils/gestureMachine.ts
+++ b/src/utils/gestureMachine.ts
@@ -1,0 +1,148 @@
+import { useRef } from 'react';
+import { useSharedValue } from 'react-native-reanimated';
+import type { SharedValue } from 'react-native-reanimated';
+import { gestureConfig } from './gestureConfig';
+
+export type GesturePhase =
+  | 'idle'
+  | 'possible'
+  | 'tracking'
+  | 'committed'
+  | 'settling'
+  | 'cancelled'
+  | 'completed';
+
+export type CommitReason = 'distance' | 'velocity' | 'hybrid' | 'hold' | 'none';
+
+export interface CommitPredicate {
+  progress: number;
+  velocity: number;
+  holdMs: number;
+}
+
+export interface MachineConfig {
+  shouldCommit: (p: CommitPredicate) => CommitReason;
+  onPhaseChange?: (phase: GesturePhase, reason: CommitReason) => void;
+  onHaptic?: (moment: 'threshold' | 'commit' | 'hold-confirm') => void;
+}
+
+export interface GestureMachine {
+  phase: SharedValue<GesturePhase>;
+  progress: SharedValue<number>;
+  commitReason: SharedValue<CommitReason>;
+  startT: SharedValue<number>;
+  thresholdFired: SharedValue<boolean>;
+  holdFired: SharedValue<boolean>;
+  reset: () => void;
+}
+
+export function useGestureMachine(cfg: MachineConfig): GestureMachine {
+  const phase = useSharedValue<GesturePhase>('idle');
+  const progress = useSharedValue(0);
+  const commitReason = useSharedValue<CommitReason>('none');
+  const startT = useSharedValue(0);
+  const thresholdFired = useSharedValue(false);
+  const holdFired = useSharedValue(false);
+
+  // Store callbacks in refs so consumers can runOnJS(ref.current) without
+  // stale closures forcing hook re-runs and machine recreation.
+  const onPhaseChangeRef = useRef(cfg.onPhaseChange);
+  onPhaseChangeRef.current = cfg.onPhaseChange;
+  const onHapticRef = useRef(cfg.onHaptic);
+  onHapticRef.current = cfg.onHaptic;
+  const shouldCommitRef = useRef(cfg.shouldCommit);
+  shouldCommitRef.current = cfg.shouldCommit;
+
+  function reset() {
+    'worklet';
+    phase.value = 'idle';
+    progress.value = 0;
+    commitReason.value = 'none';
+    startT.value = 0;
+    thresholdFired.value = false;
+    holdFired.value = false;
+  }
+
+  return {
+    phase,
+    progress,
+    commitReason,
+    startT,
+    thresholdFired,
+    holdFired,
+    reset,
+  };
+}
+
+export const commitForHome = (p: CommitPredicate): CommitReason => {
+  'worklet';
+  if (p.progress >= gestureConfig.homeCommitProgress) return 'distance';
+  if (-p.velocity >= gestureConfig.homeCommitVelocity) return 'velocity';
+  if (
+    p.progress >= gestureConfig.homeHybridProgress &&
+    -p.velocity >= gestureConfig.homeHybridVelocity
+  )
+    return 'hybrid';
+  return 'none';
+};
+
+export const commitForSwitcher = (p: CommitPredicate): CommitReason => {
+  'worklet';
+  if (
+    p.holdMs >= gestureConfig.switcherHoldMinMs &&
+    p.progress >= gestureConfig.switcherProgressMin &&
+    p.progress <= gestureConfig.switcherProgressMax &&
+    Math.abs(p.velocity) <= gestureConfig.switcherHoldVelocityMax
+  )
+    return 'hold';
+  return 'none';
+};
+
+export const commitForBack = (p: CommitPredicate): CommitReason => {
+  'worklet';
+  if (p.progress >= gestureConfig.backCommitProgress) return 'distance';
+  if (p.velocity >= gestureConfig.backCommitVelocity) return 'velocity';
+  if (
+    p.progress >= gestureConfig.backHybridProgress &&
+    p.velocity >= gestureConfig.backHybridVelocity
+  )
+    return 'hybrid';
+  return 'none';
+};
+
+export const commitForQuickSwitch = (p: CommitPredicate): CommitReason => {
+  'worklet';
+  const absV = Math.abs(p.velocity);
+  const distDp = p.progress * gestureConfig.quickSwitchDistanceDp;
+  if (p.progress >= 1) return 'distance';
+  if (absV >= gestureConfig.quickSwitchVelocity) return 'velocity';
+  if (
+    distDp >= gestureConfig.quickSwitchHybridDistanceDp &&
+    absV >= gestureConfig.quickSwitchHybridVelocity
+  )
+    return 'hybrid';
+  return 'none';
+};
+
+export const commitForPanel = (p: CommitPredicate): CommitReason => {
+  'worklet';
+  if (p.progress >= gestureConfig.panelCommitProgress) return 'distance';
+  if (p.velocity >= gestureConfig.panelCommitVelocity) return 'velocity';
+  return 'none';
+};
+
+export const commitForNC = (p: CommitPredicate): CommitReason => {
+  'worklet';
+  if (p.progress >= gestureConfig.ncCommitProgress) return 'distance';
+  if (p.velocity >= gestureConfig.ncCommitVelocity) return 'velocity';
+  return 'none';
+};
+
+export const commitForSpotlight = (p: CommitPredicate): CommitReason => {
+  'worklet';
+  const progress = Math.min(1, Math.max(0, p.progress));
+  const distDp = progress * gestureConfig.spotlightCommitDp;
+  if (distDp >= gestureConfig.spotlightCommitDp) return 'distance';
+  if (p.velocity >= gestureConfig.spotlightCommitVelocity) return 'velocity';
+  return 'none';
+};

--- a/src/utils/gestureVelocity.ts
+++ b/src/utils/gestureVelocity.ts
@@ -1,0 +1,67 @@
+import { useSharedValue } from 'react-native-reanimated';
+import type { SharedValue } from 'react-native-reanimated';
+import { gestureConfig } from './gestureConfig';
+
+export interface VelocitySample {
+  x: number;
+  y: number;
+  t: number;
+}
+
+const WINDOW = gestureConfig.velocityWindowMs;
+const CLAMP = gestureConfig.velocityClampDpPerMs;
+
+export function pushSample(buf: VelocitySample[], x: number, y: number, t: number): void {
+  'worklet';
+  buf.push({ x, y, t });
+  while (buf.length > 0 && buf[0].t < t - 2 * WINDOW) {
+    buf.shift();
+  }
+}
+
+export function sampledVelocity(buf: VelocitySample[], now: number): { vx: number; vy: number } {
+  'worklet';
+  if (buf.length < 2) {
+    return { vx: 0, vy: 0 };
+  }
+
+  const last = buf[buf.length - 1];
+  const cutoff = last.t - WINDOW;
+
+  let oldIdx = 0;
+  for (let i = 0; i < buf.length - 1; i++) {
+    if (buf[i].t >= cutoff) {
+      oldIdx = i;
+      break;
+    }
+    oldIdx = i + 1;
+  }
+
+  // Ensure we don't use the last sample as the old sample
+  if (oldIdx >= buf.length - 1) {
+    oldIdx = buf.length - 2;
+  }
+
+  const old = buf[oldIdx];
+  const dt = last.t - old.t;
+
+  if (dt === 0) {
+    return { vx: 0, vy: 0 };
+  }
+
+  const rawVx = (last.x - old.x) / dt;
+  const rawVy = (last.y - old.y) / dt;
+
+  const vx = Math.max(-CLAMP, Math.min(CLAMP, rawVx));
+  const vy = Math.max(-CLAMP, Math.min(CLAMP, rawVy));
+
+  // suppress unused parameter warning — now is available for callers that
+  // want to pass wall-clock time rather than last.t
+  void now;
+
+  return { vx, vy };
+}
+
+export function useVelocityBuffer(): SharedValue<VelocitySample[]> {
+  return useSharedValue<VelocitySample[]>([]);
+}

--- a/src/utils/useGestureReduceMotion.ts
+++ b/src/utils/useGestureReduceMotion.ts
@@ -1,0 +1,25 @@
+import { useSettings } from '../store/SettingsStore';
+import { gestureConfig } from './gestureConfig';
+import { Easing, withSpring, withTiming } from 'react-native-reanimated';
+
+export function useGestureReduceMotion() {
+  const { settings } = useSettings();
+  return settings.reduceMotion;
+}
+
+// Worklet-safe settle helper. Either pass a spring preset key or a custom config.
+// Usage: settle(finalValue, 'mediumSettle', reduceMotion)
+// NOTE: this helper is intended to be CALLED from a worklet; it returns the Reanimated
+// animation primitive to assign to a shared value.
+export function settle(
+  value: number,
+  preset: keyof typeof gestureConfig.spring | { stiffness: number; damping: number; mass?: number },
+  reduceMotion: boolean,
+) {
+  'worklet';
+  if (reduceMotion) {
+    return withTiming(value, { duration: 180, easing: Easing.out(Easing.cubic) });
+  }
+  const cfg = typeof preset === 'string' ? gestureConfig.spring[preset] : preset;
+  return withSpring(value, cfg);
+}


### PR DESCRIPTION
Centralizes all iPhone-gesture thresholds in one config matching the spec,
adds a 60ms-windowed velocity sampler replacing single-frame e.velocityY,
and introduces a gesture state machine primitive with commit predicates
for every gesture in the epic (#225). 35 unit tests cover the velocity
sampler and every commit predicate (home, switcher, back, quick-switch,
panel, NC, spotlight).

https://claude.ai/code/session_01Sv8dKzYqNbN85kHrV266qq