### PR TITLE
fix(gestures): remove SpotlightReveal hit-area that was swallowing home taps

### DIFF
--- a/src/components/SpotlightReveal.tsx
+++ b/src/components/SpotlightReveal.tsx
@@ -1,94 +1,44 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import Animated, {
-  useSharedValue,
+  SharedValue,
   useAnimatedStyle,
-  runOnJS,
-  useFrameCallback,
 } from 'react-native-reanimated';
-import { Gesture, GestureDetector } from 'react-native-gesture-handler';
-import { gestureConfig } from '../utils/gestureConfig';
-import { useVelocityBuffer, pushSample, sampledVelocity } from '../utils/gestureVelocity';
-import { commitForSpotlight } from '../utils/gestureMachine';
-import { settle, useGestureReduceMotion } from '../utils/useGestureReduceMotion';
 
 interface SpotlightRevealProps {
-  enabled: boolean;   // false when folder open / jiggling / anything that should suppress
-  onCommit: () => void; // called at settling — navigates to SpotlightSearch
+  // Externally-controlled progress (0..1+). Animation comes from the parent's
+  // pan gesture — the component is purely visual so it doesn't sit on top of
+  // home content capturing taps.
+  progress: SharedValue<number>;
 }
 
-export function SpotlightReveal({ enabled, onCommit }: SpotlightRevealProps) {
-  const reduceMotion = useGestureReduceMotion();
-  const reduceMotionShared = useSharedValue(reduceMotion);
-  useEffect(() => {
-    reduceMotionShared.value = reduceMotion;
-  }, [reduceMotion, reduceMotionShared]);
-
-  const progress = useSharedValue(0);   // 0..1 relative to spotlightCommitDp
-  const thresholdFired = useSharedValue(false);
-  const buf = useVelocityBuffer();
-  const currentT = useSharedValue(0);
-
-  useFrameCallback(({ timestamp }) => {
-    'worklet';
-    currentT.value = timestamp;
-  });
-
-  const pan = Gesture.Pan()
-    .enabled(enabled)
-    .activeOffsetY([gestureConfig.axisLockDp, 9999])
-    .onBegin(() => {
-      'worklet';
-      progress.value = 0;
-      thresholdFired.value = false;
-      buf.value = [];
-    })
-    .onUpdate((e) => {
-      'worklet';
-      const dy = Math.max(0, e.translationY);
-      pushSample(buf.value, e.translationX, e.translationY, currentT.value);
-      // Below reveal start, stay at 0 — spec §11.2 says don't interpolate noise
-      if (dy < gestureConfig.spotlightRevealDp) {
-        progress.value = 0;
-        return;
-      }
-      // Map dy to 0..1 over spotlightCommitDp so progress >= 1 means committed-by-distance
-      progress.value = Math.min(1.5, (dy - gestureConfig.spotlightRevealDp) / gestureConfig.spotlightCommitDp);
-    })
-    .onEnd((e) => {
-      'worklet';
-      pushSample(buf.value, e.translationX, e.translationY, currentT.value);
-      const { vy } = sampledVelocity(buf.value, currentT.value);
-      // Pass the distance-normalised progress (clamped) to commitForSpotlight
-      const p = Math.min(1, Math.max(0, progress.value));
-      const reason = commitForSpotlight({ progress: p, velocity: vy, holdMs: 0 });
-      if (reason !== 'none') {
-        progress.value = settle(1.5, 'mediumSettle', reduceMotionShared.value);
-        runOnJS(onCommit)();
-      } else {
-        progress.value = settle(0, 'fastSettle', reduceMotionShared.value);
-      }
-    });
-
+export function SpotlightReveal({ progress }: SpotlightRevealProps) {
   // Animated affordance: search field that slides in from above
   const fieldStyle = useAnimatedStyle(() => {
     'worklet';
     const p = Math.min(1, progress.value);
+    // Remove from layout (and therefore from hit-testing) when fully retracted.
+    const display = progress.value <= 0.001 ? 'none' : 'flex';
     return {
       opacity: p,
-      transform: [{ translateY: (p - 1) * 30 }], // slides from -30 to 0
+      transform: [{ translateY: (p - 1) * 30 }],
+      display,
     };
   });
 
   const dimStyle = useAnimatedStyle(() => {
     'worklet';
     const p = Math.min(1, progress.value);
-    return { opacity: p * 0.4 };
+    const display = progress.value <= 0.001 ? 'none' : 'flex';
+    return {
+      opacity: p * 0.4,
+      display,
+    };
   });
 
   return (
     <>
-      {/* Full-screen dim overlay behind the content */}
+      {/* Full-screen dim overlay — purely visual */}
       <Animated.View
         pointerEvents="none"
         style={[StyleSheet.absoluteFill, styles.dim, dimStyle]}
@@ -104,15 +54,6 @@ export function SpotlightReveal({ enabled, onCommit }: SpotlightRevealProps) {
           <Text style={styles.fieldLabel}>Search</Text>
         </View>
       </Animated.View>
-      {/* Invisible activation region — hidden from TalkBack */}
-      <GestureDetector gesture={pan}>
-        <View
-          style={styles.hitArea}
-          collapsable={false}
-          accessible={false}
-          importantForAccessibility="no-hide-descendants"
-        />
-      </GestureDetector>
     </>
   );
 }
@@ -142,13 +83,5 @@ const styles = StyleSheet.create({
     color: 'rgba(255,255,255,0.7)',
     fontSize: 15,
     fontWeight: '400',
-  },
-  hitArea: {
-    position: 'absolute',
-    left: 0,
-    right: 0,
-    top: 60,
-    bottom: 60,
-    zIndex: 20,
   },
 });

--- a/src/screens/LauncherHomeScreen.tsx
+++ b/src/screens/LauncherHomeScreen.tsx
@@ -51,7 +51,10 @@ import { WALLPAPERS, darkenHex } from '../utils/wallpapers';
 import { ControlCenterOverlay } from '../components/ControlCenterOverlay';
 import { NotificationCenterOverlay } from '../components/NotificationCenterOverlay';
 import { SpotlightReveal } from '../components/SpotlightReveal';
-import { zones } from '../utils/gestureConfig';
+import { zones, gestureConfig } from '../utils/gestureConfig';
+import { useVelocityBuffer, pushSample, sampledVelocity } from '../utils/gestureVelocity';
+import { commitForSpotlight } from '../utils/gestureMachine';
+import { settle, useGestureReduceMotion } from '../utils/useGestureReduceMotion';
 import type { AppNavigationProp } from '../navigation/types';
 import type { SettingsState } from '../store/SettingsStore';
 
@@ -563,18 +566,72 @@ export function LauncherHomeScreen() {
     navigation.navigate(screen as any);
   }, [navigation]);
 
