### PR TITLE
C4: fix de produção já estava em main (77d58ad) — adicionado o teste em falta que trava o gate de hidratação do ThemeProvider e a remoção do seed temporal (8 testes) (#193)

### DIFF
--- a/src/theme/__tests__/ThemeContext.test.tsx
+++ b/src/theme/__tests__/ThemeContext.test.tsx
@@ -1,0 +1,139 @@
+import React from 'react';
+import { Text } from 'react-native';
+import * as RN from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { render, waitFor, act } from '@testing-library/react-native';
+import { ThemeProvider, useTheme } from '../ThemeContext';
+import { SettingsProvider } from '../../store/SettingsStore';
+
+const THEME_KEY = '@iostoandroid/theme_preference';
+
+function ThemeProbe() {
+  const { isDark, isReady, mode } = useTheme();
+  return <Text>{`isDark=${isDark} isReady=${isReady} mode=${mode}`}</Text>;
+}
+
+/**
+ * Renders ThemeProvider with the settings gate off (settings are not what we are
+ * testing) and the theme gate on by default. The theme gate is the behaviour
+ * under test: it must hold back the first render until the saved theme has
+ * hydrated, so the app never paints a wrong-theme frame on launch.
+ */
+function renderTheme(ui: React.ReactNode, themeGateFirstRender?: boolean) {
+  return render(
+    <SettingsProvider gateFirstRender={false}>
+      <ThemeProvider gateFirstRender={themeGateFirstRender}>{ui}</ThemeProvider>
+    </SettingsProvider>,
+  );
+}
+
+beforeEach(() => {
+  (AsyncStorage.getItem as jest.Mock).mockReset();
+  (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+  jest.spyOn(RN, 'useColorScheme').mockReturnValue('light');
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('ThemeProvider launch gate (C4: no wrong-theme flash)', () => {
+  it('renders nothing until the saved theme has hydrated', async () => {
+    const { queryByText } = renderTheme(<ThemeProbe />);
+
+    // Gate on: before AsyncStorage resolves, the provider returns null, so the
+    // first frame can never be a time-based guess at the theme.
+    expect(queryByText(/isDark=/)).toBeNull();
+
+    await waitFor(() => expect(queryByText(/isDark=/)).toBeTruthy());
+  });
+
+  it('hydrates a saved dark override before first paint', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockImplementation((key: string) =>
+      key === THEME_KEY ? Promise.resolve('dark') : Promise.resolve(null),
+    );
+
+    const { getByText } = renderTheme(<ThemeProbe />);
+
+    await waitFor(() => expect(getByText(/isDark=true/)).toBeTruthy());
+    expect(getByText(/mode=dark/)).toBeTruthy();
+  });
+
+  it('hydrates a saved light override before first paint', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockImplementation((key: string) =>
+      key === THEME_KEY ? Promise.resolve('light') : Promise.resolve(null),
+    );
+
+    const { getByText } = renderTheme(<ThemeProbe />);
+
+    await waitFor(() => expect(getByText(/isDark=false/)).toBeTruthy());
+    expect(getByText(/mode=light/)).toBeTruthy();
+  });
+
+  it('defers to the system scheme when no preference is saved', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+    (RN.useColorScheme as jest.Mock).mockReturnValue('dark');
+
+    const { getByText } = renderTheme(<ThemeProbe />);
+
+    await waitFor(() => expect(getByText(/isDark=true/)).toBeTruthy());
+    expect(getByText(/mode=system/)).toBeTruthy();
+  });
+
+  it('stays light on a light system scheme when no preference is saved', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+    (RN.useColorScheme as jest.Mock).mockReturnValue('light');
+
+    const { getByText } = renderTheme(<ThemeProbe />);
+
+    await waitFor(() => expect(getByText(/isDark=false/)).toBeTruthy());
+    expect(getByText(/mode=system/)).toBeTruthy();
+  });
+
+  it('does not seed isDark from the clock before hydration', async () => {
+    // The old code computed the initial isDark from new Date().getHours()
+    // (dark 19:00–07:00). Pin the clock to 20:00 and a light system scheme:
+    // the pre-hydration render must be light, never a time-of-day guess.
+    jest.useFakeTimers();
+    try {
+      jest.setSystemTime(new Date(2026, 0, 1, 20, 0, 0));
+      (RN.useColorScheme as jest.Mock).mockReturnValue('light');
+
+      const { getByText } = renderTheme(<ThemeProbe />, false);
+
+      expect(getByText(/isDark=false/)).toBeTruthy();
+
+      // Flush the async hydration + settings sync inside act so no state
+      // update lands outside act after the test ends.
+      await act(async () => {});
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('a saved dark override wins over a light system scheme', async () => {
+    // The exact scenario from the issue: user opens the app at 10:00 (light
+    // system scheme) with a saved dark override — the first painted theme must
+    // be dark, never a light flash.
+    (AsyncStorage.getItem as jest.Mock).mockImplementation((key: string) =>
+      key === THEME_KEY ? Promise.resolve('dark') : Promise.resolve(null),
+    );
+    (RN.useColorScheme as jest.Mock).mockReturnValue('light');
+
+    const { getByText } = renderTheme(<ThemeProbe />);
+
+    await waitFor(() => expect(getByText(/isDark=true/)).toBeTruthy());
+  });
+
+  it('renders children immediately when the gate is off (test harness contract)', async () => {
+    const { getByText } = renderTheme(<ThemeProbe />, false);
+
+    // gateFirstRender={false} is what src/test-utils.tsx passes so synchronous
+    // screen tests see the subtree instead of null.
+    expect(getByText(/isDark=/)).toBeTruthy();
+
+    // Flush the async hydration + settings sync so no state update lands
+    // outside act after the test ends.
+    await act(async () => {});
+  });
+});


### PR DESCRIPTION
## Resumo

C4: fix de produção já estava em main (77d58ad) — adicionado o teste em falta que trava o gate de hidratação do ThemeProvider e a remoção do seed temporal (8 testes)

## Causa raiz

O issue descreve o mecanismo correcto, mas aponta para um estado do código que já não existe. O seed temporal (`const initHour = new Date().getHours(); const [isDark, setIsDark] = useState(initHour >= 19 || initHour < 7);`) e a ausência de gate foram corrigidos no commit `77d58ad` ("fix(C4): gate ThemeProvider render on hydration to kill theme flash (#193)"), já em `main` antes deste worktree ser cortado. O código actual em `src/theme/ThemeContext.tsx`:

- Linha 89: `mode` default `'system'` — sem seed temporal.
- Linhas 97-98: `isDark` derivado de `mode` + `useColorScheme()` (comportamento C5).
- Linha 190: `if (gateFirstRender && !isReady) return null;` — segura o primeiro render até a hidratação do AsyncStorage terminar, seguindo o padrão de `App.tsx:196` (`if (showOnboarding === null) return null;`).

O que faltava: o comentário em `src/test-utils.tsx:20` diz explicitamente que o gate "belongs in its own test", mas esse teste não existia. Os critérios de aceitação do issue estavam implementados mas não verificados por nenhum teste — o fix estava no código sem prova.

## O que mudou

- `src/theme/__tests__/ThemeContext.test.tsx` (novo): 8 testes que travam o comportamento do gate de lançamento e a derivação de `isDark`.

Não mexi no código de produção: o fix pedido pelo issue já está em `main` e está intacto neste worktree.

## Porque assim

O fix de produção já estava implementado. A contribuição é o teste em falta que o próprio harness de testes identifica como necessário (`src/test-utils.tsx:20`). Escrever o teste contra o código actual e provar que falha contra a versão buggy (sanity-check abaixo) é a única forma de fechar o issue sem reescrever código que já está correcto. Alternativa descartada: reportar `blocked` — o issue não é irresolúvel, está resolvido; o que faltava era verificação.

## Critérios de aceitação

- [x] Utilizador com override `dark` guardado abre a app a qualquer hora: primeiro pixel renderizado é dark, sem flash. → Testes "hydrates a saved dark override before first paint" e "a saved dark override wins over a light system scheme" (cenário exacto do issue: esquema claro + override dark → `isDark=true`).
- [x] Utilizador com override `light` guardado: primeiro pixel é light, sem flash. → Teste "hydrates a saved light override before first paint" (`isDark=false`, `mode=light`).
- [x] Primeiro lançamento (sem preferência guardada): segue o esquema do sistema. → Testes "defers to the system scheme when no preference is saved" (`useColorScheme='dark'` → `isDark=true`, `mode=system`) e "stays light on a light system scheme" (`useColorScheme='light'` → `isDark=false`).
- [x] O seed temporal foi removido. → Teste "does not seed isDark from the clock before hydration": relógio fixo às 20:00 (`jest.setSystemTime`) + esquema claro → `isDark=false` no render pré-hidratação. Contra o código antigo, este teste falha com `isDark=true isReady=false mode=system`.
- [x] O gate segura o render até a hidratação. → Teste "renders nothing until the saved theme has hydrated": `queryByText(/isDark=/)` é `null` antes do AsyncStorage resolver.
- [x] O que NÃO devia mudar: `gateFirstRender={false}` continua a renderizar filhos imediatamente (contrato do harness de testes). → Teste "renders children immediately when the gate is off (test harness contract)".

## Testes

- **Passo vermelho:** como o fix já estava em `main`, os testes passaram à primeira. Para provar que estão ligados ao comportamento, reverti temporariamente o fix de produção (removi o gate + restaurei o seed temporal) e a suite falhou pelas razões certas:
  - "renders nothing until the saved theme has hydrated": `expect(received).toBeNull()` — sem o gate, o probe renderiza imediatamente.
  - "does not seed isDark from the clock before hydration": `Unable to find an element with text: /isDark=false/` — o probe mostra `isDark=true isReady=false mode=system` às 20:00 com esquema claro.
  Restaurei o fix e os 8 testes passam.
- **Casos cobertos:** gate (render nulo antes da hidratação), overrides `dark`/`light` guardados, esquema do sistema (dark e light), ausência de preferência, override guardado a vencer o esquema do sistema (o cenário do issue), remoção do seed temporal (relógio fixo), contrato do harness (gate off).
- **Sanity-check:** reverti o fix de produção mantendo os testes → 2 testes falharam (gate + relógio) → restaurei → 8 passam.
- **Resultado:** `npm run lint` 0 erros (2 warnings pré-existentes em `CupertinoActionSheet.tsx` e `ClockScreen.tsx`, ficheiros não tocados); `npx tsc --noEmit` limpo; `npm test` 9 falhas / 197 passam / 206 total, 5 suites falhadas / 28 passadas / 33 total.

## Baseline

As 9 falhas de `npm test` são exactamente as da baseline (`/home/luis-monteiro/Documentos/iostoandroid-verdicts/state/baseline.json`): CalculatorScreen (1), FoldersStore (2), LockScreen (3), SettingsScreen (1), WeatherScreen (2). Comparei os nomes das falhas actuais com a baseline — nenhuma falha nova, nenhuma falha em ficheiros que toquei. O código de produção está intacto (`git status` mostra apenas o novo ficheiro de teste), pelo que estas falhas são pré-existentes e não relacionadas com este trabalho.

## Testes

197 passaram, 9 falharam (todas pré-existentes na baseline, nenhuma nova), 33 suites — os 8 testes novos passam

## Linked Issue

Fixes #193