### PR TITLE
C5: testes que travam o tri-state do ThemeContext (system/light/dark via useColorScheme) — fix de produção já estava em main (#194)

### DIFF
--- a/src/screens/settings/__tests__/DisplayBrightnessScreen.test.tsx
+++ b/src/screens/settings/__tests__/DisplayBrightnessScreen.test.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { render } from '../../../test-utils';
+import { DisplayBrightnessScreen } from '../DisplayBrightnessScreen';
+
+const mockNavigation = { navigate: jest.fn(), goBack: jest.fn(), push: jest.fn() };
+
+describe('DisplayBrightnessScreen', () => {
+  it('offers Light / Dark / Automatic appearance options', () => {
+    const { getAllByText } = render(<DisplayBrightnessScreen navigation={mockNavigation as never} />);
+    // 'Light'/'Dark' appear both as the phone-mock labels and as the segmented
+    // control options; 'Automatic' only exists in the segmented control.
+    expect(getAllByText('Light').length).toBeGreaterThan(0);
+    expect(getAllByText('Dark').length).toBeGreaterThan(0);
+    expect(getAllByText('Automatic').length).toBeGreaterThan(0);
+  });
+});

--- a/src/theme/__tests__/ThemeContext.test.tsx
+++ b/src/theme/__tests__/ThemeContext.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Text } from 'react-native';
 import * as RN from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { render, waitFor, act } from '@testing-library/react-native';
+import { render, waitFor, act, fireEvent } from '@testing-library/react-native';
 import { ThemeProvider, useTheme } from '../ThemeContext';
 import { SettingsProvider } from '../../store/SettingsStore';
 
@@ -13,23 +13,42 @@ function ThemeProbe() {
   return <Text>{`isDark=${isDark} isReady=${isReady} mode=${mode}`}</Text>;
 }
 
+function ThemeControlProbe() {
+  const { isDark, mode, setThemeMode } = useTheme();
+  return (
+    <>
+      <Text>{`isDark=${isDark} mode=${mode}`}</Text>
+      <Text onPress={() => setThemeMode('light')}>set-light</Text>
+      <Text onPress={() => setThemeMode('dark')}>set-dark</Text>
+      <Text onPress={() => setThemeMode('system')}>set-system</Text>
+    </>
+  );
+}
+
 /**
  * Renders ThemeProvider with the settings gate off (settings are not what we are
  * testing) and the theme gate on by default. The theme gate is the behaviour
  * under test: it must hold back the first render until the saved theme has
  * hydrated, so the app never paints a wrong-theme frame on launch.
+ *
+ * The providers are passed as the `wrapper` so `rerender` keeps the same
+ * provider instances (and their state) — needed to simulate a live system-scheme
+ * change without remounting the tree.
  */