-  // Vertical swipe gesture: up → App Drawer only.
-  // Downward → Spotlight is handled by SpotlightReveal below.
-  // CC and NC top-zone swipes are handled by ControlCenterOverlay / NotificationCenterOverlay.
+  // Vertical swipe gesture on the home body:
+  //   up   → App Drawer
+  //   down → Spotlight (progress tracked into spotlightProgress; navigate on commit)
+  // CC and NC top-zone swipes are handled by the respective overlays' own
+  // activation zones (44dp top strip), which win over this parent gesture
+  // because they are nested children.
+  const spotlightProgress = useSharedValue(0);
+  const spotlightBuf = useVelocityBuffer();
+  const spotlightT = useSharedValue(0);
+  const reduceMotion = useGestureReduceMotion();
+  const reduceMotionShared = useSharedValue(reduceMotion);
+  useEffect(() => {
+    reduceMotionShared.value = reduceMotion;
+  }, [reduceMotion, reduceMotionShared]);
+
+  // Mirror of `canSpotlight` (computed from React state further below) so
+  // worklets can gate the gesture without touching JS state.
+  const canSpotlightShared = useSharedValue(true);
+
   const panGesture = Gesture.Pan()
     .activeOffsetY([-20, 20])
+    .onUpdate((e) => {
+      'worklet';
+      if (!canSpotlightShared.value) return;
+      if (e.translationY <= 0) {
+        spotlightProgress.value = 0;
+        return;
+      }
+      spotlightT.value = Date.now();
+      pushSample(spotlightBuf.value, e.translationX, e.translationY, spotlightT.value);
+      const dy = e.translationY;
+      if (dy < gestureConfig.spotlightRevealDp) {
+        spotlightProgress.value = 0;
+        return;
+      }
+      spotlightProgress.value = Math.min(
+        1.5,
+        (dy - gestureConfig.spotlightRevealDp) / gestureConfig.spotlightCommitDp,
+      );
+    })
     .onEnd((event) => {
       'worklet';
       const { translationY, velocityY } = event;
 
+      // Up-swipe → App Library
       if (translationY < -60 && velocityY < -200) {
+        spotlightProgress.value = settle(0, 'fastSettle', reduceMotionShared.value);
         runOnJS(navigateTo)('AppLibrary');
+        return;
       }
+
+      // Down-swipe → Spotlight (commit check)
+      if (canSpotlightShared.value && translationY > 0) {
+        spotlightT.value = Date.now();
+        pushSample(spotlightBuf.value, event.translationX, event.translationY, spotlightT.value);
+        const { vy } = sampledVelocity(spotlightBuf.value, spotlightT.value);
+        const p = Math.min(1, Math.max(0, spotlightProgress.value));
+        const reason = commitForSpotlight({ progress: p, velocity: vy, holdMs: 0 });
+        if (reason !== 'none') {
+          spotlightProgress.value = settle(1, 'mediumSettle', reduceMotionShared.value);
+          runOnJS(navigateTo)('SpotlightSearch');
+          return;
+        }
+      }
+
+      spotlightProgress.value = settle(0, 'fastSettle', reduceMotionShared.value);
     });
 
   // Request permissions on first launch
