### PR TITLE
fix(pipeline): push harness repairs immediately; move the fallback low tier

### DIFF
--- a/scripts/team/implement.sh
+++ b/scripts/team/implement.sh
@@ -90,6 +90,14 @@ if git -C "$WT" ls-files --error-unmatch node_modules >/dev/null 2>&1; then
   git -C "$WT" -c user.name="qa-implementer" -c user.email="qa@local" \
     commit -q -m "$BRANCH: remove node_modules symlink committed by an earlier attempt" \
     >/dev/null 2>&1 || true
+  # PUSH IT NOW, not at the end. This is a harness repair, not agent work, and it
+  # must not depend on the agent succeeding: the first time it ran, the agent
+  # produced no verdict, implement.sh took the early-exit path, the worktree was
+  # deleted, and the removal never reached the remote — so the reviewer went on
+  # blocking PR #295 for junk that had already been "fixed" twice locally.
+  git -C "$WT" push -q origin "$BRANCH" >/dev/null 2>&1 \
+    && log "limpeza do node_modules enviada para o remoto" \
+    || warn "não consegui enviar a limpeza do node_modules"
 fi
 
 ISSUE_JSON=$(gh issue view "$ISSUE" --repo "$REPO" \

--- a/scripts/team/lib.sh
+++ b/scripts/team/lib.sh
@@ -78,16 +78,33 @@ COOLDOWN_FILE="$STATE_DIR/claude-usage-cooldown"
 # takes a hyphen: `glm5.2:cloud` does not exist, and `glm-4.7` was retired
 # 2026-07-15.
 #
-# LOW tier — chosen by measurement, see TEAM_FALLBACK_LOW's value in the repo's
-# bakeoff notes. The only low-usage model the implement bakeoff ever tested,
-# `gemma4:cloud`, scored 10/18 and crucially came back with produced_diff=false —
-# it wrote a verdict but no code. So a low tag is only used here once it has been
-# shown to produce a diff on a real issue in THIS repo.
+# LOW TIER ON THE FALLBACK: THERE IS NO EVIDENCE FOR A LOW-USAGE MODEL THAT CODES.
+#
+# The sibling repo's bakeoffs tested exactly one low-usage model on the implement
+# role — `gemma4:cloud` — and it scored 10/18 with produced_diff=FALSE: a verdict,
+# no code. The other low tags (`gpt-oss:20b-cloud`, `nemotron-3-nano:30b-cloud`)
+# only ever ran the *gate* bakeoff, which is counting lines and writing a JSON
+# object, not programming.
+#
+# `gpt-oss:20b-cloud` then got two real runs here and lost both:
+#   * #217 — implemented and wrote the test, but emitted a verdict with unescaped
+#     quotes that did not parse. Recoverable only because repair-verdict.py now
+#     salvages it.
+#   * #215 rework — no verdict at all, in 2m35s.
+#
+# Two for two is not proof of incapability, but it is the only evidence there is
+# and it points one way. So the FALLBACK low tier is the model that has actually
+# produced clean verdicts here (#215 first run, end to end in 4m34s). The Claude
+# side keeps `haiku` for haiku-ready issues, which is what the labels ask for — the
+# downgrade applies only while the subscription is out and something has to run.
+#
+# Set TEAM_FALLBACK_LOW=gpt-oss:20b-cloud to go back to a genuinely low-usage tag
+# once there is evidence for one.
 TEAM_MODEL_LOW_CLAUDE="${TEAM_MODEL_LOW_CLAUDE:-haiku}"
 TEAM_MODEL_MED_CLAUDE="${TEAM_MODEL_MED_CLAUDE:-sonnet}"
 TEAM_MODEL_STRONG_CLAUDE="${TEAM_MODEL_STRONG_CLAUDE:-opus}"
 
-TEAM_FALLBACK_LOW="${TEAM_FALLBACK_LOW:-gpt-oss:20b-cloud}"
+TEAM_FALLBACK_LOW="${TEAM_FALLBACK_LOW:-deepseek-v4-flash:cloud}"
 TEAM_FALLBACK_MED="${TEAM_FALLBACK_MED:-deepseek-v4-flash:cloud}"
 TEAM_FALLBACK_STRONG="${TEAM_FALLBACK_STRONG:-deepseek-v4-pro:cloud}"
 


### PR DESCRIPTION
**1. A harness repair must not depend on the agent succeeding.** The retroactive `node_modules` removal waited for the end of the run to push. The agent produced no verdict, `implement.sh` took the early-exit path, the worktree was deleted, and the removal never reached the remote — so the reviewer kept blocking PR #295 for junk already "fixed" twice locally. It now pushes the moment it is made.

**2. The low fallback tier had no evidence behind it, and now has evidence against it.** The sibling bakeoffs tested exactly one low-usage model on the implement role (`gemma4:cloud`): 10/18, `produced_diff=FALSE` — a verdict, no code. The other low tags were only measured on the *gate* bakeoff (counting lines, writing JSON).

`gpt-oss:20b-cloud` got two real runs here and lost both — #217 wrote code but emitted unparseable JSON; the #215 rework produced no verdict in 2m35s. Two for two is not proof, but it is the only evidence there is. The fallback low tier moves to the model that has produced a clean verdict here. The Claude side keeps `haiku` for `haiku-ready` issues; the downgrade applies only during a quota outage.