### PR TITLE
chore(pipeline): wait out quota cooldown instead of spinning on an unusable fallback

### DIFF
--- a/scripts/team/lib.sh
+++ b/scripts/team/lib.sh
@@ -37,6 +37,40 @@ STATE_DIR="${TEAM_STATE_DIR:-$HOME/Documentos/iostoandroid-verdicts/state}"
 
 LOCK_PREFIX="${TEAM_LOCK_PREFIX:-/tmp/ios2android-agent}"
 
+# THE OLLAMA FALLBACK IS OFF BY DEFAULT HERE, AND THAT IS A MEASUREMENT, NOT A
+# PREFERENCE.
+#
+# The sibling project keeps working through a quota outage on `ollama launch claude`
+# with a cloud model, and its logs justify that: the fallback there produced real
+# implementations. It does not work for this repo's roles. Measured on the first
+# live run, with `deepseek-v4-flash:cloud`:
+#
+#   * a two-word prompt returns "OK" in seconds — the engine and credential are fine;
+#   * the actual 16KB implementer prompt, with the same flags, produced ZERO bytes of
+#     output for four minutes and had to be killed.
+#
+# Three dispatches of #190 burned that way, each looking from the log like an agent
+# that ran and declined to answer. Retrying it every 45 seconds for the three hours
+# until the subscription resets buys nothing and makes the log lie about what the
+# pipeline is doing.
+#
+# So when the subscription is in cooldown the orchestrator WAITS instead, and says
+# so. Set TEAM_USE_FALLBACK=1 (optionally with AGENT_FALLBACK_MODEL pointing at a
+# larger cloud tag) to try the fallback again — if a bigger model does cope with a
+# prompt this size, this default is the thing to revisit.
+TEAM_USE_FALLBACK="${TEAM_USE_FALLBACK:-0}"
+
+COOLDOWN_FILE="$STATE_DIR/claude-usage-cooldown"
+
+# Seconds remaining on the subscription cooldown; 0 when there is none.
+cooldown_remaining() {
+  [ -f "$COOLDOWN_FILE" ] || { echo 0; return; }
+  local until_ts now
+  until_ts=$(cat "$COOLDOWN_FILE" 2>/dev/null || echo 0)
+  now=$(date +%s)
+  if [ "$now" -lt "$until_ts" ]; then echo $(( until_ts - now )); else echo 0; fi
+}
+
 mkdir -p "$VERDICT_DIR" "$LOG_DIR" "$STATE_DIR" "$WT_ROOT" 2>/dev/null || true
 
 # ── Labels: the pipeline state machine ─────────────────────────────────────
@@ -186,6 +220,10 @@ no_verdict_is_real_failure() {
 
   if [ "$rc" = "75" ]; then
     warn "sem veredicto porque o slot '$slot' estava ocupado (exit 75) — não escalo"
+    return 1
+  fi
+  if [ "$rc" = "77" ]; then
+    warn "sem veredicto porque a subscrição está em cooldown e o fallback está desligado (exit 77) — não escalo"
     return 1
   fi
   if agent_used_fallback "$slot"; then

--- a/scripts/team/orchestrator.sh
+++ b/scripts/team/orchestrator.sh
@@ -361,6 +361,27 @@ while true; do
 
   cleanup_stale
 
+  # ── Subscription cooldown: WAIT, don't spin ───────────────────────────────
+  #
+  # With the fallback off (the default — see lib.sh), no write-path role can run
+  # while the subscription is exhausted. Cycling every 45s to re-discover that
+  # produces a log full of dispatches that did nothing, and on the first live run
+  # it burned three attempts on #190 against an engine that returns no output at
+  # all for a prompt this size.
+  #
+  # Sleep to the reset instead, in chunks, so the pipeline picks straight back up
+  # and a `--stop` still lands promptly.
+  if [ "${TEAM_USE_FALLBACK:-0}" != "1" ]; then
+    REMAIN=$(cooldown_remaining)
+    if [ "$REMAIN" -gt 0 ]; then
+      log "subscrição esgotada — volta às $(date -d "@$(( $(date +%s) + REMAIN ))" +%H:%M). A aguardar (fallback desligado)."
+      if [ "$ONCE" = "1" ]; then exit 0; fi
+      while [ "$(cooldown_remaining)" -gt 0 ]; do sleep 60; done
+      log "subscrição de volta — a retomar"
+      continue
+    fi
+  fi
+
   # One read of the world per cycle. Everything below reasons from this snapshot. If
   # it fails we know nothing about the queue, so the cycle does nothing rather than
   # acting on a guess.

--- a/scripts/team/run-agent.sh
+++ b/scripts/team/run-agent.sh
@@ -239,6 +239,14 @@ else
 fi
 
 # ── 2. Fallback (Ollama Cloud model behind the same harness) ───────────────
+if [ -z "$USED" ] && [ "${TEAM_USE_FALLBACK:-0}" != "1" ]; then
+  # Measured not to work for these roles on this repo — see the comment on
+  # TEAM_USE_FALLBACK in lib.sh. Exit 77 so the caller can tell "we deliberately
+  # did not run" from "the agent ran and failed", and leave the work untouched.
+  echo "[run-agent] subscrição indisponível e fallback desligado (TEAM_USE_FALLBACK=0) — não corro" >&2
+  exit 77
+fi
+
 if [ -z "$USED" ]; then
   # Credential: explicit env wins, then a local override file, then the sibling
   # project's .env, which is where this key is maintained on this machine.


### PR DESCRIPTION
Measured on the first live run: with `deepseek-v4-flash:cloud`, a two-word prompt returns `OK` in seconds, but the real 16KB implementer prompt produced **zero output for four minutes**. Three dispatches of #190 burned that way.

`TEAM_USE_FALLBACK` now defaults to `0` — `run-agent.sh` exits 77 instead of reaching for an engine that cannot do the job, callers treat 77 as a deliberate no-run and leave the issue untouched, and the orchestrator sleeps to the reset time rather than re-discovering the outage every 45 seconds.

Set `TEAM_USE_FALLBACK=1` (with `AGENT_FALLBACK_MODEL` on a larger cloud tag) to try it again.