### PR TITLE
Fix overlay panels lingering under modal after commit

### DIFF
--- a/src/components/ControlCenterOverlay.tsx
+++ b/src/components/ControlCenterOverlay.tsx
@@ -69,7 +69,10 @@ export function ControlCenterOverlay({ zone, onCommit }: Props) {
       const progress = panelProgress.value;
       const reason = commitForPanel({ progress, velocity: vy, holdMs: 0 });
       if (reason !== 'none') {
-        panelProgress.value = settle(1, 'mediumSettle', reduceMotionShared.value);
+        // Hand off to the real screen: retract the preview so it doesn't
+        // linger underneath the transparent modal and block the home screen
+        // when the user returns.
+        panelProgress.value = settle(0, 'fastSettle', reduceMotionShared.value);
         runOnJS(onCommit)();
       } else {
         panelProgress.value = settle(0, 'fastSettle', reduceMotionShared.value);

--- a/src/components/NotificationCenterOverlay.tsx
+++ b/src/components/NotificationCenterOverlay.tsx
@@ -68,7 +68,10 @@ export function NotificationCenterOverlay({ zone, onCommit }: Props) {
       const progress = panelProgress.value;
       const reason = commitForNC({ progress, velocity: vy, holdMs: 0 });
       if (reason !== 'none') {
-        panelProgress.value = settle(1, 'mediumSettle', reduceMotionShared.value);
+        // Hand off to the real screen: retract the preview so it doesn't
+        // linger underneath the transparent modal and block the home screen
+        // when the user returns.
+        panelProgress.value = settle(0, 'fastSettle', reduceMotionShared.value);
         runOnJS(onCommit)();
       } else {
         panelProgress.value = settle(0, 'fastSettle', reduceMotionShared.value);


### PR DESCRIPTION
## Summary
Fixed an issue where the Control Center and Notification Center overlay panels would remain visible underneath the transparent modal after being committed, potentially blocking interaction with the home screen.

## Changes
- **ControlCenterOverlay.tsx**: Changed panel retraction behavior on commit from `settle(1, 'mediumSettle')` to `settle(0, 'fastSettle')` to fully retract the preview panel
- **NotificationCenterOverlay.tsx**: Applied the same fix to retract the notification panel completely on commit

## Details
When a panel was committed (user action completed), it was being settled to progress value `1` (fully expanded) with a medium animation duration. This caused the panel to remain visible underneath the transparent modal overlay, blocking user interaction with the home screen.

The fix changes the behavior to settle to progress value `0` (fully retracted) with a fast animation, ensuring the preview panel is completely hidden before handing off to the real screen. This prevents the panel from lingering and interfering with the underlying UI.

https://claude.ai/code/session_01Q4YZc7jGKAg2RZs5xzo91e