@@ -749,6 +806,9 @@ export function LauncherHomeScreen() {
 
   // Spotlight reveal is suppressed when jiggling, folder is open, or action sheet is up
   const canSpotlight = !isJiggling && !actionSheet.visible && openFolder === null;
+  useEffect(() => {
+    canSpotlightShared.value = canSpotlight;
+  }, [canSpotlight, canSpotlightShared]);
 
   const handleScroll = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
     const offsetX = event.nativeEvent.contentOffset.x;
@@ -1170,10 +1230,7 @@ export function LauncherHomeScreen() {
       {/* ---------------------------------------------------------------- */}
       {/* Spotlight progressive reveal (downward swipe on home)             */}
       {/* ---------------------------------------------------------------- */}
-      <SpotlightReveal
-        enabled={canSpotlight}
-        onCommit={() => navigation.navigate('SpotlightSearch')}
-      />
+      <SpotlightReveal progress={spotlightProgress} />
 
       {/* ---------------------------------------------------------------- */}
       {/* Top-zone progressive reveal overlays (CC + NC)                    */}


### PR DESCRIPTION
## Summary

PRs #240 and #241 fixed the CC/NC preview overlays, but home icons still don't respond to taps. The actual blocker is a different component that was missed: **`SpotlightReveal`**.

### Root cause

`src/components/SpotlightReveal.tsx` wraps its Pan gesture around an empty hit-area `View`:

```tsx
<GestureDetector gesture={pan}>
  <View style={styles.hitArea} />
</GestureDetector>
```

…with `styles.hitArea = { position: 'absolute', left: 0, right: 0, top: 60, bottom: 60, zIndex: 20 }`, no `pointerEvents`, no children. It sits on top of every app icon, widget and dock slot on the home screen. The Pan requires ±10dp of motion to activate (axis-lock), so a plain tap never activates a gesture — but the hit-area `View` is still the top-most view at the tap point and absorbs the touch, and since it's a dead-end sibling of the real home content there's nowhere for the tap to forward to. No icon on home responds.

This is the same anti-pattern the CC/NC fix couldn't help with: their overlays only cover a 44dp top strip, while SpotlightReveal's hitArea covers practically the whole home.

### Fix

Move the spotlight Pan logic into `LauncherHomeScreen`'s existing root `panGesture`, which already wraps the home as a parent `GestureDetector` with `activeOffsetY([-20, 20])` — so children (real app icons) keep receiving taps until a gesture actually activates. That `panGesture` now:

- `onUpdate`: tracks down-swipe progress into a shared value, gated by `canSpotlight`
- `onEnd`: commits to Spotlight if `commitForSpotlight` says so; else falls back to the existing AppLibrary up-swipe check; else settles progress back to 0

`SpotlightReveal` becomes a pure visual component driven by an external `SharedValue<number>` — no hit-area, no internal gesture. Its dim and field styles also get `display: 'none'` when progress ≈ 0, matching the CC/NC fix.

## Test plan
- [ ] Every app icon, widget, and dock slot on the home responds to tap and long-press
- [ ] Drag down in the middle of the home → Spotlight preview fades in → release past threshold → Spotlight search opens
- [ ] Cancel a down-drag before threshold → preview retracts, home still tappable
- [ ] Up-swipe still navigates to App Library
- [ ] Control Center drag (top-right) and Notification Center drag (top-left) still work and don't get stolen by the parent gesture
- [ ] With a folder open / jiggle mode / action sheet visible, the down-drag does nothing (canSpotlight gate)
- [ ] Reduce-motion setting still produces clean retracts

https://claude.ai/code/session_01Q4YZc7jGKAg2RZs5xzo91e