### PR TITLE
C1: add unit test proving every launcher bridge catch reports via reportBridgeError (production fix already landed in #237) (#190)

### DIFF
--- a/modules/launcher-module/src/__tests__/index.test.ts
+++ b/modules/launcher-module/src/__tests__/index.test.ts
@@ -1,0 +1,114 @@
+import type { LauncherModuleType } from '../index';
+
+// The native module returned by requireNativeModule('LauncherModule').
+// Swapped per test so each bridge instance captures the right behaviour.
+let mockNativeModule: Record<string, jest.Mock>;
+
+jest.mock('expo', () => ({
+  requireNativeModule: jest.fn(() => mockNativeModule),
+}));
+
+function makeNativeModule(reject: boolean): Record<string, jest.Mock> {
+  return new Proxy({}, {
+    get: (target, prop) => {
+      if (prop === 'addListener') return undefined;
+      return jest.fn(() =>
+        reject ? Promise.reject(new Error('native failure')) : Promise.resolve(true),
+      );
+    },
+  }) as unknown as Record<string, jest.Mock>;
+}
+
+// Load the REAL bridge module, bypassing the jest.setup.js mock and the
+// moduleNameMapper (which only matches the package-main import specifier).
+// Each call gets a fresh module instance with its own listener set.
+function loadBridge() {
+  let mod: typeof import('../index');
+  jest.isolateModules(() => {
+    mod = jest.requireActual('../index');
+  });
+  return mod!;
+}
+
+describe('LauncherModule bridge error reporting', () => {
+  let mod: typeof import('../index');
+  let listener: jest.Mock;
+  let unsubscribe: () => void;
+
+  beforeAll(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterAll(() => {
+    (console.error as jest.Mock).mockRestore();
+  });
+
+  beforeEach(() => {
+    mockNativeModule = makeNativeModule(true);
+    mod = loadBridge();
+    listener = jest.fn();
+    unsubscribe = mod.onBridgeError(listener);
+  });
+
+  afterEach(() => {
+    unsubscribe();
+  });
+
+  it('reports getWifiInfo failures to onBridgeError listeners', async () => {
+    await expect(mod.default.getWifiInfo()).resolves.toEqual({
+      enabled: false,
+      ssid: '',
+      rssi: 0,
+      linkSpeed: 0,
+      ip: '',
+    });
+    expect(listener).toHaveBeenCalledWith('getWifiInfo', expect.any(Error));
+  });
+
+  it('reports failures for every bridge method', async () => {
+    const methods = Object.keys(mod.default) as (keyof LauncherModuleType)[];
+    for (const method of methods) {
+      const fn = (mod.default as unknown as Record<string, () => Promise<unknown>>)[method];
+      await expect(fn()).resolves.toBeDefined();
+      expect(listener).toHaveBeenCalledWith(method, expect.any(Error));
+    }
+  });
+
+  it('does not report when the native call succeeds', async () => {
+    mockNativeModule = makeNativeModule(false);
+    mod = loadBridge();
+    const okListener = jest.fn();
+    const unsub = mod.onBridgeError(okListener);
+    await expect(mod.default.getWifiInfo()).resolves.toBe(true);
+    expect(okListener).not.toHaveBeenCalled();
+    unsub();
+  });
+
+  it('stops reporting after unsubscribing', async () => {
+    unsubscribe();
+    await mod.default.getWifiInfo();
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('reportBridgeError notifies every listener', () => {
+    const l1 = jest.fn();
+    const l2 = jest.fn();
+    mod.onBridgeError(l1);
+    mod.onBridgeError(l2);
+    const err = new Error('boom');
+    mod.reportBridgeError('getVolume', err);
+    expect(l1).toHaveBeenCalledWith('getVolume', err);
+    expect(l2).toHaveBeenCalledWith('getVolume', err);
+  });
+
+  it('a throwing listener does not prevent other listeners from being notified', () => {
+    const throwing = jest.fn(() => {
+      throw new Error('listener boom');
+    });
+    const ok = jest.fn();
+    mod.onBridgeError(throwing);
+    mod.onBridgeError(ok);
+    mod.reportBridgeError('getVolume', new Error('boom'));
+    expect(ok).toHaveBeenCalledWith('getVolume', expect.any(Error));
+  });
+});


### PR DESCRIPTION
## Resumo

C1: add unit test proving every launcher bridge catch reports via reportBridgeError (production fix already landed in #237)

## Causa raiz

O issue descrevia um estado que já não existe no código. A premissa "só 3 métodos chamam `reportBridgeError`" estava desactualizada: o commit `77d58ad` (PR #237) já tinha implementado o fix completo. Verificação no estado actual do worktree:

- `babel.config.js:7` já passa `{ exclude: ['error', 'warn'] }` ao `transform-remove-console` — `console.error`/`console.warn` já são preservados em produção.
- `modules/launcher-module/src/index.ts` — os 48 catch blocks de `createBridgedModule()` já chamam `reportBridgeError('<method>', e)` (grep: 0 catch blocks sem `reportBridgeError`).
- `App.tsx:57` já subscreve `onBridgeError` e mostra banners de notificação.

O que faltava do issue era o critério de aceitação #3: o teste unitário que prova o comportamento. Esse era o trabalho real desta corrida.

## O que mudou

- `modules/launcher-module/src/__tests__/index.test.ts` (novo) — 6 testes que carregam o módulo bridge **real** (não o mock), mockam `requireNativeModule` com um `Proxy` cujos métodos rejeitam, e verificam que `onBridgeError` é invocado com `(method, Error)`.

Nenhum código de produção mudou — já satisfazia os critérios do issue.

## Porque assim

O teste carrega o módulo real contornando o mock de `jest.setup.js` e o `moduleNameMapper` de `jest.config.js`: o specifier `../index` (mesmo directório) não casa com o pattern `.*modules/launcher-module/src.*`, e `jest.requireActual` ignora o mock registry. O `expo` é mockado com `requireNativeModule` a devolver um `Proxy` que rejeita qualquer chamada — assim cada catch block do bridge é exercitado sem depender do módulo nativo.

Alternativa descartada: alterar o `moduleNameMapper` para permitir o path explícito `.../src/index` — desnecessário, o specifier local já o contorna. Testado empiricamente e revertido.

## Critérios de aceitação

- [x] `babel.config.js` passa `{ exclude: ['error', 'warn'] }` ao `transform-remove-console` — já estava (linha 7); verificado, sem alteração.
- [x] Todos os catch blocks chamam `reportBridgeError('<method>', e)` — já estavam (48/48); grep confirma 0 sem `reportBridgeError`.
- [x] Teste unitário: `getWifiInfo` rejeitado → listener `onBridgeError` invocado com `('getWifiInfo', Error)` — teste novo, passa.
- [x] Testes comportamentais existentes continuam a passar — 9 falhas, exactamente as da baseline (`baseline.json`, sha `470a816`), zero novas.
- [x] Grep `catch (e) { console.error('LauncherModule.*failed` sem `reportBridgeError` → 0 resultados.

## Testes

- **Passo vermelho:** o fix de produção já existia, por isso o teste passou à primeira. Para provar que está ligado ao comportamento, reverti o fix (removi `reportBridgeError('getWifiInfo', e)` do catch) e o teste falhou com:
  ```
  expect(jest.fn()).toHaveBeenCalledWith(...expected)
  Expected: "getWifiInfo", Any<Error>
  Number of calls: 0
  ```
  Restaurei o fix e a suite voltou a passar.
- **Casos cobertos:**
  - Critério exacto: `getWifiInfo` rejeitado → listener invocado com `('getWifiInfo', Error)`.
  - Iteração sobre **todos** os 48 métodos do bridge: cada um reporta o seu próprio nome.
  - Inverso do fix: chamada nativa que resolve → listener **não** é invocado.
  - Unsubscribe: depois de `onBridgeError` devolver o unsubscriber, o listener deixa de ser notificado.
  - `reportBridgeError` notifica todos os listeners registados.
  - Listener que lança excepção não impede os outros de serem notificados (try/catch no `reportBridgeError`).
- **Sanity-check:** revertido o fix de produção, 2 testes falharam (getWifiInfo + iteração), restaurado, 6/6 passam.
- `npm run lint`: 0 erros, 2 warnings pré-existentes (CupertinoActionSheet, ClockScreen — ficheiros não tocados).
- `npx tsc --noEmit`: limpo.
- `npm test`: 9 falharam, 177 passaram, 186 total, 31 suites. As 9 falhas são exactamente as da baseline; os 6 testes novos passam.

## Testes

9 falharam, 177 passaram, 186 total (31 suites); as 9 falhas são as da baseline, os 6 testes novos passam

## Linked Issue

Fixes #190