### PR TITLE
fix(pipeline): stop agent prose from closing unrelated issues

### DIFF
--- a/scripts/team/curator.sh
+++ b/scripts/team/curator.sh
@@ -100,6 +100,9 @@ fi
 OUTCOME=$(jqv "$VERDICT_FILE" '.outcome' 'ready')
 SUMMARY=$(jqv "$VERDICT_FILE" '.summary' '(sem resumo)'); SUMMARY="${SUMMARY:0:600}"
 ANALYSIS=$(jqv "$VERDICT_FILE" '.analysis' '')
+# The analysis is published as an issue comment and cites related issues freely.
+SUMMARY=$(printf '%s' "$SUMMARY" | sanitize_closing_keywords)
+ANALYSIS=$(printf '%s' "$ANALYSIS" | sanitize_closing_keywords)
 PRIORITY=$(jqv "$VERDICT_FILE" '.priority' '')
 
 log "outcome=$OUTCOME priority=${PRIORITY:-n/d}"

--- a/scripts/team/implement.sh
+++ b/scripts/team/implement.sh
@@ -184,6 +184,14 @@ SUMMARY=$(jqv "$VERDICT_FILE" '.summary' 'correção automática'); SUMMARY="${S
 DESCRIPTION=$(jqv "$VERDICT_FILE" '.description' '')
 TESTS=$(jqv "$VERDICT_FILE" '.tests' '(não reportado)'); TESTS="${TESTS:0:400}"
 
+# Model-written prose goes into a commit message and a PR body, both of which
+# GitHub scans for closing keywords. An agent writing "this also fixes #212"
+# would close #212. Only the `Fixes #$ISSUE` line the harness appends below is
+# meant to close anything.
+SUMMARY=$(printf '%s' "$SUMMARY" | sanitize_closing_keywords)
+DESCRIPTION=$(printf '%s' "$DESCRIPTION" | sanitize_closing_keywords)
+TESTS=$(printf '%s' "$TESTS" | sanitize_closing_keywords)
+
 # Ignore build artefacts and the dependency symlink when deciding "did anything
 # change".
 CHANGED=$(git -C "$WT" status --porcelain 2>/dev/null \

--- a/scripts/team/lib.sh
+++ b/scripts/team/lib.sh
@@ -279,6 +279,35 @@ create_pr_api() {
   return 1
 }
 
+# Break accidental issue-closing keywords in model-written prose.
+#
+# GitHub closes an issue when a commit message or PR body contains `fix #N`,
+# `closes #N`, `resolved #N` and friends — anywhere, in any sentence. Everything
+# this pipeline publishes is written by an agent and is full of issue numbers:
+# summaries, PR descriptions, reviewer findings, curator analyses.
+#
+# It has already bitten. My own commit said
+#
+#     "...and with this fix #215 ran end to end on that same slot..."
+#
+# and GitHub read `fix #215` as a directive and CLOSED #215 — an issue whose PR was
+# open and blocked at the time. Nothing warned; the issue simply left the board as
+# if delivered. An agent writing "this also fixes #212" in a description would do
+# the same to someone else's work.
+#
+# So every field that reaches GitHub goes through this, and the ONLY closing
+# keyword that survives is the `Fixes #N` line the harness itself appends, after
+# sanitising. `#N` on its own is left intact — a plain reference is useful and
+# harmless.
+# FLAT alternation, exactly three capture groups. Nested groups here silently
+# renumber the back-references: a first attempt used `(fix(es|ed)?)` and emitted
+# `\1\4issue \5`, which turned "fix #215" into "fixissue" — the issue NUMBER was
+# dropped, destroying the very information the text was carrying. POSIX ERE has no
+# non-capturing groups, so the alternatives are spelled out instead of nested.
+sanitize_closing_keywords() {
+  sed -E 's/\b([Ff]ix|[Ff]ixes|[Ff]ixed|[Cc]lose|[Cc]loses|[Cc]losed|[Cc]losing|[Rr]esolve|[Rr]esolves|[Rr]esolved|[Rr]esolving)([[:space:]]+)#([0-9]+)/\1\2issue \3/g'
+}
+
 comment_issue() {
   local issue="$1" body="$2"
   gh issue comment "$issue" --repo "$REPO" --body "$body" >/dev/null 2>&1 \

--- a/scripts/team/review.sh
+++ b/scripts/team/review.sh
@@ -162,6 +162,9 @@ fi
 
 VERDICT=$(jqv "$VERDICT_FILE" '.verdict' 'blocked-impl')
 SUMMARY=$(jqv "$VERDICT_FILE" '.summary' '(sem resumo)'); SUMMARY="${SUMMARY:0:1500}"
+# The reviewer's findings are posted as PR and issue comments and routinely cite
+# other issue numbers. See sanitize_closing_keywords in lib.sh.
+SUMMARY=$(printf '%s' "$SUMMARY" | sanitize_closing_keywords)
 
 # Per-dimension detail, so the defect is visible in the comment without opening the
 # verdict — and so it is auditable whether the reviewer actually filled it in.


### PR DESCRIPTION
GitHub closes an issue when a commit message or PR body contains `fix #N` / `closes #N` **anywhere, in any sentence**. Everything this pipeline publishes is agent-written and dense with issue numbers.

It already happened. A commit message here read *"...and with this fix #215 ran end to end..."* — GitHub parsed it as a directive and **closed #215**, an issue whose PR was open and blocked by the reviewer at the time. Nothing warned; it left the board as if delivered. Found only by a state audit showing it closed while still labelled `qa:blocked-impl`. #215 is reopened.

An agent writing *"this also fixes #212"* does the same to someone else's work, unattended.

Model-written fields now pass through `sanitize_closing_keywords` — keyword broken, **number kept**, plain `#212` left intact. The only surviving closing keyword is the `Fixes #N` line the harness appends.

Flat alternation on purpose: the nested first version renumbered its own back-references and turned `fix #215` into `fixissue`, deleting the number.