### PR TITLE
feat(pipeline): model tiers from issue labels + verdicts that must parse

### DIFF
--- a/scripts/team/curator.sh
+++ b/scripts/team/curator.sh
@@ -29,7 +29,8 @@ ROLE="curator"
 VERDICT_FILE="$VERDICT_DIR/curator-$ISSUE.json"
 WT=""
 PROMPT="/tmp/ios2a-curator-prompt-$ISSUE.txt"
-MODEL="${CURATOR_MODEL:-sonnet}"
+MODEL="${CURATOR_MODEL:-$TEAM_MODEL_MED_CLAUDE}"
+export AGENT_FALLBACK_MODEL="${AGENT_FALLBACK_MODEL:-$TEAM_FALLBACK_MED}"
 
 cleanup() { [ -n "$WT" ] && wt_remove "$WT"; }
 trap cleanup EXIT
@@ -76,7 +77,7 @@ AGENT_SLOT=curator CLAUDE_MODEL="$MODEL" \
   bash "$SCRIPT_DIR/run-agent.sh" "$PROMPT" "$WT" "${CURATOR_TIMEOUT:-1200}" \
   >> "$LOG_DIR/curator-$ISSUE.log" 2>&1; AGENT_RC=$?
 
-if [ ! -f "$VERDICT_FILE" ]; then
+if ! verdict_readable "$VERDICT_FILE"; then
   # A failed RUN is not a failed issue: leave the state alone so it is picked up
   # again. Nobody is coming to unpark it.
   if ! no_verdict_is_real_failure curator "$AGENT_RC"; then

--- a/scripts/team/implement.sh
+++ b/scripts/team/implement.sh
@@ -24,24 +24,15 @@ VERDICT_FILE="$VERDICT_DIR/implement-$ISSUE.json"
 PROMPT="/tmp/ios2a-implement-prompt-$ISSUE.txt"
 WT=""
 
-# Model. This repo's backlog is already triaged with `haiku-ready` / `sonnet-ready`,
-# but that triage was about the SIZE OF THE CHANGE, not about the size of the job
-# this agent does: investigate root cause, write a failing test, prove the red step,
-# implement, run three gates, then write a structured verdict. A one-line fix still
-# carries all of that, so honouring `haiku-ready` by default would silently degrade
-# most of the queue.
-#
-# Default is therefore sonnet everywhere. Set IMPLEMENT_HONOUR_READY_LABELS=1 to
-# trust the labels instead.
-MODEL="${IMPLEMENT_MODEL:-sonnet}"
-if [ -z "${IMPLEMENT_MODEL:-}" ] && [ "${IMPLEMENT_HONOUR_READY_LABELS:-0}" = "1" ]; then
-  if gh issue view "$ISSUE" --repo "$REPO" --json labels \
-       --jq '[.labels[].name] | index("haiku-ready")' 2>/dev/null | grep -qv '^null$'; then
-    MODEL="haiku"
-  fi
-fi
+# The issue's own triage picks the tier: `haiku-ready` -> low, `sonnet-ready` -> med,
+# and repeated failure promotes to strong. resolve_models returns the pair, so the
+# difficulty class stays the same whether we are on the subscription or on the
+# Ollama fallback.
+read -r MODEL FALLBACK_TAG TIER <<<"$(resolve_models "$ISSUE")"
+MODEL="${IMPLEMENT_MODEL:-$MODEL}"
+export AGENT_FALLBACK_MODEL="${AGENT_FALLBACK_MODEL:-$FALLBACK_TAG}"
 
-log "issue #$ISSUE branch=$BRANCH modelo=$MODEL"
+log "issue #$ISSUE branch=$BRANCH tier=$TIER modelo=$MODEL fallback=$AGENT_FALLBACK_MODEL"
 
 set_state "$ISSUE" "$L_WIP"
 
