### PR TITLE
CupertinoSearchBar: opção (B) já implementada em main — acrescentado o teste em falta (10 testes) que trava o comportamento do botão Cancel (#215)

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/home/luis-monteiro/Documentos/iosToAndroid/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/home/luis-monteiro/Documentos/iosToAndroid/node_modules

--- a/src/components/__tests__/CupertinoSearchBar.test.tsx
+++ b/src/components/__tests__/CupertinoSearchBar.test.tsx
@@ -1,0 +1,119 @@
+import React from 'react';
+import { render, fireEvent } from '../../test-utils';
+import { CupertinoSearchBar } from '../CupertinoSearchBar';
+
+describe('CupertinoSearchBar', () => {
+  it('renders the search input with the default placeholder', () => {
+    const { getByPlaceholderText } = render(
+      <CupertinoSearchBar value="" onChangeText={jest.fn()} />,
+    );
+    expect(getByPlaceholderText('Search')).toBeTruthy();
+  });
+
+  it('hides Cancel when not focused and value is empty', () => {
+    const { queryByText } = render(
+      <CupertinoSearchBar value="" onChangeText={jest.fn()} />,
+    );
+    expect(queryByText('Cancel')).toBeNull();
+  });
+
+  it('shows Cancel when focused even with an empty value', () => {
+    const { getByPlaceholderText, getByText } = render(
+      <CupertinoSearchBar value="" onChangeText={jest.fn()} />,
+    );
+    fireEvent(getByPlaceholderText('Search'), 'focus');
+    expect(getByText('Cancel')).toBeTruthy();
+  });
+
+  it('shows Cancel when value has text even without focus', () => {
+    const { getByText } = render(
+      <CupertinoSearchBar value="hello" onChangeText={jest.fn()} />,
+    );
+    expect(getByText('Cancel')).toBeTruthy();
+  });
+
+  it('hides Cancel after blur when value is empty', () => {
+    const { getByPlaceholderText, queryByText } = render(
+      <CupertinoSearchBar value="" onChangeText={jest.fn()} />,
+    );
+    const input = getByPlaceholderText('Search');
+    fireEvent(input, 'focus');
+    expect(queryByText('Cancel')).toBeTruthy();
+    fireEvent(input, 'blur');
+    expect(queryByText('Cancel')).toBeNull();
+  });
+
+  it('keeps Cancel visible after blur when value has text', () => {
+    const { getByPlaceholderText, getByText } = render(
+      <CupertinoSearchBar value="hello" onChangeText={jest.fn()} />,
+    );
+    fireEvent(getByPlaceholderText('Search'), 'blur');
+    expect(getByText('Cancel')).toBeTruthy();
+  });
+
+  it('clears the text and calls onCancel when Cancel is pressed', () => {
+    const onChangeText = jest.fn();
+    const onCancel = jest.fn();
+    const { getByText } = render(
+      <CupertinoSearchBar
+        value="hello"
+        onChangeText={onChangeText}
+        onCancel={onCancel}
+      />,
+    );
+    fireEvent.press(getByText('Cancel'));
+    expect(onChangeText).toHaveBeenCalledWith('');
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it('hides Cancel after pressing it when the parent clears the value', () => {
+    const onChangeText = jest.fn();
+    const onCancel = jest.fn();
+    const { getByText, queryByText, rerender } = render(
+      <CupertinoSearchBar
+        value="hello"
+        onChangeText={onChangeText}
+        onCancel={onCancel}
+      />,
+    );
+    fireEvent.press(getByText('Cancel'));
+    // Parent updates value in response to onChangeText('')
+    rerender(
+      <CupertinoSearchBar
+        value=""
+        onChangeText={onChangeText}
+        onCancel={onCancel}
+      />,
+    );
+    expect(queryByText('Cancel')).toBeNull();
+  });
+
+  it('calls onFocusChange with true on focus and false on blur', () => {
+    const onFocusChange = jest.fn();
+    const { getByPlaceholderText } = render(
+      <CupertinoSearchBar
+        value=""
+        onChangeText={jest.fn()}
+        onFocusChange={onFocusChange}
+      />,
+    );
+    const input = getByPlaceholderText('Search');
+    fireEvent(input, 'focus');
+    expect(onFocusChange).toHaveBeenCalledWith(true);
+    fireEvent(input, 'blur');
+    expect(onFocusChange).toHaveBeenCalledWith(false);
+  });
+
+  it('reports focus loss when Cancel is pressed', () => {
+    const onFocusChange = jest.fn();
+    const { getByText } = render(
+      <CupertinoSearchBar
+        value="hello"
+        onChangeText={jest.fn()}
+        onFocusChange={onFocusChange}
+      />,
+    );
+    fireEvent.press(getByText('Cancel'));
+    expect(onFocusChange).toHaveBeenCalledWith(false);
+  });
+});


### PR DESCRIPTION
## Resumo

CupertinoSearchBar: opção (B) já implementada em main — acrescentado o teste em falta (10 testes) que trava o comportamento do botão Cancel

## Causa raiz

A premissa do issue está desactualizada. `src/components/CupertinoSearchBar.tsx:109` lê `(isFocused || value.length > 0)` — o estado `isFocused` **é** lido, e o botão Cancel é focus-driven **ou** text-driven. Isto é exactamente a opção (B) que o issue recomenda, e foi implementado no commit `77d58ad` (PR #237). O issue foi escrito contra um snapshot anterior ao fix: antes desse commit, o estado era `const [, setIsFocused] = useState(false)` (morto) e o Cancel era renderizado incondicionalmente.

O problema real que restava: **não existia nenhum teste** para `CupertinoSearchBar` — o comportamento do botão Cancel (a única coisa que o issue pede para travar) não estava coberto.

## O que mudou

- `src/components/__tests__/CupertinoSearchBar.test.tsx` (novo, 10 testes):
  - Cancel escondido quando não focado e `value` vazio.
  - Cancel visível quando focado mesmo com `value` vazio (caminho focus-driven).
  - Cancel visível com texto sem foco (caminho text-driven).
  - Cancel esconde-se após blur com `value` vazio (inverso do fix).
  - Cancel mantém-se visível após blur com texto.
  - Press em Cancel limpa o texto (`onChangeText('')`) e chama `onCancel`.
  - Ciclo completo: press → parent limpa `value` → Cancel esconde.
  - `onFocusChange(true/false)` em focus/blur e no press de Cancel.

Nenhuma alteração de produção: o código já implementa a opção (B).

## Porque assim

O issue oferece (A) remover o estado ou (B) usá-lo para `showCancel = isFocused || value.length > 0`. O código actual já é (B) — o estado não é morto, entrega visibilidade do Cancel. Remover o estado (A) **mudaria** o comportamento actual (Cancel deixaria de aparecer ao focar com campo vazio), o que seria uma regressão face ao que está em `main`. Escolhi documentar e travar (B), que é o comportamento já em vigor e o que o issue recomenda.

## Critérios de aceitação

- [x] Escolha (A) ou (B) documentada: **(B)** — já implementada em `main` (commit `77d58ad`); esta corrida trava-a com teste.
- [x] Comportamento do Cancel previsível e coberto por teste: 10 testes em `src/components/__tests__/CupertinoSearchBar.test.tsx` cobrem os 4 estados (foco × texto) e a acção.
- [x] Sem estado morto: `isFocused` é lido em `CupertinoSearchBar.tsx:109`; confirmado por `git diff` vazio na produção.
- [x] O que NÃO devia mudar: input com placeholder, `onChangeText` passthrough, contract de `onFocusChange` — todos verificados por teste; produção intocada (`git diff --stat` vazio).

## Testes

- **Passo vermelho:** o comportamento (B) já existia, por isso o teste passou à primeira contra o código actual. Para provar que o teste tem dentes, reverti a produção para o estado pré-fix (`const [, setIsFocused]` + Cancel renderizado incondicionalmente) e a suite falhou com 3 testes:
  - `expect(received).toBeNull()` em "hides Cancel when not focused and value is empty" — o elemento "Cancel" existia quando devia estar ausente.
  - "hides Cancel after blur when value is empty" e "hides Cancel after pressing it when the parent clears the value" — mesmas falhas.
  Restaurei a produção; 10/10 passam.
- **Casos cobertos:** os 4 estados de visibilidade (foco × texto), o inverso do fix (escondido quando deve), o ciclo completo de cancel (press → parent limpa → esconde), e o contract de `onFocusChange`. Não testei o botão clear (X) — não tem testID nem texto acessível, e está fora do âmbito do issue.
- **Sanity-check:** reverti o fix de produção (estado pré-fix), a suite falhou (3 testes), restaurei — ver acima.
- `npm run lint`: 0 erros (2 warnings pré-existentes em ficheiros não tocados).
- `npx tsc --noEmit`: limpo.
- `npm test`: 9 falhados (todos do baseline conhecido — SettingsStore `firstSyncDone`), 181 passados, 190 total, 31 suites. Zero falhas novas; os 10 testes novos passam.

## Testes

9 falharam (baseline conhecido), 181 passaram, 190 total, 31 suites — zero falhas novas; os 10 testes novos passam

## Linked Issue

Fixes #215