### PR TITLE
fix(pipeline): enter the worktree before running the agent

### DIFF
--- a/scripts/team/README.md
+++ b/scripts/team/README.md
@@ -122,6 +122,38 @@ volta a ser estrito sozinho: quando `main` estiver verde, apaga
 Volta a correr `baseline.sh` sempre que `main` receber um lote de correcções de
 testes, ou a linha de base envelhece e passa a perdoar regressões reais.
 
+## Quando a subscrição esgota
+
+`run-agent.sh` detecta o limite de sessão, lê a hora de reset da mensagem do CLI,
+grava um cooldown, e passa para o mesmo harness com um modelo do Ollama Cloud
+(`TEAM_USE_FALLBACK=1`, por omissão). Medido: o #215 correu de ponta a ponta no
+fallback em 4m34s — veredicto, push e PR.
+
+Põe `TEAM_USE_FALLBACK=0` para o orquestrador **dormir** até ao reset em vez de
+trabalhar em modo degradado.
+
+### Diagnosticar um agente que "não produz nada"
+
+`claude -p` **não faz streaming** — imprime só a mensagem final. Ausência de output
+não é prova de falha; é o aspecto normal de um agente a trabalhar. Para ver o que
+se passa:
+
+```bash
+ollama launch claude --model <tag> --yes -- -p "$(cat /tmp/ios2a-implement-prompt-N.txt)" \
+  --output-format stream-json --verbose --strict-mcp-config --mcp-config '{"mcpServers":{}}' < /dev/null
+```
+
+E antes de culpar o modelo, **prova que ele tem acesso ao que precisa** — uma sonda
+de duas linhas (`pwd` + `ls <ficheiro do worktree>`) responde a isso em segundos:
+
+```bash
+printf 'Executa `pwd` e diz o resultado. Depois `ls <WT>/package.json`.\n' > /tmp/p.txt
+cd scripts/team && AGENT_SLOT=probe AGENT_FORCE_FALLBACK=1 bash run-agent.sh /tmp/p.txt <WT> 240
+```
+
+Foi exactamente essa sonda que revelou que o agente corria em `scripts/team` e não
+no worktree.
+
 ## Ficheiros e estado
 
 Tudo o que é volátil vive **fora** do repositório, de propósito: dentro da árvore
@@ -162,6 +194,7 @@ Tudo por variável de ambiente, com omissões em `lib.sh`:
 | `REVIEW_TIMEOUT` | `1800` | segundos |
 | `CURATOR_TIMEOUT` | `1200` | segundos |
 | `AGENT_FALLBACK_MODEL` | `deepseek-v4-flash:cloud` | motor quando a subscrição esgota |
+| `TEAM_USE_FALLBACK` | `1` | a `0`, dorme até ao reset em vez de usar o fallback |
 
 Sobre `IMPLEMENT_HONOUR_READY_LABELS`: o backlog está triado com
 `haiku-ready`/`sonnet-ready`, mas essa triagem é sobre o **tamanho da alteração**,

--- a/scripts/team/curator.sh
+++ b/scripts/team/curator.sh
@@ -71,9 +71,10 @@ rm -f "$VERDICT_FILE"
 # or the reviewer, and serialising it onto them would add its whole runtime to every
 # issue that needs repair. The slot lock still guarantees two curators never run at
 # the same time.
+agent_log_header "$LOG_DIR/curator-$ISSUE.log" "curator #$ISSUE modelo=$MODEL"
 AGENT_SLOT=curator CLAUDE_MODEL="$MODEL" \
   bash "$SCRIPT_DIR/run-agent.sh" "$PROMPT" "$WT" "${CURATOR_TIMEOUT:-1200}" \
-  > "$LOG_DIR/curator-$ISSUE.log" 2>&1; AGENT_RC=$?
+  >> "$LOG_DIR/curator-$ISSUE.log" 2>&1; AGENT_RC=$?
 
 if [ ! -f "$VERDICT_FILE" ]; then
   # A failed RUN is not a failed issue: leave the state alone so it is picked up

--- a/scripts/team/implement.sh
+++ b/scripts/team/implement.sh
@@ -160,9 +160,10 @@ fi
         -e "s|__BASE_BRANCH__|$BASE_BRANCH|g" > "$PROMPT"
 
 rm -f "$VERDICT_FILE"
