### PR TITLE
fix(pipeline): refresh branch against main before the PR; treat conflicts like blocked

### DIFF
--- a/scripts/team/implement.sh
+++ b/scripts/team/implement.sh
@@ -300,8 +300,54 @@ git -C "$WT" add -A -- ':!scripts/team' ':!.github' ':!android' ':!ios' ':!.expo
   || git -C "$WT" add -A -- ':!node_modules' >/dev/null 2>&1 || true
 # Belt and braces: if it got staged some other way, unstage it before committing.
 git -C "$WT" rm --cached -q --ignore-unmatch node_modules >/dev/null 2>&1 || true
+# NEVER COMMIT CONFLICT MARKERS.
+#
+# The pre-run merge leaves markers in the tree for the agent to resolve by intent.
+# If it did not resolve them, `add -A` happily stages `<<<<<<<` and the branch ships
+# code that cannot even parse — and the reviewer then spends a full run discovering
+# that. Treat it exactly like `blocked`: the work is not finished, hand it back with
+# the file list.
+UNMERGED=$(git -C "$WT" diff --name-only --diff-filter=U 2>/dev/null || true)
+MARKERS=$(git -C "$WT" grep -lE '^(<<<<<<<|>>>>>>>) ' -- . 2>/dev/null | head -5 || true)
+if [ -n "$UNMERGED" ] || [ -n "$MARKERS" ]; then
+  BAD=$(printf '%s\n%s' "$UNMERGED" "$MARKERS" | grep -v '^$' | sort -u | tr '\n' ' ')
+  log "CONFLITO POR RESOLVER — não commito: $BAD"
+  log "#$ISSUE: rejeição $(bump_attempts "$ISSUE") de $MAX_ATTEMPTS"
+  set_state "$ISSUE" "$L_BLOCKED_IMPL"
+  comment_issue "$ISSUE" "## Implementador: conflito por resolver
+
+O agente declarou \`implemented\` mas deixou marcadores de conflito por resolver:
+
+$(printf '%s' "$BAD" | tr ' ' '\n' | sed 's/^/- /')
+
+Nada foi commitado — código com \`<<<<<<<\` não compila sequer, e não vale a pena
+gastar uma review a descobri-lo. Volta ao implementador, que recebe os marcadores
+outra vez e as instruções para resolver por intenção."
+  wt_remove "$WT"
+  exit 0
+fi
+
 git -C "$WT" -c user.name="qa-implementer" -c user.email="qa@local" \
   commit -m "fix/$ISSUE: $SUMMARY" >/dev/null 2>&1 || true
+
+# ── Bring the branch up to date with main, NOW, right before the PR ─────────
+#
+# The tree was already merged with main once, at the top of this script — but that
+# was before the agent ran, and an implementation takes minutes during which other
+# PRs land on main. A branch that was current when the work started is routinely
+# stale by the time the PR opens, and a PR that cannot merge is as good as no PR.
+#
+# If this second merge conflicts, there is no agent left to resolve it: it has
+# already written its verdict and exited. So the WORK IS PRESERVED (the commit above
+# is pushed) and the issue goes back to blocked-impl — the same treatment as any
+# other "not finished yet". The next run's pre-agent merge recreates the markers and
+# hands them to a live agent with the resolve-by-intent instructions.
+git -C "$WT" fetch origin "$BASE_BRANCH" >/dev/null 2>&1 || true
+CONFLICT_AFTER=""
+if ! git -C "$WT" merge --no-edit "origin/$BASE_BRANCH" >/dev/null 2>&1; then
+  CONFLICT_AFTER=$(git -C "$WT" diff --name-only --diff-filter=U 2>/dev/null || true)
+  git -C "$WT" merge --abort >/dev/null 2>&1 || true
+fi
 
 if ! git -C "$WT" push -u origin "$BRANCH" --force >/dev/null 2>&1; then
   log "ERRO: push falhou — volta a $PREV_STATE"
@@ -314,6 +360,29 @@ infraestrutura, não do issue — volta à fila."
   exit 1
 fi
 log "push ok -> $BRANCH"
+
+# The work is safe on the remote. Now honour the conflict found above: do NOT open
+# or refresh a PR that cannot merge. Sending it to review would burn a full agent
+# run to be told what git already said in a second.
+if [ -n "$CONFLICT_AFTER" ]; then
+  log "CONFLITO com $BASE_BRANCH depois do trabalho — sem PR, volta a $L_BLOCKED_IMPL"
+  log "#$ISSUE: rejeição $(bump_attempts "$ISSUE") de $MAX_ATTEMPTS"
+  set_state "$ISSUE" "$L_BLOCKED_IMPL"
+  comment_issue "$ISSUE" "## Implementador: trabalho feito, mas o branch já não integra
+
+O código está no branch \`$BRANCH\` e **não se perde**. Entretanto o \`$BASE_BRANCH\`
+avançou e estes ficheiros entram em conflito:
+
+$(printf '%s' "$CONFLICT_AFTER" | sed 's/^/- /')
+
+Não abro PR neste estado — um PR que não integra não é revisível, e gastar uma
+review para o descobrir é desperdício. Na próxima passagem o \`$BASE_BRANCH\` é
+integrado neste branch antes do agente arrancar, os marcadores ficam na árvore, e a
+resolução é feita por intenção: perceber o que cada lado queria e preservar as duas
+intenções. **Não refaças o trabalho** — ele já está aqui."
+  wt_remove "$WT"
+  exit 0
+fi
 
 # ── PR into main ───────────────────────────────────────────────────────────
 # `Fixes #N` is mandatory: the reviewer reads it to find its way back to the issue,

