### PR TITLE
fix(gestures): unblock home taps and retract CC/NC preview after commit

### DIFF
--- a/src/components/ControlCenterOverlay.tsx
+++ b/src/components/ControlCenterOverlay.tsx
@@ -82,15 +82,22 @@ export function ControlCenterOverlay({ zone, onCommit }: Props) {
   const sheetStyle = useAnimatedStyle(() => {
     'worklet';
     const translateY = -SCREEN_HEIGHT * (1 - panelProgress.value);
+    // When fully retracted, drop the view out of the render tree so its
+    // layout-based hit area cannot absorb taps on the home content behind it.
+    const display = panelProgress.value <= 0.001 ? 'none' : 'flex';
     return {
       transform: [{ translateY }],
+      display,
     };
   });
 
   const backdropStyle = useAnimatedStyle(() => {
     'worklet';
+    const opacity = panelProgress.value * 0.5;
+    const display = panelProgress.value <= 0.001 ? 'none' : 'flex';
     return {
-      opacity: panelProgress.value * 0.5,
+      opacity,
+      display,
     };
   });
 

--- a/src/components/ControlCenterOverlay.tsx
+++ b/src/components/ControlCenterOverlay.tsx
@@ -69,7 +69,10 @@ export function ControlCenterOverlay({ zone, onCommit }: Props) {
       const progress = panelProgress.value;
       const reason = commitForPanel({ progress, velocity: vy, holdMs: 0 });
       if (reason !== 'none') {
-        panelProgress.value = settle(1, 'mediumSettle', reduceMotionShared.value);
+        // Hand off to the real screen: retract the preview so it doesn't
+        // linger underneath the transparent modal and block the home screen
+        // when the user returns.
+        panelProgress.value = settle(0, 'fastSettle', reduceMotionShared.value);
         runOnJS(onCommit)();
       } else {
         panelProgress.value = settle(0, 'fastSettle', reduceMotionShared.value);

--- a/src/components/NotificationCenterOverlay.tsx
+++ b/src/components/NotificationCenterOverlay.tsx
@@ -68,7 +68,10 @@ export function NotificationCenterOverlay({ zone, onCommit }: Props) {
       const progress = panelProgress.value;
       const reason = commitForNC({ progress, velocity: vy, holdMs: 0 });
       if (reason !== 'none') {
-        panelProgress.value = settle(1, 'mediumSettle', reduceMotionShared.value);
+        // Hand off to the real screen: retract the preview so it doesn't
+        // linger underneath the transparent modal and block the home screen
+        // when the user returns.
+        panelProgress.value = settle(0, 'fastSettle', reduceMotionShared.value);
         runOnJS(onCommit)();
       } else {
         panelProgress.value = settle(0, 'fastSettle', reduceMotionShared.value);

--- a/src/components/NotificationCenterOverlay.tsx
+++ b/src/components/NotificationCenterOverlay.tsx
@@ -81,15 +81,22 @@ export function NotificationCenterOverlay({ zone, onCommit }: Props) {
   const sheetStyle = useAnimatedStyle(() => {
     'worklet';
     const translateY = -SCREEN_HEIGHT * (1 - panelProgress.value);
+    // When fully retracted, drop the view out of the render tree so its
+    // layout-based hit area cannot absorb taps on the home content behind it.
+    const display = panelProgress.value <= 0.001 ? 'none' : 'flex';
     return {
       transform: [{ translateY }],
+      display,
     };
   });
 
   const backdropStyle = useAnimatedStyle(() => {
     'worklet';
+    const opacity = panelProgress.value * 0.5;
+    const display = panelProgress.value <= 0.001 ? 'none' : 'flex';
     return {
-      opacity: panelProgress.value * 0.5,
+      opacity,
+      display,
     };
   });
 


### PR DESCRIPTION
## Summary

Two related bugs in the `ControlCenterOverlay` / `NotificationCenterOverlay` preview sheets (added in the gesture foundation PR) were causing the user-visible "two notification panels, one won't close, home is unclickable" symptom.

### 1. Preview stayed fully open after commit
On commit, `panelProgress` was settled to `1` and never reset. Since `LauncherHomeScreen` remains mounted beneath the transparent CC/NC modal, when the user returned to home the preview sheet was still fully extended (`pointerEvents="none"`, so it couldn't be dismissed) with a 50% black backdrop over the whole screen. That's the "second panel that won't close".

**Fix:** settle `panelProgress` back to `0` on commit. The real screen takes over; the preview is already retracted when the user returns.

### 2. Sheet's layout hit-area blocked home taps even when off-screen
The sheet (`position: 'absolute', top: 0, height: 55–65% of screen`) relied on the `pointerEvents="none"` prop on `Animated.View` to let taps pass through. Under RN 0.81 + Reanimated 4 / Fabric, that prop isn't reliably honoured — the view's layout-based hit area kept absorbing taps on the first rows of app icons even when the sheet was translated off-screen.

**Fix:** drive `display: 'flex' | 'none'` from `useAnimatedStyle` so the sheet and backdrop are removed from the hit-test tree entirely whenever `panelProgress <= 0.001`. During the drag (progress > 0) they animate normally.

## Test plan
- [ ] Open CC (drag down top-right) → navigate happens → close modal → home icons and dock are tappable, no stuck dim/sheet on screen
- [ ] Same flow for NC (drag down top-left)
- [ ] Cancel a drag below commit threshold → preview retracts, home remains tappable
- [ ] Fully retracted state: every row of app icons responds to tap and long-press (including the top row just below the status bar)
- [ ] Reduce-motion setting still produces a clean retract on commit/cancel

https://claude.ai/code/session_01Q4YZc7jGKAg2RZs5xzo91e