-function renderTheme(ui: React.ReactNode, themeGateFirstRender?: boolean) {
-  return render(
-    <SettingsProvider gateFirstRender={false}>
-      <ThemeProvider gateFirstRender={themeGateFirstRender}>{ui}</ThemeProvider>
-    </SettingsProvider>,
-  );
+function renderTheme(ui: React.ReactElement, themeGateFirstRender?: boolean) {
+  return render(ui, {
+    wrapper: ({ children }) => (
+      <SettingsProvider gateFirstRender={false}>
+        <ThemeProvider gateFirstRender={themeGateFirstRender}>{children}</ThemeProvider>
+      </SettingsProvider>
+    ),
+  });
 }
 
 beforeEach(() => {
   (AsyncStorage.getItem as jest.Mock).mockReset();
   (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+  (AsyncStorage.setItem as jest.Mock).mockClear();
   jest.spyOn(RN, 'useColorScheme').mockReturnValue('light');
 });
 
@@ -135,5 +154,107 @@ describe('ThemeProvider launch gate (C4: no wrong-theme flash)', () => {
     // Flush the async hydration + settings sync so no state update lands
     // outside act after the test ends.
     await act(async () => {});
+  });
+});
+
+describe('ThemeProvider tri-state mode (C5: system scheme, not clock)', () => {
+  it('live-updates isDark when the system scheme changes while mode=system', async () => {
+    // The OS scheme is not a constant: useColorScheme re-renders the provider
+    // when Appearance changes. Simulate the dispatch by mutating the mock and
+    // re-rendering the tree — isDark must follow the new scheme, not a cached
+    // value and not the clock.
+    let scheme: 'light' | 'dark' | null = 'light';
+    (RN.useColorScheme as jest.Mock).mockImplementation(() => scheme);
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+
+    const { getByText, rerender } = renderTheme(<ThemeProbe />);
+
+    await waitFor(() => expect(getByText(/isDark=false/)).toBeTruthy());
+    expect(getByText(/mode=system/)).toBeTruthy();
+
+    // The OS flips to dark while the app is open.
+    scheme = 'dark';
+    rerender(<ThemeProbe />);
+
+    await waitFor(() => expect(getByText(/isDark=true/)).toBeTruthy());
+    expect(getByText(/mode=system/)).toBeTruthy();
+  });
+
+  it('setThemeMode cycles light → dark → system and system follows the OS', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+    (RN.useColorScheme as jest.Mock).mockReturnValue('dark');
+
+    const { getByText } = renderTheme(<ThemeControlProbe />);
+
+    // No stored override → mode=system, follows the dark system scheme.
+    await waitFor(() => expect(getByText(/isDark=true mode=system/)).toBeTruthy());
+
+    // Force light — must stay light even though the system is dark.
+    fireEvent.press(getByText('set-light'));
+    await waitFor(() => expect(getByText(/isDark=false mode=light/)).toBeTruthy());
+
+    // Force dark.
+    fireEvent.press(getByText('set-dark'));
+    await waitFor(() => expect(getByText(/isDark=true mode=dark/)).toBeTruthy());
+
+    // Back to system — follows the OS again (dark).
+    fireEvent.press(getByText('set-system'));
+    await waitFor(() => expect(getByText(/isDark=true mode=system/)).toBeTruthy());
+  });
+
+  it('persists the selected mode to AsyncStorage', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+    (RN.useColorScheme as jest.Mock).mockReturnValue('light');
+
+    const { getByText } = renderTheme(<ThemeControlProbe />);
+    await waitFor(() => expect(getByText(/mode=system/)).toBeTruthy());
+
+    fireEvent.press(getByText('set-dark'));
+    await waitFor(() => expect(getByText(/mode=dark/)).toBeTruthy());
+
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(THEME_KEY, 'dark');
+  });
+
+  it('treats an unknown stored theme value as system (migration safety)', async () => {
+    // A value that is neither 'light'/'dark'/'system' (e.g. a legacy format)
+    // must not be treated as an override — the app falls back to the system.
+    (AsyncStorage.getItem as jest.Mock).mockImplementation((key: string) =>
+      key === THEME_KEY ? Promise.resolve('blue') : Promise.resolve(null),
+    );
+    (RN.useColorScheme as jest.Mock).mockReturnValue('dark');
+
+    const { getByText } = renderTheme(<ThemeProbe />);
+
+    await waitFor(() => expect(getByText(/mode=system/)).toBeTruthy());
+    expect(getByText(/isDark=true/)).toBeTruthy();
+  });
+
+  it('a saved override is not affected by a later system scheme change', async () => {
+    // Pin the clock to daytime so a time-based regression (the old C5 bug)
+    // would deterministically render light and fail this test, no matter when
+    // the suite runs.
+    jest.useFakeTimers();
+    try {
+      jest.setSystemTime(new Date(2026, 0, 1, 12, 0, 0));
+      let scheme: 'light' | 'dark' | null = 'light';
+      (RN.useColorScheme as jest.Mock).mockImplementation(() => scheme);
+      (AsyncStorage.getItem as jest.Mock).mockImplementation((key: string) =>
+        key === THEME_KEY ? Promise.resolve('dark') : Promise.resolve(null),
+      );
+
+      const { getByText, rerender } = renderTheme(<ThemeProbe />);
+
+      await waitFor(() => expect(getByText(/isDark=true/)).toBeTruthy());
+      expect(getByText(/mode=dark/)).toBeTruthy();
+
+      // The OS flips to light, but the saved dark override must hold.
+      scheme = 'light';
+      rerender(<ThemeProbe />);
+
+      await waitFor(() => expect(getByText(/isDark=true/)).toBeTruthy());
+      expect(getByText(/mode=dark/)).toBeTruthy();
+    } finally {
+      jest.useRealTimers();
+    }
   });
 });


