### PR TITLE
fix(pipeline): count judged rejections, not dispatches

### DIFF
--- a/scripts/team/implement.sh
+++ b/scripts/team/implement.sh
@@ -194,6 +194,11 @@ log "outcome=$OUTCOME alterações=${CHANGED:+sim}${CHANGED:-nao}"
 if [ "$OUTCOME" != "implemented" ] || [ -z "$CHANGED" ]; then
   REASON="$OUTCOME"
   [ -n "$OUTCOME" ] && [ -z "$CHANGED" ] && REASON="$OUTCOME (sem alterações reais no código)"
+  # A JUDGED REJECTION: the agent ran, produced a verdict, and the verdict was not
+  # usable work. This is what the attempt counter is for — not dispatches, and not
+  # runs that died on infrastructure.
+  log "#$ISSUE: rejeição $(bump_attempts "$ISSUE") de $MAX_ATTEMPTS"
+
   # THIS IS THE DOOR TO THE CURATOR. `blocked` means the implementer investigated
   # and the issue is not actionable as written — analysis is now warranted. Anything
   # else that failed to produce code goes the same way rather than being parked,

--- a/scripts/team/lib.sh
+++ b/scripts/team/lib.sh
@@ -91,6 +91,37 @@ TEAM_FALLBACK_LOW="${TEAM_FALLBACK_LOW:-gpt-oss:20b-cloud}"
 TEAM_FALLBACK_MED="${TEAM_FALLBACK_MED:-deepseek-v4-flash:cloud}"
 TEAM_FALLBACK_STRONG="${TEAM_FALLBACK_STRONG:-deepseek-v4-pro:cloud}"
 
+# How many judged rejections before the orchestrator changes strategy (curator,
+# then a forced split). Lives here, not in the orchestrator, because implement.sh
+# and review.sh both report against it.
+MAX_ATTEMPTS="${TEAM_MAX_ATTEMPTS:-3}"
+
+ATTEMPTS_DIR="$STATE_DIR/attempts"
+mkdir -p "$ATTEMPTS_DIR" 2>/dev/null || true
+
+# Count a JUDGED REJECTION, never a dispatch.
+#
+# This used to fire when the orchestrator handed an issue to the implementer, so it
+# counted three different things as the same thing: real work that a reviewer
+# rejected, a run that died because run-agent.sh never entered the worktree, and the
+# mere fact of starting. #190 reached the strong tier — opus, deepseek-v4-pro — on
+# two attempts that were both MY bugs, having never once been judged on its merits.
+#
+# The counter exists to answer one question: "has the cheap model been given a fair
+# shot and failed?" Only a verdict that was produced and then rejected answers it.
+# Infrastructure failures requeue the work without counting, which is what
+# no_verdict_is_real_failure already decides for the state machine.
+bump_attempts() {
+  local issue="$1" n
+  n=$(( $(cat "$ATTEMPTS_DIR/$issue" 2>/dev/null || echo 0) + 1 ))
+  echo "$n" > "$ATTEMPTS_DIR/$issue"
+  printf '%s' "$n"
+}
+
+attempts_of() { cat "$ATTEMPTS_DIR/${1}" 2>/dev/null || echo 0; }
+
+clear_attempts() { rm -f "$ATTEMPTS_DIR/${1}" 2>/dev/null || true; }
+
 # After this many failed attempts an issue is promoted to the strong tier. This is
 # the "only if it needs it" rule made mechanical: nobody guesses up front which
 # issue is hard, the issue demonstrates it by defeating the cheaper model.