--- a/scripts/team/review.sh
+++ b/scripts/team/review.sh
@@ -65,6 +65,49 @@ MODEL="${REVIEW_MODEL:-$RMODEL}"
 export AGENT_FALLBACK_MODEL="${AGENT_FALLBACK_MODEL:-$RFALLBACK}"
 log "tier=$RTIER modelo=$MODEL fallback=$AGENT_FALLBACK_MODEL"
 
+# ── A PR THAT CANNOT MERGE IS NOT REVIEWABLE ───────────────────────────────
+#
+# Check mergeability BEFORE spending an agent. A conflicted PR would otherwise get
+# the full treatment — checkout, npm install, lint, tsc, the whole suite, a diff read
+# end to end — only to be told at the merge step what git could have said in one API
+# call. That is 10-25 minutes of quota per attempt, and it repeats every time the
+# branch is touched.
+#
+# Conflicts are handled like `blocked`: back to the implementer, which merges the
+# base into the branch before the agent starts and hands it the markers to resolve by
+# intent.
+#
+# UNKNOWN is not CONFLICTING. GitHub computes mergeability asynchronously and answers
+# UNKNOWN while it is still thinking; treating that as a conflict would bounce
+# perfectly good PRs. Ask again a few times, and if it still will not say, review
+# normally — the merge step is the backstop.
+MSTATE=""
+for _ in 1 2 3; do
+  MSTATE=$(gh pr view "$PR" --repo "$REPO" --json mergeable --jq .mergeable 2>/dev/null || echo "")
+  [ "$MSTATE" = "UNKNOWN" ] || [ -z "$MSTATE" ] || break
+  sleep 3
+done
+if [ "$MSTATE" = "CONFLICTING" ]; then
+  log "PR #$PR em conflito com $BASE — devolvido sem gastar uma review"
+  gh pr comment "$PR" --repo "$REPO" --body "## Reviewer: em conflito, nao revisto
+
+Este PR nao integra em \`$BASE\` — tem conflitos por resolver. Nao o revi: uma
+review custa a suite completa e o diff todo, para no fim bater no mesmo que o git ja
+diz numa chamada.
+
+**Nao e um juizo sobre o codigo.** Volta ao implementador, que integra o \`$BASE\`
+neste branch antes de arrancar e resolve os marcadores por intencao — percebendo o
+que cada lado queria e preservando as duas intencoes. Depois disso volto a olhar." >/dev/null 2>&1 || true
+  if [ -n "$ISSUE" ]; then
+    comment_issue "$ISSUE" "## Reviewer: PR #$PR em conflito com \`$BASE\`
+
+Devolvido ao implementador para resolver os conflitos. O trabalho no branch
+mantem-se — nao e para refazer."
+    set_state "$ISSUE" "$L_BLOCKED_IMPL"
+  fi
+  exit 0
+fi
+
 # wt_checkout, NOT wt_create: the reviewer needs the PR's code. wt_create would cut
 # a new branch from the base, the diff would come out EMPTY, and the reviewer would
 # be judging the PR by its title alone — with no error in the log to reveal it.


### PR DESCRIPTION
**1. The branch was only merged with main *before* the agent ran.** An implementation takes minutes, and other PRs land during them — a branch current at the start is routinely stale when the PR opens. There is now a second merge immediately before PR creation.

If that merge conflicts there is no agent left to resolve it, so: work is preserved (commit pushed), **no PR is opened in that state**, and the issue returns to `qa:blocked-impl`. The next run's pre-agent merge recreates the markers for a live agent, and the comment says plainly the work is on the branch and must not be redone.

**2. Conflict markers could be committed.** The pre-run merge deliberately leaves `<<<<<<<` for the agent to resolve. If it didn't, `add -A` staged them and the branch shipped code that does not parse — with the reviewer spending a full run to discover it. Unmerged paths or marker lines now abort the commit and hand the issue back, exactly like `blocked`.

**3. The reviewer burned whole runs on PRs git already knew were unmergeable.** Checkout, npm install, lint, tsc, full suite, end-to-end diff read — 10-25 minutes of quota — to reach the merge step and learn what one API call says. Mergeability is checked first now; a `CONFLICTING` PR goes back to the implementer with no agent run.

`UNKNOWN` is explicitly not `CONFLICTING` — GitHub computes mergeability asynchronously, and treating "still thinking" as a conflict would bounce good PRs.