### PR TITLE
fix/201: H7: LauncherHomeScreen — auditoria ao setInterval confirma cleanup correto; testes de regressão adicionados (#201)

### DIFF
--- a/src/screens/__tests__/LauncherHomeScreen.test.tsx
+++ b/src/screens/__tests__/LauncherHomeScreen.test.tsx
@@ -19,3 +19,72 @@ describe('LauncherHomeScreen', () => {
     expect(toJSON()).toBeTruthy();
   });
 });
+
+// H7: the screen ticks a 60s clock (`setInterval(() => setNow(...), 60_000)`)
+// in its own effect. It's mounted as the navigator root so it rarely unmounts
+// in production, but lock/unlock cycles and hot reload can remount it — a
+// dropped `clearInterval` would leak one timer handle per mount and, if the
+// stale interval ever fired, call `setState` on a detached component.
+//
+// These spy on the real global setInterval/clearInterval and filter by the
+// screen's 60_000ms delay, rather than asserting a raw Jest timer count,
+// because other providers in the test tree (DeviceStore's 30s poll,
+// SettingsStore's 500ms sync fallback) register their own timers on the same
+// tree — a global count would conflate their cleanup with this screen's.
+describe('LauncherHomeScreen clock interval cleanup (H7)', () => {
+  const CLOCK_DELAY_MS = 60_000;
+
+  function clockIntervalCalls(setIntervalSpy: jest.SpyInstance) {
+    return setIntervalSpy.mock.calls
+      .map((args, i) => ({ delay: args[1], id: setIntervalSpy.mock.results[i].value }))
+      .filter((call) => call.delay === CLOCK_DELAY_MS);
+  }
+
+  // Fake timers: a leaked `setInterval` must not become a real pending OS
+  // timer that keeps the Jest process alive after the file finishes.
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('clears the clock interval on unmount', () => {
+    const setIntervalSpy = jest.spyOn(global, 'setInterval');
+    const clearIntervalSpy = jest.spyOn(global, 'clearInterval');
+
+    const { unmount } = render(<LauncherHomeScreen />);
+
+    const calls = clockIntervalCalls(setIntervalSpy);
+    expect(calls).toHaveLength(1);
+
+    unmount();
+
+    expect(clearIntervalSpy).toHaveBeenCalledWith(calls[0].id);
+
+    setIntervalSpy.mockRestore();
+    clearIntervalSpy.mockRestore();
+  });
+
+  it('does not leak the clock interval across rapid mount/unmount cycles', () => {
+    const setIntervalSpy = jest.spyOn(global, 'setInterval');
+    const clearIntervalSpy = jest.spyOn(global, 'clearInterval');
+
+    for (let i = 0; i < 20; i++) {
+      const { unmount } = render(<LauncherHomeScreen />);
+      unmount();
+    }
+
+    const calls = clockIntervalCalls(setIntervalSpy);
+    expect(calls).toHaveLength(20);
+
+    const clearedIds = new Set(clearIntervalSpy.mock.calls.map(([id]) => id));
+    for (const { id } of calls) {
+      expect(clearedIds.has(id)).toBe(true);
+    }
+
+    setIntervalSpy.mockRestore();
+    clearIntervalSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Resumo

fix/201: H7: LauncherHomeScreen — auditoria ao setInterval confirma cleanup correto; testes de regressão adicionados

## Causa raiz

O issue levanta uma hipótese ("Possible (needs confirmation)") de fuga de `setInterval` no `LauncherHomeScreen.tsx`. Fiz o levantamento pedido pelo próprio issue (grep a `setInterval`, `setTimeout`, `addEventListener`, `DeviceEventEmitter`, e todos os `useEffect`) e o resultado **não confirma a hipótese**: o ficheiro tem exactamente um timer, em `src/screens/LauncherHomeScreen.tsx:665-668`:

```tsx
useEffect(() => {
  const id = setInterval(() => setNow(new Date()), 60_000);
  return () => clearInterval(id);
}, []);
```

Já tem `clearInterval` no cleanup, dependências `[]` (corre uma vez), e não há `setTimeout`, `addEventListener` nem `DeviceEventEmitter.addListener` no ficheiro inteiro. `git log -S'setInterval' -- src/screens/LauncherHomeScreen.tsx` mostra que este código nunca foi alterado desde o commit que introduziu o ecrã (`e461410`, `feat: convert to Android launcher`) — o cleanup esteve sempre lá, não é uma regressão recente nem uma fuga latente.

Os restantes `useEffect` do ficheiro (linhas 169, 534, 581, 639, 654, 709, 736) foram todos auditados: os que fazem trabalho assíncrono ou não chamam `setState` (639: permission check; 654: NavigationBar/StatusBar) ou já têm guarda `mounted` (709: leitura do wallpaper custom do AsyncStorage) ou só escrevem em `useSharedValue` do Reanimated, que não é estado React e sobrevive ao unmount sem aviso (581, 736). Nenhum tem risco de "setState after unmount".

Também confirmei empiricamente (probe descartável, não commitado) que o React 19 usado neste projeto **já não emite o aviso** "Can't perform a React state update on an unmounted component" — foi removido no React 18+. Por isso um teste que dependesse desse `console.error` para provar a fuga seria decorativo (nunca falharia, mesmo com o bug real). Os testes que escrevi verificam o par `setInterval`/`clearInterval` directamente.

**Onde o issue estava errado:** descreve o cenário como "possible, needs confirmation" e pede para adicionar guarda `mounted` e considerar `useFocusEffect` para pausar o tick fora de foco. A guarda `mounted` é redundante aqui — como o `clearInterval` corre sincronamente no cleanup do React, e JS é single-threaded, não há como o callback do interval disparar depois do cleanup ter corrido (ao contrário de uma Promise em voo, aqui não há gap assíncrono a proteger). E o próprio issue já reconhece que "clock/date might stay" a correr fora de foco — não implementei `useFocusEffect` porque não há defeito de bateria a corrigir (é o único timer do ecrã, 1x por minuto, e o ecrã é a raiz do navigator) e adicioná-lo seria scope creep sobre um comportamento que o issue já aceita como correcto.

## O que mudou

- `src/screens/__tests__/LauncherHomeScreen.test.tsx`: acrescentei o describe `LauncherHomeScreen clock interval cleanup (H7)` com 2 testes novos. Nenhum ficheiro de produção foi alterado — o comportamento já estava correto.

## Porque assim

O issue pedia trabalho de auditoria ("needs confirmation") mais o item 5 explícito: "add a test that mounts/unmounts in a tight loop and asserts no open handles remain". Como a auditoria não encontrou defeito, a acção correta é documentar a investigação e fixar o comportamento correto num teste de regressão — não alterar código que já está certo. Considerei também usar `jest.getTimerCount()` global, mas descartei: os outros providers montados pelo `test-utils.tsx` (`DeviceStore` tem o seu próprio `setInterval` de 30s, `SettingsStore` tem um `setTimeout` de 500ms) também registam timers na mesma árvore, e ambos já têm cleanup correto (confirmei lendo o código) — uma contagem global misturaria a cobertura desses ficheiros com a deste. Por isso os testes usam `jest.spyOn(global, 'setInterval'/'clearInterval')` filtrado pelo delay de 60_000ms, isolando especificamente o timer do `LauncherHomeScreen`.

## Critérios de aceitação

- [x] Todos os intervals/timeouts/listeners têm cleanup — confirmado por auditoria linha a linha; o único timer (`setInterval` de 665-668) já tinha `clearInterval`.
- [x] Mount/unmount rápido não gera avisos de estado em componente desmontado — confirmado com um loop de 20 ciclos de mount/unmount (teste novo); adicionalmente verifiquei empiricamente que este aviso específico não existe no React 19 deste projeto, por isso a prova real é a simetria `setInterval`/`clearInterval`, não o `console.error`.
- [x] `useFocusEffect` para timers que não devem correr fora de foco — não aplicável: é o único timer do ecrã, é o relógio, e o próprio issue aceita que "clock/date might stay" a correr. Não implementado, para não introduzir mudança de comportamento não pedida.
- [x] `Jest --detectOpenHandles` passa para o teste novo — corrido explicitamente (`npx jest src/screens/__tests__/LauncherHomeScreen.test.tsx --detectOpenHandles`), sem avisos de handles abertos.
- [x] Nada fora de `LauncherHomeScreen.tsx`/o seu teste foi tocado — confirmado, `git diff --stat` mostra só o ficheiro de teste.

## Testes

- **Passo vermelho:** antes de reverter, confirmei que os 2 testes novos passam contra o código actual (correto). Para provar que os testes de facto detectam a fuga descrita no issue, parti temporariamente o `useEffect` de produção (removi o `return () => clearInterval(id)`), corri a suite, e obtive falha real nos dois testes novos:
  - `clears the clock interval on unmount`: `expect(clearIntervalSpy).toHaveBeenCalledWith(calls[0].id)` — "Number of calls: 1" mas com o objecto de retorno errado (o clearInterval nunca foi chamado com o id do timer do relógio).
  - `does not leak the clock interval across rapid mount/unmount cycles`: `expect(clearedIds.has(id)).toBe(true)` → `Received: false`.
  - Jest avisou mesmo: `Force exiting Jest: Have you considered using --detectOpenHandles...` — a fuga real prova-se sozinha.
  Depois restaurei o `clearInterval(id)` (ficheiro de produção fica bit-a-bit igual ao original, `git diff` confirma zero alterações em `LauncherHomeScreen.tsx`) e os 5 testes do ficheiro voltam a passar, incluindo `--detectOpenHandles`.
- **Casos cobertos:** unmount único (confirma o par set/clear); 20 ciclos de mount/unmount consecutivos (cobre "nested intervals left alive after fast re-mount", o segundo cenário levantado pelo issue) — verifica que nenhum dos 20 ids de interval fica por limpar.
- **Sanity-check:** ver "Passo vermelho" acima — reverti o fix (não havia fix de produção; parti o cleanup deliberadamente), a suite falhou pela razão certa, restaurei, e confirmei que `git diff` no ficheiro de produção está vazio.
- `npm run lint`: 0 erros (2 warnings pré-existentes em `CupertinoActionSheet.tsx` e `ClockScreen.tsx`, ficheiros não tocados — mesmos da baseline).
- `npx tsc --noEmit`: limpo, sem output.
- `npm test`: 248 testes totais em 37 suites — 239 passaram, 9 falharam. As 9 falhas são exactamente as da baseline (`CalculatorScreen`, `FoldersStore` x2, `LockScreen` x3, `SettingsScreen`, `WeatherScreen` x2 — todas pré-existentes por causa do `firstSyncDone`/AsyncStorage síncrono descrito na linha de base, nada relacionado com este ficheiro). Nenhuma falha nova. Todos os 5 testes de `LauncherHomeScreen.test.tsx` (3 antigos + 2 novos) passam.

## Testes

248 testes totais, 37 suites: 239 passaram, 9 falharam (as mesmas 9 falhas pré-existentes da baseline: CalculatorScreen, FoldersStore x2, LockScreen x3, SettingsScreen, WeatherScreen x2 — nenhuma falha nova). LauncherHomeScreen.test.tsx: 5/5 passaram, incluindo --detectOpenHandles limpo.

## Linked Issue

Fixes #201