### PR TITLE
Migrate notification events to Expo module event emitter

### DIFF
--- a/app.json
+++ b/app.json
@@ -69,6 +69,7 @@
     "plugins": [
       "./plugins/withAsyncStorageRepo",
       "./plugins/withLauncherIntent",
+      "./plugins/withGradleMemory",
       [
         "expo-camera",
         {

--- a/modules/launcher-module/android/src/main/java/com/iostoandroid/launcher/LauncherModule.kt
+++ b/modules/launcher-module/android/src/main/java/com/iostoandroid/launcher/LauncherModule.kt
@@ -20,6 +20,7 @@ import android.net.NetworkCapabilities
 import android.net.Uri
 import android.net.wifi.WifiManager
 import android.os.Build
+import android.os.Bundle
 import android.os.Environment
 import android.os.StatFs
 import android.telephony.TelephonyManager
@@ -47,29 +48,24 @@ class LauncherModule : Module() {
 
         /**
          * Called by [NotificationService] to forward notification events to JavaScript.
-         * Thread-safe: uses the volatile instance reference and the RCTDeviceEventEmitter.
+         * Uses Expo's built-in event emitter — declared via Events(...) in the definition.
          */
-        fun emitEvent(name: String, map: com.facebook.react.bridge.WritableMap) {
-            instance?.sendEventToJS(name, map)
+        fun emitEvent(name: String, bundle: Bundle) {
+            try {
+                instance?.sendEvent(name, bundle)
+            } catch (_: Throwable) {
+                // AppContext may not be ready, or listeners may not be attached yet.
+            }
         }
     }
 
     private val context: Context
         get() = appContext.reactContext ?: throw Exception("React context is not available")
 
-    /**
-     * Emit an arbitrary event to the JS DeviceEventEmitter.
-     * Must be called on any thread — the emitter is thread-safe.
-     */
-    fun sendEventToJS(name: String, map: com.facebook.react.bridge.WritableMap) {
-        val reactContext = appContext.reactContext ?: return
-        reactContext
-            .getJSModule(com.facebook.react.modules.core.DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
-            ?.emit(name, map)
-    }
-
     override fun definition() = ModuleDefinition {
         Name("LauncherModule")
+
+        Events("onNotificationPosted", "onNotificationRemoved")
 
         // Register this module instance so NotificationService can route events through it.
         instance = this@LauncherModule

--- a/modules/launcher-module/android/src/main/java/com/iostoandroid/launcher/NotificationService.kt
+++ b/modules/launcher-module/android/src/main/java/com/iostoandroid/launcher/NotificationService.kt
@@ -1,9 +1,8 @@
 package com.iostoandroid.launcher
 
+import android.os.Bundle
 import android.service.notification.NotificationListenerService
 import android.service.notification.StatusBarNotification
-import com.facebook.react.bridge.Arguments
-import com.facebook.react.modules.core.DeviceEventManagerModule
 
 data class NotificationData(
     val id: String,
@@ -64,14 +63,14 @@ class NotificationService : NotificationListenerService() {
     private fun emitToJS(eventName: String, sbn: StatusBarNotification) {
         try {
             val extras = sbn.notification.extras
-            val map = Arguments.createMap().apply {
+            val bundle = Bundle().apply {
                 putString("id", sbn.key)
                 putString("packageName", sbn.packageName)
                 putString("title", extras.getCharSequence("android.title")?.toString() ?: "")
                 putString("text", extras.getCharSequence("android.text")?.toString() ?: "")
                 putDouble("postedAt", sbn.postTime.toDouble())
             }
-            LauncherModule.emitEvent(eventName, map)
+            LauncherModule.emitEvent(eventName, bundle)
         } catch (e: Exception) {
             // Silently ignore — JS bridge may not be ready yet
         }

--- a/modules/launcher-module/src/index.ts
+++ b/modules/launcher-module/src/index.ts
@@ -486,9 +486,17 @@ export default LauncherModule;
 
 // ─── Event-driven notification listeners ────────────────────────────────────
 // Subscribe to real-time notification events emitted by NotificationService
-// (via RCTDeviceEventEmitter on the native side) instead of polling.
+// via the Expo module's own event emitter (sendEvent from the native side).
 
-import { DeviceEventEmitter } from 'react-native';
+type Subscription = { remove: () => void };
+
+function addModuleListener(eventName: string, handler: (payload: any) => void): Subscription {
+  if (!nativeModule || typeof nativeModule.addListener !== 'function') {
+    return { remove: () => {} };
+  }
+  const sub: Subscription = nativeModule.addListener(eventName, handler);
+  return sub;
+}
 
 /**
  * Subscribe to new notifications as they arrive.
@@ -497,7 +505,7 @@ import { DeviceEventEmitter } from 'react-native';
 export function addNotificationListener(
   listener: (n: DeviceNotification) => void,
 ): () => void {
-  const sub = DeviceEventEmitter.addListener('onNotificationPosted', listener);
+  const sub = addModuleListener('onNotificationPosted', listener);
   return () => sub.remove();
 }
 
@@ -509,7 +517,7 @@ export function addNotificationListener(
 export function addNotificationRemovedListener(
   listener: (id: string) => void,
 ): () => void {
-  const sub = DeviceEventEmitter.addListener('onNotificationRemoved', (n: { id: string }) => {
+  const sub = addModuleListener('onNotificationRemoved', (n: { id: string }) => {
     listener(n.id);
   });
   return () => sub.remove();

--- a/plugins/withGradleMemory.js
+++ b/plugins/withGradleMemory.js
@@ -1,0 +1,28 @@
+const { withGradleProperties } = require("expo/config-plugins");
+
+/**
+ * Raises Gradle JVM heap & metaspace so the Kotlin daemon doesn't run out of
+ * Metaspace mid-build. The CI-reported defaults (2 GiB heap / 512 MiB metaspace)
+ * aren't enough for this project's Kotlin compile + CMake workload.
+ */
+module.exports = function withGradleMemory(config) {
+  return withGradleProperties(config, (config) => {
+    const props = config.modResults;
+    const jvmArgs =
+      "-Xmx4096m -XX:MaxMetaspaceSize=1024m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8";
+
+    const existing = props.find(
+      (p) => p.type === "property" && p.key === "org.gradle.jvmargs",
+    );
+    if (existing) {
+      existing.value = jvmArgs;
+    } else {
+      props.push({
+        type: "property",
+        key: "org.gradle.jvmargs",
+        value: jvmArgs,
+      });
+    }
+    return config;
+  });
+};


### PR DESCRIPTION
## Summary
Refactored the notification event system to use Expo's built-in module event emitter instead of React Native's `DeviceEventEmitter`. This simplifies the event handling architecture and improves reliability by leveraging Expo's event infrastructure.

## Key Changes

- **Notification event emission**: Migrated from `RCTDeviceEventEmitter` to Expo's `Events(...)` declaration in the module definition
  - Updated `LauncherModule.kt` to use `sendEvent()` with `Bundle` instead of manually accessing the React bridge
  - Removed the `sendEventToJS()` method that directly accessed `DeviceEventManagerModule`
  - Added error handling for cases where the AppContext may not be ready

- **Event listener registration**: Changed TypeScript event listeners to use the native module's `addListener()` method
  - Created `addModuleListener()` helper function to safely access the native module's event listener API
  - Updated `addNotificationListener()` and `addNotificationRemovedListener()` to use the new helper
  - Removed dependency on React Native's `DeviceEventEmitter`

- **Notification data serialization**: Updated `NotificationService.kt` to use `Bundle` instead of React's `WritableMap`
  - Simplified data structure creation while maintaining the same payload format

- **Build configuration**: Added Gradle memory configuration plugin
  - New `withGradleMemory.js` plugin to increase JVM heap (4GB) and metaspace (1GB) to prevent out-of-memory errors during Kotlin compilation and CMake builds
  - Registered plugin in `app.json`

## Implementation Details

The event system now follows Expo's module patterns more closely:
- Events are declared upfront in the module definition, making them discoverable and type-safe
- The native side uses `sendEvent()` which is part of Expo's standard event infrastructure
- The JavaScript side uses the module's built-in `addListener()` method rather than a separate event emitter
- Error handling is more graceful, silently ignoring cases where the AppContext isn't ready yet

https://claude.ai/code/session_01Y7y3nYPqB1FhVbMCy5f7RU