+agent_log_header "$LOG_DIR/implement-$ISSUE.log" "implement #$ISSUE modelo=$MODEL"
 AGENT_SLOT=main CLAUDE_MODEL="$MODEL" \
   bash "$SCRIPT_DIR/run-agent.sh" "$PROMPT" "$WT" "${IMPLEMENT_TIMEOUT:-2700}" \
-  > "$LOG_DIR/implement-$ISSUE.log" 2>&1; AGENT_RC=$?
+  >> "$LOG_DIR/implement-$ISSUE.log" 2>&1; AGENT_RC=$?
 
 if [ ! -f "$VERDICT_FILE" ]; then
   if ! no_verdict_is_real_failure main "$AGENT_RC"; then

--- a/scripts/team/lib.sh
+++ b/scripts/team/lib.sh
@@ -37,28 +37,32 @@ STATE_DIR="${TEAM_STATE_DIR:-$HOME/Documentos/iostoandroid-verdicts/state}"
 
 LOCK_PREFIX="${TEAM_LOCK_PREFIX:-/tmp/ios2android-agent}"
 
-# THE OLLAMA FALLBACK IS OFF BY DEFAULT HERE, AND THAT IS A MEASUREMENT, NOT A
-# PREFERENCE.
+# The Ollama fallback is ON: when the Claude subscription runs out of usage, the
+# same harness keeps working behind a cloud model.
 #
-# The sibling project keeps working through a quota outage on `ollama launch claude`
-# with a cloud model, and its logs justify that: the fallback there produced real
-# implementations. It does not work for this repo's roles. Measured on the first
-# live run, with `deepseek-v4-flash:cloud`:
+# This was briefly defaulted to 0 on the belief that `deepseek-v4-flash:cloud` could
+# not handle a 16KB agentic prompt. That belief was wrong, and the evidence for it
+# was three separate misreadings — worth recording, because each one is easy to
+# repeat:
 #
-#   * a two-word prompt returns "OK" in seconds — the engine and credential are fine;
-#   * the actual 16KB implementer prompt, with the same flags, produced ZERO bytes of
-#     output for four minutes and had to be killed.
+#   * `claude -p` does not stream. It prints only the final message, so "no output
+#     for four minutes" is what a working agent looks like. Use
+#     `--output-format stream-json --verbose` to actually watch one.
+#   * the role logs were opened with `>`, so each retry destroyed the previous
+#     attempt's output. Reading the log mid-retry showed two lines and looked like
+#     an engine that ran and said nothing. (Now appended — see agent_log_header.)
+#   * the engine was probed with a two-word prompt and the real task with a short
+#     timeout. The difference measured was latency, not capability.
 #
-# Three dispatches of #190 burned that way, each looking from the log like an agent
-# that ran and declined to answer. Retrying it every 45 seconds for the three hours
-# until the subscription resets buys nothing and makes the log lie about what the
-# pipeline is doing.
+# What was actually broken was run-agent.sh never entering $WORKDIR, so the agent
+# had no access to the tree it was told to change. With that fixed, #215 ran end to
+# end on this exact fallback in 4m34s: verdict `implemented`, branch pushed, PR
+# opened.
 #
-# So when the subscription is in cooldown the orchestrator WAITS instead, and says
-# so. Set TEAM_USE_FALLBACK=1 (optionally with AGENT_FALLBACK_MODEL pointing at a
-# larger cloud tag) to try the fallback again — if a bigger model does cope with a
-# prompt this size, this default is the thing to revisit.
-TEAM_USE_FALLBACK="${TEAM_USE_FALLBACK:-0}"
+# Set TEAM_USE_FALLBACK=0 to make the orchestrator sleep out a quota window instead
+# — useful if you would rather wait for the stronger model than take fallback-grade
+# work on a delicate issue.
+TEAM_USE_FALLBACK="${TEAM_USE_FALLBACK:-1}"
 
 COOLDOWN_FILE="$STATE_DIR/claude-usage-cooldown"
 