@@ -51,7 +42,7 @@ set_state "$ISSUE" "$L_WIP"
 comment_issue "$ISSUE" "## Implementador: a trabalhar
 
 - Branch: \`$BRANCH\`
-- Modelo: \`$MODEL\`
+- Modelo: \`$MODEL\` (tier \`$TIER\`, fallback \`$AGENT_FALLBACK_MODEL\`)
 - Início: $(date '+%H:%M')
 
 Comento outra vez quando houver PR ou se ficar bloqueado."
@@ -165,7 +156,7 @@ AGENT_SLOT=main CLAUDE_MODEL="$MODEL" \
   bash "$SCRIPT_DIR/run-agent.sh" "$PROMPT" "$WT" "${IMPLEMENT_TIMEOUT:-2700}" \
   >> "$LOG_DIR/implement-$ISSUE.log" 2>&1; AGENT_RC=$?
 
-if [ ! -f "$VERDICT_FILE" ]; then
+if ! verdict_readable "$VERDICT_FILE"; then
   if ! no_verdict_is_real_failure main "$AGENT_RC"; then
     log "SEM VEREDICTO (corrida degradada ou não arrancada) — issue volta a $L_READY"
     comment_issue "$ISSUE" "## Implementador: corrida degradada, sem veredicto

--- a/scripts/team/lib.sh
+++ b/scripts/team/lib.sh
@@ -66,6 +66,68 @@ TEAM_USE_FALLBACK="${TEAM_USE_FALLBACK:-1}"
 
 COOLDOWN_FILE="$STATE_DIR/claude-usage-cooldown"
 
+# ── Model tiers ────────────────────────────────────────────────────────────
+#
+# The backlog is already triaged with `haiku-ready` / `sonnet-ready`, so the tier
+# comes from the issue, not from a global default. Each tier names BOTH engines —
+# the subscription model and the Ollama tag used when the subscription is out —
+# because a run must not silently change difficulty class just because the quota
+# ran out.
+#
+# The cloud tags below were verified to resolve (2026-08-19). Note `glm-5.2:cloud`
+# takes a hyphen: `glm5.2:cloud` does not exist, and `glm-4.7` was retired
+# 2026-07-15.
+#
+# LOW tier — chosen by measurement, see TEAM_FALLBACK_LOW's value in the repo's
+# bakeoff notes. The only low-usage model the implement bakeoff ever tested,
+# `gemma4:cloud`, scored 10/18 and crucially came back with produced_diff=false —
+# it wrote a verdict but no code. So a low tag is only used here once it has been
+# shown to produce a diff on a real issue in THIS repo.
+TEAM_MODEL_LOW_CLAUDE="${TEAM_MODEL_LOW_CLAUDE:-haiku}"
+TEAM_MODEL_MED_CLAUDE="${TEAM_MODEL_MED_CLAUDE:-sonnet}"
+TEAM_MODEL_STRONG_CLAUDE="${TEAM_MODEL_STRONG_CLAUDE:-opus}"
+
+TEAM_FALLBACK_LOW="${TEAM_FALLBACK_LOW:-gpt-oss:20b-cloud}"
+TEAM_FALLBACK_MED="${TEAM_FALLBACK_MED:-deepseek-v4-flash:cloud}"
+TEAM_FALLBACK_STRONG="${TEAM_FALLBACK_STRONG:-deepseek-v4-pro:cloud}"
+
+# After this many failed attempts an issue is promoted to the strong tier. This is
+# the "only if it needs it" rule made mechanical: nobody guesses up front which
+# issue is hard, the issue demonstrates it by defeating the cheaper model.
+TEAM_STRONG_AFTER="${TEAM_STRONG_AFTER:-2}"
+
+# Echo "<claude-model> <fallback-tag> <tier>" for an issue.
+#
+# $2 floors the tier: pass "med" for roles that must not run on the cheap model
+# regardless of the label. The reviewer does that — the label describes how hard
+# the CHANGE is, not how hard judging it is, and the reviewer is the only gate in
+# front of main.
+resolve_models() {
+  local issue="$1" floor="${2:-low}" labels tier attempts
+
+  labels=$(gh issue view "$issue" --repo "$REPO" --json labels \
+           --jq '[.labels[].name] | join(",")' 2>/dev/null || echo "")
+
+  case ",$labels," in
+    *,haiku-ready,*)  tier=low ;;
+    *,sonnet-ready,*) tier=med ;;
+    *)                tier=med ;;   # unlabelled is not evidence of being easy
+  esac
+
+  [ "$floor" = "med" ] && [ "$tier" = "low" ] && tier=med
+
+  # Earned promotion: repeated failure is the only evidence that the cheap model
+  # is not enough.
+  attempts=$(cat "$STATE_DIR/attempts/$issue" 2>/dev/null || echo 0)
+  if [ "${attempts:-0}" -ge "$TEAM_STRONG_AFTER" ]; then tier=strong; fi
+
+  case "$tier" in
+    low)    echo "$TEAM_MODEL_LOW_CLAUDE $TEAM_FALLBACK_LOW low" ;;
+    strong) echo "$TEAM_MODEL_STRONG_CLAUDE $TEAM_FALLBACK_STRONG strong" ;;
+    *)      echo "$TEAM_MODEL_MED_CLAUDE $TEAM_FALLBACK_MED med" ;;
+  esac
+}
+
 # Seconds remaining on the subscription cooldown; 0 when there is none.
 cooldown_remaining() {
   [ -f "$COOLDOWN_FILE" ] || { echo 0; return; }
@@ -254,6 +316,39 @@ agent_log_header() {
     echo "  $what — $(date '+%Y-%m-%d %H:%M:%S')"
     echo "════════════════════════════════════════════════════════════════════"
   } >> "$file"
+}
+
+# A verdict must be PRESENT and PARSEABLE before anything reads a field from it.
+#
+# `jqv` swallows a parse error and returns its fallback. For `.outcome` that
+# fallback is `blocked`, so a malformed verdict was indistinguishable from an agent
+# that declared itself blocked — and implement.sh routed the work to the curator to
+# analyse a problem that did not exist.
+#
+# Measured on #217: the agent implemented the fix, wrote the test file, and set
+# `"outcome": "implemented"` — but wrote `mensagem "onPress impreciso" (exemplo)`
+# inside the description with the inner quotes unescaped. The file stopped parsing,
+# jqv returned `blocked`, and the issue went to qa:blocked-spec. Nothing in the log
+# said the problem was syntax.
+#
+# So: try to repair, and if it still will not parse, report NO VERDICT. That path
+# requeues the work instead of misclassifying it, which is the only safe reading of
+# "I cannot tell what this agent decided".
+verdict_readable() {
+  local file="$1"
+  [ -f "$file" ] || return 1
+  jq -e . "$file" >/dev/null 2>&1 && return 0
+
+  warn "veredicto $(basename "$file") não faz parse — a tentar reparar"
+  if python3 "$(dirname "${BASH_SOURCE[0]}")/repair-verdict.py" "$file" 2>&1 \
+     | while IFS= read -r l; do warn "  $l"; done; then :; fi
+  if jq -e . "$file" >/dev/null 2>&1; then
+    warn "veredicto reparado com sucesso"
+    return 0
+  fi
+  warn "veredicto irrecuperável — tratado como SEM VEREDICTO (o trabalho volta à fila)"
+  rm -f "$file"
+  return 1
 }
 
 jqv() {

--- a/scripts/team/repair-verdict.py
+++ b/scripts/team/repair-verdict.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Normaliza o veredicto de um agente para JSON que o jq consiga ler.
+
+PORQUE ISTO EXISTE
+
+O veredicto era lido directamente com `jq` através do `jqv()`, que engole o erro de
+parse e devolve o valor por omissão. Para o `outcome` esse valor é `blocked` — logo
+**um JSON malformado era indistinguível de um agente que se declarou bloqueado**, e
+o `implement.sh` mandava o issue para o curator analisar um problema que não existe.
+
+Medido no #217: o `gpt-oss:20b-cloud` implementou, escreveu o ficheiro de teste, e
+declarou `"outcome": "implemented"` — mas dentro do `description` escreveu
+
+    mensagem "onPress impreciso - double call" (exemplo)
+
+com as aspas por escapar. O ficheiro deixou de fazer parse, o `jqv` devolveu
+`blocked`, e o trabalho foi para `qa:blocked-spec`. Nada no log dizia que o
+problema era de sintaxe.
+
+Isto não é um problema de um modelo fraco: qualquer motor pode emitir isto, e o
+custo é sempre o mesmo — trabalho real mal encaminhado, em silêncio.
+
+O reparador do projecto irmão (companion-chat) trata de cercas ```json, prosa à
+volta do objecto, caracteres de controlo crus e escapes inválidos. Não trata de
+aspas por escapar dentro de uma string, que é exactamente o caso acima — daí o
+passo de salvamento ancorado nas chaves, no fim.
+
+Reescreve o ficheiro em JSON canónico. Sai 0 se conseguiu, 1 se não há nada de
+aproveitável — e nesse caso quem chama trata como "sem veredicto" e volta a pôr o
+trabalho na fila, em vez de o classificar mal.
+
+Uso: repair-verdict.py <ficheiro>
+"""
+import json
+import re
+import sys
+
+# As chaves que os veredictos deste pipeline usam, por papel. Servem de âncora ao
+# salvamento: só se sabe onde acaba um valor com aspas a mais se se souber onde
+# começa o próximo campo.
+KNOWN_KEYS = [
+    # implement
+    "outcome", "summary", "description", "tests", "files_changed",
+    # review
+    "verdict", "lint_pass", "typecheck_pass", "tests_pass", "issue_resolved",
+    "description_matches_diff", "has_tests", "red_step_proven",
+    "edge_cases_covered", "fixes_root_cause", "junk_files", "secrets_found",
+    "required_changes",
+    # curator
+    "analysis", "priority", "subissues",
+]
+
+
+def candidates(raw):
+    """Do mais fiel ao mais agressivo. O primeiro que fizer parse ganha."""
+    yield raw
+    fenced = re.search(r"```(?:json)?\s*(.*?)```", raw, re.DOTALL)
+    if fenced:
+        yield fenced.group(1)
+    i, j = raw.find("{"), raw.rfind("}")
+    if i != -1 and j > i:
+        yield raw[i : j + 1]
+
+
+def parse(text):
+    # strict=False aceita caracteres de controlo crus dentro de strings, que é o
+    # caso mais comum: um \n literal a meio do "summary".
+    for strict in (True, False):
+        try:
+            return json.loads(text, strict=strict)
+        except Exception:
+            pass
+    # Escapar barras invertidas que não abrem um escape válido.
+    patched = re.sub(r'\\(?!["\\/bfnrtu])', r"\\\\", text)
+    try:
+        return json.loads(patched, strict=False)
+    except Exception:
+        return None
+
+
+def salvage_by_keys(raw):
+    """Último recurso: extrair cada campo conhecido e reescapá-lo.
+
+    Um valor de string vai de `"chave": "` até às aspas que precedem a próxima
+    chave conhecida (ou o fecho do objecto). Tudo o que estiver pelo meio — aspas
+    incluídas — é conteúdo, e é reescapado por nós em vez de se confiar no modelo.
+
+    Deliberadamente conservador: só reconhece as chaves do esquema. Um veredicto
+    que não tenha nenhuma delas não é salvo, e é isso que se quer — melhor voltar à
+    fila do que inventar um resultado.
+    """
+    obj = {}
+    keys_alt = "|".join(re.escape(k) for k in KNOWN_KEYS)
+    # Onde começa cada campo conhecido.
+    starts = [(m.start(), m.group(1), m.end())
+              for m in re.finditer(r'"(' + keys_alt + r')"\s*:\s*', raw)]
+    if not starts:
+        return None
+
+    for idx, (_, key, val_at) in enumerate(starts):
+        end = starts[idx + 1][0] if idx + 1 < len(starts) else len(raw)
+        chunk = raw[val_at:end]
+        # Aparar a vírgula/chaveta que pertence ao campo seguinte.
+        chunk = re.sub(r'[\s,]*$', '', chunk)
+        chunk = re.sub(r'\}\s*$', '', chunk).rstrip().rstrip(',')
+
+        if chunk.startswith('"'):
+            body = chunk[1:]
+            if body.endswith('"'):
+                body = body[:-1]
+            # Reescapar do zero: desfazer os escapes que o modelo acertou, para não
+            # os duplicar, e depois escapar tudo corretamente.
+            body = body.replace('\\"', '"').replace("\\\\", "\\")
+            obj[key] = body
+        else:
+            try:
+                obj[key] = json.loads(chunk)
+            except Exception:
+                obj[key] = chunk.strip()
+    return obj or None
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("uso: repair-verdict.py <ficheiro>", file=sys.stderr)
+        return 1
+    path = sys.argv[1]
+    try:
+        with open(path, encoding="utf-8", errors="replace") as fh:
+            raw = fh.read()
+    except OSError as exc:
+        print(f"repair-verdict: não consegui ler {path}: {exc}", file=sys.stderr)
+        return 1
+
+    for text in candidates(raw):
+        obj = parse(text)
+        if isinstance(obj, dict):
+            with open(path, "w", encoding="utf-8") as fh:
+                json.dump(obj, fh, ensure_ascii=False)
+            return 0
+
+    obj = salvage_by_keys(raw)
+    if isinstance(obj, dict):
+        with open(path, "w", encoding="utf-8") as fh:
+            json.dump(obj, fh, ensure_ascii=False)
+        print("repair-verdict: salvo por âncora de chaves (JSON estava malformado)",
+              file=sys.stderr)
+        return 0
+
+    print("repair-verdict: nada de aproveitável no veredicto", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/team/review.sh
+++ b/scripts/team/review.sh
@@ -19,7 +19,7 @@ ROLE="review"
 
 VERDICT_FILE="$VERDICT_DIR/review-$PR.json"
 PROMPT="/tmp/ios2a-review-prompt-$PR.txt"
-MODEL="${REVIEW_MODEL:-sonnet}"
+# (modelo resolvido mais abaixo, a partir do issue ligado)
 WT=""
 
 cleanup() { [ -n "$WT" ] && wt_remove "$WT"; }
@@ -34,7 +34,7 @@ BASE=$(printf '%s' "$PR_INFO" | jq -r '.baseRefName')
 TITLE=$(printf '%s' "$PR_INFO" | jq -r '.title')
 STATE=$(printf '%s' "$PR_INFO" | jq -r '.state')
 
-log "PR #$PR $BRANCH -> $BASE ($STATE) modelo=$MODEL"
+log "PR #$PR $BRANCH -> $BASE ($STATE)"
 
 if [ "$STATE" != "OPEN" ]; then
   log "PR #$PR não está aberto — nada a rever"
@@ -47,6 +47,23 @@ ISSUE=$(printf '%s' "$PR_INFO" | jq -r '.body' \
   | grep -oiE '(Fixes|Closes|Resolves)[[:space:]]+#[0-9]+' \
   | grep -oE '[0-9]+' | head -1 || true)
 log "issue ligado: ${ISSUE:-nenhum}"
+
+# Tier from the linked issue, but FLOORED AT MED.
+#
+# The `haiku-ready` label says how hard the CHANGE is, not how hard judging it is —
+# and judging is the harder half here: enumerate the blast radius, compare the diff
+# against the issue, prove the red step by reverting production code. This reviewer
+# is also the only gate in front of `main`, with no verifier behind it and no CI on
+# pull requests, so a cheap reviewer waving work through is the one failure this
+# pipeline cannot detect on its own.
+if [ -n "$ISSUE" ]; then
+  read -r RMODEL RFALLBACK RTIER <<<"$(resolve_models "$ISSUE" med)"
+else
+  RMODEL="$TEAM_MODEL_MED_CLAUDE"; RFALLBACK="$TEAM_FALLBACK_MED"; RTIER="med"
+fi
+MODEL="${REVIEW_MODEL:-$RMODEL}"
+export AGENT_FALLBACK_MODEL="${AGENT_FALLBACK_MODEL:-$RFALLBACK}"
+log "tier=$RTIER modelo=$MODEL fallback=$AGENT_FALLBACK_MODEL"
 
 # wt_checkout, NOT wt_create: the reviewer needs the PR's code. wt_create would cut
 # a new branch from the base, the diff would come out EMPTY, and the reviewer would
@@ -123,7 +140,7 @@ AGENT_SLOT=main CLAUDE_MODEL="$MODEL" \
   bash "$SCRIPT_DIR/run-agent.sh" "$PROMPT" "$WT" "${REVIEW_TIMEOUT:-1800}" \
   >> "$LOG_DIR/review-$PR.log" 2>&1; AGENT_RC=$?
 
-if [ ! -f "$VERDICT_FILE" ]; then
+if ! verdict_readable "$VERDICT_FILE"; then
   if ! no_verdict_is_real_failure main "$AGENT_RC"; then
     log "SEM VEREDICTO (corrida degradada ou não arrancada) — PR fica para nova review"
     gh pr comment "$PR" --repo "$REPO" --body "## Reviewer: corrida degradada, sem veredicto


### PR DESCRIPTION
## Tiers

Tier comes from the issue's own triage, and names **both** engines so a run does not change difficulty class when the quota runs out:

| tier | trigger | subscription | fallback |
|---|---|---|---|
| low | `haiku-ready` | `haiku` | `gpt-oss:20b-cloud` |
| med | `sonnet-ready` / unlabelled | `sonnet` | `deepseek-v4-flash:cloud` |
| strong | **≥2 failed attempts** | `opus` | `deepseek-v4-pro:cloud` |

"Stronger model only if needed" is mechanical: the issue proves it is hard by defeating the cheaper model twice. Tags verified by probe — note `glm-5.2:cloud` takes a hyphen; `glm5.2:cloud` does not resolve and `glm-4.7` was retired 2026-07-15.

Reviewer is floored at `med`: the label says how hard the *change* is, not how hard *judging* it is, and it is the only gate in front of `main`.

## A verdict that does not parse is not a verdict

`jqv` swallowed jq parse errors and returned its fallback — `blocked` for `.outcome`. So **malformed JSON was indistinguishable from a genuine `blocked`**, and real work got routed to the curator.

Measured on #217: the agent implemented the fix and set `"outcome": "implemented"`, but wrote unescaped quotes inside `description`. File stopped parsing → `blocked` → `qa:blocked-spec`. Nothing in the log mentioned syntax. Any engine can do this, Claude included.

Every role now goes through `verdict_readable()`: parse → repair → else **no verdict, requeue**. `repair-verdict.py` is ported from the sibling harness plus a key-anchored salvage pass for unescaped quotes, which the sibling version cannot recover.