### PR TITLE
chore: green the test suite and add the agent delivery pipeline

### DIFF
--- a/modules/launcher-module/src/index.ts
+++ b/modules/launcher-module/src/index.ts
@@ -490,7 +490,13 @@ export default LauncherModule;
 
 type Subscription = { remove: () => void };
 
-function addModuleListener(eventName: string, handler: (payload: any) => void): Subscription {
+// Generic rather than `any`: each caller already knows the shape the native side
+// emits for its event, and stating it here propagates that type to the handler
+// instead of erasing it at the boundary.
+function addModuleListener<TPayload>(
+  eventName: string,
+  handler: (payload: TPayload) => void,
+): Subscription {
   if (!nativeModule || typeof nativeModule.addListener !== 'function') {
     return { remove: () => {} };
   }

--- a/scripts/team/README.md
+++ b/scripts/team/README.md
@@ -1,0 +1,201 @@
+# Pipeline de agentes — iosToAndroid
+
+Fila autónoma que pega nos issues abertos do GitHub, implementa-os, revê-os e
+fecha-os. Portado do harness de QA do `monthy_budget`, sem o critic e sem o
+verificador: aqui o backlog já está escrito e não há tester da app a correr.
+
+## A máquina de estados
+
+```
+issue aberto ──seed──► qa:ready ──► IMPLEMENTADOR ──► qa:review ──► REVIEWER ──► qa:done
+                          ▲             │                              │         (fechado)
+                          │             │ blocked                      │ blocked-impl
+                          │             ▼                              │
+                          │      qa:blocked-spec ◄──── blocked-spec ───┤
+                          │             │                              │
+                          │             ▼                              ▼
+                          └──────── CURATOR ◄──── escalada após N tentativas
+```
+
+**Exactamente um label `qa:*` é o estado do issue.** Os comentários são o registo
+de auditoria; o label é aquilo sobre o qual o orquestrador despacha.
+
+### O curator não está no caminho normal
+
+Nada entra pelo curator. Os issues vão directos para o implementador, que
+investiga o código sozinho. A análise só acontece quando alguém a pede:
+
+| Porta | Quem abre | Quando |
+|---|---|---|
+| `blocked` | implementador | investigou e o issue não é executável como está |
+| `blocked-spec` | reviewer | o código fazia o que o issue pedia, e o pedido estava errado |
+| escalada | orquestrador | 3 tentativas sem integrar; à 6ª força `split` |
+
+Curar 42 issues à cabeça custaria uma corrida de agente por cada um para produzir
+um briefing que o implementador acaba por re-derivar de qualquer maneira.
+
+## Arrancar
+
+```bash
+cd ~/Documentos/iosToAndroid
+
+# 1. labels
+bash scripts/team/setup.sh --labels
+
+# 2. medir o que já está partido em main (ver "O portão é regressão" abaixo)
+bash scripts/team/baseline.sh
+bash scripts/team/baseline.sh --show
+
+# 3. pôr o backlog na fila (vê primeiro o que vai acontecer)
+bash scripts/team/setup.sh --seed --dry-run
+bash scripts/team/setup.sh --seed
+
+# 4. uma passagem só, para veres o comportamento antes de o largar
+bash scripts/team/orchestrator.sh --once
+
+# 5. a sério, em tmux
+bash scripts/team/start.sh
+bash scripts/team/start.sh --status
+bash scripts/team/start.sh --attach
+bash scripts/team/start.sh --stop
+```
+
+Alvos explícitos, úteis a depurar:
+
+```bash
+bash scripts/team/orchestrator.sh --issue 212   # despacha o papel certo para o estado dele
+bash scripts/team/orchestrator.sh --pr 300      # só revê este PR
+bash scripts/team/curator.sh 212                # força análise
+```
+
+O orquestrador **termina sozinho** quando não houver nenhum issue accionável.
+
+## Os papéis
+
+| Script | Papel | Slot | Escreve |
+|---|---|---|---|
+| `implement.sh` | investiga, escreve o teste vermelho, corrige, abre PR | `main` | branch `qa/issue-N`, PR |
+| `review.sh` | corre lint+tsc+jest, confere o diff contra o issue, faz merge | `main` | merge para `main`, fecha o issue |
+| `curator.sh` | análise de reparação: causa raiz, AC, passos de teste, `split` | `curator` | comentários e labels |
+
+`main` é um lock exclusivo — **um agente de escrita de cada vez**. Dois agentes a
+fazer push ao mesmo repositório é como se perde trabalho. O curator corre no seu
+próprio slot em paralelo: só escreve comentários no GitHub, sem git e sem build.
+
+## O reviewer é o único portão
+
+Não há verificador a seguir e **não há CI em pull requests** neste repositório
+(`build-apk.yml` só corre ao publicar uma release). O que o reviewer correr —
+`npm run lint`, `npx tsc --noEmit`, `npm test` — é tudo o que alguma vez corre
+antes de o código estar em `main`.
+
+Se quiseres uma segunda rede, o sítio certo é um workflow `pull_request` com
+essas três verificações; o reviewer passa então a lê-lo em vez de ser a única
+fonte.
+
+## O portão é REGRESSÃO, não perfeição
+
+Medido em `main@22d2202` no momento em que isto foi montado:
+
+| verificação | estado |
+|---|---|
+| `npm run lint` | **2 erros**, 2 avisos |
+| `npx tsc --noEmit` | limpo |
+| `npm test` | **103 de 180 testes a falhar**, em 24 de 30 suites |
+
+Um portão estrito contra isto bloqueia **todos** os PRs por falhas que o autor não
+causou: 42 issues × 3 tentativas cada, tudo a falhar, e o log com bom aspecto do
+princípio ao fim. Por isso `baseline.sh` grava o que já estava partido e os
+prompts do implementador e do reviewer recebem essa lista: bloqueiam por falhas
+**novas**, nunca por herdadas. Os testes que o próprio trabalho traz têm de passar
+sempre.
+
+**A causa dominante das 103 falhas é uma linha.** `src/store/SettingsStore.tsx:258`
+faz `if (!firstSyncDone) return null;` e `firstSyncDone` só fica verdadeiro depois
+de uma leitura assíncrona do `AsyncStorage`. Os testes renderizam de forma síncrona
+através de `src/test-utils.tsx`, portanto o provider devolve `null`, a árvore do
+ecrã vem vazia, e todos os `getByText` falham. Não são 103 defeitos; é o mesmo
+defeito 103 vezes. Corrigi-lo primeiro é o que torna o portão estrito viável — e
+volta a ser estrito sozinho: quando `main` estiver verde, apaga
+`~/Documentos/iostoandroid-verdicts/state/baseline.json`.
+
+Volta a correr `baseline.sh` sempre que `main` receber um lote de correcções de
+testes, ou a linha de base envelhece e passa a perdoar regressões reais.
+
+## Ficheiros e estado
+
+Tudo o que é volátil vive **fora** do repositório, de propósito: dentro da árvore
+de trabalho os veredictos acabavam commitados, herdados entre corridas, e
+arrastados para o diff pelo `git add -A`.
+
+| O quê | Onde |
+|---|---|
+| veredictos JSON | `~/Documentos/iostoandroid-verdicts/` |
+| estado (tentativas, shas revistos, cooldown) | `~/Documentos/iostoandroid-verdicts/state/` |
+| worktrees dos agentes | `~/Documentos/iostoandroid-wt/` |
+| logs | `/tmp/ios2android-team/` |
+| locks | `/tmp/ios2android-agent.<slot>.lock` |
+
+Os worktrees são **irmãos** do repositório, nunca dentro dele: um worktree
+aninhado aparece como conteúdo não versionado e acaba commitado por acidente.
+
+### node_modules nos worktrees
+
+`npm ci` em cada worktree custa ~40-60s e este pipeline cria um por issue, por
+review e por retrabalho. Quando o `package-lock.json` do worktree é idêntico ao
+do checkout principal, `wt_prepare_node` faz **symlink** ao `node_modules`
+principal em vez de instalar. Quando o lock difere — porque o issue mexeu nas
+dependências — instala a sério, porque aí o symlink mutaria a árvore do checkout
+principal por baixo de um agente vivo.
+
+## Configuração
+
+Tudo por variável de ambiente, com omissões em `lib.sh`:
+
+| Variável | Omissão | Efeito |
+|---|---|---|
+| `TEAM_CYCLE_SLEEP` | `45` | segundos entre ciclos |
+| `TEAM_MAX_ATTEMPTS` | `3` | tentativas antes de escalar para o curator |
+| `IMPLEMENT_MODEL` / `REVIEW_MODEL` / `CURATOR_MODEL` | `sonnet` | modelo por papel |
+| `IMPLEMENT_HONOUR_READY_LABELS` | `0` | a `1`, usa `haiku` nos issues com `haiku-ready` |
+| `IMPLEMENT_TIMEOUT` | `2700` | segundos |
+| `REVIEW_TIMEOUT` | `1800` | segundos |
+| `CURATOR_TIMEOUT` | `1200` | segundos |
+| `AGENT_FALLBACK_MODEL` | `deepseek-v4-flash:cloud` | motor quando a subscrição esgota |
+
+Sobre `IMPLEMENT_HONOUR_READY_LABELS`: o backlog está triado com
+`haiku-ready`/`sonnet-ready`, mas essa triagem é sobre o **tamanho da alteração**,
+não sobre o tamanho do trabalho que o agente faz — investigar a causa, escrever o
+teste vermelho, provar o passo vermelho, correr três gates e produzir um veredicto
+estruturado. Um fix de uma linha carrega tudo isso na mesma. Por isso a omissão é
+`sonnet` para todos.
+
+## Quando a subscrição esgota
+
+`run-agent.sh` detecta o limite de sessão, lê a hora de reset da mensagem do CLI,
+grava um cooldown, e passa para o mesmo harness com um modelo do Ollama Cloud. A
+diferença fica registada em `/tmp/ios2android-agent.<slot>.engine`, e os papéis
+usam-na para distinguir "esta corrida foi degradada" de "este issue derrotou o
+pipeline" — sem isso, uma falta de quota temporária consome trabalho real de forma
+permanente.
+
+O fallback **não aceita imagens**: fazer `Read` num `.png` devolve 400 e mata a
+corrida inteira sem veredicto. O prompt é anexado com um aviso quando esse motor
+está em uso.
+
+## Falhas conhecidas que este código já defende
+
+Cada uma custou trabalho real no projecto irmão e está comentada no sítio:
+
+- ler os issues com `2>/dev/null || echo ""` faz uma falha de API parecer um
+  backlog vazio — o orquestrador declarava vitória sobre leituras falhadas;
+- rever um PR pelo número em vez de pelo sha da HEAD gerou 184 reviews do mesmo
+  commit numa noite;
+- `wt_create` em vez de `wt_checkout` na review dá diff **vazio**, e o reviewer
+  julga o PR pelo título sem erro nenhum no log;
+- `| head -c N` num diff sob `set -o pipefail` mata o script por SIGPIPE;
+- não fechar o fd do lock (`9>&-`) deixa o agente a segurar o lock depois de o
+  pai sair;
+- não fechar o stdin (`< /dev/null`) faz o `ollama launch` pendurar até ao timeout;
+- confiar no código de saída do `gh pr merge` reporta falha em merges que
+  aconteceram, e fila retrabalho de código já integrado.

--- a/scripts/team/baseline.sh
+++ b/scripts/team/baseline.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# baseline.sh — record what is ALREADY broken on `main`, so the reviewer can block
+# on regressions instead of on inherited failures.
+#
+# WHY THIS EXISTS
+#
+# The pipeline was designed around "lint, tsc and jest must all pass". On this
+# repository, at the time it was set up, they did not: `main` had 2 eslint errors
+# and 103 of 180 tests failing across 24 of 30 suites. A strict gate against that
+# baseline blocks EVERY pull request for failures the author did not cause — 42
+# issues would each burn three implementation attempts and deliver nothing, and the
+# log would look busy the whole time.
+#
+# So the gate is: **no NEW failures**. This file is the record of "old".
+#
+# It is deliberately a snapshot, not a policy. Once `main` is green, delete
+# $STATE_DIR/baseline.json and the gate becomes strict again on its own — the
+# review prompt says so when no baseline is present.
+#
+# Re-run this after any change to `main` that fixes a batch of tests, or the
+# baseline goes stale and starts forgiving real regressions.
+#
+# Usage: baseline.sh [--show]
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+ROLE="baseline"
+
+BASELINE_FILE="$STATE_DIR/baseline.json"
+
+if [ "${1:-}" = "--show" ]; then
+  [ -f "$BASELINE_FILE" ] && cat "$BASELINE_FILE" || echo "(sem baseline — o portão está em modo estrito)"
+  exit 0
+fi
+
+WT=""
+cleanup() { [ -n "$WT" ] && wt_remove "$WT"; }
+trap cleanup EXIT
+
+log "a medir $BASE_BRANCH num worktree limpo..."
+WT_OUT=$(wt_checkout "$BASE_BRANCH" "baseline") || { warn "checkout falhou"; exit 1; }
+WT="$WT_OUT"
+wt_prepare_node "$WT"
+
+cd "$WT" || exit 1
+
+# ── lint ───────────────────────────────────────────────────────────────────
+LINT_OUT=$(npm run lint 2>&1 || true)
+LINT_ERRORS=$(printf '%s' "$LINT_OUT" | grep -cE '^\s+[0-9]+:[0-9]+\s+error' || true)
+LINT_WARNINGS=$(printf '%s' "$LINT_OUT" | grep -cE '^\s+[0-9]+:[0-9]+\s+warning' || true)
+log "lint: $LINT_ERRORS erro(s), $LINT_WARNINGS aviso(s)"
+
+# ── tsc ────────────────────────────────────────────────────────────────────
+if npx tsc --noEmit >/dev/null 2>&1; then TSC_OK=true; else TSC_OK=false; fi
+log "tsc: ok=$TSC_OK"
+
+# ── jest ───────────────────────────────────────────────────────────────────
+# --json into a file, not stdout: jest writes progress to stderr and the summary to
+# stdout, and mixing them makes the JSON unparseable exactly when it matters.
+JEST_JSON="/tmp/ios2a-baseline-jest.json"
+rm -f "$JEST_JSON"
+npx jest --json --outputFile="$JEST_JSON" >/dev/null 2>&1 || true
+
+if [ ! -s "$JEST_JSON" ]; then
+  warn "jest não produziu JSON — baseline não escrita (melhor sem baseline do que com uma errada)"
+  exit 1
+fi
+
+FAILED_TESTS=$(jq -r '
+  [ .testResults[].assertionResults[]? | select(.status == "failed")
+    | ((.ancestorTitles // []) + [.title]) | join(" › ") ] | sort' "$JEST_JSON")
+FAILED_SUITES=$(jq -r '
+  [ .testResults[] | select(.status == "failed") | .name ] | sort' "$JEST_JSON")
+
+jq -n \
+  --argjson lint_errors "${LINT_ERRORS:-0}" \
+  --argjson lint_warnings "${LINT_WARNINGS:-0}" \
+  --argjson tsc_ok "$TSC_OK" \
+  --argjson failed_tests "$FAILED_TESTS" \
+  --argjson failed_suites "$FAILED_SUITES" \
+  --arg sha "$(git rev-parse --short HEAD)" \
+  --argjson totals "$(jq '{suites: .numTotalTestSuites, tests: .numTotalTests, failed_tests: .numFailedTests, failed_suites: .numFailedTestSuites}' "$JEST_JSON")" \
+  '{sha: $sha, lint_errors: $lint_errors, lint_warnings: $lint_warnings,
+    tsc_ok: $tsc_ok, totals: $totals,
+    failed_suites: $failed_suites, failed_tests: $failed_tests}' \
+  > "$BASELINE_FILE"
+
+rm -f "$JEST_JSON"
+
+log "baseline escrita em $BASELINE_FILE"
+jq -r '"  sha=\(.sha)  lint_errors=\(.lint_errors)  tsc_ok=\(.tsc_ok)  testes a falhar=\(.totals.failed_tests)/\(.totals.tests) em \(.totals.failed_suites)/\(.totals.suites) suites"' "$BASELINE_FILE"
+
+if [ "${LINT_ERRORS:-0}" = "0" ] && [ "$TSC_OK" = "true" ] \
+   && [ "$(jq -r '.totals.failed_tests' "$BASELINE_FILE")" = "0" ]; then
+  log "$BASE_BRANCH está VERDE — apaga $BASELINE_FILE para pôr o portão em modo estrito"
+fi

--- a/scripts/team/curator-prompt.md
+++ b/scripts/team/curator-prompt.md
@@ -1,0 +1,162 @@
+# iosToAndroid — Curator (analista)
+
+## ⛔ Sessão HEADLESS — não há próximo turno
+
+Isto corre sem ninguém do outro lado. **Não existe** notificação, nem segundo
+turno, nem alguém que te responda. Se terminares a tua resposta à espera de algo,
+a corrida acaba ali e todo o teu trabalho é descartado.
+
+- **Corre tudo de forma síncrona.** Nada em background: sem `&`, sem `nohup`, sem
+  processos a monitorizar. Se um comando demora, espera por ele.
+- **Não digas "vou aguardar"** por um processo ou por uma notificação. Não vem nada.
+- **A última coisa que fazes é escrever o veredicto** em `__VERDICT_PATH__`. Sem
+  veredicto, a corrida conta como falhada mesmo que o teu trabalho esteja feito.
+- Se ficares sem tempo, escreve o veredicto **com o que tens**.
+
+És o **curator** — o analista. Não escreves código de produção. Investigas,
+decides, e escreves a análise a partir da qual o implementador trabalha.
+
+## 🔴 PORQUE É QUE ESTE ISSUE CHEGOU ATÉ TI
+
+Neste pipeline os issues vão **directos para o implementador**. Tu não vês a fila
+normal; só vês o que já falhou. Este issue está aqui por uma de três razões, e o
+histórico de comentários diz-te qual:
+
+1. **O implementador devolveu `blocked`** — investigou e concluiu que o issue não
+   é executável como está.
+2. **O reviewer devolveu `blocked-spec`** — o código submetido fazia o que o
+   issue pedia, e o que o issue pedia estava errado.
+3. **O orquestrador escalou** — o issue já deu N voltas sem ser integrado, e
+   repetir a mesma abordagem deixou de fazer sentido.
+
+**Lê o histórico primeiro, e lê-o como evidência, não como ruído.** É o registo
+de tentativas reais contra código real: diz-te exactamente onde é que cada uma
+bateu. Uma análise que ignore isso vai propor o caminho que já falhou, e o issue
+volta cá numa hora.
+
+Nunca devolvas o issue com uma reformulação do enunciado original. Se a tua
+análise não contiver informação que **não estava** no issue, não fizeste nada.
+
+## O projecto
+
+App React Native / Expo em TypeScript que replica a interface do iOS em Android.
+Repositório em `__REPO_PKG__`.
+
+- `src/screens/` ecrãs, `src/components/` componentes `Cupertino*`,
+  `src/store/` estado, `modules/` módulo nativo Kotlin com bridge JS.
+- Testes em `src/**/__tests__/*.test.tsx` (`jest-expo/android`,
+  `@testing-library/react-native`).
+- `android/` e `ios/` são gerados pelo `expo prebuild` — configuração permanente
+  vive em `app.json` e em `plugins/`.
+
+## O teu trabalho
+
+1. **Lê o histórico.** O que foi tentado, o que falhou, e com que mensagem.
+2. **Reproduz no código.** Encontra o ficheiro e a linha onde o problema nasce.
+   `Grep`/`Read`/`git log -S` em `__REPO_PKG__`. Uma análise sem `ficheiro:linha`
+   obriga o implementador a repetir a tua investigação — e é aí que ele se perde
+   outra vez.
+3. **Distingue causa de sintoma.** O issue descreve o que se vê; tu explicas
+   porque acontece.
+4. **Verifica se ainda existe.** O issue pode ter sido corrigido entretanto por
+   outro fix. Se o código já está correcto, o veredicto é `already-fixed`.
+5. **Decide o veredicto** e escreve a análise.
+
+## Veredicto
+
+Escreve EXACTAMENTE este JSON em `__VERDICT_PATH__`:
+
+```json
+{
+  "outcome": "ready|not-a-defect|already-fixed|split",
+  "priority": "P0|P1|P2|P3",
+  "summary": "uma frase: a causa raiz",
+  "analysis": "o briefing completo em markdown — ver a estrutura abaixo",
+  "subissues": [{ "title": "...", "body": "..." }]
+}
+```
+
+### ⛔ Não existe "needs-human". Tens de decidir.
+
+Este pipeline resolve os issues de ponta a ponta, sem intervenção humana. **Não há
+para onde escalar.** Um issue que devolvas indeciso fica parado para sempre, e isso
+é pior que qualquer decisão que possas tomar.
+
+Se te sentires tentado a pedir ajuda, escolhe em vez disso:
+
+- **Falta-te informação?** Vai buscá-la. Lê o código, corre `git log`/`git blame`,
+  procura os chamadores, corre os testes existentes. Tens as ferramentas todas.
+- **É uma decisão de produto?** Toma-a, aplicando o critério mais defensável, e
+  **regista o raciocínio e a alternativa** no `analysis`. Um humano que discorde
+  reabre; um issue parado nunca se resolve. Na dúvida escolhe o que for menos
+  destrutivo e mais consistente com o resto da app.
+- **É demasiado grande ou vago?** Usa `split`. É essa a saída para a complexidade
+  — não o impasse.
+- **Não consegues confirmar que é defeito?** Se investigaste e não se sustenta,
+  `not-a-defect` com o porquê.
+
+### Critérios
+
+- **ready** — encontraste a causa e o issue cabe numa corrida de implementação.
+  Escreve o `analysis` completo. **Só declaras `ready` se a análise disser algo
+  que o implementador não sabia** — caso contrário estás a mandá-lo repetir a
+  tentativa que já falhou.
+- **not-a-defect** — o comportamento está correcto, ou quem abriu o issue
+  interpretou mal. Explica **porquê** no `analysis`: o issue vai ser fechado com
+  esse texto e alguém vai lê-lo daqui a seis meses.
+- **already-fixed** — o código já não tem o problema. Diz em `analysis` o commit
+  ou o estado actual do ficheiro que o comprova.
+- **split** — o issue toca em coisas independentes, é grande demais para uma
+  corrida, **ou já falhou várias vezes**. Parte em 2 a 5 `subissues`, cada um com
+  `title` e `body` concretos e independentes. Cada um tem de caber sozinho e ser
+  **mais fácil** que o original — se partires em pedaços igualmente difíceis, não
+  resolveste nada. Os sub-issues entram directamente na fila do implementador,
+  por isso o `body` de cada um tem de ser auto-suficiente.
+
+### Estrutura obrigatória do `analysis`
+
+O campo `analysis` é publicado como comentário no issue. Tem de ter estas cinco
+secções, com estes títulos:
+
+```markdown
+## Porque falhou antes
+
+O que a(s) tentativa(s) anterior(es) fizeram e porque não chegou lá. Cita o
+comentário. Se este issue nunca foi tentado, diz isso e passa à frente.
+
+## Causa raiz
+
+O que está mal e porquê, com `ficheiro:linha`. Não repitas o sintoma — explica
+o mecanismo.
+
+## Como corrigir
+
+A abordagem concreta: o que mudar, onde, e porque é essa a forma certa.
+Menciona armadilhas (outros sítios que dependem disto, testes e snapshots que
+vão quebrar, comportamento a preservar). Não escrevas o patch todo — indica o
+caminho, e diz explicitamente qual o caminho a **não** repetir.
+
+## Critérios de aceitação
+
+- [ ] Afirmações verificáveis, uma por linha.
+- [ ] Cada uma tem de ser objectivamente verdadeira ou falsa depois do fix.
+- [ ] Inclui o que NÃO deve mudar (protege contra regressões).
+
+## Como testar
+
+1. O teste automático a criar ou actualizar, com o caminho do ficheiro.
+2. O que ele deve verificar, e qual a mensagem de falha esperada antes do fix.
+3. Casos além do caminho feliz que este defeito exige.
+```
+
+Critérios de aceitação vagos são a principal razão pela qual um fix passa a
+review e não resolve nada. "O ecrã funciona bem" não é verificável; "o botão
+deixa de disparar `onPress` duas vezes num duplo toque em menos de 300ms" é.
+
+## Notas
+
+- Investiga antes de decidir. Não adivinhes a causa a partir do título.
+- Se o issue tem prova (screenshot, erro de consola), usa-a.
+- Se a prioridade original está errada face ao que descobriste, corrige-a em
+  `priority`.
+- Responde em português.

--- a/scripts/team/curator.sh
+++ b/scripts/team/curator.sh
@@ -1,0 +1,205 @@
+#!/bin/bash
+# curator.sh — the CURATOR (the analyst role). Finds the root cause in the code and
+# writes the briefing the implementer works from: root cause, fix approach,
+# acceptance criteria and test steps. Also closes issues that turn out to be
+# non-defects or already fixed, and splits ones that are too big.
+#
+# THIS IS A REPAIR PATH, NOT THE FRONT DOOR. Nothing routes new issues here. It runs
+# only when one of three things happened:
+#
+#   * the implementer investigated and returned `blocked` — not actionable as written
+#   * the reviewer returned `blocked-spec` — the issue asked for the wrong thing
+#   * the orchestrator's attempt counter escalated after repeated failures
+#
+# In every case the issue's comment thread already contains the failure history, and
+# that history is the most valuable input this role has. Read it first.
+#
+# Never touches production code — only the issue.
+#
+# Usage: curator.sh <issue_number>
+set -uo pipefail
+
+ISSUE="${1:?issue obrigatorio}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+ROLE="curator"
+
+VERDICT_FILE="$VERDICT_DIR/curator-$ISSUE.json"
+WT=""
+PROMPT="/tmp/ios2a-curator-prompt-$ISSUE.txt"
+MODEL="${CURATOR_MODEL:-sonnet}"
+
+cleanup() { [ -n "$WT" ] && wt_remove "$WT"; }
+trap cleanup EXIT
+
+log "issue #$ISSUE modelo=$MODEL"
+
+# A read-only checkout of main. Detached, so nothing can be pushed from here.
+WT_OUT=$(wt_checkout "$BASE_BRANCH" "curator-$ISSUE") || { log "ERRO: checkout de $BASE_BRANCH falhou"; exit 1; }
+WT="$WT_OUT"
+
+ISSUE_JSON=$(gh issue view "$ISSUE" --repo "$REPO" \
+  --json title,body,labels,comments --jq '
+  "# " + .title + "\n\n" +
+  "## Corpo\n\n" + (.body // "(vazio)") + "\n\n" +
+  "## Labels\n\n" + ([.labels[].name] | join(", ")) + "\n\n" +
+  "## Histórico (porque é que este issue chegou aqui)\n\n" +
+  (if (.comments | length) > 0 then
+     ([.comments[] | "- **@" + (.author.login // "anon") + "**: " + (.body // "")] | join("\n\n"))
+   else "(sem comentários)" end)
+' 2>/dev/null) || { log "ERRO: não consegui ler o issue #$ISSUE"; exit 1; }
+
+{
+  cat "$SCRIPT_DIR/curator-prompt.md"
+  echo ""
+  echo "---"
+  echo ""
+  echo "# O issue a analisar"
+  echo ""
+  printf '%s\n' "$ISSUE_JSON"
+} | sed -e "s|__VERDICT_PATH__|$VERDICT_FILE|g" \
+        -e "s|__REPO_PKG__|$WT|g" > "$PROMPT"
+
+# STALE: delete before the run, so a verdict inherited from a previous run can never
+# be read as this run's result.
+rm -f "$VERDICT_FILE"
+
+# Its OWN slot, not `main`. The curator writes only GitHub comments and labels: no
+# git, no branch, no build, no npm install. It does not collide with the implementer
+# or the reviewer, and serialising it onto them would add its whole runtime to every
+# issue that needs repair. The slot lock still guarantees two curators never run at
+# the same time.
+AGENT_SLOT=curator CLAUDE_MODEL="$MODEL" \
+  bash "$SCRIPT_DIR/run-agent.sh" "$PROMPT" "$WT" "${CURATOR_TIMEOUT:-1200}" \
+  > "$LOG_DIR/curator-$ISSUE.log" 2>&1; AGENT_RC=$?
+
+if [ ! -f "$VERDICT_FILE" ]; then
+  # A failed RUN is not a failed issue: leave the state alone so it is picked up
+  # again. Nobody is coming to unpark it.
+  if ! no_verdict_is_real_failure curator "$AGENT_RC"; then
+    log "SEM VEREDICTO (corrida degradada ou não arrancada) — issue fica onde está"
+    comment_issue "$ISSUE" "## Curator: corrida degradada, sem veredicto
+
+A corrida não produziu veredicto por uma razão alheia ao issue: ou o slot estava
+ocupado, ou a subscrição estava esgotada e o fallback não conseguiu concluir a
+análise. **Isto não é um problema do issue** — fica na fila para nova análise."
+    exit 0
+  fi
+  log "SEM VEREDICTO — fica na fila para nova tentativa"
+  comment_issue "$ISSUE" "## Curator: corrida sem veredicto
+
+A corrida terminou sem escrever veredicto (ver \`$LOG_DIR/curator-$ISSUE.log\`).
+Falha da corrida, não do issue — fica na fila para ser reanalisado."
+  exit 0
+fi
+
+OUTCOME=$(jqv "$VERDICT_FILE" '.outcome' 'ready')
+SUMMARY=$(jqv "$VERDICT_FILE" '.summary' '(sem resumo)'); SUMMARY="${SUMMARY:0:600}"
+ANALYSIS=$(jqv "$VERDICT_FILE" '.analysis' '')
+PRIORITY=$(jqv "$VERDICT_FILE" '.priority' '')
+
+log "outcome=$OUTCOME priority=${PRIORITY:-n/d}"
+
+# Re-grade priority when the curator disagrees with the original triage.
+set_priority "$ISSUE" "$PRIORITY"
+
+case "$OUTCOME" in
+  ready)
+    if [ -z "${ANALYSIS//[[:space:]]/}" ]; then
+      # A "ready" with no briefing is the exact failure this role exists to prevent:
+      # the implementer already tried without one and asked for analysis. Sending it
+      # back unchanged would loop forever.
+      log "outcome=ready mas analysis vazio — fica em $L_BLOCKED_SPEC para nova análise"
+      comment_issue "$ISSUE" "## Curator: análise vazia — a repetir
+
+Declarou \`ready\` sem escrever a análise. Este issue chegou aqui **precisamente
+porque** o implementador não conseguiu resolvê-lo sem briefing, por isso devolvê-lo
+sem causa raiz nem critérios de aceitação repetiria a mesma falha. Fica na fila
+para ser analisado outra vez."
+      exit 0
+    fi
+    comment_issue "$ISSUE" "## Curator: analisado — pronto a implementar
+
+**Causa raiz (resumo):** $SUMMARY
+
+$ANALYSIS"
+    set_state "$ISSUE" "$L_READY"
+    log "#$ISSUE -> $L_READY"
+    ;;
+
+  not-a-defect)
+    comment_issue "$ISSUE" "## Curator: não é defeito
+
+$SUMMARY
+
+$ANALYSIS"
+    set_state "$ISSUE" "$L_DONE"
+    gh issue close "$ISSUE" --repo "$REPO" --reason "not planned" >/dev/null 2>&1 || true
+    log "#$ISSUE fechado (not-a-defect)"
+    ;;
+
+  already-fixed)
+    comment_issue "$ISSUE" "## Curator: já corrigido
+
+$SUMMARY
+
+$ANALYSIS"
+    set_state "$ISSUE" "$L_DONE"
+    gh issue close "$ISSUE" --repo "$REPO" --reason completed >/dev/null 2>&1 || true
+    log "#$ISSUE fechado (already-fixed)"
+    ;;
+
+  split)
+    COUNT=$(jq '(.subissues // []) | length' "$VERDICT_FILE" 2>/dev/null || echo 0)
+    if [ "$COUNT" -lt 2 ]; then
+      log "split com $COUNT sub-issues — insuficiente, fica em $L_BLOCKED_SPEC"
+      comment_issue "$ISSUE" "## Curator: split inválido — a repetir
+
+Pediu \`split\` mas indicou $COUNT sub-issues; um split precisa de pelo menos 2.
+O issue volta à fila para ser decidido de outra forma."
+      exit 0
+    fi
+    # Sub-issues enter at qa:ready, straight to the implementer — the whole point of
+    # a split is that each piece is now unambiguous enough not to need curating.
+    PRIO_LABEL="${PRIORITY:-P2}"
+    CREATED=""
+    for i in $(seq 0 $((COUNT - 1))); do
+      ST=$(jq -r ".subissues[$i].title // \"\"" "$VERDICT_FILE")
+      SB=$(jq -r ".subissues[$i].body // \"\"" "$VERDICT_FILE")
+      [ -z "${ST//[[:space:]]/}" ] && continue
+      BODY=$(printf 'Parte de #%s\n\n%s\n' "$ISSUE" "$SB")
+      URL=$(gh issue create --repo "$REPO" --title "$ST" --body "$BODY" \
+              --label "$L_READY,$PRIO_LABEL" 2>/dev/null || echo "")
+      [ -n "$URL" ] && CREATED="$CREATED
+- $URL"
+      log "  sub-issue: ${URL:-FALHOU}"
+    done
+    comment_issue "$ISSUE" "## Curator: partido em sub-issues
+
+$SUMMARY
+$CREATED
+
+O trabalho acontece nos sub-issues; este fica como registo e é fechado — um
+agregador aberto sem trabalho próprio só entope a fila."
+    set_state "$ISSUE" "$L_DONE"
+    gh issue close "$ISSUE" --repo "$REPO" --reason completed >/dev/null 2>&1 || true
+    ;;
+
+  *)
+    # An unrecognised outcome means the agent did not follow the contract. That is a
+    # run problem — requeue rather than park.
+    comment_issue "$ISSUE" "## Curator: resultado não reconhecido (\`$OUTCOME\`)
+
+$SUMMARY
+
+$ANALYSIS
+
+O veredicto não usou um dos resultados válidos, por isso o issue volta à fila."
+    log "#$ISSUE outcome inválido — fica em $L_BLOCKED_SPEC"
+    ;;
+esac
+
+rm -f "$VERDICT_FILE"
+log "done #$ISSUE"

--- a/scripts/team/implement-prompt.md
+++ b/scripts/team/implement-prompt.md
@@ -1,0 +1,221 @@
+# iosToAndroid — Implementador
+
+## ⛔ Sessão HEADLESS — não há próximo turno
+
+Isto corre sem ninguém do outro lado. **Não existe** notificação, nem segundo
+turno, nem alguém que te responda. Se terminares a tua resposta à espera de algo,
+a corrida acaba ali e todo o teu trabalho é descartado.
+
+- **Corre tudo de forma síncrona.** Nada em background: sem `&`, sem `nohup`, sem
+  processos a monitorizar. Se um comando demora, espera por ele.
+- **Não digas "vou aguardar"** por um processo ou por uma notificação. Não vem nada.
+- **A última coisa que fazes é escrever o veredicto** em `__VERDICT_PATH__`. Sem
+  veredicto, a corrida conta como falhada mesmo que o teu trabalho esteja feito.
+- Se ficares sem tempo, escreve o veredicto **com o que tens**.
+
+És o **implementador**, e és o **primeiro** agente a ver este issue.
+
+**Não há curator à tua frente.** Ninguém investigou isto por ti, ninguém escreveu
+critérios de aceitação. O issue é o que o autor escreveu — pode estar certo, pode
+estar incompleto, pode descrever um sintoma sem a causa. Encontrar a causa raiz é
+parte do teu trabalho, não um pré-requisito que alguém devia ter cumprido.
+
+Estás num worktree isolado (`__WORKDIR__`), no branch `__BRANCH__`, cortado de
+`__BASE_BRANCH__`. Ninguém mais mexe aqui.
+
+## O projecto
+
+App React Native / Expo em TypeScript que replica a interface do iOS em Android.
+
+- `src/screens/` ecrãs, `src/components/` componentes `Cupertino*`,
+  `src/store/` estado, `modules/` módulo nativo Kotlin com bridge JS.
+- Testes em `src/**/__tests__/*.test.tsx`, com `jest-expo/android` e
+  `@testing-library/react-native`. Há snapshots (`*.snap.android`) — se um
+  snapshot mudar, confirma que a mudança é **intencional** antes de o actualizar
+  com `npx jest -u`. Um `-u` reflexo é como aceitar a regressão por escrito.
+- Não há CI em pull requests. O que tu correres é a única prova que existe.
+
+## O teu trabalho — por TDD, nesta ordem
+
+1. **Investiga antes de escrever código.** Lê o issue, depois vai ao código
+   confirmar. `Grep` pelo sintoma, pelos nomes dos componentes, pelas strings do
+   ecrã; `git log -S` para achar quando apareceu. Só continuas quando souberes
+   dizer `ficheiro:linha` e explicar o **mecanismo** — não o sintoma.
+
+   Se o que encontrares contradisser o issue, **o código ganha**. Corrige o
+   problema real e diz no `description` em que é que o issue estava errado.
+
+2. **Define tu os critérios de aceitação.** Antes de mexer, escreve para ti
+   mesmo as afirmações verificáveis que têm de ser verdadeiras no fim — incluindo
+   **o que não deve mudar**. Vão para o corpo do PR e o reviewer confere-as uma a
+   uma contra o diff. Vagas não servem: "os contactos funcionam bem" não é
+   verificável; "a lista mantém a ordem alfabética depois de apagar um contacto"
+   é.
+
+3. **🔴 ESCREVE O TESTE PRIMEIRO, E VÊ-O FALHAR.** Antes de tocar no código de
+   produção, escreve o teste que expõe o defeito e **corre-o**. Tem de falhar, e
+   tem de falhar **pela razão certa** — se falha porque o componente não existe
+   ou porque um mock rebentou, ainda não estás a testar o defeito.
+
+   Isto não é cerimónia. Um reviewer deste pipeline já **refutou empiricamente**
+   um teste escrito depois do fix: reverteu o código de produção, o teste
+   continuou a passar, e ficou provado que não testava nada. O passo vermelho é a
+   única prova de que o teste está ligado ao comportamento.
+
+   Regista no `description` **a mensagem de falha** que obtiveste. É a tua prova.
+
+4. **🟢 Implementa até passar** — a causa raiz, não o sintoma. Esconder o erro
+   (um `try/catch` vazio, um `?? 0` que tapa um `undefined` inesperado, um
+   `?.` que evita o caso em vez de o tratar, um `as any` que cala o compilador)
+   é pior que não corrigir: o defeito passa a ser invisível.
+
+5. **🧪 Cobre o que corre mal, não só o caminho feliz.** Um teste do caso nominal
+   não protege quase nada — o defeito volta pelas bordas. Para o que tocaste,
+   acrescenta o que se aplicar:
+
+   - **Fronteiras** — 0, 1, o valor máximo, o limite exacto e o limite ±1.
+   - **Vazio e ausente** — lista vazia, string vazia, `null`/`undefined`, campo
+     em falta, ecrã sem dados nenhuns, permissão negada.
+   - **Inválido e hostil** — texto onde se espera número, negativos onde só faz
+     sentido positivo, valores absurdamente grandes, datas fora do intervalo.
+   - **Ordem e repetição** — a acção feita duas vezes seguidas (o duplo toque é
+     um defeito recorrente neste repositório), fora de ordem, ou interrompida.
+   - **Assíncrono** — a resposta que chega depois do componente desmontar, duas
+     chamadas em voo ao mesmo tempo, o `AsyncStorage` que devolve `null` na
+     primeira leitura.
+   - **O inverso do fix** — se passaste a mostrar algo, testa que continua
+     escondido quando deve estar.
+
+   Não escrevas testes decorativos: cada um deve poder falhar por uma razão
+   diferente. Se dois testes falham sempre juntos, um deles é redundante.
+
+6. **Corre as verificações** (abaixo) até passarem.
+
+7. **Sanity-check obrigatório antes de concluir:** reverte o teu fix de produção
+   (mantendo os testes), confirma que a suite **falha**, e restaura. Se passar
+   sem o fix, os teus testes não valem nada e o trabalho não está feito.
+
+8. **Escreve o veredicto.**
+
+## Verificações obrigatórias
+
+Corre isto no worktree (`__WORKDIR__`):
+
+```bash
+npm run lint
+npx tsc --noEmit
+npm test
+```
+
+Não há CI em pull requests neste repositório — se deixares algo vermelho, entra
+vermelho no `main`.
+
+**Se houver uma secção "LINHA DE BASE" mais abaixo, lê-a antes de correr isto.**
+Diz-te o que já estava partido em `$BASE_BRANCH` antes de tu chegares, e nesse
+caso o critério é **não piorar**, não "ficar tudo verde". Sem essa secção, as três
+verificações têm de passar por inteiro.
+
+Em qualquer dos casos: **os testes que tu escreves para este trabalho passam
+sempre**, e nunca apagas nem pões `.skip` num teste alheio para ficar verde.
+Se um teste já falhava antes de mexeres, diz isso no veredicto com a prova
+(`git stash` + corre + `git stash pop`).
+
+## Regras que não se negoceiam
+
+- **Só mexes no que o issue pede.** Refactors oportunistas noutros ficheiros
+  fazem a review descarrilar e escondem o fix no meio do ruído.
+- **Nada de segredos** no código (chaves, tokens, URLs de produção).
+- **Nada de `any` novo** para calar o `tsc`. Se o tipo não encaixa, ou o tipo
+  está errado ou o código está — arruma o que estiver.
+- **Não commitas nem fazes push.** O harness faz isso a partir do teu veredicto.
+  Deixa as alterações no worktree.
+- **Não toques em** `scripts/team/`, `.github/`, `android/`, `ios/`, `node_modules/`,
+  nem em ficheiros de veredicto. `android/` e `ios/` são gerados pelo
+  `expo prebuild` — o que é permanente vive em `app.json` e em `plugins/`.
+
+## Veredicto
+
+Escreve EXACTAMENTE este JSON em `__VERDICT_PATH__`:
+
+```json
+{
+  "outcome": "implemented|blocked",
+  "summary": "uma linha: o que mudaste (vai para o título do commit e do PR)",
+  "description": "markdown para o corpo do PR — ver estrutura abaixo",
+  "tests": "resultado real, ex: '48 passaram, 0 falharam, 6 suites'",
+  "files_changed": ["src/caminho/relativo.tsx"]
+}
+```
+
+### Critérios
+
+- **implemented** — implementaste, as três verificações passam, e há alterações
+  reais no código. **É este o resultado esperado na esmagadora maioria dos casos.**
+
+- **blocked** — o issue **não é executável como está** e precisa de análise antes
+  de alguém lhe tocar. Isto **manda o issue para o curator**, que escreve o
+  briefing e o devolve. É um recurso legítimo, e é o único que tens.
+
+  Mas é caro: custa uma volta inteira ao issue. Antes de o usares, esgota isto —
+
+  - **Falta o ficheiro ou a linha?** Procura. `Grep`, `git log -S`, os chamadores.
+  - **Não percebes o comportamento actual?** Escreve um teste que o exponha e
+    corre-o. Um teste que falha diz-te mais que qualquer descrição.
+  - **O issue é ambíguo?** Escolhe a leitura mais defensável, implementa-a, e diz
+    no `description` qual escolheste e qual descartaste. Uma escolha registada é
+    revisível; um impasse não é.
+  - **É uma decisão de produto?** Toma-a pelo critério menos destrutivo e mais
+    consistente com o resto da app, e regista-a.
+
+  `blocked` é para quando investigaste a sério e o issue é genuinamente
+  irresolúvel como está: exige uma dependência que não existe, dois requisitos
+  contradizem-se de forma irreconciliável, ou o âmbito real é grande demais para
+  uma corrida e precisa de ser partido.
+
+  Diz **exactamente** o que investigaste, o que descobriste, e porque não há
+  caminho. O curator vai trabalhar a partir disso. Um `blocked` sem investigação
+  documentada é trabalho não feito, e volta para ti na mesma.
+
+### Estrutura do `description` (corpo do PR)
+
+```markdown
+## Causa raiz
+
+O mecanismo, com `ficheiro:linha`. Não repitas o sintoma do issue — explica
+porque acontece. Se o issue descrevia mal o problema, di-lo aqui.
+
+## O que mudou
+
+Descrição factual das alterações, por ficheiro. Diz o que o código faz agora
+que antes não fazia.
+
+## Porque assim
+
+A decisão técnica e as alternativas que descartaste.
+
+## Critérios de aceitação
+
+- [x] Cada critério que definiste, marcado, com uma nota de como o cumpriste.
+- [x] Inclui o que NÃO devia mudar, e como o confirmaste.
+
+## Testes
+
+- **Passo vermelho:** o teste que escreveste primeiro e a mensagem de falha exacta
+  que obteve antes do fix.
+- **Casos cobertos:** o que testaste além do caminho feliz (fronteiras, vazios,
+  inválidos, repetição, assíncrono, o inverso do fix) e porque escolheste esses.
+- **Sanity-check:** confirma que reverteste o fix, a suite falhou, e restauraste.
+- Resultado de `npm run lint`, `npx tsc --noEmit` e `npm test`.
+```
+
+O `description` é lido pelo reviewer **em confronto com o diff**. Se disser que
+mexeste num ficheiro que não está no diff, o PR é bloqueado. Descreve o que
+fizeste de facto.
+
+## Notas
+
+- Se houver feedback de uma review anterior no contexto, é retrabalho: corrige
+  **o que o reviewer apontou**. Não repitas a correção que foi bloqueada.
+- Se houver uma análise do curator no contexto, ela já é fruto de uma volta
+  perdida — segue-a, e se o código a contradisser explica o desvio.
+- Responde em português.

--- a/scripts/team/implement.sh
+++ b/scripts/team/implement.sh
@@ -1,0 +1,309 @@
+#!/bin/bash
+# implement.sh — the IMPLEMENTER. Takes an issue, investigates the code, implements
+# the fix on a branch cut from main, and opens a PR describing what it did.
+#
+# This is the FIRST agent to see an issue. There is no curation step ahead of it, so
+# finding the root cause is part of its job — see implement-prompt.md. It escalates
+# to the curator (verdict `blocked`) only when the issue is genuinely not actionable
+# as written.
+#
+# Branches are named `qa/issue-N`.
+#
+# Usage: implement.sh <issue_number>
+set -uo pipefail
+
+ISSUE="${1:?issue obrigatorio}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+ROLE="implement"
+
+BRANCH="qa/issue-$ISSUE"
+VERDICT_FILE="$VERDICT_DIR/implement-$ISSUE.json"
+PROMPT="/tmp/ios2a-implement-prompt-$ISSUE.txt"
+WT=""
+
+# Model. This repo's backlog is already triaged with `haiku-ready` / `sonnet-ready`,
+# but that triage was about the SIZE OF THE CHANGE, not about the size of the job
+# this agent does: investigate root cause, write a failing test, prove the red step,
+# implement, run three gates, then write a structured verdict. A one-line fix still
+# carries all of that, so honouring `haiku-ready` by default would silently degrade
+# most of the queue.
+#
+# Default is therefore sonnet everywhere. Set IMPLEMENT_HONOUR_READY_LABELS=1 to
+# trust the labels instead.
+MODEL="${IMPLEMENT_MODEL:-sonnet}"
+if [ -z "${IMPLEMENT_MODEL:-}" ] && [ "${IMPLEMENT_HONOUR_READY_LABELS:-0}" = "1" ]; then
+  if gh issue view "$ISSUE" --repo "$REPO" --json labels \
+       --jq '[.labels[].name] | index("haiku-ready")' 2>/dev/null | grep -qv '^null$'; then
+    MODEL="haiku"
+  fi
+fi
+
+log "issue #$ISSUE branch=$BRANCH modelo=$MODEL"
+
+set_state "$ISSUE" "$L_WIP"
+
+# Say so at the START, not only at the end. In the sibling project the only comment
+# came when the run finished, so for the 25 minutes an implementation takes the
+# issue looked abandoned: right state, no sign of life.
+comment_issue "$ISSUE" "## Implementador: a trabalhar
+
+- Branch: \`$BRANCH\`
+- Modelo: \`$MODEL\`
+- Início: $(date '+%H:%M')
+
+Comento outra vez quando houver PR ou se ficar bloqueado."
+
+# Fresh worktree on a branch cut from main. If the branch already exists (this is
+# rework after a block) wt_create resumes from the remote tip.
+wt_remove "$WT_ROOT/implement-$ISSUE"
+WT_OUT=$(wt_create "$BRANCH" "implement-$ISSUE" "$BASE_BRANCH") || {
+  log "ERRO: não criei worktree — volta a $L_READY"
+  set_state "$ISSUE" "$L_READY"
+  comment_issue "$ISSUE" "## Implementador: falhou a preparar o worktree
+
+Não foi possível criar o branch \`$BRANCH\` a partir de \`$BASE_BRANCH\`."
+  exit 1
+}
+WT="$WT_OUT"
+
+# Bring the branch up to date with main. On rework other fixes have landed since it
+# was cut, and a PR that cannot merge is as good as no PR at all.
+#
+# A conflict here is NOT a reason to redo the work or bounce the issue: the fix is
+# already written, it just met someone else's change. The conflict is left in the
+# tree with its markers and handed to the agent as part of the task.
+MERGE_CONFLICT=""
+if ! git -C "$WT" merge --no-edit "origin/$BASE_BRANCH" >/dev/null 2>&1; then
+  CONFLICTED=$(git -C "$WT" diff --name-only --diff-filter=U 2>/dev/null)
+  if [ -n "$CONFLICTED" ]; then
+    log "CONFLITO ao integrar $BASE_BRANCH: $(printf '%s' "$CONFLICTED" | tr '\n' ' ')"
+    MERGE_CONFLICT="$CONFLICTED"
+  else
+    git -C "$WT" merge --abort >/dev/null 2>&1 || true
+  fi
+fi
+
+log "a preparar dependências..."
+wt_prepare_node "$WT"
+
+ISSUE_JSON=$(gh issue view "$ISSUE" --repo "$REPO" \
+  --json title,body,labels,comments --jq '
+  "# " + .title + "\n\n" +
+  "## Corpo\n\n" + (.body // "(vazio)") + "\n\n" +
+  "## Labels\n\n" + ([.labels[].name] | join(", ")) + "\n\n" +
+  "## Comentários\n\n" +
+  (if (.comments | length) > 0 then
+     ([.comments[] | "- **@" + (.author.login // "anon") + "**: " + (.body // "")] | join("\n\n"))
+   else "(sem comentários)" end)
+' 2>/dev/null) || { log "ERRO: não consegui ler o issue"; exit 1; }
+
+# Rework: pull the reviewer's objections into the prompt.
+PR_FEEDBACK=""
+EXISTING_PR=$(gh pr list --repo "$REPO" --head "$BRANCH" --state open \
+  --json number --jq '.[0].number // empty' 2>/dev/null || echo "")
+if [ -n "$EXISTING_PR" ]; then
+  PR_FEEDBACK=$(gh pr view "$EXISTING_PR" --repo "$REPO" --json comments --jq '
+    (if (.comments | length) > 0 then
+       ([.comments[] | "- **@" + (.author.login // "anon") + "**: " + (.body // "")] | join("\n\n"))
+     else "(sem comentários)" end)' 2>/dev/null || echo "")
+fi
+
+{
+  cat "$SCRIPT_DIR/implement-prompt.md"
+  baseline_block
+  echo ""
+  echo "---"
+  echo ""
+  echo "# O issue a implementar"
+  echo ""
+  printf '%s\n' "$ISSUE_JSON"
+  if [ -n "$MERGE_CONFLICT" ]; then
+    echo ""
+    echo "---"
+    echo ""
+    echo "# ⚠️ CONFLITO DE MERGE POR RESOLVER — resolve-o primeiro"
+    echo ""
+    echo "Ao integrar \`origin/$BASE_BRANCH\` neste branch houve conflito. A árvore"
+    echo "está com os marcadores por resolver nestes ficheiros:"
+    echo ""
+    printf '%s\n' "$MERGE_CONFLICT" | sed 's/^/  - /'
+    echo ""
+    echo "**O teu fix não está errado** — apenas encontrou outra alteração que entrou"
+    echo "em \`$BASE_BRANCH\` entretanto. Resolve por INTENÇÃO, não por escolha cega:"
+    echo ""
+    echo "- Percebe o que **cada lado** queria fazer (\`git log\` nos dois lados)."
+    echo "- O resultado tem de preservar **as duas** intenções. Escolher \`--ours\` ou"
+    echo "  \`--theirs\` em bloco costuma apagar em silêncio o trabalho do outro."
+    echo "- Em ficheiros gerados (snapshots do jest, \`package-lock.json\`): não"
+    echo "  resolvas à mão — regenera (\`npx jest -u\`, \`npm install\`)."
+    echo "- Depois de resolver: \`git add\` nos ficheiros e corre a suite completa."
+    echo "  Um conflito mal resolvido passa despercebido até partir outra coisa."
+    echo ""
+    echo "Só depois disto continua com o trabalho do issue."
+  fi
+  if [ -n "${PR_FEEDBACK//[[:space:]]/}" ]; then
+    echo ""
+    echo "---"
+    echo ""
+    echo "# RETRABALHO — feedback no PR #$EXISTING_PR"
+    echo ""
+    printf '%s\n' "$PR_FEEDBACK"
+    echo ""
+    echo "Corrige o que foi apontado acima. Não repitas a correção que foi bloqueada."
+  fi
+} | sed -e "s|__VERDICT_PATH__|$VERDICT_FILE|g" \
+        -e "s|__WORKDIR__|$WT|g" \
+        -e "s|__BRANCH__|$BRANCH|g" \
+        -e "s|__BASE_BRANCH__|$BASE_BRANCH|g" > "$PROMPT"
+
+rm -f "$VERDICT_FILE"
+AGENT_SLOT=main CLAUDE_MODEL="$MODEL" \
+  bash "$SCRIPT_DIR/run-agent.sh" "$PROMPT" "$WT" "${IMPLEMENT_TIMEOUT:-2700}" \
+  > "$LOG_DIR/implement-$ISSUE.log" 2>&1; AGENT_RC=$?
+
+if [ ! -f "$VERDICT_FILE" ]; then
+  if ! no_verdict_is_real_failure main "$AGENT_RC"; then
+    log "SEM VEREDICTO (corrida degradada ou não arrancada) — issue volta a $L_READY"
+    comment_issue "$ISSUE" "## Implementador: corrida degradada, sem veredicto
+
+A corrida não produziu veredicto por uma razão alheia ao issue: ou o slot estava
+ocupado, ou a subscrição estava esgotada e o modelo de fallback não conseguiu
+concluir. **Isto não é um problema do issue** — volta a \`$L_READY\` para nova
+tentativa."
+    set_state "$ISSUE" "$L_READY"
+    wt_remove "$WT"
+    exit 0
+  fi
+  log "SEM VEREDICTO — volta a $L_READY para nova tentativa"
+  set_state "$ISSUE" "$L_READY"
+  comment_issue "$ISSUE" "## Implementador: corrida sem veredicto
+
+Terminou sem escrever veredicto (ver \`$LOG_DIR/implement-$ISSUE.log\`). Falha da
+corrida, não do issue — volta à fila."
+  wt_remove "$WT"
+  exit 0
+fi
+
+OUTCOME=$(jqv "$VERDICT_FILE" '.outcome' 'blocked')
+SUMMARY=$(jqv "$VERDICT_FILE" '.summary' 'correção automática'); SUMMARY="${SUMMARY:0:200}"
+DESCRIPTION=$(jqv "$VERDICT_FILE" '.description' '')
+TESTS=$(jqv "$VERDICT_FILE" '.tests' '(não reportado)'); TESTS="${TESTS:0:400}"
+
+# Ignore build artefacts and the dependency symlink when deciding "did anything
+# change".
+CHANGED=$(git -C "$WT" status --porcelain 2>/dev/null \
+  | grep -vE '(^.. )?(node_modules|android/|ios/|\.expo/)' | head -1 || true)
+
+log "outcome=$OUTCOME alterações=${CHANGED:+sim}${CHANGED:-nao}"
+
+if [ "$OUTCOME" != "implemented" ] || [ -z "$CHANGED" ]; then
+  REASON="$OUTCOME"
+  [ -n "$OUTCOME" ] && [ -z "$CHANGED" ] && REASON="$OUTCOME (sem alterações reais no código)"
+  # THIS IS THE DOOR TO THE CURATOR. `blocked` means the implementer investigated
+  # and the issue is not actionable as written — analysis is now warranted. Anything
+  # else that failed to produce code goes the same way rather than being parked,
+  # because the curator has the failure text to work from and nobody else is coming.
+  set_state "$ISSUE" "$L_BLOCKED_SPEC"
+  if [ "$OUTCOME" = "blocked" ]; then
+    comment_issue "$ISSUE" "## Implementador: bloqueado — pedido de análise
+
+$SUMMARY
+
+$DESCRIPTION
+
+O issue não era executável como está. O curator vai analisá-lo e reescrever o
+briefing."
+  else
+    comment_issue "$ISSUE" "## Implementador: $REASON — enviado para análise
+
+$SUMMARY
+
+$DESCRIPTION"
+  fi
+  wt_remove "$WT"
+  exit 0
+fi
+
+# ── Commit + push ──────────────────────────────────────────────────────────
+# Scoped add: the harness and CI live in paths the implementer is told not to
+# touch, and never staging them enforces it. Native output dirs are generated by
+# `expo prebuild` and must never be committed.
+git -C "$WT" add -A -- ':!scripts/team' ':!.github' ':!android' ':!ios' ':!.expo' >/dev/null 2>&1 \
+  || git -C "$WT" add -A >/dev/null 2>&1 || true
+git -C "$WT" -c user.name="qa-implementer" -c user.email="qa@local" \
+  commit -m "fix/$ISSUE: $SUMMARY" >/dev/null 2>&1 || true
+
+if ! git -C "$WT" push -u origin "$BRANCH" --force >/dev/null 2>&1; then
+  log "ERRO: push falhou — volta a $L_READY"
+  set_state "$ISSUE" "$L_READY"
+  comment_issue "$ISSUE" "## Implementador: push falhou
+
+O código foi escrito mas não chegou ao remoto (branch \`$BRANCH\`). Falha de
+infraestrutura, não do issue — volta à fila."
+  wt_remove "$WT"
+  exit 1
+fi
+log "push ok -> $BRANCH"
+
+# ── PR into main ───────────────────────────────────────────────────────────
+# `Fixes #N` is mandatory: the reviewer reads it to find its way back to the issue,
+# and GitHub closes the issue on merge.
+PR_BODY=$(cat <<EOF
+## Resumo
+
+$SUMMARY
+
+$DESCRIPTION
+
+## Testes
+
+$TESTS
+
+## Linked Issue
+
+Fixes #$ISSUE
+EOF
+)
+
+EXISTING_PR=$(gh pr list --repo "$REPO" --head "$BRANCH" --base "$BASE_BRANCH" \
+  --state open --json number --jq '.[0].number // empty' 2>/dev/null || echo "")
+
+if [ -n "$EXISTING_PR" ]; then
+  gh pr edit "$EXISTING_PR" --repo "$REPO" \
+    --title "$SUMMARY (#$ISSUE)" --body "$PR_BODY" >/dev/null 2>&1 || true
+  gh pr comment "$EXISTING_PR" --repo "$REPO" --body "## Implementador: retrabalho submetido
+
+$SUMMARY
+
+Testes: $TESTS" >/dev/null 2>&1 || true
+  PR_NUM="$EXISTING_PR"
+  log "PR #$PR_NUM actualizado"
+else
+  PR_NUM=$(create_pr_api "$BRANCH" "$BASE_BRANCH" "$SUMMARY (#$ISSUE)" "$PR_BODY" || echo "")
+  if [ -z "$PR_NUM" ]; then
+    log "ERRO: PR não criado — volta a $L_READY"
+    set_state "$ISSUE" "$L_READY"
+    comment_issue "$ISSUE" "## Implementador: PR não criado
+
+O branch \`$BRANCH\` foi enviado mas o PR para \`$BASE_BRANCH\` não foi aberto."
+    wt_remove "$WT"
+    exit 1
+  fi
+  log "PR criado: #$PR_NUM ($REPO)"
+fi
+
+comment_issue "$ISSUE" "## Implementador: implementado
+
+$SUMMARY
+
+Testes: $TESTS
+
+PR: #$PR_NUM (\`$BRANCH\` → \`$BASE_BRANCH\`)"
+set_state "$ISSUE" "$L_REVIEW"
+
+rm -f "$VERDICT_FILE"
+wt_remove "$WT"
+log "done #$ISSUE -> $L_REVIEW (PR #$PR_NUM)"

--- a/scripts/team/lib.sh
+++ b/scripts/team/lib.sh
@@ -1,0 +1,379 @@
+#!/bin/bash
+# lib.sh — shared configuration and helpers for the delivery pipeline agents.
+# Sourced by every role script. Not executable on its own.
+#
+# Ported from the monthy_budget QA harness, minus the critic and the verifier:
+# this repo already has a filed backlog, and there is no running-app tester here.
+# What remains is the write path — curator, implementer, reviewer.
+
+# ── Repository / paths ─────────────────────────────────────────────────────
+REPO="${TEAM_REPO:-lfrmonteiro99/iosToAndroid}"
+
+TEAM_ROOT="${TEAM_ROOT:-$HOME/Documentos/iosToAndroid}"
+
+# Branch topology: SINGLE branch.
+#
+# The sibling project runs main + dev because its critic tests the app built from
+# main while fixes stage on dev. There is no critic here and nothing re-tests dev,
+# so a staging branch would only mean a later, bigger merge with the same single
+# gate — the reviewer. Implementer branches are `qa/issue-N` and their PRs target
+# main directly.
+BASE_BRANCH="${TEAM_BASE_BRANCH:-main}"
+
+# Verdicts live OUTSIDE the repository.
+#
+# Inside the working tree they caused three separate failures at once in the
+# sibling project: they got committed, a run that died before writing inherited
+# the PREVIOUS run's verdict and reported another issue's work as its own, and
+# `git add -A` dragged them into the PR diff. Outside the repo none is possible.
+VERDICT_DIR="${TEAM_VERDICT_DIR:-$HOME/Documentos/iostoandroid-verdicts}"
+
+# Worktrees are siblings of the repo, never inside it: a worktree nested in the
+# repo shows up as untracked content and eventually gets committed by accident.
+WT_ROOT="${TEAM_WT_ROOT:-$HOME/Documentos/iostoandroid-wt}"
+
+LOG_DIR="${TEAM_LOG_DIR:-/tmp/ios2android-team}"
+STATE_DIR="${TEAM_STATE_DIR:-$HOME/Documentos/iostoandroid-verdicts/state}"
+
+LOCK_PREFIX="${TEAM_LOCK_PREFIX:-/tmp/ios2android-agent}"
+
+mkdir -p "$VERDICT_DIR" "$LOG_DIR" "$STATE_DIR" "$WT_ROOT" 2>/dev/null || true
+
+# ── Labels: the pipeline state machine ─────────────────────────────────────
+# Exactly one qa:* label is the authoritative state of an issue. Comments are
+# the audit trail; the label is what the orchestrator dispatches on.
+L_TRIAGE="qa:triage"              # in the queue, awaiting the curator
+L_READY="qa:ready"                # curated: root cause + plan + AC + test steps
+L_WIP="qa:wip"                    # implementer working
+L_REVIEW="qa:review"              # PR open into main, awaiting reviewer
+L_DONE="qa:done"                  # merged / closed
+L_BLOCKED_IMPL="qa:blocked-impl"  # back to implementer (code problem)
+L_BLOCKED_SPEC="qa:blocked-spec"  # back to curator (spec problem)
+L_HUMAN="qa:needs-human"          # pipeline gave up
+
+ALL_QA_LABELS="$L_TRIAGE,$L_READY,$L_WIP,$L_REVIEW,$L_DONE,$L_BLOCKED_IMPL,$L_BLOCKED_SPEC,$L_HUMAN"
+
+# Severity reuses the priority labels this repo already carries (P0..P3) instead
+# of inventing a parallel sev:* scheme. The orchestrator dispatches worst-first on
+# these; the curator may re-grade.
+ALL_PRIO_LABELS="P0,P1,P2,P3"
+
+log() { echo "[${ROLE:-team}] $(date +%H:%M:%S) $*"; }
+warn() { echo "[${ROLE:-team}] $(date +%H:%M:%S) WARN $*" >&2; }
+
+# ── Issue state transitions ────────────────────────────────────────────────
+# Move an issue to exactly one qa:* state, VERIFYING the change landed.
+#
+# It used to fire-and-forget with a warning on failure, and that turned a GitHub
+# outage into repeated work in the sibling project: a transition silently failed,
+# the issue stayed put, the orchestrator re-dispatched it, and the curator split
+# it three times — creating sub-issues on each pass. A state machine whose
+# transitions can silently not happen is not a state machine.
+set_state() {
+  local issue="$1" state="$2"
+  local remove attempt actual
+  remove=$(printf '%s' "$ALL_QA_LABELS" | tr ',' '\n' | grep -vxF "$state" | paste -sd, -)
+
+  local read_ok=0
+  for attempt in 1 2 3 4; do
+    gh issue edit "$issue" --repo "$REPO" \
+      --add-label "$state" --remove-label "$remove" >/dev/null 2>&1
+
+    # GitHub is eventually consistent, so give it a moment before reading back.
+    sleep 2
+    actual=$(get_state "$issue")
+    [ "$actual" = "$state" ] && return 0
+    [ -n "$actual" ] && read_ok=1
+
+    [ "$attempt" -lt 4 ] && sleep $((attempt * 4))
+  done
+
+  # An unreadable state is NOT the same as a wrong state, and conflating them
+  # produces false alarms during an API outage — the transition usually did land,
+  # we just could not confirm it.
+  if [ "$read_ok" = "0" ]; then
+    warn "não confirmei a transição de #$issue para '$state' (a API não respondeu à leitura)"
+    warn "  a etiqueta provavelmente foi aplicada; o ciclo seguinte relê o estado real"
+    return 0
+  fi
+
+  warn "TRANSIÇÃO FALHOU: #$issue continua em '$actual' e não em '$state'"
+  warn "  o orquestrador vai voltar a despachar este issue — risco de trabalho repetido"
+  return 1
+}
+
+# Read the single qa:* state label of an issue ("" when it has none).
+get_state() {
+  local issue="$1"
+  gh issue view "$issue" --repo "$REPO" --json labels \
+    --jq '[.labels[].name] | map(select(startswith("qa:"))) | .[0] // ""' 2>/dev/null || echo ""
+}
+
+# Re-grade priority to exactly one of P0..P3.
+set_priority() {
+  local issue="$1" prio="$2" remove
+  case "$prio" in P0|P1|P2|P3) ;; *) return 0 ;; esac
+  remove=$(printf '%s' "$ALL_PRIO_LABELS" | tr ',' '\n' | grep -vxF "$prio" | paste -sd, -)
+  gh issue edit "$issue" --repo "$REPO" \
+    --add-label "$prio" --remove-label "$remove" >/dev/null 2>&1 || true
+}
+
+# Add a label via the REST API, not `gh pr edit --add-label`.
+#
+# `gh pr edit` resolves project cards over GraphQL on the way through, and on the
+# sibling repo that fails outright with a Projects-classic deprecation error — the
+# label is then never applied and gh reports failure for an unrelated reason. The
+# issues endpoint works for PRs too; GitHub treats them as issues for labelling.
+add_label_api() {
+  local number="$1" label="$2"
+  gh api -X POST "repos/$REPO/issues/$number/labels" \
+    -f "labels[]=$label" >/dev/null 2>&1
+}
+
+# Open a PR via the REST API. Same reason as add_label_api: `gh pr create` can die
+# on Projects-classic resolution, so the branch is pushed and the PR never opens —
+# which in the sibling project stranded two fully-implemented issues for hours.
+create_pr_api() {
+  local head="$1" base="$2" title="$3" body="$4"
+  local resp num
+  resp=$(gh api -X POST "repos/$REPO/pulls" \
+           -f title="$title" -f head="$head" -f base="$base" -f body="$body" 2>&1)
+  num=$(printf '%s' "$resp" | jq -r '.number // empty' 2>/dev/null)
+  if [ -n "$num" ]; then printf '%s' "$num"; return 0; fi
+  # An existing PR for this head is success, not failure.
+  num=$(gh api "repos/$REPO/pulls?head=${REPO%%/*}:$head&base=$base&state=open" \
+        --jq '.[0].number // empty' 2>/dev/null)
+  if [ -n "$num" ]; then printf '%s' "$num"; return 0; fi
+  warn "não abri PR $head -> $base: $(printf '%s' "$resp" | jq -r '.message // .' 2>/dev/null | head -1)"
+  return 1
+}
+
+comment_issue() {
+  local issue="$1" body="$2"
+  gh issue comment "$issue" --repo "$REPO" --body "$body" >/dev/null 2>&1 \
+    || warn "não consegui comentar #$issue"
+}
+
+# ── Verdict helpers ────────────────────────────────────────────────────────
+# NOTE ON `head -c`: never pipe a verdict field through `head -c N`. Under
+# `set -o pipefail`, when the value is longer than N, head closes the pipe, the
+# writer takes SIGPIPE, and the SCRIPT DIES mid-run. Truncate with bash parameter
+# expansion (`${v:0:N}`) instead — no pipe, no subshell, no signal.
+#
+# NOTE ON NAMING: keep the path variable and the value variable distinct.
+# `VERDICT=$(jq ... "$VERDICT")` overwrites the path with the value, and the next
+# jq call then tries to open a file named "blocked".
+
+# True when the last agent on this slot ran on the FALLBACK engine rather than the
+# subscription. A role that produced no verdict on the fallback must not be treated
+# as "this issue defeated the pipeline": the fallback model is materially weaker, so
+# a temporary quota outage would otherwise park real work permanently.
+agent_used_fallback() {
+  local slot="${1:-main}"
+  grep -q '^ollama/' "$LOCK_PREFIX.$slot.engine" 2>/dev/null
+}
+
+# Standard handling for "the agent produced no verdict". Returns 0 when the caller
+# should ESCALATE (real failure), 1 when it should leave the issue alone for a
+# later retry.
+#
+# Two things look identical from the outside — no verdict file — and neither is the
+# issue's fault: the fallback engine ran and could not finish, or the run never
+# started because the lock slot was busy (exit 75). The second happens whenever the
+# orchestrator is restarted while an agent is still mid-run.
+no_verdict_is_real_failure() {
+  local slot="${1:-main}" rc="${2:-}"
+
+  if [ "$rc" = "75" ]; then
+    warn "sem veredicto porque o slot '$slot' estava ocupado (exit 75) — não escalo"
+    return 1
+  fi
+  if agent_used_fallback "$slot"; then
+    warn "sem veredicto mas o motor era o fallback — não escalo, fica para nova tentativa"
+    return 1
+  fi
+  return 0
+}
+
+jqv() {
+  local file="$1" filter="$2" fallback="${3:-}"
+  local out
+  out=$(jq -r "$filter" "$file" 2>/dev/null) || out=""
+  [ "$out" = "null" ] && out=""
+  printf '%s' "${out:-$fallback}"
+}
+
+# ── Node dependencies in a worktree ────────────────────────────────────────
+# A fresh worktree has no node_modules (it is gitignored), and nothing — not lint,
+# not tsc, not jest — runs without it.
+#
+# `npm ci` in every worktree costs ~40-60s each and this pipeline creates one per
+# issue, per review, per rework. So: when the worktree's package-lock.json is
+# byte-identical to the main checkout's, SYMLINK the main checkout's node_modules
+# instead. Identical lock means identical tree, and no agent writes into
+# node_modules.
+#
+# When the lock DIFFERS the symlink would be actively dangerous — installing would
+# mutate the main checkout's tree under a live agent — so that case always gets its
+# own real install.
+wt_prepare_node() {
+  local wt="$1"
+  [ -f "$wt/package.json" ] || return 0
+
+  if [ -d "$TEAM_ROOT/node_modules" ] \
+     && [ -f "$wt/package-lock.json" ] && [ -f "$TEAM_ROOT/package-lock.json" ] \
+     && cmp -s "$wt/package-lock.json" "$TEAM_ROOT/package-lock.json"; then
+    ln -sfn "$TEAM_ROOT/node_modules" "$wt/node_modules" 2>/dev/null && return 0
+  fi
+
+  rm -f "$wt/node_modules" 2>/dev/null || true   # a stale symlink, never a real dir
+  if ( cd "$wt" && npm ci --prefer-offline --no-audit --fund=false >/dev/null 2>&1 ); then
+    return 0
+  fi
+
+  # `npm install` REWRITES package-lock.json, and a worktree whose lock silently
+  # gained 40KB of churn puts that churn in the implementer's PR — a diff nobody
+  # asked for, on the one file a reviewer is least likely to read line by line. So
+  # it is a last resort, and the lock is restored immediately afterwards. If the
+  # issue genuinely means to change dependencies, the agent edits package.json and
+  # regenerates the lock itself, deliberately.
+  warn "npm ci falhou em $wt — a tentar npm install (o lock é reposto a seguir)"
+  ( cd "$wt" && npm install --no-audit --fund=false >/dev/null 2>&1 ) \
+    || warn "npm install também falhou em $wt — o agente vai ter de o resolver"
+  git -C "$wt" checkout -- package-lock.json >/dev/null 2>&1 || true
+}
+
+# ── Baseline (what is already broken on main) ──────────────────────────────
+# See baseline.sh for why this exists. Emits the markdown block appended to the
+# implementer's and the reviewer's prompts. Prints NOTHING when there is no
+# baseline file — and the prompts read that absence as "the gate is strict".
+BASELINE_FILE="$STATE_DIR/baseline.json"
+
+baseline_block() {
+  [ -s "$BASELINE_FILE" ] || return 0
+  local le tsc ft tt fs ts
+  le=$(jqv "$BASELINE_FILE" '.lint_errors' '0')
+  tsc=$(jqv "$BASELINE_FILE" '.tsc_ok' 'true')
+  ft=$(jqv "$BASELINE_FILE" '.totals.failed_tests' '0')
+  tt=$(jqv "$BASELINE_FILE" '.totals.tests' '?')
+  fs=$(jqv "$BASELINE_FILE" '.totals.failed_suites' '0')
+  ts=$(jqv "$BASELINE_FILE" '.totals.suites' '?')
+
+  # Everything already green: say so, and say the gate is strict. Silence here
+  # would be read as "no baseline", which means the same thing — but saying it
+  # removes the ambiguity for the agent.
+  if [ "$le" = "0" ] && [ "$tsc" = "true" ] && [ "$ft" = "0" ]; then
+    cat <<EOF
+
+---
+
+# 📏 LINHA DE BASE: \`$BASE_BRANCH\` ESTÁ VERDE
+
+Sem erros de lint, \`tsc\` limpo, $tt testes a passar. **O portão é estrito:** as
+três verificações têm de passar por inteiro. Qualquer falha é tua.
+EOF
+    return 0
+  fi
+
+  cat <<EOF
+
+---
+
+# 📏 LINHA DE BASE: \`$BASE_BRANCH\` JÁ ESTÁ VERMELHO
+
+**Não bloqueies (nem desistas) por falhas que já existiam antes deste trabalho.**
+Medido em \`$BASE_BRANCH\` (\`$(jqv "$BASELINE_FILE" '.sha' '?')\`):
+
+- \`npm run lint\`: **$le erro(s)** já existentes
+- \`npx tsc --noEmit\`: $( [ "$tsc" = "true" ] && echo "limpo" || echo "**já falha**" )
+- \`npm test\`: **$ft de $tt testes a falhar**, em $fs de $ts suites
+
+A causa dominante é conhecida e é **uma linha**: \`src/store/SettingsStore.tsx\`
+faz \`if (!firstSyncDone) return null;\`, e \`firstSyncDone\` só fica verdadeiro
+depois de uma leitura assíncrona do \`AsyncStorage\`. Os testes renderizam de
+forma síncrona através de \`src/test-utils.tsx\`, por isso o provider devolve
+\`null\` e a árvore do ecrã vem vazia — daí os "Unable to find an element with
+text: ...". Não é um defeito por teste; é o mesmo defeito 100 vezes.
+
+## O critério, portanto, é REGRESSÃO, não perfeição
+
+- Corre as três verificações e **compara com estes números**.
+- Se o total de testes a falhar **não subiu** e não há falhas novas em ficheiros
+  que tocaste, isso **não bloqueia**.
+- Se aparece uma falha que não estava aqui, **isso bloqueia** — e nomeia-a.
+- Os testes que TU escreves para este trabalho têm de passar. Sempre. Sem
+  desculpa de baseline.
+
+A lista completa dos testes já a falhar está em \`$BASELINE_FILE\`; lê-a com
+\`jq -r '.failed_tests[]' $BASELINE_FILE\` quando precisares de decidir se uma
+falha é nova.
+EOF
+}
+
+# ── Git worktrees ──────────────────────────────────────────────────────────
+# Create a worktree on a NEW branch cut from $BASE_BRANCH. This is what the
+# IMPLEMENTER wants.
+#
+# Do NOT use this to review a PR. If the branch doesn't exist locally, `-b` creates
+# it pointing at the base, the worktree ends up holding the BASE's content,
+# `git diff base...HEAD` returns EMPTY, and the reviewer reviews nothing at all —
+# with no error in the log. Use wt_checkout for that.
+wt_create() {
+  local branch="$1" dirname="$2" base="${3:-$BASE_BRANCH}"
+  local wt="$WT_ROOT/$dirname"
+  git -C "$TEAM_ROOT" fetch origin "$base" >/dev/null 2>&1 || true
+  # Also fetch the work branch itself: on REWORK it already exists on the remote
+  # and carries the previous attempt.
+  git -C "$TEAM_ROOT" fetch origin \
+    "+refs/heads/$branch:refs/remotes/origin/$branch" >/dev/null 2>&1 || true
+
+  if git -C "$TEAM_ROOT" rev-parse --verify --quiet "origin/$branch" >/dev/null 2>&1; then
+    # REWORK. Start from the REMOTE tip, not from any local branch of the same
+    # name: a leftover local ref is usually behind what was pushed, and since
+    # implement.sh finishes with `push --force`, resuming from it would silently
+    # discard the previous attempt — including the very code the reviewer asked to
+    # have corrected.
+    git -C "$TEAM_ROOT" worktree add --detach "$wt" "origin/$branch" >/dev/null 2>&1 \
+      || { warn "não criou worktree $wt em origin/$branch"; return 1; }
+    git -C "$wt" checkout -B "$branch" >/dev/null 2>&1 || true
+  else
+    git -C "$TEAM_ROOT" worktree add "$wt" -b "$branch" "origin/$base" >/dev/null 2>&1 \
+      || git -C "$TEAM_ROOT" worktree add "$wt" "$branch" >/dev/null 2>&1 \
+      || { warn "não criou worktree $wt para $branch"; return 1; }
+  fi
+  echo "$wt"
+}
+
+# Check out an EXISTING remote branch, detached. This is what the REVIEWER wants:
+# the tree must hold the code under test, not a fresh branch off the base.
+wt_checkout() {
+  local ref_name="$1" dirname="$2"
+  local wt="$WT_ROOT/$dirname"
+  git -C "$TEAM_ROOT" fetch origin \
+    "+refs/heads/$ref_name:refs/remotes/origin/$ref_name" >/dev/null 2>&1 || true
+  local ref=""
+  for cand in "origin/$ref_name" "$ref_name"; do
+    if git -C "$TEAM_ROOT" rev-parse --verify --quiet "$cand" >/dev/null 2>&1; then
+      ref="$cand"; break
+    fi
+  done
+  if [ -z "$ref" ]; then
+    warn "branch '$ref_name' não existe no remoto nem localmente"
+    return 1
+  fi
+  git -C "$TEAM_ROOT" worktree add --detach "$wt" "$ref" >/dev/null 2>&1 \
+    || { warn "não criou worktree $wt em $ref"; return 1; }
+  echo "$wt"
+}
+
+wt_remove() {
+  local wt="$1"
+  [ -n "$wt" ] && [ -d "$wt" ] || return 0
+  # Drop the node_modules symlink FIRST. `git worktree remove --force` follows it
+  # on some git versions and would delete the main checkout's dependency tree.
+  [ -L "$wt/node_modules" ] && rm -f "$wt/node_modules"
+  git -C "$TEAM_ROOT" worktree remove --force "$wt" >/dev/null 2>&1 || rm -rf "$wt"
+  local branch
+  branch=$(basename "$wt")
+  git -C "$TEAM_ROOT" branch -D "$branch" >/dev/null 2>&1 || true
+}

--- a/scripts/team/orchestrator.sh
+++ b/scripts/team/orchestrator.sh
@@ -1,0 +1,438 @@
+#!/bin/bash
+# orchestrator.sh — drives the delivery pipeline. Runs locally.
+#
+# THE PIPELINE
+#
+#   backlog on GitHub  ──seeded──►  qa:ready
+#                                       │ implementer: fix on qa/issue-N, PR ──► main
+#                                       ▼
+#                                   qa:review
+#                                       │ reviewer: reads the diff, runs lint/tsc/jest
+#                       ┌───────────────┼───────────────┐
+#              blocked-impl         approved        blocked-spec
+#                 (code)           + merged         (briefing)
+#                       │               ▼               │
+#                       │           qa:done             │
+#                       │           (closed)            │
+#                       │                               ▼
+#                       │                        qa:blocked-spec
+#                       │                               │ CURATOR
+#                       └───────────────────────────────┘
+#
+# THE CURATOR IS A REPAIR PATH, NOT AN ENTRY POINT. Issues go straight to the
+# implementer, which investigates the code itself. Analysis only happens when the
+# implementer asks for it (verdict `blocked`), when the reviewer rules the briefing
+# wrong (`blocked-spec`), or when the attempt counter escalates. Curating 42 issues
+# up front would cost a full agent run each to produce a briefing the implementer
+# mostly re-derives anyway.
+#
+# Exactly ONE qa:* label is an issue's state. Comments are the audit trail.
+#
+# One write-path agent at a time (they share a lock): two agents pushing to the same
+# repo at once is how you get lost work. The curator is the exception — it only
+# reads code and writes GitHub comments, so it runs on its own slot alongside.
+#
+# Usage:
+#   orchestrator.sh [--once] [--issue N] [--pr N] [--max-cycles N]
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+ROLE="orchestrator"
+
+ONCE=0
+MAX_CYCLES=0           # 0 = forever
+TARGET_ISSUE=""
+TARGET_PR=""
+CYCLE_SLEEP="${TEAM_CYCLE_SLEEP:-45}"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --once) ONCE=1; shift ;;
+    --issue) TARGET_ISSUE="$2"; shift 2 ;;
+    --issue=*) TARGET_ISSUE="${1#--issue=}"; shift ;;
+    --pr) TARGET_PR="$2"; shift 2 ;;
+    --pr=*) TARGET_PR="${1#--pr=}"; shift ;;
+    --max-cycles) MAX_CYCLES="$2"; shift 2 ;;
+    --max-cycles=*) MAX_CYCLES="${1#--max-cycles=}"; shift ;;
+    *) shift ;;
+  esac
+done
+
+REVIEWED_STATE="$STATE_DIR/reviewed-shas"
+touch "$REVIEWED_STATE" 2>/dev/null || true
+
+# ── Issue queries ──────────────────────────────────────────────────────────
+#
+# CRITICAL: "no results" and "could not ask" must never look the same.
+#
+# In the sibling project these queries ended in `2>/dev/null || echo ""`, so a
+# failed API call produced an empty list — indistinguishable from a genuinely empty
+# label. During a GitHub outage that made the orchestrator believe the backlog was
+# empty while 25 issues sat queued: it dispatched nothing and declared victory. A
+# false conclusion built entirely on failed reads.
+#
+# ONE query per cycle, then count locally. Per-label queries were both unreliable
+# (`gh issue list --label X` returns non-zero inconsistently, so "empty" and
+# "failed" cannot be told apart from the exit code) and expensive (12+ API calls
+# every 45 seconds, which is how you get rate-limited).
+ISSUE_CACHE=""
+
+refresh_issue_cache() {
+  local json
+  json=$(gh issue list --repo "$REPO" --state open --limit 300 \
+         --json number,labels 2>/dev/null) || return 1
+  # Explicit shape check: a truncated or error response must not pass as data.
+  printf '%s' "$json" | jq -e 'type == "array"' >/dev/null 2>&1 || return 1
+  ISSUE_CACHE="$json"
+  return 0
+}
+
+# Issue numbers carrying a label, WORST FIRST, then oldest first. Reads the cache —
+# no API call.
+#
+# Ordering by priority costs nothing and is the difference between a pipeline and a
+# queue. In the sibling project the order was plain issue number, i.e. filing order,
+# and a BLOCKER sat untouched for seventeen hours behind eight lesser issues while
+# the pipeline burned three cycles on a cosmetic nit. Every log line looked healthy.
+#
+# Ties break on issue number, so within a priority the oldest goes first and nothing
+# starves. Issues with no P* label sort LAST — an unlabelled issue is not evidence
+# of importance.
+issues_with() {
+  printf '%s' "$ISSUE_CACHE" \
+    | jq -r --arg l "$1" '
+        def prank(ns):
+          if   (ns | index("P0")) then 0
+          elif (ns | index("P1")) then 1
+          elif (ns | index("P2")) then 2
+          elif (ns | index("P3")) then 3
+          else 4 end;
+        [ .[]
+          | select([.labels[].name] | index($l))
+          | {n: .number, r: prank([.labels[].name])} ]
+        | sort_by(.r, .n) | .[].n' \
+      2>/dev/null
+}
+
+first_with() { issues_with "$1" | head -1; }
+
+# Labels on one issue, straight from the cache.
+labels_of() {
+  printf '%s' "$ISSUE_CACHE" \
+    | jq -r --argjson n "$1" '.[] | select(.number == $n) | .labels[].name' 2>/dev/null
+}
+
+count_actionable() {
+  local n=0 s
+  for s in "$L_TRIAGE" "$L_READY" "$L_REVIEW" "$L_BLOCKED_IMPL" "$L_BLOCKED_SPEC" "$L_WIP"; do
+    n=$(( n + $(issues_with "$s" | grep -c . || true) ))
+  done
+  echo "$n"
+}
+
+# ── Attempt budget per issue ───────────────────────────────────────────────
+#
+# Rework outranks new work in the dispatch order, which is right — finishing what is
+# started beats starting more. But with no limit it means a single hard issue
+# monopolises the pipeline indefinitely. Measured in the sibling project: one issue
+# went round the loop for over two hours on its third implementation cycle while 21
+# issues sat untouched. From outside the pipeline looked busy and was delivering
+# nothing.
+MAX_ATTEMPTS="${TEAM_MAX_ATTEMPTS:-3}"
+ATTEMPTS_DIR="$STATE_DIR/attempts"
+mkdir -p "$ATTEMPTS_DIR" 2>/dev/null || true
+
+bump_attempts() {
+  local issue="$1" n
+  n=$(( $(cat "$ATTEMPTS_DIR/$issue" 2>/dev/null || echo 0) + 1 ))
+  echo "$n" > "$ATTEMPTS_DIR/$issue"
+  printf '%s' "$n"
+}
+
+# ESCALATE THE STRATEGY, NEVER TO A HUMAN.
+#
+# Repeating the same approach after it has failed twice is the definition of a stuck
+# loop — but parking the issue is not the answer either, because nobody is coming.
+# So each exhaustion changes the APPROACH instead:
+#
+#   attempts 1-2   implement normally, no analysis
+#   attempt  3     hand it to the CURATOR with the full failure history, so the
+#                  briefing is written from what actually went wrong
+#   attempt  4+    force a split: too big or too tangled to land whole
+#
+# This is the second of the three doors into the curator, and the only automatic
+# one. Returns 0 to proceed with the normal action, 1 when it has been redirected.
+escalate_if_stuck() {
+  local issue="$1" n
+  n=$(cat "$ATTEMPTS_DIR/$issue" 2>/dev/null || echo 0)
+  [ "$n" -lt "$MAX_ATTEMPTS" ] && return 0
+
+  if [ "$n" -lt $(( MAX_ATTEMPTS * 2 )) ]; then
+    log "#$issue: $n tentativas — a chamar o curator com o histórico de falhas"
+    comment_issue "$issue" "## Orquestrador: mudar de abordagem após $n tentativas
+
+Este issue já passou $n vezes pelo ciclo sem ser integrado. Repetir a mesma
+abordagem não vai resolver.
+
+**Curator:** escreve a análise a partir do que **falhou de facto** — os
+comentários acima do reviewer dizem exactamente onde é que cada tentativa bateu.
+O implementador não estava a chegar lá sozinho; procura outra via, ou parte o
+issue se o problema for de tamanho."
+    set_state "$issue" "$L_BLOCKED_SPEC"
+    return 1
+  fi
+
+  log "#$issue: $n tentativas — a forçar split"
+  comment_issue "$issue" "## Orquestrador: partir após $n tentativas
+
+Duas rondas de reanálise não resolveram isto. O problema é de **tamanho ou de
+emaranhado**, não de esforço.
+
+**Curator:** usa \`split\`. Parte em pedaços em que cada um seja inequívoco e
+resolúvel isoladamente — um ecrã, um componente, um cálculo de cada vez. Se um
+pedaço continuar a parecer difícil, parte-o outra vez. O histórico de falhas acima
+diz-te onde estão as fronteiras naturais."
+  echo 0 > "$ATTEMPTS_DIR/$issue"   # the pieces start fresh
+  set_state "$issue" "$L_BLOCKED_SPEC"
+  return 1
+}
+
+# ── PR selection ───────────────────────────────────────────────────────────
+# Never just take the first open PR. Doing that produced an infinite loop in the
+# sibling project: a PR the reviewer rightly blocked stays OPEN, so the next cycle
+# picked it up again — 184 reviews of the same commit in one night, ~22% of the
+# weekly quota burned, and the implementer never ran because there was always a PR
+# ahead of it.
+#
+# A PR is only reviewed again when its HEAD MOVES. Re-reviewing the same commit
+# cannot produce a different answer.
+pick_pr() {
+  local list line num sha
+  list=$(gh pr list --repo "$REPO" --base "$BASE_BRANCH" --state open \
+           --json number,headRefOid,headRefName \
+           --jq '.[] | select(.headRefName | startswith("qa/")) | "\(.number) \(.headRefOid)"' \
+           2>/dev/null || echo "")
+  [ -n "$list" ] || return 0
+  # here-string, not a pipe: with `set -o pipefail` a `| head -1` closes the pipe,
+  # the writer takes SIGPIPE and the ORCHESTRATOR DIES — the log then fills with
+  # "cycle 1" forever.
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    num=${line%% *}; sha=${line##* }
+    if ! grep -qxF "$num $sha" "$REVIEWED_STATE" 2>/dev/null; then
+      echo "$num"; return 0
+    fi
+  done <<< "$list"
+  return 0
+}
+
+mark_reviewed() {
+  local num="$1" sha
+  sha=$(gh pr view "$num" --repo "$REPO" --json headRefOid --jq '.headRefOid' 2>/dev/null || echo "")
+  [ -n "$sha" ] || return 0
+  echo "$num $sha" >> "$REVIEWED_STATE"
+  tail -300 "$REVIEWED_STATE" > "$REVIEWED_STATE.tmp" && mv "$REVIEWED_STATE.tmp" "$REVIEWED_STATE"
+}
+
+# ── Stale cleanup ──────────────────────────────────────────────────────────
+# Nothing survives from one cycle to the next. An inherited verdict makes an agent
+# report the PREVIOUS run's work as its own.
+cleanup_stale() {
+  local lock="$LOCK_PREFIX.main.lock"
+  if flock -w 0 -n "$lock" true 2>/dev/null; then
+
+    # Only the roles whose slot is provably free. Deleting the verdict of a live
+    # agent running in another slot is exactly the bug that destroyed the critic's
+    # findings in the sibling project — four real findings lost, which from the
+    # outside looked like "it found nothing".
+    local roles="implement review"
+    if flock -w 0 -n "$LOCK_PREFIX.curator.lock" true 2>/dev/null; then
+      roles="curator $roles"
+    fi
+    for role in $roles; do
+      rm -f "$VERDICT_DIR/$role"-*.json 2>/dev/null || true
+    done
+
+    local pgidfile="$lock.pgid"
+    if [ -f "$pgidfile" ]; then
+      local pgid; pgid=$(cat "$pgidfile" 2>/dev/null || echo "")
+      if [ -n "$pgid" ] && kill -0 -"$pgid" 2>/dev/null; then
+        log "stale: a matar a árvore do agente (pgid $pgid)"
+        kill -TERM -"$pgid" 2>/dev/null || true
+        sleep 2
+        kill -KILL -"$pgid" 2>/dev/null || true
+      fi
+      rm -f "$pgidfile"
+    fi
+    for wt in "$WT_ROOT"/implement-* "$WT_ROOT"/review-* "$WT_ROOT"/curator-*; do
+      [ -e "$wt" ] || continue
+      log "stale: a remover worktree $(basename "$wt")"
+      wt_remove "$wt"
+    done
+    git -C "$TEAM_ROOT" worktree prune 2>/dev/null || true
+  fi
+}
+
+# An issue stuck in qa:wip with no agent alive means the implementer died. Left
+# alone it blocks that issue forever, because nothing dispatches on qa:wip.
+rescue_stuck_wip() {
+  local lock="$LOCK_PREFIX.main.lock"
+  flock -w 0 -n "$lock" true 2>/dev/null || return 0   # an agent is running; leave it
+  local issue pr
+  for issue in $(issues_with "$L_WIP"); do
+    # "No agent alive" does NOT mean "no work done". The implementer opens the PR
+    # and only then transitions the issue, so a crash in that window leaves a real,
+    # complete PR behind on an issue still marked qa:wip. Demoting that to qa:ready
+    # dispatches a second implementer onto work already in review. So ask GitHub
+    # what exists before deciding, rather than inferring from the agent's absence.
+    pr=$(gh pr list --repo "$REPO" --head "qa/issue-$issue" --base "$BASE_BRANCH" \
+      --state open --json number --jq '.[0].number // empty' 2>/dev/null || echo "")
+    if [ -n "$pr" ]; then
+      log "resgate: #$issue estava em $L_WIP mas o PR #$pr está aberto -> $L_REVIEW"
+      comment_issue "$issue" "## Orquestrador: corrida interrompida depois do PR
+
+O implementador morreu **depois** de abrir o PR #$pr, deixando o issue em
+\`$L_WIP\`. O trabalho existe e o PR está aberto, por isso segue para
+\`$L_REVIEW\` em vez de ser reimplementado."
+      set_state "$issue" "$L_REVIEW"
+      continue
+    fi
+    log "resgate: #$issue estava em $L_WIP sem agente vivo e sem PR -> $L_READY"
+    comment_issue "$issue" "## Orquestrador: corrida interrompida
+
+O issue estava em \`$L_WIP\`, nenhum agente estava vivo (timeout ou crash) e não
+existe PR aberto para \`qa/issue-$issue\`.
+Devolvido a \`$L_READY\` para nova tentativa."
+    set_state "$issue" "$L_READY"
+  done
+}
+
+# ── Role dispatch ──────────────────────────────────────────────────────────
+run_implement() { log "IMPLEMENTADOR -> #$1"; bash "$SCRIPT_DIR/implement.sh" "$1" || log "implement falhou #$1"; }
+run_review()    { log "REVIEWER -> PR #$1"; bash "$SCRIPT_DIR/review.sh" "$1" || log "review falhou PR #$1"; mark_reviewed "$1"; }
+
+# The curator runs DETACHED on its own slot. It writes only GitHub comments and
+# labels — no git, no build, no push — so it costs nothing to run alongside the
+# heavy role, and blocking the cycle on it would serialise ~15 minutes onto every
+# issue that needs repair.
+#
+# POSITION MATTERS. In the sibling project this launch sat after the blocking
+# dispatches, which meant it was simply never reached until the heavy role finished:
+# detached-but-last is not concurrent, it is the same serial order with extra
+# machinery. It goes FIRST, and sets no DID, so the same pass still dispatches a
+# heavy role.
+launch_curator_if_needed() {
+  local i
+  i=$(first_with "$L_BLOCKED_SPEC")
+  [ -n "$i" ] || i=$(first_with "$L_TRIAGE")
+  [ -n "$i" ] || return 0
+
+  if ! flock -w 0 -n "$LOCK_PREFIX.curator.lock" true 2>/dev/null; then
+    log "curator já a correr no seu slot — #$i espera a vez"
+    return 0
+  fi
+  log "CURATOR (paralelo) -> #$i"
+  nohup bash "$SCRIPT_DIR/curator.sh" "$i" >> "$LOG_DIR/curator-bg.log" 2>&1 &
+}
+
+# ── Explicit targets ───────────────────────────────────────────────────────
+if [ -n "$TARGET_PR" ]; then run_review "$TARGET_PR"; exit 0; fi
+
+if [ -n "$TARGET_ISSUE" ]; then
+  STATE=$(get_state "$TARGET_ISSUE")
+  log "target #$TARGET_ISSUE estado=${STATE:-nenhum}"
+  case "$STATE" in
+    "$L_TRIAGE"|"$L_BLOCKED_SPEC") bash "$SCRIPT_DIR/curator.sh" "$TARGET_ISSUE" ;;
+    "$L_READY"|"$L_BLOCKED_IMPL")  run_implement "$TARGET_ISSUE" ;;
+    *) log "#$TARGET_ISSUE não está num estado accionável (${STATE:-sem estado})" ;;
+  esac
+  exit 0
+fi
+
+# ── Main loop ──────────────────────────────────────────────────────────────
+CYCLE=0
+log "arranque. base=$BASE_BRANCH repo=$REPO"
+
+while true; do
+  CYCLE=$((CYCLE + 1))
+  log "──── ciclo $CYCLE ────"
+
+  cleanup_stale
+
+  # One read of the world per cycle. Everything below reasons from this snapshot. If
+  # it fails we know nothing about the queue, so the cycle does nothing rather than
+  # acting on a guess.
+  if ! refresh_issue_cache; then
+    log "não consegui ler os issues (API falhou) — ciclo sem acções"
+    if [ "$ONCE" = "1" ]; then exit 0; fi
+    log "a aguardar ${CYCLE_SLEEP}s..."
+    sleep "$CYCLE_SLEEP"
+    continue
+  fi
+
+  rescue_stuck_wip
+
+  # Repair analysis runs alongside delivery, never in front of it.
+  launch_curator_if_needed
+
+  DID=0
+
+  # Priority order matters. Reviewing first is what unblocks merges and closes
+  # issues; only then do we start new work — otherwise the backlog grows faster
+  # than it drains and nothing ever reaches qa:done.
+
+  # 1. Review open PRs whose head has moved since the last review.
+  PR=$(pick_pr)
+  if [ -n "$PR" ]; then run_review "$PR"; DID=1; fi
+
+  # 2. Rework: code problems back to the implementer.
+  if [ "$DID" = "0" ]; then
+    I=$(first_with "$L_BLOCKED_IMPL")
+    if [ -n "$I" ]; then
+      if escalate_if_stuck "$I"; then
+        log "#$I: tentativa $(bump_attempts "$I") de $MAX_ATTEMPTS"
+        run_implement "$I"
+      fi
+      DID=1
+    fi
+  fi
+
+  # 3. New work. No curation step: the implementer investigates the code itself and
+  #    only asks for analysis when the issue genuinely is not actionable.
+  if [ "$DID" = "0" ]; then
+    I=$(first_with "$L_READY")
+    if [ -n "$I" ]; then
+      log "#$I: tentativa $(bump_attempts "$I") de $MAX_ATTEMPTS"
+      run_implement "$I"
+      DID=1
+    fi
+  fi
+
+  # 4. Nothing dispatched.
+  if [ "$DID" = "0" ]; then
+    ACTIONABLE=$(count_actionable)
+    if [ "$ACTIONABLE" -gt 0 ]; then
+      # Almost always: the only remaining work is blocked-spec, and the curator is
+      # already chewing on it in its own slot.
+      log "nada a despachar neste ciclo; ainda há $ACTIONABLE issue(s) em curso"
+    else
+      log "BACKLOG VAZIO — nenhum issue accionável em $REPO. Terminado."
+      exit 0
+    fi
+  fi
+
+  if [ "$ONCE" = "1" ]; then
+    log "──── fim (once) ────"
+    exit 0
+  fi
+
+  if [ "$MAX_CYCLES" -gt 0 ] && [ "$CYCLE" -ge "$MAX_CYCLES" ]; then
+    log "atingidos os $MAX_CYCLES ciclos pedidos. A terminar."
+    exit 0
+  fi
+
+  log "a aguardar ${CYCLE_SLEEP}s..."
+  sleep "$CYCLE_SLEEP"
+done

--- a/scripts/team/review-prompt.md
+++ b/scripts/team/review-prompt.md
@@ -1,0 +1,193 @@
+# iosToAndroid — Reviewer
+
+## ⛔ Sessão HEADLESS — não há próximo turno
+
+Isto corre sem ninguém do outro lado. **Não existe** notificação, nem segundo
+turno, nem alguém que te responda. Se terminares a tua resposta à espera de algo,
+a corrida acaba ali e todo o teu trabalho é descartado.
+
+- **Corre tudo de forma síncrona.** Nada em background: sem `&`, sem `nohup`, sem
+  processos a monitorizar. Se um comando demora, espera por ele.
+- **Não digas "vou aguardar"** por um processo ou por uma notificação. Não vem nada.
+- **A última coisa que fazes é escrever o veredicto** em `__VERDICT_PATH__`. Sem
+  veredicto, a corrida conta como falhada mesmo que o teu trabalho esteja feito.
+- Se ficares sem tempo, escreve o veredicto **com o que tens**.
+
+És o **reviewer**. Decides se este PR entra em `main`.
+
+## ⚠️ ÉS O ÚNICO PORTÃO
+
+Não há verificador a seguir e **não há CI em pull requests** neste repositório
+(`build-apk.yml` só corre quando se publica uma release). O que tu correres é
+tudo o que alguma vez vai correr antes de este código estar em `main`.
+
+Isto muda o cálculo em duas direcções, e ambas importam:
+
+- **Não aprovas nada que não tenhas corrido.** "Parece bem" não é um veredicto.
+- **Mas também não bloqueias por precaução.** Se os critérios estão cumpridos e
+  as três verificações passam, aprova. Não há rede a seguir, mas também não há
+  ninguém a quem passar a decisão — bloquear por dúvida vaga custa uma volta
+  inteira e não produz informação nova.
+
+Rever aqui **não é ver se os testes passam**. Tens de verificar tudo o que está
+abaixo, e o veredicto tem um campo por cada coisa.
+
+## A fonte de verdade é o DIFF, nunca o título nem o corpo
+
+O corpo do PR é escrito pelo implementador e pode estar errado — por descuido ou
+porque descreve o que ele *pretendia* fazer. Já aconteceu neste tipo de pipeline
+um PR cujo corpo descrevia o trabalho de outro issue enquanto o diff fazia outra
+coisa.
+
+Se o corpo diz que mexeu em ficheiros que não estão no diff, **isso é um defeito
+a reportar**, não uma pista sobre onde procurar. A lista completa de ficheiros
+vai no contexto abaixo e nunca é truncada — usa-a.
+
+## O que verificar
+
+1. **As três verificações** — corre-as no worktree (`__WORKDIR__`):
+   ```bash
+   npm run lint
+   npx tsc --noEmit
+   npm test
+   ```
+   **Se houver uma secção "LINHA DE BASE" mais abaixo, lê-a antes de julgares o
+   resultado.** Diz-te o que já estava partido em `main` antes deste PR, e nesse
+   caso o critério é **regressão**: bloqueias por falhas NOVAS, não por falhas
+   herdadas. Sem essa secção, as três têm de passar por inteiro.
+
+   Os campos `lint_pass` / `typecheck_pass` / `tests_pass` do veredicto significam
+   sempre **"não regrediu"**. Diz no `summary` os números que obtiveste e contra o
+   que os comparaste.
+
+2. **O issue fica resolvido** — não há critérios escritos por um curator; o
+   contrato é o **issue original**, que vai no contexto. Lê-o e percorre-o contra
+   o **diff**. O implementador escreveu os critérios dele no corpo do PR: confere
+   se são fiéis ao issue (não uma versão facilitada dele) e se estão de facto
+   cumpridos.
+
+3. **Causa raiz, não sintoma** — o fix resolve o mecanismo, ou esconde-o? Um
+   `try/catch` vazio, um `?? 0` que tapa um `undefined` inesperado, um `?.` que
+   evita o caso em vez de o tratar, um `as any` que cala o `tsc`: tudo isso é
+   bloqueio.
+
+4. **Cobertura, e o teste é mesmo válido** — não basta existirem testes.
+
+   - **Exige a prova do passo vermelho.** O corpo do PR deve trazer a mensagem de
+     falha que o teste deu **antes** do fix. Se não trouxer, ou se parecer
+     inventada, verifica tu: reverte o ficheiro de produção no worktree, corre a
+     suite, e vê se falha. **Já aconteceu neste pipeline** um teste que passava
+     sem o fix — o implementador tinha-o escrito depois, e não testava nada.
+   - **Casos além do caminho feliz.** Fronteiras (0, 1, o limite ±1), vazios e
+     `undefined`, entradas inválidas, a acção repetida duas vezes, assíncrono
+     (resposta depois do unmount, duas chamadas em voo), e o inverso do fix. Se
+     só há teste do caso feliz, isso é `blocked-impl` com o caso em falta
+     **nomeado** — não um comentário simpático.
+   - **Testes que não podem falhar** são pior que nenhum: dão confiança falsa. Um
+     `expect` sobre algo que o fix não altera, ou um `getByText` que casa quer o
+     comportamento esteja certo ou errado, contam como ausência de teste.
+   - **Snapshots actualizados sem justificação.** Um `.snap.android` alterado no
+     diff é uma mudança de UI declarada. Se o corpo do PR não explica porque
+     mudou, ou se a mudança não corresponde ao issue, isso é uma regressão
+     aceite por descuido — bloqueia.
+
+5. **Âmbito** — mexe apenas no que o issue pedia? Alterações não relacionadas
+   escondem o fix e aumentam o risco.
+
+6. **Lixo versionado** — o diff arrasta o que nunca devia entrar?
+   (`node_modules/`, `android/`, `ios/`, `.expo/`, `*.log`, ficheiros de
+   veredicto, `.apk`). `android/` e `ios/` são gerados pelo `expo prebuild`:
+   qualquer ficheiro deles no diff é bloqueio, e o que era preciso mudar
+   pertence a `app.json` ou a `plugins/`.
+
+7. **Segredos** — chaves, tokens ou URLs de produção no diff.
+
+8. **Raio de impacto (blast radius)** — **enumera** quem consome o código
+   alterado; não te limites a "pensar" nisso. Para cada símbolo tocado
+   (componente, store, hook, utilitário, método do módulo nativo):
+
+   ```bash
+   grep -rn "NomeDoSimbolo" src/ modules/ | grep -v "<ficheiro alterado>"
+   ```
+
+   Depois, para **cada** consumidor encontrado, diz explicitamente no `summary`
+   se continua correcto e porquê. Os componentes `Cupertino*` são partilhados por
+   quase todos os ecrãs; uma alteração a um deles atinge-os a todos, e o autor
+   normalmente só olhou para o que estava a corrigir.
+
+   Se o diff muda a **assinatura** ou o **comportamento por omissão** de algo
+   partilhado, e há consumidores que o diff não tocou, isso é bloqueio até ficar
+   demonstrado que cada um deles se mantém correcto.
+
+9. **Só afecta o que devia** — o inverso do ponto anterior, e mais perigoso: a
+   alteração produz efeitos onde não lhe compete? Um fix de apresentação que
+   passa a alterar estado persistido, um filtro que passa a excluir casos
+   legítimos, uma correcção num ecrã que muda comportamento partilhado. Se o
+   issue era sobre um ecrã e o diff muda comportamento global, justifica porque é
+   essa a correcção certa em vez de uma local.
+
+10. **Bridge nativo** — se o diff toca em `modules/`, verifica que o lado JS e o
+    lado Kotlin continuam a concordar: nome do método, aridade, tipos, e o que
+    acontece quando o módulo nativo não está disponível (Expo Go, testes).
+
+## Veredicto
+
+Escreve EXACTAMENTE este JSON em `__VERDICT_PATH__`:
+
+```json
+{
+  "verdict": "approved|blocked-impl|blocked-spec",
+  "lint_pass": true,
+  "typecheck_pass": true,
+  "tests_pass": true,
+  "issue_resolved": true,
+  "description_matches_diff": true,
+  "has_tests": true,
+  "red_step_proven": true,
+  "edge_cases_covered": true,
+  "fixes_root_cause": true,
+  "junk_files": [],
+  "secrets_found": [],
+  "summary": "o que verificaste e o que decidiste — descreve o que o DIFF faz",
+  "required_changes": ["mudança concreta 1", "mudança concreta 2"]
+}
+```
+
+### Como escolher o veredicto
+
+- **approved** — tudo acima está bem. O PR é integrado em `main` e o issue é
+  fechado. Não há mais nada depois de ti.
+
+- **blocked-impl** — **problema de código**: uma das três verificações falha, o
+  issue não fica resolvido, o fix trata o sintoma, falta teste ou o teste não
+  prova nada, há lixo ou segredos, ou há regressão num consumidor. Volta para o
+  implementador. Preenche `required_changes` com o que ele tem de fazer —
+  concreto e verificável, não "melhorar o código".
+
+- **blocked-spec** — **problema do enunciado**: o issue pede algo ambíguo,
+  contraditório, ou que não corresponde ao código real; ou o âmbito real é muito
+  maior do que o issue sugere. O implementador fez o que lhe pediram e o pedido
+  estava mal. Isto envia o issue para o **curator**, que escreve uma análise
+  completa antes de alguém voltar a tentar. Diz em `required_changes` o que a
+  análise tem de esclarecer.
+
+A distinção entre `blocked-impl` e `blocked-spec` é importante: mandar de volta
+ao implementador um issue cujo enunciado está errado gera um ciclo infinito em
+que ele reimplementa a mesma coisa errada. Se a instrução estava mal, o problema
+é a instrução.
+
+### ⛔ Não existe "needs-human". Decides tu.
+
+Não há revisor humano a seguir. Um PR que deixes indeciso fica aberto para sempre
+e bloqueia o issue.
+
+- **Não consegues avaliar sem correr algo?** Corre. Tens o worktree e o shell.
+- **Dúvida sobre segurança ou perda de dados do utilizador?** Isso é motivo para
+  `blocked-impl` com o risco descrito em `required_changes`, não para empatar.
+
+## Notas
+
+- No `summary`, descreve o que o **diff** faz, não o que o título diz.
+- Não aprovas um PR sem alterações de código reais.
+- Não cites números de issue que não estejam no contexto que te foi dado.
+- Responde em português.

--- a/scripts/team/review.sh
+++ b/scripts/team/review.sh
@@ -1,0 +1,281 @@
+#!/bin/bash
+# review.sh — the REVIEWER. Reads a PR targeting `main`, comments its findings, and
+# either merges it (closing the issue) or routes it back: code problems to the
+# implementer, briefing problems to the curator.
+#
+# THIS IS THE ONLY GATE. There is no verifier behind it and no CI on pull requests
+# in this repo (build-apk.yml fires on release publish only), so whatever this agent
+# runs — lint, tsc, jest — is the entire quality bar before main moves.
+#
+# Usage: review.sh <pr_number>
+set -uo pipefail
+
+PR="${1:?PR obrigatorio}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+ROLE="review"
+
+VERDICT_FILE="$VERDICT_DIR/review-$PR.json"
+PROMPT="/tmp/ios2a-review-prompt-$PR.txt"
+MODEL="${REVIEW_MODEL:-sonnet}"
+WT=""
+
+cleanup() { [ -n "$WT" ] && wt_remove "$WT"; }
+trap cleanup EXIT
+
+PR_INFO=$(gh pr view "$PR" --repo "$REPO" \
+  --json number,title,body,headRefName,baseRefName,state 2>/dev/null) \
+  || { log "ERRO: não consegui ler o PR #$PR"; exit 1; }
+
+BRANCH=$(printf '%s' "$PR_INFO" | jq -r '.headRefName')
+BASE=$(printf '%s' "$PR_INFO" | jq -r '.baseRefName')
+TITLE=$(printf '%s' "$PR_INFO" | jq -r '.title')
+STATE=$(printf '%s' "$PR_INFO" | jq -r '.state')
+
+log "PR #$PR $BRANCH -> $BASE ($STATE) modelo=$MODEL"
+
+if [ "$STATE" != "OPEN" ]; then
+  log "PR #$PR não está aberto — nada a rever"
+  exit 0
+fi
+
+# The issue comes from the closing keyword in the body, which the implementer always
+# writes.
+ISSUE=$(printf '%s' "$PR_INFO" | jq -r '.body' \
+  | grep -oiE '(Fixes|Closes|Resolves)[[:space:]]+#[0-9]+' \
+  | grep -oE '[0-9]+' | head -1 || true)
+log "issue ligado: ${ISSUE:-nenhum}"
+
+# wt_checkout, NOT wt_create: the reviewer needs the PR's code. wt_create would cut
+# a new branch from the base, the diff would come out EMPTY, and the reviewer would
+# be judging the PR by its title alone — with no error in the log to reveal it.
+WT_OUT=$(wt_checkout "$BRANCH" "review-$PR") || { log "ERRO: checkout de $BRANCH falhou"; exit 1; }
+WT="$WT_OUT"
+
+git -C "$TEAM_ROOT" fetch origin "$BASE" >/dev/null 2>&1 || true
+
+# NEVER pipe the diff through `head -c N`. Under `set -o pipefail`, once the diff
+# exceeds N, head closes the pipe, git takes SIGPIPE, and the script dies before
+# writing anything. Truncate in bash instead. The FULL file list always goes in the
+# prompt (it is small) so description-vs-diff matching never depends on the cut.
+DIFF=$(git -C "$WT" --no-pager diff "origin/$BASE...HEAD" 2>/dev/null || true)
+FILES=$(git -C "$WT" --no-pager diff "origin/$BASE...HEAD" --name-only 2>/dev/null || true)
+DIFF_BYTES=${#DIFF}
+DIFF="${DIFF:0:60000}"
+
+if [ -z "${DIFF//[[:space:]]/}" ]; then
+  log "DIFF VAZIO — não se revê um PR pelo título"
+  gh pr comment "$PR" --repo "$REPO" --body "## Reviewer: sem diff
+
+O worktree do branch \`$BRANCH\` não produziu diff contra \`$BASE\`. Sem diff não
+há o que rever, por isso o issue volta ao implementador para reenviar o trabalho." >/dev/null 2>&1 || true
+  [ -n "$ISSUE" ] && set_state "$ISSUE" "$L_BLOCKED_IMPL"
+  exit 1
+fi
+
+log "diff: ${DIFF_BYTES}B em $(printf '%s' "$FILES" | grep -c . || echo 0) ficheiro(s)"
+
+log "a preparar dependências para o reviewer correr os testes..."
+wt_prepare_node "$WT"
+
+ISSUE_JSON=""
+if [ -n "$ISSUE" ]; then
+  ISSUE_JSON=$(gh issue view "$ISSUE" --repo "$REPO" --json title,body,comments --jq '
+    "# " + .title + "\n\n" + (.body // "") + "\n\n## Comentários\n\n" +
+    (if (.comments | length) > 0 then
+       ([.comments[] | "- **@" + (.author.login // "anon") + "**: " + (.body // "")] | join("\n\n"))
+     else "(sem comentários)" end)' 2>/dev/null || echo "")
+fi
+
+{
+  cat "$SCRIPT_DIR/review-prompt.md"
+  baseline_block
+  echo ""
+  echo "---"
+  echo ""
+  echo "# PR #$PR: $TITLE"
+  echo ""
+  echo "\`$BRANCH\` → \`$BASE\`"
+  echo ""
+  echo "## Corpo do PR (escrito pelo implementador — pode estar errado)"
+  echo ""
+  printf '%s\n' "$(printf '%s' "$PR_INFO" | jq -r '.body')"
+  echo ""
+  echo "## Issue original (o contrato: o que tinha de ficar resolvido)"
+  echo ""
+  printf '%s\n' "${ISSUE_JSON:-(sem issue ligado)}"
+  echo ""
+  echo "## Ficheiros no diff (lista completa — nunca truncada)"
+  echo ""
+  printf '%s\n' "$FILES"
+  echo ""
+  echo "## Diff (${DIFF_BYTES} bytes no total)"
+  echo ""
+  printf '%s\n' "$DIFF"
+} | sed -e "s|__VERDICT_PATH__|$VERDICT_FILE|g" \
+        -e "s|__WORKDIR__|$WT|g" > "$PROMPT"
+
+rm -f "$VERDICT_FILE"
+AGENT_SLOT=main CLAUDE_MODEL="$MODEL" \
+  bash "$SCRIPT_DIR/run-agent.sh" "$PROMPT" "$WT" "${REVIEW_TIMEOUT:-1800}" \
+  > "$LOG_DIR/review-$PR.log" 2>&1; AGENT_RC=$?
+
+if [ ! -f "$VERDICT_FILE" ]; then
+  if ! no_verdict_is_real_failure main "$AGENT_RC"; then
+    log "SEM VEREDICTO (corrida degradada ou não arrancada) — PR fica para nova review"
+    gh pr comment "$PR" --repo "$REPO" --body "## Reviewer: corrida degradada, sem veredicto
+
+A corrida não produziu veredicto por uma razão alheia ao PR: ou o slot estava
+ocupado, ou a subscrição estava esgotada e o fallback não conseguiu concluir. O PR
+fica como está e será revisto de novo." >/dev/null 2>&1 || true
+    exit 0
+  fi
+  # A failed run must not consume the PR: leave it open so the next cycle picks it
+  # up again (its head sha is unchanged, and no reviewed-sha record was written).
+  log "SEM VEREDICTO — PR fica aberto para nova review"
+  gh pr comment "$PR" --repo "$REPO" --body "## Reviewer: corrida sem veredicto
+
+A corrida terminou sem escrever veredicto (ver \`$LOG_DIR/review-$PR.log\`). Falha
+da corrida, não do PR — será revisto de novo." >/dev/null 2>&1 || true
+  exit 0
+fi
+
+VERDICT=$(jqv "$VERDICT_FILE" '.verdict' 'blocked-impl')
+SUMMARY=$(jqv "$VERDICT_FILE" '.summary' '(sem resumo)'); SUMMARY="${SUMMARY:0:1500}"
+
+# Per-dimension detail, so the defect is visible in the comment without opening the
+# verdict — and so it is auditable whether the reviewer actually filled it in.
+DETAIL=$(jq -r '
+  [ (if .tests_pass == false then "os testes falham" else empty end),
+    (if .lint_pass == false then "o lint falha" else empty end),
+    (if .typecheck_pass == false then "o tsc falha" else empty end),
+    (if .issue_resolved == false then "o issue não fica resolvido" else empty end),
+    (if .description_matches_diff == false then "a descrição do PR não corresponde ao diff" else empty end),
+    (if .has_tests == false then "não traz testes" else empty end),
+    (if .red_step_proven == false then "não prova o passo vermelho (o teste pode passar sem o fix)" else empty end),
+    (if .edge_cases_covered == false then "só testa o caminho feliz" else empty end),
+    (if .fixes_root_cause == false then "trata o sintoma, não a causa raiz" else empty end),
+    (if ((.junk_files // []) | length) > 0 then "lixo versionado: " + ((.junk_files // []) | join(", ")) else empty end),
+    (if ((.secrets_found // []) | length) > 0 then "SEGREDOS no diff: " + ((.secrets_found // []) | join(", ")) else empty end)
+  ] | if length == 0 then "" else "\n\n**Defeitos:**\n- " + join("\n- ") end
+' "$VERDICT_FILE" 2>/dev/null || echo "")
+
+CHANGES=$(jq -r '
+  (.required_changes // []) | if length == 0 then "" else
+  "\n\n**Alterações necessárias:**\n- " + join("\n- ") end
+' "$VERDICT_FILE" 2>/dev/null || echo "")
+
+log "verdict=$VERDICT"
+
+case "$VERDICT" in
+  approved)
+    gh pr comment "$PR" --repo "$REPO" --body "## Reviewer: aprovado
+
+$SUMMARY" >/dev/null 2>&1 || true
+
+    # Whether the merge happened is decided by READING the PR, never by trusting an
+    # exit code. `gh pr merge` returns non-zero for things that occur AFTER a
+    # successful merge — deleting the branch, for one — and reports "already merged"
+    # as an error. In the sibling project that made the script record a failure on a
+    # merge that had landed, and queue a redo of work already integrated.
+    merge_landed() {
+      [ "$(gh pr view "$PR" --repo "$REPO" --json state --jq .state 2>/dev/null)" = "MERGED" ]
+    }
+
+    MERGE_OK=0
+    gh pr merge "$PR" --repo "$REPO" --squash --delete-branch >/dev/null 2>&1 || true
+    if merge_landed; then
+      MERGE_OK=1
+    else
+      MSTATUS=$(gh pr view "$PR" --repo "$REPO" --json mergeStateStatus --jq .mergeStateStatus 2>/dev/null || echo "")
+      log "merge recusado (mergeStateStatus=$MSTATUS)"
+      case "$MSTATUS" in
+        DIRTY|BEHIND)
+          # A conflicted or stale branch is NOT bad code — the review itself was
+          # fine. Say so explicitly, so the implementer resolves the conflict
+          # instead of re-doing work that was already accepted. implement.sh leaves
+          # the conflict markers in the worktree for exactly this.
+          gh pr comment "$PR" --repo "$REPO" --body "## Reviewer: aprovado, mas o branch não integra (\`$MSTATUS\`)
+
+O código foi **aprovado** — o problema é só que o branch não integra em \`$BASE\`,
+por conflito ou por estar atrasado.
+
+**Não refaças o trabalho.** Na próxima passagem o \`$BASE\` é integrado neste branch
+e, se houver conflito, os marcadores ficam na árvore para resolveres por intenção:
+percebe o que cada lado queria e preserva as duas intenções. Depois corre a suite
+completa e reenvia." >/dev/null 2>&1 || true
+          ;;
+      esac
+    fi
+
+    if [ "$MERGE_OK" = "1" ]; then
+      log "PR #$PR integrado em $BASE"
+      if [ -n "$ISSUE" ]; then
+        # No verifier behind this. The reviewer ran lint, tsc and the suite against
+        # this exact code and approved it; that is the whole gate, so the issue is
+        # done. Closed EXPLICITLY rather than relying on the `Fixes #N` keyword —
+        # a squash-merge closes it only when GitHub attributes the merge to a user
+        # token, and depending on that has silently left issues open before.
+        comment_issue "$ISSUE" "## Reviewer: aprovado e integrado
+
+$SUMMARY
+
+PR #$PR integrado em \`$BASE\`."
+        set_state "$ISSUE" "$L_DONE"
+        gh issue close "$ISSUE" --repo "$REPO" --reason completed >/dev/null 2>&1 || true
+      fi
+    else
+      log "merge falhou (conflito ou gate)"
+      gh pr comment "$PR" --repo "$REPO" --body "## Reviewer: aprovado mas o merge falhou
+
+Provavelmente conflito com \`$BASE\` ou uma protecção de branch. O implementador
+deve actualizar o branch." >/dev/null 2>&1 || true
+      [ -n "$ISSUE" ] && set_state "$ISSUE" "$L_BLOCKED_IMPL"
+    fi
+    ;;
+
+  blocked-impl)
+    gh pr comment "$PR" --repo "$REPO" --body "## Reviewer: bloqueado — problema de código
+
+$SUMMARY$DETAIL$CHANGES
+
+Devolvido ao implementador." >/dev/null 2>&1 || true
+    [ -n "$ISSUE" ] && {
+      comment_issue "$ISSUE" "## Reviewer: bloqueado (código)
+
+$SUMMARY$DETAIL$CHANGES"
+      set_state "$ISSUE" "$L_BLOCKED_IMPL"
+    }
+    ;;
+
+  blocked-spec)
+    gh pr comment "$PR" --repo "$REPO" --body "## Reviewer: bloqueado — problema do enunciado
+
+$SUMMARY$DETAIL$CHANGES
+
+O implementador fez o que o issue pedia; o pedido é que estava mal. Enviado ao
+curator para escrever uma análise." >/dev/null 2>&1 || true
+    [ -n "$ISSUE" ] && {
+      comment_issue "$ISSUE" "## Reviewer: bloqueado (enunciado)
+
+$SUMMARY$DETAIL$CHANGES"
+      set_state "$ISSUE" "$L_BLOCKED_SPEC"
+    }
+    ;;
+
+  *)
+    # Unrecognised verdict = the contract was not followed. Treat as a code block so
+    # the implementer gets another pass, rather than parking the issue.
+    gh pr comment "$PR" --repo "$REPO" --body "## Reviewer: resultado não reconhecido (\`$VERDICT\`)
+
+$SUMMARY$DETAIL
+
+O veredicto não usou um dos resultados válidos; devolvido ao implementador." >/dev/null 2>&1 || true
+    [ -n "$ISSUE" ] && set_state "$ISSUE" "$L_BLOCKED_IMPL"
+    ;;
+esac
+
+rm -f "$VERDICT_FILE"
+log "done PR #$PR"

--- a/scripts/team/run-agent.sh
+++ b/scripts/team/run-agent.sh
@@ -1,0 +1,284 @@
+#!/bin/bash
+# run-agent.sh — runs ONE agent: the Claude Code harness plus a prompt.
+#
+# Primary path is the local `claude` CLI on the user's subscription. When that
+# subscription is out of usage we fall back to running the same harness against an
+# Ollama Cloud model (`ollama launch claude`). The harness — and therefore the tools
+# the agent has — is identical either way; only the model behind it changes.
+#
+# Usage: run-agent.sh <prompt-file> <workdir> [timeout_s]
+#
+# Environment:
+#   AGENT_SLOT          lock scope. Roles that write to git/GitHub share the
+#                       default slot so only one of them ever runs at a time.
+#   AGENT_ALLOWED_TOOLS --allowedTools value (default: a read/write/bash set)
+#   AGENT_ADD_DIRS      colon-separated extra --add-dir paths
+#   CLAUDE_MODEL        default: sonnet
+#   FALLBACK_MODEL      default: deepseek-v4-flash:cloud
+#   AGENT_FORCE_FALLBACK=1  skip the subscription entirely (for testing)
+set -uo pipefail
+
+PROMPT_FILE="${1:?ficheiro de prompt obrigatorio}"
+WORKDIR="${2:?workdir obrigatorio}"
+TIMEOUT_S="${3:-900}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+ROLE="run-agent"
+
+CLAUDE_MODEL="${CLAUDE_MODEL:-sonnet}"
+FALLBACK_MODEL="${AGENT_FALLBACK_MODEL:-${FALLBACK_MODEL:-deepseek-v4-flash:cloud}}"
+AGENT_SLOT="${AGENT_SLOT:-main}"
+
+[ -f "$PROMPT_FILE" ] || { echo "ERRO: prompt não existe: $PROMPT_FILE" >&2; exit 1; }
+[ -d "$WORKDIR" ]     || { echo "ERRO: workdir não existe: $WORKDIR" >&2; exit 1; }
+
+# ── Lock ───────────────────────────────────────────────────────────────────
+# `-w 0`: if this slot is already busy, ABORT NOW rather than queue. Waiting is
+# what let a timed-out agent stay alive while the next cycle started another one on
+# top of it — two live agents on the same repo.
+LOCK="$LOCK_PREFIX.$AGENT_SLOT.lock"
+exec 9>"$LOCK"
+if ! flock -w 0 9; then
+  echo "[run-agent] ABORTADO: slot '$AGENT_SLOT' já tem um agente a correr" >&2
+  exit 75
+fi
+
+# `setsid` puts the agent and every descendant in their own process group, and we
+# record the leader pid (= pgid). That is what lets the orchestrator kill exactly
+# OUR agent tree later. Do not reach for `pkill -f claude`: it also kills whatever
+# `claude` the user happens to be running in another terminal.
+PGID_FILE="$LOCK.pgid"
+cleanup() { rm -f "$PGID_FILE"; }
+trap cleanup EXIT
+
+COOLDOWN_FILE="$STATE_DIR/claude-usage-cooldown"
+
+# True when a previous run hit the usage limit recently. Without this we would spend
+# one doomed request per cycle re-discovering that the quota is gone.
+in_cooldown() {
+  [ -f "$COOLDOWN_FILE" ] || return 1
+  local until_ts now
+  until_ts=$(cat "$COOLDOWN_FILE" 2>/dev/null || echo 0)
+  now=$(date +%s)
+  [ "$now" -lt "$until_ts" ]
+}
+
+start_cooldown() {
+  local mins="${1:-45}"
+  echo $(( $(date +%s) + mins * 60 )) > "$COOLDOWN_FILE"
+  echo "[run-agent] cooldown da subscrição: ${mins}min" >&2
+}
+
+# The CLI states when the quota comes back — "resets 3:20pm (Europe/Lisbon)" — so
+# use it instead of guessing. A fixed 45min cooldown against a 79min wait just means
+# waking up early, failing again, and cooling down a second time.
+cooldown_until_reset() {
+  local out="$1" stamp target now mins
+  stamp=$(grep -oiE 'resets? [0-9]{1,2}(:[0-9]{2})? ?(am|pm)?' <<<"$out" | head -1 \
+          | sed -E 's/^resets? //I')
+  if [ -n "$stamp" ]; then
+    target=$(date -d "$stamp" +%s 2>/dev/null || echo "")
+    if [ -n "$target" ]; then
+      now=$(date +%s)
+      [ "$target" -le "$now" ] && target=$((target + 86400))
+      # +2min of slack: waking at the exact boundary tends to fail once more.
+      mins=$(( (target - now) / 60 + 2 ))
+      [ "$mins" -gt 0 ] && [ "$mins" -lt 1440 ] && { start_cooldown "$mins"; return 0; }
+    fi
+  fi
+  return 1
+}
+
+# Distinguish "out of quota" from "the agent failed at its task". Only the former
+# justifies burning the fallback model.
+#
+# BE GENEROUS WITH THE PATTERNS. The first version matched 'usage limit' but the CLI
+# actually says "You've hit your session limit · resets 3:20pm" — so the fallback
+# never fired and a perfectly good issue was parked mid-run. Missing an exhaustion
+# message costs a whole work item; over-matching costs one cheap fallback run.
+is_usage_exhausted() {
+  local out="$1"
+  grep -qiE \
+    'usage limit|session limit|hit your [a-z ]*limit|limit.*reset|resets? (at|[0-9])|rate.?limit|quota (exceeded|reached)|too many requests|429|insufficient (quota|credit)|upgrade to (pro|max)|out of (credit|quota)' \
+    <<<"$out"
+}
+
+build_add_dirs() {
+  local -a args=()
+  # The verdict is written OUTSIDE the working tree, so the harness has to be told
+  # that directory is in scope — otherwise it refuses the Write and the agent
+  # finishes having recorded nothing, which is the exact failure this whole design
+  # exists to prevent.
+  args+=(--add-dir "$VERDICT_DIR")
+  if [ -n "${AGENT_ADD_DIRS:-}" ]; then
+    local IFS=':'
+    for d in $AGENT_ADD_DIRS; do
+      [ -n "$d" ] && args+=(--add-dir "$d")
+    done
+  fi
+  printf '%s\n' "${args[@]}"
+}
+
+DEFAULT_TOOLS='Read,Write,Edit,Glob,Grep,Bash,TodoWrite'
+ALLOWED_TOOLS="${AGENT_ALLOWED_TOOLS:-$DEFAULT_TOOLS}"
+
+mapfile -t ADD_DIR_ARGS < <(build_add_dirs)
+
+run_harness() {
+  local kind="$1" model="$2"; shift 2
+  local -a cmd=("$@")
+
+  echo "[run-agent] motor=$kind modelo=$model workdir=$WORKDIR timeout=${TIMEOUT_S}s" >&2
+
+  local out_file
+  out_file=$(mktemp "/tmp/run-agent-$AGENT_SLOT.XXXXXX.out")
+
+  # Output is STREAMED, not captured-then-printed. Capturing meant a 30-minute agent
+  # produced exactly one line in the log until the moment it finished, which made
+  # perfectly healthy runs look dead. For something unattended for hours, being able
+  # to watch it work is not a luxury.
+  #
+  # Process substitution keeps `$!` pointing at the setsid leader (so the pgid
+  # bookkeeping still works) while tee-ing to our stdout and keeping a copy for the
+  # usage-exhaustion check below.
+  #
+  # `-k 30`: if SIGTERM doesn't kill it, SIGKILL follows 30s later.
+  #
+  # `9>&-` CLOSES THE LOCK FD IN THE CHILD. Without it the agent inherits fd 9 — the
+  # descriptor this script's flock is held on — and keeps holding the lock after
+  # run-agent.sh exits. The next dispatch then aborts with exit 75 against an
+  # "agent" that is nobody's child and whose pgid file the exit trap already deleted.
+  #
+  # `< /dev/null` CLOSES STDIN, and its absence cost most of a day in the sibling
+  # project: `ollama launch claude` waits on stdin before doing anything, so with
+  # stdin inherited it printed "Execution error" and hung until the timeout reaped
+  # it — ~1800s per run for zero verdicts, with logs that look like a run that found
+  # nothing.
+  setsid timeout -k 30 "$TIMEOUT_S" "${cmd[@]}" < /dev/null > >(tee "$out_file") 2>&1 9>&- &
+  local pid=$!
+  echo "$pid" > "$PGID_FILE"
+
+  # Watchdog: an engine that refuses can print its error in seconds and then never
+  # exit. The timeout eventually reaps it, but "eventually" is the whole budget. If
+  # the error signature is there and nothing else arrived within the grace period,
+  # kill the group and let the caller have its failure now.
+  (
+    sleep "${AGENT_ERROR_GRACE_S:-45}"
+    if [ -s "$out_file" ] \
+       && [ "$(wc -c < "$out_file")" -lt 400 ] \
+       && grep -qiE 'Execution error|failed to launch|connection refused' "$out_file"; then
+      echo "[run-agent] motor falhou de imediato e ficou pendurado — abortado sem esperar pelo timeout" >&2
+      kill -TERM -"$pid" 2>/dev/null || true
+      sleep 5
+      kill -KILL -"$pid" 2>/dev/null || true
+    fi
+  ) >/dev/null 2>&1 &
+  local watchdog=$!
+  # If THIS script is killed, take the whole group down — no orphans.
+  trap 'kill -TERM -"'"$pid"'" 2>/dev/null; cleanup' TERM INT
+
+  wait "$pid"
+  local rc=$?
+  kill "$watchdog" 2>/dev/null || true
+  # tee may still be flushing after the agent exits.
+  sleep 1
+  AGENT_OUTPUT=$(cat "$out_file" 2>/dev/null || echo "")
+  rm -f "$out_file"
+  return $rc
+}
+
+PROMPT="$(cat "$PROMPT_FILE")"
+RC=1
+USED=""
+
+# VISION IS NOT UNIVERSAL, AND ASSUMING IT KILLS THE WHOLE RUN.
+#
+# Issues in this repo can carry screenshots, and the prompts tell agents to `Read`
+# the evidence. Claude does that fine. The fallback model does not accept image
+# input at all, and the failure is not graceful: the API returns
+# `400 this model does not support image input` and the entire run dies with no
+# verdict. The agent has no way to know which engine it is on, so we tell it.
+append_no_vision_note() {
+  cat <<'EOF'
+
+---
+
+# 👁 IMAGENS: NÃO USES `Read` EM FICHEIROS DE IMAGEM
+
+Este motor não aceita imagens. Fazer `Read` num `.png`/`.jpg`/`.gif` devolve erro
+400 e **mata a corrida inteira**, sem veredicto.
+
+Trabalha só com o que é texto: o corpo do issue, os comentários, o código, o
+output dos comandos. Se a decisão depender mesmo de uma imagem que não podes ver,
+diz isso explicitamente no veredicto em vez de a inventares.
+EOF
+}
+
+# ── 1. Subscription (claude CLI) ───────────────────────────────────────────
+if [ "${AGENT_FORCE_FALLBACK:-0}" != "1" ] && ! in_cooldown && command -v claude >/dev/null 2>&1; then
+  USED="claude/$CLAUDE_MODEL"
+  run_harness "claude" "$CLAUDE_MODEL" \
+    claude -p "$PROMPT" \
+      --model "$CLAUDE_MODEL" \
+      "${ADD_DIR_ARGS[@]}" \
+      --permission-mode acceptEdits \
+      --allowedTools "$ALLOWED_TOOLS" \
+      --strict-mcp-config --mcp-config '{"mcpServers":{}}'
+  RC=$?
+
+  if [ "$RC" -ne 0 ] && is_usage_exhausted "${AGENT_OUTPUT:-}"; then
+    echo "[run-agent] subscrição sem usage — a passar para o fallback" >&2
+    cooldown_until_reset "${AGENT_OUTPUT:-}" || start_cooldown 45
+    RC=1
+    USED=""
+  fi
+else
+  if in_cooldown; then echo "[run-agent] subscrição em cooldown — fallback directo" >&2; fi
+fi
+
+# ── 2. Fallback (Ollama Cloud model behind the same harness) ───────────────
+if [ -z "$USED" ]; then
+  # Credential: explicit env wins, then a local override file, then the sibling
+  # project's .env, which is where this key is maintained on this machine.
+  if [ -z "${OLLAMA_API_KEY:-}" ]; then
+    for src in "$HOME/.config/ios2android-team/env" "$HOME/Documentos/companion-chat/.env"; do
+      if [ -f "$src" ]; then
+        key=$(grep -E '^(OLLAMA_API_KEY|MANAGED_CHAT_API_KEY)=' "$src" 2>/dev/null | head -1 | cut -d= -f2-)
+        if [ -n "$key" ]; then export OLLAMA_API_KEY="$key"; break; fi
+      fi
+    done
+  fi
+
+  if ! command -v ollama >/dev/null 2>&1 || [ -z "${OLLAMA_API_KEY:-}" ]; then
+    echo "[run-agent] SEM FALLBACK: ollama ou OLLAMA_API_KEY em falta" >&2
+    exit 76
+  fi
+
+  export OLLAMA_BASE_URL="${OLLAMA_BASE_URL:-https://cloud.ollama.ai}"
+  # The fallback model isn't in Claude Code's model table; without these it warns on
+  # stderr every single run.
+  export CLAUDE_CODE_MAX_CONTEXT_TOKENS="${CLAUDE_CODE_MAX_CONTEXT_TOKENS:-200000}"
+  export CLAUDE_CODE_DISABLE_UNKNOWN_MODEL_WINDOW_ENFORCEMENT=1
+
+  USED="ollama/$FALLBACK_MODEL"
+  PROMPT="$PROMPT$(append_no_vision_note)"
+  run_harness "ollama" "$FALLBACK_MODEL" \
+    ollama launch claude --model "$FALLBACK_MODEL" --yes -- \
+      -p "$PROMPT" \
+      "${ADD_DIR_ARGS[@]}" \
+      --permission-mode acceptEdits \
+      --allowedTools "$ALLOWED_TOOLS" \
+      --strict-mcp-config --mcp-config '{"mcpServers":{}}'
+  RC=$?
+fi
+
+echo "[run-agent] fim: motor=$USED rc=$RC" >&2
+
+# Record which engine actually ran, so the caller can tell a DEGRADED run from a
+# genuine failure. Without this marker "no verdict" reads as "this issue defeated
+# the pipeline" and a temporary quota outage permanently consumes real work items.
+echo "$USED" > "$LOCK_PREFIX.$AGENT_SLOT.engine" 2>/dev/null || true
+
+exit "$RC"

--- a/scripts/team/setup.sh
+++ b/scripts/team/setup.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# setup.sh — one-off: create the qa:* labels and put the existing backlog in the
+# queue. Idempotent; safe to re-run.
+#
+# Usage:
+#   setup.sh --labels          only create the labels
+#   setup.sh --seed            only enqueue open issues (qa:ready)
+#   setup.sh --seed --dry-run  show what would be enqueued
+#   setup.sh                   both
+#
+# Seeding targets every OPEN issue that has no qa:* label yet. Issues labelled
+# `epic` are skipped: they are containers, not units of work, and dispatching an
+# implementer at one produces either a giant PR or an immediate `blocked`.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+ROLE="setup"
+
+DO_LABELS=0
+DO_SEED=0
+DRY=0
+SKIP_LABELS="${TEAM_SEED_SKIP_LABELS:-epic}"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --labels) DO_LABELS=1; shift ;;
+    --seed) DO_SEED=1; shift ;;
+    --dry-run) DRY=1; shift ;;
+    *) shift ;;
+  esac
+done
+if [ "$DO_LABELS" = "0" ] && [ "$DO_SEED" = "0" ]; then DO_LABELS=1; DO_SEED=1; fi
+
+# ── Labels ─────────────────────────────────────────────────────────────────
+if [ "$DO_LABELS" = "1" ]; then
+  # `gh label create` fails when the label exists; --force updates it instead.
+  mklabel() {
+    gh label create "$1" --repo "$REPO" --color "$2" --description "$3" --force >/dev/null 2>&1 \
+      && log "label ok: $1" || warn "label falhou: $1"
+  }
+  mklabel "$L_TRIAGE"       "FBCA04" "Na fila para análise do curator (entrada manual)"
+  mklabel "$L_READY"        "0E8A16" "Na fila do implementador"
+  mklabel "$L_WIP"          "1D76DB" "Implementador a trabalhar"
+  mklabel "$L_REVIEW"       "5319E7" "PR aberto, à espera do reviewer"
+  mklabel "$L_DONE"         "CCCCCC" "Integrado e fechado pelo pipeline"
+  mklabel "$L_BLOCKED_IMPL" "D93F0B" "Devolvido ao implementador (problema de código)"
+  mklabel "$L_BLOCKED_SPEC" "B60205" "Devolvido ao curator (enunciado por analisar)"
+  mklabel "$L_HUMAN"        "000000" "O pipeline desistiu; precisa de decisão humana"
+fi
+
+# ── Seed ───────────────────────────────────────────────────────────────────
+if [ "$DO_SEED" = "1" ]; then
+  JSON=$(gh issue list --repo "$REPO" --state open --limit 300 \
+         --json number,title,labels 2>/dev/null) \
+    || { warn "não consegui listar os issues"; exit 1; }
+  printf '%s' "$JSON" | jq -e 'type == "array"' >/dev/null 2>&1 \
+    || { warn "resposta inesperada da API — não sigo"; exit 1; }
+
+  # Two lists, because "skipped because it is an epic" and "skipped because it is
+  # already in the pipeline" are different facts and both are worth printing.
+  MAPFILE=$(printf '%s' "$JSON" | jq -r --arg skip "$SKIP_LABELS" '
+    ($skip | split(",")) as $sk
+    | .[]
+    | . as $i
+    | ([$i.labels[].name]) as $ns
+    | (if   ($ns | map(startswith("qa:")) | any)   then "HAS_STATE"
+       elif (($ns - ($ns - $sk)) | length) > 0     then "SKIP"
+       else "SEED" end) as $verd
+    | "\($verd)\t\($i.number)\t\($i.title)"')
+
+  N_SEED=0; N_SKIP=0; N_STATE=0
+  while IFS=$'\t' read -r verd num title; do
+    [ -n "${num:-}" ] || continue
+    case "$verd" in
+      SEED)
+        N_SEED=$((N_SEED + 1))
+        if [ "$DRY" = "1" ]; then
+          echo "  + #$num  $title"
+        else
+          gh issue edit "$num" --repo "$REPO" --add-label "$L_READY" >/dev/null 2>&1 \
+            && log "#$num -> $L_READY" || warn "#$num falhou"
+          # Gentle: 42 edits back-to-back is a good way to meet a secondary rate limit.
+          sleep 1
+        fi
+        ;;
+      SKIP)  N_SKIP=$((N_SKIP + 1));  [ "$DRY" = "1" ] && echo "  - #$num  ($SKIP_LABELS) $title" ;;
+      HAS_STATE) N_STATE=$((N_STATE + 1)) ;;
+    esac
+  done <<< "$MAPFILE"
+
+  echo
+  log "para a fila: $N_SEED    ignorados ($SKIP_LABELS): $N_SKIP    já no pipeline: $N_STATE"
+  [ "$DRY" = "1" ] && log "(--dry-run: nada foi alterado)"
+fi

--- a/scripts/team/start.sh
+++ b/scripts/team/start.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+# start.sh — run the pipeline in a detached tmux session so it survives the terminal
+# closing, and so you can attach to watch it work.
+#
+# Usage: start.sh [--attach] [--stop] [--status] [-- <orchestrator args>]
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+ROLE="start"
+
+SESSION="${TEAM_SESSION:-ios2android-qa}"
+ACTION="start"
+declare -a ORCH_ARGS=()
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --attach) ACTION="attach"; shift ;;
+    --stop) ACTION="stop"; shift ;;
+    --status) ACTION="status"; shift ;;
+    --) shift; ORCH_ARGS+=("$@"); break ;;
+    *) ORCH_ARGS+=("$1"); shift ;;
+  esac
+done
+
+case "$ACTION" in
+  attach)
+    exec tmux attach -t "$SESSION"
+    ;;
+  stop)
+    tmux kill-session -t "$SESSION" 2>/dev/null && log "sessão '$SESSION' terminada" \
+      || log "sessão '$SESSION' não estava a correr"
+
+    # Killing the tmux session is NOT enough. run-agent.sh puts each agent in its own
+    # process group via setsid precisely so it can be killed as a unit — which also
+    # means it SURVIVES the session dying, and keeps holding its lock slot. The next
+    # orchestrator's first dispatch then aborts instantly with exit 75 and produces
+    # no verdict.
+    for pgidfile in "$LOCK_PREFIX".*.lock.pgid; do
+      [ -f "$pgidfile" ] || continue
+      pgid=$(cat "$pgidfile" 2>/dev/null || echo "")
+      if [ -n "$pgid" ] && kill -0 -"$pgid" 2>/dev/null; then
+        log "a terminar a árvore do agente (pgid $pgid)"
+        kill -TERM -"$pgid" 2>/dev/null || true
+        sleep 2
+        kill -KILL -"$pgid" 2>/dev/null || true
+      fi
+      rm -f "$pgidfile"
+    done
+
+    # Belt and braces: kill whatever still holds a lock file even if no pgid file
+    # points at it. An agent that outlived its parent has no pgid record (the exit
+    # trap removes it), so the lock file itself is the only remaining handle on it.
+    for lock in "$LOCK_PREFIX".*.lock; do
+      [ -f "$lock" ] || continue
+      holders=$(fuser "$lock" 2>/dev/null | tr -s ' ' '\n' | grep -E '^[0-9]+$' || true)
+      for pid in $holders; do
+        log "a terminar processo órfão $pid que ainda segura $(basename "$lock")"
+        kill -TERM "$pid" 2>/dev/null || true
+      done
+      [ -n "$holders" ] && { sleep 2; for pid in $holders; do kill -KILL "$pid" 2>/dev/null || true; done; }
+    done
+    exit 0
+    ;;
+  status)
+    if tmux has-session -t "$SESSION" 2>/dev/null; then
+      echo "orquestrador: a correr (tmux '$SESSION')"
+    else
+      echo "orquestrador: parado"
+    fi
+    echo -n "issues por estado: "
+    for s in qa:ready qa:wip qa:review qa:blocked-impl qa:blocked-spec qa:triage qa:needs-human; do
+      n=$(gh issue list --repo "$REPO" --label "$s" --state open --json number --jq 'length' 2>/dev/null || echo 0)
+      [ "$n" != "0" ] && printf '%s=%s ' "$s" "$n"
+    done
+    echo
+    echo -n "PRs abertos (qa/*): "
+    gh pr list --repo "$REPO" --base "$BASE_BRANCH" --state open \
+      --json number,headRefName --jq '[.[] | select(.headRefName|startswith("qa/")) | "#\(.number)"] | join(" ")' \
+      2>/dev/null || echo "?"
+    echo "fechados até agora: $(gh issue list --repo "$REPO" --label qa:done --state closed --json number --jq 'length' 2>/dev/null || echo '?')"
+    exit 0
+    ;;
+esac
+
+if tmux has-session -t "$SESSION" 2>/dev/null; then
+  log "sessão '$SESSION' já está a correr. Usa --attach, ou --stop primeiro."
+  exit 1
+fi
+
+LOGFILE="$LOG_DIR/orchestrator-$(date +%Y%m%d-%H%M%S).log"
+log "a arrancar em tmux '$SESSION'; log: $LOGFILE"
+
+# `tee` into a file as well as the pane: once a pane closes there is no way to
+# inspect what happened, and this thing runs for hours unattended.
+tmux new-session -d -s "$SESSION" -n orchestrator \
+  "cd '$SCRIPT_DIR' && bash orchestrator.sh ${ORCH_ARGS[*]:-} 2>&1 | tee '$LOGFILE'; echo '--- TERMINOU ---'; read -r"
+
+cat <<EOF
+Pipeline a correr.
+  Ver:      tmux attach -t $SESSION      (ou: start.sh --attach)
+  Estado:   bash scripts/team/start.sh --status
+  Log:      tail -f $LOGFILE
+  Parar:    bash scripts/team/start.sh --stop
+EOF

--- a/src/components/__tests__/CupertinoCard.test.tsx
+++ b/src/components/__tests__/CupertinoCard.test.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
 import { Text } from 'react-native';
-import { render } from '@testing-library/react-native';
+// Shared harness, not a hand-rolled provider wrapper: SettingsProvider and
+// ThemeProvider gate their first render on an async load, so wrapping them here
+// rendered `null` and every snapshot compared against nothing. test-utils turns
+// that gate off — see the comment there.
+import { render as renderWithTheme } from '../../test-utils';
 import { CupertinoCard } from '../CupertinoCard';
-import { ThemeProvider } from '../../theme/ThemeContext';
-import { SettingsProvider } from '../../store/SettingsStore';
-
-const renderWithTheme = (ui: React.ReactElement) =>
-  render(<SettingsProvider><ThemeProvider>{ui}</ThemeProvider></SettingsProvider>);
 
 describe('CupertinoCard', () => {
   it('renders with title and subtitle', () => {

--- a/src/components/__tests__/CupertinoProgressBar.test.tsx
+++ b/src/components/__tests__/CupertinoProgressBar.test.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
-import { render } from '@testing-library/react-native';
+// Shared harness, not a hand-rolled provider wrapper: SettingsProvider and
+// ThemeProvider gate their first render on an async load, so wrapping them here
+// rendered `null` and every snapshot compared against nothing. test-utils turns
+// that gate off — see the comment there.
+import { render as renderWithTheme } from '../../test-utils';
 import { CupertinoProgressBar } from '../CupertinoProgressBar';
-import { ThemeProvider } from '../../theme/ThemeContext';
-import { SettingsProvider } from '../../store/SettingsStore';
-
-const renderWithTheme = (ui: React.ReactElement) =>
-  render(<SettingsProvider><ThemeProvider>{ui}</ThemeProvider></SettingsProvider>);
 
 describe('CupertinoProgressBar', () => {
   it('renders at 0%', () => {

--- a/src/components/__tests__/__snapshots__/CupertinoCard.test.tsx.snap.android
+++ b/src/components/__tests__/__snapshots__/CupertinoCard.test.tsx.snap.android
@@ -18,7 +18,7 @@ exports[`CupertinoCard renders with title and subtitle 1`] = `
         "shadowRadius": 10,
       },
       {
-        "backgroundColor": "#1C1C1E",
+        "backgroundColor": "#FFFFFF",
         "borderRadius": 12,
         "padding": 16,
       },
@@ -36,7 +36,7 @@ exports[`CupertinoCard renders with title and subtitle 1`] = `
           "lineHeight": 22,
         },
         {
-          "color": "#FFFFFF",
+          "color": "#000000",
           "marginBottom": 2,
         },
       ]
@@ -54,7 +54,7 @@ exports[`CupertinoCard renders with title and subtitle 1`] = `
           "lineHeight": 20,
         },
         {
-          "color": "rgba(235, 235, 245, 0.6)",
+          "color": "rgba(60, 60, 67, 0.6)",
           "marginBottom": 8,
         },
       ]
@@ -86,7 +86,7 @@ exports[`CupertinoCard renders without title 1`] = `
         "shadowRadius": 10,
       },
       {
-        "backgroundColor": "#1C1C1E",
+        "backgroundColor": "#FFFFFF",
         "borderRadius": 12,
         "padding": 16,
       },

--- a/src/components/__tests__/__snapshots__/CupertinoProgressBar.test.tsx.snap.android
+++ b/src/components/__tests__/__snapshots__/CupertinoProgressBar.test.tsx.snap.android
@@ -11,7 +11,7 @@ exports[`CupertinoProgressBar renders at 0% 1`] = `
         "width": "100%",
       },
       {
-        "backgroundColor": "#2C2C2E",
+        "backgroundColor": "#E5E5EA",
       },
       undefined,
     ]
@@ -25,7 +25,7 @@ exports[`CupertinoProgressBar renders at 0% 1`] = `
           "height": "100%",
         },
         {
-          "backgroundColor": "#0A84FF",
+          "backgroundColor": "#007AFF",
         },
         {
           "width": "0%",
@@ -47,7 +47,7 @@ exports[`CupertinoProgressBar renders at 50% 1`] = `
         "width": "100%",
       },
       {
-        "backgroundColor": "#2C2C2E",
+        "backgroundColor": "#E5E5EA",
       },
       undefined,
     ]
@@ -61,7 +61,7 @@ exports[`CupertinoProgressBar renders at 50% 1`] = `
           "height": "100%",
         },
         {
-          "backgroundColor": "#0A84FF",
+          "backgroundColor": "#007AFF",
         },
         {
           "width": "50%",
@@ -83,7 +83,7 @@ exports[`CupertinoProgressBar renders at 100% 1`] = `
         "width": "100%",
       },
       {
-        "backgroundColor": "#2C2C2E",
+        "backgroundColor": "#E5E5EA",
       },
       undefined,
     ]
@@ -97,7 +97,7 @@ exports[`CupertinoProgressBar renders at 100% 1`] = `
           "height": "100%",
         },
         {
-          "backgroundColor": "#0A84FF",
+          "backgroundColor": "#007AFF",
         },
         {
           "width": "100%",

--- a/src/screens/LauncherHomeScreen.tsx
+++ b/src/screens/LauncherHomeScreen.tsx
@@ -722,6 +722,20 @@ export function LauncherHomeScreen() {
     return counts;
   }, [device.messages]);
 
+  // Spotlight reveal is suppressed when jiggling, folder is open, or action sheet
+  // is up.
+  //
+  // This lives ABOVE the early returns deliberately. It used to sit ~80 lines
+  // further down, after the non-Android and loading returns, so on any render that
+  // took one of those paths the effect was skipped — React saw a different number
+  // of hooks between renders, which is the "Rendered more hooks than during the
+  // previous render" crash waiting to happen. eslint's rules-of-hooks was reporting
+  // it as an error, correctly.
+  const canSpotlight = !isJiggling && !actionSheet.visible && openFolder === null;
+  useEffect(() => {
+    canSpotlightShared.value = canSpotlight;
+  }, [canSpotlight, canSpotlightShared]);
+
   // Non-Android fallback
   if (Platform.OS !== 'android' && !isLoading && nonDockApps.length === 0 && dockApps.length === 0) {
     return <NonAndroidFallback />;
@@ -803,12 +817,6 @@ export function LauncherHomeScreen() {
 
   // +1 for the App Library page appended at the end
   const totalPages = pages.length + 1;
-
-  // Spotlight reveal is suppressed when jiggling, folder is open, or action sheet is up
-  const canSpotlight = !isJiggling && !actionSheet.visible && openFolder === null;
-  useEffect(() => {
-    canSpotlightShared.value = canSpotlight;
-  }, [canSpotlight, canSpotlightShared]);
 
   const handleScroll = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
     const offsetX = event.nativeEvent.contentOffset.x;

--- a/src/store/SettingsStore.tsx
+++ b/src/store/SettingsStore.tsx
@@ -134,7 +134,23 @@ interface SettingsContextValue {
 
 const SettingsContext = createContext<SettingsContextValue | null>(null);
 
-export function SettingsProvider({ children }: { children: React.ReactNode }) {
+export function SettingsProvider({
+  children,
+  gateFirstRender = true,
+}: {
+  children: React.ReactNode;
+  /**
+   * Hold back the first render until AsyncStorage has loaded and the initial
+   * device sync has completed, so the UI never flashes default settings before
+   * the real ones arrive.
+   *
+   * Consumers that render synchronously and cannot wait for that round trip pass
+   * `false` — notably the test harness (`src/test-utils.tsx`). With the gate on,
+   * a synchronous render returns `null` for the whole subtree, which is why every
+   * screen test used to fail with "Unable to find an element with text: ...".
+   */
+  gateFirstRender?: boolean;
+}) {
   const [settings, setSettings] = useState<SettingsState>(DEFAULT_SETTINGS);
   const [isReady, setIsReady] = useState(false);
   const [firstSyncDone, setFirstSyncDone] = useState(false);
@@ -255,7 +271,7 @@ export function SettingsProvider({ children }: { children: React.ReactNode }) {
     [settings, update, updateMany, reset, syncFromDevice, isReady, activeFocusMode, setFocusMode],
   );
 
-  if (!firstSyncDone) return null;
+  if (gateFirstRender && !firstSyncDone) return null;
 
   return <SettingsContext.Provider value={value}>{children}</SettingsContext.Provider>;
 }

--- a/src/test-utils.tsx
+++ b/src/test-utils.tsx
@@ -8,10 +8,21 @@ import { AppsProvider } from './store/AppsStore';
 import { DeviceProvider } from './store/DeviceStore';
 import { FoldersProvider } from './store/FoldersStore';
 
+// gateFirstRender={false} on the two gated providers.
+//
+// Both normally hold back their first render until an async AsyncStorage read
+// finishes (and, for settings, an initial device sync), so the app never flashes
+// default settings or the wrong theme on launch. `render` below is SYNCHRONOUS, so
+// with the gate on the entire subtree comes back as `null` and every query fails
+// with "Unable to find an element with text: ..." — that single mechanism was
+// responsible for 103 of 180 test failures across 24 suites.
+//
+// The gate is app-shell launch behaviour and belongs in its own test; these tests
+// are about what the screens render once settings exist.
 function AllProviders({ children }: { children: React.ReactNode }) {
   return (
-    <SettingsProvider>
-      <ThemeProvider>
+    <SettingsProvider gateFirstRender={false}>
+      <ThemeProvider gateFirstRender={false}>
         <ContactsProvider>
           <ProfileProvider>
             <AppsProvider>

--- a/src/theme/ThemeContext.tsx
+++ b/src/theme/ThemeContext.tsx
@@ -74,7 +74,18 @@ interface ThemeContextValue {
 
 const ThemeContext = createContext<ThemeContextValue | null>(null);
 
-export function ThemeProvider({ children }: { children: React.ReactNode }) {
+export function ThemeProvider({
+  children,
+  gateFirstRender = true,
+}: {
+  children: React.ReactNode;
+  /**
+   * Hold back the first render until the saved theme has loaded, so the app never
+   * flashes the wrong theme on launch. See the sibling flag on `SettingsProvider`
+   * — the test harness passes `false` because it renders synchronously.
+   */
+  gateFirstRender?: boolean;
+}) {
   const [mode, setMode] = useState<ThemeMode>('system');
   const [isReady, setIsReady] = useState(false);
   const [accentColor, setAccentColorState] = useState<AccentColorKey>('blue');
@@ -176,7 +187,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
     [isDark, isReady, mode, accentColor, highContrast, textScale, settings.textSizeIndex, settings.boldText, toggleTheme, setDark, setThemeMode, setAccentColor, setHighContrast]
   );
 
-  if (!isReady) return null;
+  if (gateFirstRender && !isReady) return null;
 
   return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
 }


### PR DESCRIPTION
## Summary

Two commits:

1. **Unblock the suite.** 103 of 180 tests were failing across 24 of 30 suites, from one mechanism: `SettingsProvider` and `ThemeProvider` gate their first render on an async AsyncStorage read, and `src/test-utils.tsx` renders synchronously — so the gate returned `null` for the whole subtree. Both providers now take `gateFirstRender` (default `true`, app behaviour unchanged); the test harness passes `false`. Also fixed two genuine lint errors: a `useEffect` sitting below two early returns in `LauncherHomeScreen` (a real rules-of-hooks violation), and an `any` at the native-module event boundary.

2. **Add `scripts/team/`** — the agent delivery pipeline (curator, implementer, reviewer) that works the issue backlog autonomously. See `scripts/team/README.md`.

## Results

| | before | after |
|---|---|---|
| `npm run lint` | 2 errors | **0 errors** (2 pre-existing warnings, both filed) |
| `npx tsc --noEmit` | clean | clean |
| `npm test` | 103/180 failing, 24/30 suites | **9/180 failing, 5/30 suites** |

The 9 remaining failures are real defects with issues already open — #212 (float precision), #205 (AsyncStorage namespace), and the LockScreen/Weather/Settings ones. They are the pipeline's work, deliberately left red.

## Testes

- `npm run lint` — 0 errors, 2 warnings
- `npx tsc --noEmit` — clean
- `npx jest` — 171 passed, 9 failed, 6 snapshots passed
- Snapshots re-recorded, not patched: they had captured a dark theme while the environment renders light, and every changed value is the correct light-mode counterpart.