### PR DESCRIPTION
## Resumo

C5: testes que travam o tri-state do ThemeContext (system/light/dark via useColorScheme) — fix de produção já estava em main

## Causa raiz

O issue descreve `src/theme/ThemeContext.tsx:126-135` com um `useEffect` time-based (`setInterval` 60s, janela 19:00–07:00, `hasUserOverride`). **O código actual não tem isso** — o fix de produção já estava em `main` no commit `77d58ad` (PR #237, o mesmo que resolveu C1/C4):

- `ThemeMode` tri-state (`'system' | 'light' | 'dark'`) substituiu `hasUserOverride`.
- `isDark = mode === 'system' ? systemScheme === 'dark' : mode === 'dark'` (`ThemeContext.tsx:97-98`) — segue `useColorScheme()` quando `mode='system'`.
- O `setInterval` de 60s foi removido; `setThemeMode()` foi exposto no contexto.
- Migração: `'light'/'dark'` armazenados → override; ausente/desconhecido → `'system'` (`ThemeContext.tsx:107-112`).
- UI follow-up já em `main`: `SettingsScreen.tsx:240-244` e `DisplayBrightnessScreen.tsx:120-124` têm o segmented control Light/Dark/Automatic.

O C4 (issue 193) já tinha sido tratado no commit `4297f99` (teste do gate de hidratação + remoção do seed temporal, 8 testes). O que faltava para o C5 eram os testes que travam o comportamento — sobretudo o **live-update** quando o system scheme muda (critério 2 do issue), que nenhum teste cobria.

## O que mudou

Só ficheiros de teste — nenhuma alteração de produção.

- **`src/theme/__tests__/ThemeContext.test.tsx`** — bloco novo `ThemeProvider tri-state mode (C5: system scheme, not clock)`, 5 testes:
  1. `live-updates isDark when the system scheme changes while mode=system` — mock mutável de `useColorScheme` + `rerender`; simula o dispatch do Appearance com a app aberta.
  2. `setThemeMode cycles light → dark → system and system follows the OS` — força light com sistema dark, força dark, volta a system (Automatic segue o OS).
  3. `persists the selected mode to AsyncStorage` — `setItem(THEME_KEY, 'dark')` após seleccionar dark.
  4. `treats an unknown stored theme value as system (migration safety)` — valor `'blue'` armazenado não vira override.
  5. `a saved override is not affected by a later system scheme change` — override dark mantém-se quando o sistema muda para light; relógio fixo em 12:00 para o teste ser determinístico contra uma regressão time-based.
  - Infra no ficheiro: `renderTheme` passou a usar a opção `wrapper` do `render` (o `rerender` substituía a árvore inteira e perdia os providers — necessário para simular o live-update sem remontar a árvore); `mockClear` no `AsyncStorage.setItem`; import de `fireEvent`; novo `ThemeControlProbe`.
- **`src/screens/settings/__tests__/DisplayBrightnessScreen.test.tsx`** — novo, 1 teste: o ecrã oferece as opções Light / Dark / Automatic (critério 5 do issue).

## Porque assim

O fix de produção já estava em `main`; a lacuna era cobertura de teste. O teste de live-update usa um mock mutável de `useColorScheme` + `rerender` com os providers como `wrapper` — testa a responsabilidade da app (derivar `isDark` de `useColorScheme` em cada render), não o mecanismo interno do RN (Appearance → re-render), que é responsabilidade da framework. O teste 5 fixa o relógio em horário diurno para que uma regressão time-based falhe deterministicamente a qualquer hora do dia (a suite corre às 02:18, dentro da janela escura — sem o relógio fixo, o teste passaria por coincidência).

A migration key one-shot `@iostoandroid/theme_migrated_v2` (opcional no issue) não foi adicionada: a migração é idempotente — o código interpreta o valor armazenado (`'light'/'dark'/'system'`) sem o transformar, por isso não há migração a correr uma única vez.

Call sites verificados: `LauncherSettingsScreen.tsx:234` usa `toggleTheme()` para o switch Dark Mode — com o tri-state alterna entre light/dark (nunca volta a `'system'`), consistente com o Control Center do iOS. `setDark` não tem call sites (mantido para back-compat).

## Critérios de aceitação

- [x] **Sem override armazenado e sistema Android em dark, a app renderiza dark** — teste C4 existente `defers to the system scheme when no preference is saved` + teste C5 2 (`isDark=true mode=system` com `useColorScheme='dark'`).
- [x] **Mudar o system scheme com a app aberta actualiza o tema em tempo real** — teste C5 1: mock de `useColorScheme` muda de light para dark e `isDark` segue, com `mode=system`.
- [x] **Utilizadores com override `light`/`dark` guardado continuam a ver esse modo após upgrade** — testes C4 `hydrates a saved dark/light override` + teste C5 5 (override mantém-se mesmo com o sistema a mudar).
- [x] **`setInterval` time-based removido** — verificado no código (`ThemeContext.tsx` não tem `setInterval`/`setTimeout` de tema) + teste C4 `does not seed isDark from the clock before hydration`.
- [x] **Settings oferece Light / Dark / Automatic; Automatic liga ao sistema** — UI em `SettingsScreen.tsx:240-244` e `DisplayBrightnessScreen.tsx:120-124`; teste novo do `DisplayBrightnessScreen` confirma as opções; testes C5 2 confirmam que `system` segue o OS.
- [x] **Teste: `useColorScheme='dark'` com `mode='system'` → `isDark===true`** — teste C4 `defers to the system scheme` + teste C5 2.
- [x] **O que NÃO devia mudar**: nenhum ficheiro de produção foi tocado; o comportamento de override para utilizadores existentes mantém-se (testes C4 + C5 5); a suite não ganhou falhas novas (comparação com `baseline.json` idêntica).

## Testes

- **Passo vermelho:** como o fix de produção já estava em `main`, o vermelho foi obtido por reversão temporária da produção para o comportamento antigo (isDark time-based, valores desconhecidos tratados como override, persistência removida). Com essa regressão, os 5 testes C5 falharam: `live-updates isDark...`, `setThemeMode cycles...`, `persists the selected mode...`, `treats an unknown stored theme value...`, `a saved override is not affected...`. Restaurei a produção e os 13 testes do ThemeContext passam.
- **Casos cobertos:** live-update do system scheme (assíncrono/dispatch), ciclo tri-state completo, persistência, valor armazenado desconhecido (migração), override vs mudança de sistema (inverso do fix), e relógio fixo para determinismo. O teste 5 cobre o inverso do fix: o que devia continuar escondido (override a ser ignorado) falha quando a regressão o reintroduz.
- **Sanity-check:** reverti o fix de produção (mantendo os testes) → 5 testes C5 falharam → restaurei → 13/13 passam.
- `npm run lint`: 0 erros (2 warnings pré-existentes em `CupertinoActionSheet.tsx` e `ClockScreen.tsx`, não tocados).
- `npx tsc --noEmit`: limpo.
- `npm test`: 9 falhas (baseline idêntico — FoldersStore, CalculatorScreen, SettingsScreen, LockScreen, WeatherScreen), 203 passaram, 212 total, 34 suites. Zero falhas novas; os 6 testes novos passam.

## Testes

203 passaram, 9 falharam (baseline pré-existente idêntico), 212 total, 34 suites

## Linked Issue

Fixes #194