@@ -231,6 +235,25 @@ no_verdict_is_real_failure() {
     return 1
   fi
   return 0
+}
+
+# ── Agent logs: APPEND, never truncate ─────────────────────────────────────
+#
+# These used to be opened with `>`, so every retry destroyed the evidence of the
+# attempt before it. That is exactly how I misdiagnosed the first live run: I read
+# implement-190.log while the THIRD attempt was still starting, saw two lines, and
+# concluded the engine had run and produced nothing. Attempts 1 and 2 — the ones
+# that actually failed and would have shown why — had already been overwritten.
+#
+# A log that deletes the failure you are trying to explain is worse than no log.
+agent_log_header() {
+  local file="$1" what="$2"
+  {
+    echo
+    echo "════════════════════════════════════════════════════════════════════"
+    echo "  $what — $(date '+%Y-%m-%d %H:%M:%S')"
+    echo "════════════════════════════════════════════════════════════════════"
+  } >> "$file"
 }
 
 jqv() {

--- a/scripts/team/review.sh
+++ b/scripts/team/review.sh
@@ -118,9 +118,10 @@ fi
         -e "s|__WORKDIR__|$WT|g" > "$PROMPT"
 
 rm -f "$VERDICT_FILE"
+agent_log_header "$LOG_DIR/review-$PR.log" "review PR #$PR modelo=$MODEL"
 AGENT_SLOT=main CLAUDE_MODEL="$MODEL" \
   bash "$SCRIPT_DIR/run-agent.sh" "$PROMPT" "$WT" "${REVIEW_TIMEOUT:-1800}" \
-  > "$LOG_DIR/review-$PR.log" 2>&1; AGENT_RC=$?
+  >> "$LOG_DIR/review-$PR.log" 2>&1; AGENT_RC=$?
 
 if [ ! -f "$VERDICT_FILE" ]; then
   if ! no_verdict_is_real_failure main "$AGENT_RC"; then

--- a/scripts/team/run-agent.sh
+++ b/scripts/team/run-agent.sh
@@ -105,8 +105,30 @@ is_usage_exhausted() {
     <<<"$out"
 }
 
+# THE AGENT MUST ACTUALLY BE IN THE WORKTREE.
+#
+# This script took $WORKDIR, validated it, printed it in the log — and never
+# entered it. So the harness inherited the CALLER's cwd, which for every role is
+# `scripts/team` inside the main checkout. Claude Code roots its project scope at
+# the process cwd, so the worktree the agent was told to work in
+# (`__WORKDIR__` in the prompt) sat entirely outside that scope: Read/Write/Edit
+# on the code under test were out of bounds, and the only writable path was the
+# verdict dir from --add-dir.
+#
+# From the outside that looks exactly like "the model could not do the task" —
+# three dispatches of #190 died in ~3 minutes each, and I read that as the
+# fallback engine being incapable. It was not: probed directly, the same engine
+# answers correctly on the same slot. It was an implementer with no access to the
+# tree it was asked to change.
+#
+# Inherited from the sibling project's run-agent.sh, which has the same gap.
+cd "$WORKDIR" || { echo "ERRO: não consegui entrar em $WORKDIR" >&2; exit 1; }
+
 build_add_dirs() {
   local -a args=()
+  # Belt and braces alongside the cd: if a role ever passes a workdir that is not
+  # the tree root (or cwd changes underneath), the tree stays in scope.
+  args+=(--add-dir "$WORKDIR")
   # The verdict is written OUTSIDE the working tree, so the harness has to be told
   # that directory is in scope — otherwise it refuses the Write and the agent
   # finishes having recorded nothing, which is the exact failure this whole design


### PR DESCRIPTION
`run-agent.sh` validated `$WORKDIR`, printed it, and never `cd`'d into it — so the agent ran rooted at `scripts/team` and the code under test was **outside its project scope**. An implementer that cannot reach the tree it must change gives up in minutes without a verdict.

That is what killed three dispatches of #190, which I misread as the Ollama fallback being incapable. It is not. Same slot, same engine, with the fix: **#215 ran end to end in 4m34s** — verdict `implemented`, branch pushed, PR #295 opened.

Also in here, because it is what destroyed the evidence:
- role logs were opened with `>`, so each retry overwrote the previous attempt — now appended with a per-run header;
- `TEAM_USE_FALLBACK` back to `1` (the `0` default was reasoning from the wrong cause);
- README documents that `claude -p` does not stream, and the two-line `pwd`/`ls` probe that would have found this in seconds.

Inherited from the sibling monthy_budget harness, which has the same gap.