### PR TITLE
C2: validação de packageName em launchApp extraída para PackageNameValidator testável (JVM pura) + rejeições reportadas ao JS via reportBridgeError (#191)

### DIFF
--- a/modules/launcher-module/android/build.gradle
+++ b/modules/launcher-module/android/build.gradle
@@ -28,6 +28,7 @@ android {
 
 dependencies {
     implementation project(':expo-modules-core')
+    testImplementation 'junit:junit:4.13.2'
 }
 
 def safeExtGet(prop, fallback) {

--- a/modules/launcher-module/android/src/main/java/com/iostoandroid/launcher/LauncherModule.kt
+++ b/modules/launcher-module/android/src/main/java/com/iostoandroid/launcher/LauncherModule.kt
@@ -42,7 +42,6 @@ class LauncherModule : Module() {
     companion object {
         var flashlightState = false
         private val PHONE_REGEX = Regex("^[+0-9*#(). -]{1,20}$")
-        private val PKG_REGEX = Regex("^[a-zA-Z][a-zA-Z0-9_]*(\\.[a-zA-Z][a-zA-Z0-9_]*)+\$")
 
         @Volatile private var instance: LauncherModule? = null
 
@@ -98,12 +97,14 @@ class LauncherModule : Module() {
         }
 
         AsyncFunction("launchApp") { packageName: String ->
-            if (!PKG_REGEX.matches(packageName)) {
-                return@AsyncFunction false
+            // Shape regex first, then whitelist via PackageManager: malformed names
+            // never reach the resolver, and non-installed / non-launchable packages
+            // resolve to null. See PackageNameValidator for the pure-JVM logic.
+            val intent = PackageNameValidator.resolveIfValidShape(packageName) {
+                context.packageManager.getLaunchIntentForPackage(it)
             }
-            val intent = context.packageManager.getLaunchIntentForPackage(packageName)
             if (intent == null) {
-                return@AsyncFunction false  // not installed or not launchable
+                return@AsyncFunction false  // malformed, not installed, or not launchable
             }
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
             context.startActivity(intent)

--- a/modules/launcher-module/android/src/main/java/com/iostoandroid/launcher/PackageNameValidator.kt
+++ b/modules/launcher-module/android/src/main/java/com/iostoandroid/launcher/PackageNameValidator.kt
@@ -1,0 +1,23 @@
+package com.iostoandroid.launcher
+
+/**
+ * Pure-JVM validation for package names passed to [LauncherModule.launchApp].
+ * Kept free of android.* imports so it can be unit-tested without a device.
+ */
+object PackageNameValidator {
+    val PKG_REGEX = Regex("^[a-zA-Z][a-zA-Z0-9_]*(\\.[a-zA-Z][a-zA-Z0-9_]*)+\$")
+
+    /** True when [packageName] is a plausible Java/Android package identifier. */
+    fun isValidShape(packageName: String): Boolean = PKG_REGEX.matches(packageName)
+
+    /**
+     * Resolves [packageName] through [resolve] only when it passes the shape
+     * check; returns null otherwise. [resolve] is the whitelist lookup
+     * (e.g. PackageManager.getLaunchIntentForPackage) — kept as a parameter so
+     * this stays pure-JVM testable.
+     */
+    fun <T> resolveIfValidShape(packageName: String, resolve: (String) -> T?): T? {
+        if (!isValidShape(packageName)) return null
+        return resolve(packageName)
+    }
+}

--- a/modules/launcher-module/android/src/test/java/com/iostoandroid/launcher/PackageNameValidatorTest.kt
+++ b/modules/launcher-module/android/src/test/java/com/iostoandroid/launcher/PackageNameValidatorTest.kt
@@ -1,0 +1,78 @@
+package com.iostoandroid.launcher
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure-JVM unit tests for [PackageNameValidator] — the shape regex and the
+ * whitelist resolution used by LauncherModule.launchApp. No android.* imports,
+ * so these run without a device or the Android SDK.
+ */
+class PackageNameValidatorTest {
+
+    @Test
+    fun `accepts well-formed package names`() {
+        assertTrue(PackageNameValidator.isValidShape("com.android.settings"))
+        assertTrue(PackageNameValidator.isValidShape("com.nonexistent.app"))
+        assertTrue(PackageNameValidator.isValidShape("not.a.package"))
+        assertTrue(PackageNameValidator.isValidShape("a.b"))
+        assertTrue(PackageNameValidator.isValidShape("com.example.my_app"))
+        assertTrue(PackageNameValidator.isValidShape("com.example.app2"))
+    }
+
+    @Test
+    fun `rejects empty and malformed package names`() {
+        assertFalse(PackageNameValidator.isValidShape(""))
+        assertFalse(PackageNameValidator.isValidShape("no_dot"))
+        assertFalse(PackageNameValidator.isValidShape(".leading"))
+        assertFalse(PackageNameValidator.isValidShape("com..double"))
+        assertFalse(PackageNameValidator.isValidShape("com.trailing."))
+        assertFalse(PackageNameValidator.isValidShape("1com.example"))
+        assertFalse(PackageNameValidator.isValidShape("com.example.app-"))
+        assertFalse(PackageNameValidator.isValidShape("com.example.app "))
+        assertFalse(PackageNameValidator.isValidShape("com.example.app\n"))
+        assertFalse(PackageNameValidator.isValidShape("com.example.app/extra"))
+        assertFalse(PackageNameValidator.isValidShape("com.example.app?x=1"))
+        assertFalse(PackageNameValidator.isValidShape("com.example.app#frag"))
+        assertFalse(PackageNameValidator.isValidShape("com.example.app:port"))
+        assertFalse(PackageNameValidator.isValidShape("com.example.app;param"))
+        assertFalse(PackageNameValidator.isValidShape("com.example.app,com.other"))
+        assertFalse(PackageNameValidator.isValidShape("com.example.app.1"))
+        assertFalse(PackageNameValidator.isValidShape("a"))
+    }
+
+    @Test
+    fun `resolves launch intent only for valid shape`() {
+        var resolverCalls = 0
+        val resolver: (String) -> String? = { pkg ->
+            resolverCalls++
+            if (pkg == "com.android.settings") "launch-intent" else null
+        }
+
+        assertEquals(
+            "launch-intent",
+            PackageNameValidator.resolveIfValidShape("com.android.settings", resolver)
+        )
+        assertEquals(1, resolverCalls)
+
+        assertNull(PackageNameValidator.resolveIfValidShape("com.nonexistent.app", resolver))
+        assertEquals(2, resolverCalls)
+    }
+
+    @Test
+    fun `does not call resolver for malformed names`() {
+        var resolverCalls = 0
+        val resolver: (String) -> String? = { pkg ->
+            resolverCalls++
+            "launch-intent"
+        }
+
+        assertNull(PackageNameValidator.resolveIfValidShape("", resolver))
+        assertNull(PackageNameValidator.resolveIfValidShape("not a package", resolver))
+        assertNull(PackageNameValidator.resolveIfValidShape("com.example.app/extra", resolver))
+        assertEquals(0, resolverCalls)
+    }
+}

--- a/modules/launcher-module/src/__tests__/index.test.ts
+++ b/modules/launcher-module/src/__tests__/index.test.ts
@@ -8,10 +8,14 @@ jest.mock('expo', () => ({
   requireNativeModule: jest.fn(() => mockNativeModule),
 }));
 
-function makeNativeModule(reject: boolean): Record<string, jest.Mock> {
+function makeNativeModule(
+  reject: boolean,
+  overrides: Record<string, jest.Mock> = {},
+): Record<string, jest.Mock> {
   return new Proxy({}, {
     get: (target, prop) => {
       if (prop === 'addListener') return undefined;
+      if (prop in overrides) return overrides[prop as string];
       return jest.fn(() =>
         reject ? Promise.reject(new Error('native failure')) : Promise.resolve(true),
       );
@@ -80,6 +84,30 @@ describe('LauncherModule bridge error reporting', () => {
     const okListener = jest.fn();
     const unsub = mod.onBridgeError(okListener);
     await expect(mod.default.getWifiInfo()).resolves.toBe(true);
+    expect(okListener).not.toHaveBeenCalled();
+    unsub();
+  });
+
+  it('reports a launchApp rejection (native returns false) to onBridgeError listeners', async () => {
+    mockNativeModule = makeNativeModule(false, {
+      launchApp: jest.fn().mockResolvedValue(false),
+    });
+    mod = loadBridge();
+    const okListener = jest.fn();
+    const unsub = mod.onBridgeError(okListener);
+    await expect(mod.default.launchApp('com.nonexistent.app')).resolves.toBe(false);
+    expect(okListener).toHaveBeenCalledWith('launchApp', expect.any(Error));
+    unsub();
+  });
+
+  it('does not report when launchApp succeeds', async () => {
+    mockNativeModule = makeNativeModule(false, {
+      launchApp: jest.fn().mockResolvedValue(true),
+    });
+    mod = loadBridge();
+    const okListener = jest.fn();
+    const unsub = mod.onBridgeError(okListener);
+    await expect(mod.default.launchApp('com.android.settings')).resolves.toBe(true);
     expect(okListener).not.toHaveBeenCalled();
     unsub();
   });

--- a/modules/launcher-module/src/index.ts
+++ b/modules/launcher-module/src/index.ts
@@ -270,8 +270,15 @@ function createBridgedModule(): LauncherModuleType {
       catch (e) { console.error('LauncherModule.getInstalledApps failed:', e); reportBridgeError('getInstalledApps', e); return []; }
     },
     launchApp: async (packageName: string) => {
-      try { return await nativeModule.launchApp(packageName); }
-      catch (e) { console.error('LauncherModule.launchApp failed:', e); reportBridgeError('launchApp', e); return false; }
+      try {
+        const ok = await nativeModule.launchApp(packageName);
+        // A false result is a rejection (malformed / not installed / not
+        // launchable), not an exception — surface it so the UI can react.
+        if (!ok) {
+          reportBridgeError('launchApp', new Error(`Could not launch app: ${packageName}`));
+        }
+        return ok;
+      } catch (e) { console.error('LauncherModule.launchApp failed:', e); reportBridgeError('launchApp', e); return false; }
     },
     getAppIcon: async (packageName: string) => {
       try { return await nativeModule.getAppIcon(packageName); }


### PR DESCRIPTION
## Resumo

C2: validação de packageName em launchApp extraída para PackageNameValidator testável (JVM pura) + rejeições reportadas ao JS via reportBridgeError

## Causa raiz

O issue descreve `launchApp` como aceitando "any string" e passando-a directamente a `getLaunchIntentForPackage` (linhas 78-85). Isso era verdade **antes** do commit `77d58ad` (fix C1, #190/#237), que já implementou a maior parte do C2: regex `PKG_REGEX` (validação de forma), null-check de `getLaunchIntentForPackage` (whitelist) e `FLAG_ACTIVITY_NEW_TASK`. O código actual (`LauncherModule.kt:99-112`) já rejeita `""`, `"not.a.package"` e `"com.nonexistent.app"` devolvendo `false` sem chamar `startActivity`.

O que faltava do issue: **(a)** testes unitários para o regex e a whitelist (critério de aceitação 5 — não existia nenhum teste Kotlin no módulo) e **(b)** o report de falhas ao JS (item 4 — o bridge devolvia `false` silenciosamente, sem notificar `onBridgeError`).

## O que mudou

- **`PackageNameValidator.kt` (novo)** — objecto Kotlin puro (sem imports `android.*`) com `PKG_REGEX`, `isValidShape()` e `resolveIfValidShape(packageName, resolve)`. A lógica de validação foi extraída do companion object para aqui para ser testável em JVM pura.
- **`LauncherModule.kt`** — `launchApp` agora chama `PackageNameValidator.resolveIfValidShape(packageName) { context.packageManager.getLaunchIntentForPackage(it) }`. Comportamento idêntico ao anterior (regex → whitelist → `FLAG_ACTIVITY_NEW_TASK` → `startActivity`), mas a lógica fica acessível a testes. Removido `PKG_REGEX` do companion object (movido, sem mudança de comportamento).
- **`build.gradle`** — adicionado `testImplementation 'junit:junit:4.13.2'` para o teste unitário do módulo.
- **`src/index.ts`** — o wrapper do bridge agora reporta rejeições de `launchApp` (resultado `false` do nativo) via `reportBridgeError('launchApp', new Error(...))`, além das excepções que já reportava. Continua a devolver `false` ao chamador (contrato inalterado).
- **`PackageNameValidatorTest.kt` (novo)** — 4 testes JUnit cobrindo o regex e a whitelist.
- **`src/__tests__/index.test.ts`** — 2 testes novos (rejeição reportada; sucesso não reportado) + helper `makeNativeModule` ganhou um parâmetro `overrides` para simular retorno `false`.

## Porque assim

- **Whitelist via `getLaunchIntentForPackage`** (escolha do C1) em vez de `queryIntentActivities` + cache: sem cache, uma app recém-instalada nunca é rejeitada por TTL — o critério 4 do issue fica satisfeito por construção. Adicionar cache introduziria exactamente o problema que o critério 4 tenta evitar.
- **Extracção para `PackageNameValidator`** (objecto puro) é o mínimo que torna o regex e a whitelist testáveis sem toolchain Android. O teste corre em JVM pura (kotlinc + JUnit) e o padrão de chamada com trailing lambda + inferência genérica foi verificado a compilar e a correr.
- **Reportar rejeições via `reportBridgeError`** (em vez de lançar excepção no Kotlin) preserva o contrato `false` do critério de aceitação 1 e segue o padrão C1 já existente no bridge.
- **Item 5 (banner "Couldn't open app" no App.tsx)** é opcional e está fora da lista "Files to Modify" do issue — não implementado deliberadamente. O mecanismo de report (item 4) está ligado; qualquer listener de `onBridgeError` pode reagir.

## Critérios de aceitação

- [x] `launchApp("")`, `launchApp("not.a.package")`, `launchApp("com.nonexistent.app")` devolvem `false` e NÃO chamam `startActivity` — teste Kotlin `does not call resolver for malformed names` (resolver nunca é chamado para nomes malformados) e `resolves launch intent only for valid shape` (resolver devolve null → null → `false`). `startActivity` só é alcançado com intent não-nulo.
- [x] `launchApp("com.android.settings")` continua a funcionar — `isValidShape` aceita, resolver devolve o intent → `startActivity` → `true`. Teste `resolves launch intent only for valid shape`.
- [x] Invocações de contextos não-Activity não rebentam — `FLAG_ACTIVITY_NEW_TASK` mantido (inalterado).
- [x] App nova dentro do TTL de cache não é rejeitada — não há cache; `getLaunchIntentForPackage` é consultado de fresco a cada chamada.
- [x] Teste unitário cobre o regex e a whitelist — `PackageNameValidatorTest.kt` (4 testes), corrido em JVM pura: OK.
- [x] O que NÃO devia mudar: `launchApp` continua a devolver `false` (não lança) em rejeição; apps instaladas continuam a abrir; os testes bridge existentes continuam a passar (8/8).

## Testes

- **Passo vermelho (JS):** teste `reports a launchApp rejection (native returns false) to onBridgeError listeners` falhou antes do fix com `expect(jest.fn()).toHaveBeenCalledWith(...expected) — Number of calls: 0`.
- **Passo vermelho (Kotlin):** `PackageNameValidatorTest.kt` não compilava — `error: unresolved reference 'PackageNameValidator'`.
- **Casos cobertos (Kotlin):** forma válida (6 casos); malformados (17 casos: vazio, sem ponto, ponto inicial, ponto duplo, ponto final, começa com dígito, hífen, espaço, newline, `/`, `?`, `#`, `:`, `;`, `,`, segmento a começar por dígito, segmento único); whitelist (resolver chamado só para forma válida; resolver null → null); inverso do fix (resolver NÃO chamado para malformados).
- **Casos cobertos (JS):** rejeição reportada; sucesso não reportado (inverso do fix); mais os 6 testes bridge existentes.
- **Sanity-check:** revertido o fix JS → o teste de rejeição falhou; removido o validator Kotlin → o teste não compila; restaurados ambos.
- **Resultados:** `npm run lint` 0 erros (2 warnings pré-existentes na baseline); `npx tsc --noEmit` limpo; `npm test` 189 passaram, 9 falharam (as mesmas 9 da baseline, nenhuma nova), 198 total, 32 suites; Kotlin JVM pura: OK (4 testes).

## Testes

189 passaram, 9 falharam (baseline pré-existente, nenhuma nova), 198 total, 32 suites; + 4 testes Kotlin em JVM pura OK

## Linked Issue

Fixes #191