--- a/scripts/team/orchestrator.sh
+++ b/scripts/team/orchestrator.sh
@@ -140,16 +140,7 @@ count_actionable() {
 # went round the loop for over two hours on its third implementation cycle while 21
 # issues sat untouched. From outside the pipeline looked busy and was delivering
 # nothing.
-MAX_ATTEMPTS="${TEAM_MAX_ATTEMPTS:-3}"
-ATTEMPTS_DIR="$STATE_DIR/attempts"
-mkdir -p "$ATTEMPTS_DIR" 2>/dev/null || true
-
-bump_attempts() {
-  local issue="$1" n
-  n=$(( $(cat "$ATTEMPTS_DIR/$issue" 2>/dev/null || echo 0) + 1 ))
-  echo "$n" > "$ATTEMPTS_DIR/$issue"
-  printf '%s' "$n"
-}
+# MAX_ATTEMPTS lives in lib.sh — the roles report against it too.
 
 # ESCALATE THE STRATEGY, NEVER TO A HUMAN.
 #
@@ -166,7 +157,7 @@ bump_attempts() {
 # one. Returns 0 to proceed with the normal action, 1 when it has been redirected.
 escalate_if_stuck() {
   local issue="$1" n
-  n=$(cat "$ATTEMPTS_DIR/$issue" 2>/dev/null || echo 0)
+  n=$(attempts_of "$issue")
   [ "$n" -lt "$MAX_ATTEMPTS" ] && return 0
 
   if [ "$n" -lt $(( MAX_ATTEMPTS * 2 )) ]; then
@@ -194,7 +185,7 @@ emaranhado**, não de esforço.
 resolúvel isoladamente — um ecrã, um componente, um cálculo de cada vez. Se um
 pedaço continuar a parecer difícil, parte-o outra vez. O histórico de falhas acima
 diz-te onde estão as fronteiras naturais."
-  echo 0 > "$ATTEMPTS_DIR/$issue"   # the pieces start fresh
+  clear_attempts "$issue"   # the pieces start fresh
   set_state "$issue" "$L_BLOCKED_SPEC"
   return 1
 }
@@ -413,7 +404,7 @@ while true; do
     I=$(first_with "$L_BLOCKED_IMPL")
     if [ -n "$I" ]; then
       if escalate_if_stuck "$I"; then
-        log "#$I: tentativa $(bump_attempts "$I") de $MAX_ATTEMPTS"
+        log "#$I: rejeições até agora: $(attempts_of "$I") de $MAX_ATTEMPTS"
         run_implement "$I"
       fi
       DID=1
@@ -425,7 +416,6 @@ while true; do
   if [ "$DID" = "0" ]; then
     I=$(first_with "$L_READY")
     if [ -n "$I" ]; then
-      log "#$I: tentativa $(bump_attempts "$I") de $MAX_ATTEMPTS"
       run_implement "$I"
       DID=1
     fi

--- a/scripts/team/review.sh
+++ b/scripts/team/review.sh
@@ -242,6 +242,7 @@ $SUMMARY
 
 PR #$PR integrado em \`$BASE\`."
         set_state "$ISSUE" "$L_DONE"
+        clear_attempts "$ISSUE"
         gh issue close "$ISSUE" --repo "$REPO" --reason completed >/dev/null 2>&1 || true
       fi
     else
@@ -255,6 +256,8 @@ deve actualizar o branch." >/dev/null 2>&1 || true
     ;;
 
   blocked-impl)
+    # Judged rejection — this is what promotes an issue to a stronger tier.
+    [ -n "$ISSUE" ] && log "#$ISSUE: rejeição $(bump_attempts "$ISSUE")"
     gh pr comment "$PR" --repo "$REPO" --body "## Reviewer: bloqueado — problema de código
 
 $SUMMARY$DETAIL$CHANGES
@@ -269,6 +272,7 @@ $SUMMARY$DETAIL$CHANGES"
     ;;
 
   blocked-spec)
+    [ -n "$ISSUE" ] && log "#$ISSUE: rejeição $(bump_attempts "$ISSUE")"
     gh pr comment "$PR" --repo "$REPO" --body "## Reviewer: bloqueado — problema do enunciado
 
 $SUMMARY$DETAIL$CHANGES


### PR DESCRIPTION
The attempt counter drives tier promotion (→ opus / deepseek-v4-pro) and strategy escalation. It incremented at **dispatch**, so it counted work a reviewer rejected, a run that died on my cwd bug, and the mere fact of starting — all as the same thing.

Caught live: **#190 was dispatched as `tier=strong` on `opus`** on two attempts that were both my own bugs. It had never been judged on its merits, and "use a stronger model only if needed" was firing on infrastructure noise.

Now it increments only where a verdict was produced and rejected (`review.sh` on `blocked-impl`/`blocked-spec`, `implement.sh` on unusable outcomes). Dispatch counts nothing; infra failures requeue without counting. A merged PR clears the counter so a reopened issue starts fresh.