### PR TITLE
CalendarScreen: fix central do issue já estava em main (safe setters); corrigi 2 defeitos remanescentes (hora 24 no picker ao cruzar meia-noite + normalização de eventos legados end<=start no modo edi (#202)

### DIFF
--- a/src/screens/CalendarScreen.tsx
+++ b/src/screens/CalendarScreen.tsx
@@ -117,6 +117,13 @@ export function CalendarScreen({ navigation }: { navigation: AppNavigationProp }
     const endDate = new Date(evt.end);
     setEndHour(endDate.getHours());
     setEndMinute(endDate.getMinutes());
+    // Legacy/invalid stored events may carry end <= start. Normalize the end
+    // shown in the picker to start + 1h so the value persisted on Save matches
+    // what the user sees — the same correction the save-time guard applies.
+    if (!evt.allDay && endDate.getTime() <= startDate.getTime()) {
+      setEndHour(startDate.getHours() + 1);
+      setEndMinute(startDate.getMinutes());
+    }
     setShowAddEvent(true);
   }, []);
 
@@ -499,7 +506,7 @@ export function CalendarScreen({ navigation }: { navigation: AppNavigationProp }
                   <View style={styles.timePicker}>
                     <Pressable onPress={() => setSafeEndHour((endHour + 1) % 24)} style={styles.timeBtn}>
                       <Text style={[typography.headline, { color: colors.systemRed }]}>
-                        {String(endHour).padStart(2, '0')}
+                        {String(endHour % 24).padStart(2, '0')}
                       </Text>
                     </Pressable>
                     <Text style={[typography.headline, { color: colors.label }]}>:</Text>

--- a/src/screens/__tests__/CalendarScreen.test.tsx
+++ b/src/screens/__tests__/CalendarScreen.test.tsx
@@ -1,0 +1,216 @@
+import React from 'react';
+import { render, fireEvent, screen } from '../../test-utils';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { CalendarScreen } from '../CalendarScreen';
+import type { AppNavigationProp } from '../../navigation/types';
+
+const mockNavigation = { navigate: jest.fn(), goBack: jest.fn(), push: jest.fn() } as unknown as AppNavigationProp;
+
+// ---------------------------------------------------------------------------
+// Helpers: the modal's time pickers are increment-only Pressables that show
+// the current hour/minute as their label text. We drive them by climbing from
+// the "Starts"/"Ends" label up to the time-row container and pressing the
+// hour/minute button nodes directly.
+// ---------------------------------------------------------------------------
+
+// Minimal structural view of the react-test-renderer tree RNTL exposes.
+interface TestNode {
+  children: (TestNode | string)[];
+  parent: TestNode | null;
+  props: Record<string, unknown>;
+}
+
+function asNode(n: unknown): TestNode {
+  return n as TestNode;
+}
+
+function getTimePicker(label: string): TestNode {
+  let node = asNode(screen.getByText(label));
+  while (node.parent) {
+    node = node.parent;
+    if (node.children && node.children.length >= 2) break;
+  }
+  return asNode(node.children[1]);
+}
+
+function deepestText(node: TestNode): string {
+  if (node.children && node.children.length) {
+    const first = node.children[0];
+    if (typeof first === 'string') return first;
+    return deepestText(first);
+  }
+  return '';
+}
+
+// Open the add/edit modal via the "+" button in the navigation bar.
+function openAddModal() {
+  let node = asNode(screen.getAllByText('Today')[0]);
+  while (node.parent) {
+    node = node.parent;
+    const style = node.props.style;
+    const flat = Array.isArray(style) ? style[0] : style;
+    const flex = flat && typeof flat === 'object' ? (flat as { flexDirection?: string }).flexDirection : undefined;
+    if (flex === 'row') break;
+  }
+  fireEvent.press(asNode(node.children[1]));
+}
+
+function pressTime(label: string, hourTaps: number, minuteTaps: number) {
+  const picker = getTimePicker(label);
+  const inner = asNode(picker.children[0]);
+  const hourBtn = asNode(inner.children[0]);
+  const minBtn = asNode(inner.children[2]);
+  for (let i = 0; i < hourTaps; i++) fireEvent.press(hourBtn);
+  for (let i = 0; i < minuteTaps; i++) fireEvent.press(minBtn);
+}
+
+function readTime(label: string) {
+  const picker = getTimePicker(label);
+  const inner = asNode(picker.children[0]);
+  return `${deepestText(asNode(inner.children[0]))}:${deepestText(asNode(inner.children[2]))}`;
+}
+
+interface StoredEvent {
+  id: string;
+  start: number;
+  end: number;
+}
+
+function lastStoredEvents(): StoredEvent[] {
+  const calls = (AsyncStorage.setItem as jest.Mock).mock.calls;
+  const payload = calls[calls.length - 1][1];
+  return JSON.parse(payload) as StoredEvent[];
+}
+
+beforeEach(() => {
+  (AsyncStorage.setItem as jest.Mock).mockClear();
+});
+
+describe('CalendarScreen — end-time auto-correction (issue 202)', () => {
+  it('keeps the default add-modal times unchanged (09:00 → 10:00)', async () => {
+    render(<CalendarScreen navigation={mockNavigation} />);
+    await screen.findByText('No events scheduled');
+    openAddModal();
+    expect(readTime('Starts')).toBe('09:00');
+    expect(readTime('Ends')).toBe('10:00');
+  });
+
+  it('auto-bumps the end time shown in the picker when start moves past end (issue scenario)', async () => {
+    render(<CalendarScreen navigation={mockNavigation} />);
+    await screen.findByText('No events scheduled');
+    openAddModal();
+
+    // Set end to 17:15 while start is 09:00 (a valid duration).
+    pressTime('Ends', 7, 1);
+    expect(readTime('Starts')).toBe('09:00');
+    expect(readTime('Ends')).toBe('17:15');
+
+    // Move start to 17:30. The end must be bumped forward in the picker —
+    // it must NOT keep showing 17:15 while a later value would be persisted.
+    pressTime('Starts', 8, 2);
+    expect(readTime('Starts')).toBe('17:30');
+    expect(readTime('Ends')).toBe('18:15');
+  });
+
+  it('persists exactly the end time shown when Save is tapped', async () => {
+    render(<CalendarScreen navigation={mockNavigation} />);
+    await screen.findByText('No events scheduled');
+    openAddModal();
+
+    pressTime('Ends', 7, 1);
+    pressTime('Starts', 8, 2);
+    expect(readTime('Starts')).toBe('17:30');
+    expect(readTime('Ends')).toBe('18:15');
+
+    fireEvent.changeText(screen.getByPlaceholderText('Event Title'), 'Meeting');
+    fireEvent.press(screen.getByText('Add'));
+
+    expect(AsyncStorage.setItem).toHaveBeenCalled();
+    const stored = lastStoredEvents();
+    expect(stored).toHaveLength(1);
+    expect(new Date(stored[0].start).getHours()).toBe(17);
+    expect(new Date(stored[0].start).getMinutes()).toBe(30);
+    expect(new Date(stored[0].end).getHours()).toBe(18);
+    expect(new Date(stored[0].end).getMinutes()).toBe(15);
+  });
+
+  it('pushes the end forward when start is moved past it', async () => {
+    render(<CalendarScreen navigation={mockNavigation} />);
+    await screen.findByText('No events scheduled');
+    openAddModal();
+
+    // start 09:45, end 10:00 (still valid)
+    pressTime('Starts', 0, 3);
+    expect(readTime('Starts')).toBe('09:45');
+    expect(readTime('Ends')).toBe('10:00');
+
+    // start hour 09 → 10 would overtake end 10:00 → both jump by one hour
+    pressTime('Starts', 1, 0);
+    expect(readTime('Starts')).toBe('10:45');
+    expect(readTime('Ends')).toBe('11:45');
+  });
+
+  it('never shows an hour of 24 in the picker when auto-correction crosses midnight', async () => {
+    render(<CalendarScreen navigation={mockNavigation} />);
+    await screen.findByText('No events scheduled');
+    openAddModal();
+
+    // 09:00 → 23:45; the end is bumped past midnight by the correction.
+    pressTime('Starts', 14, 3);
+    expect(readTime('Starts')).toBe('23:45');
+    expect(readTime('Ends')).toBe('00:00');
+
+    // The event persists with the end on the NEXT day, matching the display.
+    fireEvent.changeText(screen.getByPlaceholderText('Event Title'), 'Late');
+    fireEvent.press(screen.getByText('Add'));
+    const stored = lastStoredEvents();
+    expect(new Date(stored[0].start).getHours()).toBe(23);
+    expect(new Date(stored[0].start).getMinutes()).toBe(45);
+    expect(new Date(stored[0].end).getHours()).toBe(0);
+    expect(new Date(stored[0].end).getMinutes()).toBe(0);
+  });
+
+  it('normalizes a legacy stored event with end <= start in the edit picker', async () => {
+    const base = new Date();
+    base.setHours(0, 0, 0, 0);
+    const start = new Date(base);
+    start.setHours(17, 30, 0, 0);
+    const end = new Date(base);
+    end.setHours(17, 15, 0, 0); // invalid: end before start
+
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(
+      JSON.stringify([
+        { id: 'user_legacy1', title: 'Legacy', start: start.getTime(), end: end.getTime(), allDay: false, location: '', notes: '', repeat: 'never' },
+      ])
+    );
+
+    render(<CalendarScreen navigation={mockNavigation} />);
+    await screen.findByText('Legacy');
+
+    fireEvent.press(screen.getByLabelText('Edit event Legacy'));
+
+    // The picker shows the corrected end (17:30 → 18:30), not the raw 17:15.
+    expect(readTime('Starts')).toBe('17:30');
+    expect(readTime('Ends')).toBe('18:30');
+
+    // Saving persists exactly what the picker showed.
+    fireEvent.press(screen.getByText('Save'));
+    const stored = lastStoredEvents();
+    expect(stored).toHaveLength(1);
+    expect(new Date(stored[0].end).getHours()).toBe(18);
+    expect(new Date(stored[0].end).getMinutes()).toBe(30);
+  });
+
+  it('hides the time pickers for all-day events (no correction applies)', async () => {
+    render(<CalendarScreen navigation={mockNavigation} />);
+    await screen.findByText('No events scheduled');
+    openAddModal();
+
+    expect(screen.getByText('Starts')).toBeTruthy();
+    expect(screen.getByText('Ends')).toBeTruthy();
+
+    fireEvent.press(screen.getByText('All Day'));
+    expect(screen.queryByText('Starts')).toBeNull();
+    expect(screen.queryByText('Ends')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Resumo

CalendarScreen: fix central do issue já estava em main (safe setters); corrigi 2 defeitos remanescentes (hora 24 no picker ao cruzar meia-noite + normalização de eventos legados end<=start no modo edi

## Causa raiz

O defeito central descrito no issue — o modal mostra `endHour`/`endMinute` crus e a persistência corrige para `start + 1h`, criando desfasamento entre o mostrado e o guardado — **já estava corrigido em `main`** no commit `77d58ad` (PR #237, o mesmo do issue 190). Os "safe time setters" (`setSafeStartHour`/`setSafeStartMinute`/`setSafeEndHour`/`setSafeEndMinute`, `src/screens/CalendarScreen.tsx:142-186`) aplicam a correção (B) recomendada pelo issue no próprio callback do picker: quando o end ficaria ≤ start, o estado do picker é empurrado para `start + 1h`, e os botões do modal passaram a usar estes setters (`:484-510`). O issue foi escrito contra um snapshot anterior a esse commit.

Verifiquei empiricamente que o cenário central já não é reproduzível: com end em 17:15 e start levado a 17:30, o picker mostra **18:15** (corrigido) e o evento persiste 18:15. Nota sobre o exemplo do issue ("18:30"): o valor real é 18:15 porque o bump ocorre no instante em que o start cruza o end (17:15 + 1h) e depois o start move-se para 17:30; o estado end=17:15 com start=17:30 não é alcançável pela UI de incrementos. O princípio (end mostrado == end persistido, sempre > start) cumpre-se.

Encontrei, porém, **dois defeitos reais remanescentes na mesma lógica**:

1. **Hora "24" no picker ao cruzar a meia-noite.** Quando o bump produz `endHour = startHour + 1 = 24` (start nas 23:xx), o picker renderizava `String(endHour).padStart(2, '0')` = **"24:30"** — hora inexistente num relógio 0-23. O evento persistia correctamente (`end.setHours(24, ...)` = dia seguinte 00:30), mas o modal re-aberto mostra "00:30": o mostrado e o re-renderizado divergiam.
2. **Evento legado com end ≤ start em modo edição.** `openEditModal` (`:106-121`) copia os timestamps crus para o estado do picker. Um evento armazenado inválido (end ≤ start — dados legados/corrompidos) abria com o picker a mostrar 17:30 → 17:15 e o Save persistia 18:30 — exactamente o defeito do issue, ainda alcançável por esse caminho.

## O que mudou

`src/screens/CalendarScreen.tsx`:
- **Display do picker de fim** (`:509`): `String(endHour).padStart(2, '0')` → `String(endHour % 24).padStart(2, '0')`. O picker nunca mostra a hora 24; a convenção interna `endHour = 24` (= dia seguinte) mantém-se e a persistência (`setHours(24, ...)`) fica intacta.
- **`openEditModal`** (`:117-123`): após copiar os timestamps do evento, se `!evt.allDay && endDate <= startDate`, o estado do end é normalizado para `start + 1h` (mesma correção que a guarda de save em `:199-202` aplicaria). O picker mostra o valor corrigido e o Save persiste exactamente o que é mostrado.

`src/screens/__tests__/CalendarScreen.test.tsx` (novo, 7 testes) — não existia nenhum teste de CalendarScreen. Helpers conduzem os botões de incremento do picker (sobem da label "Starts"/"Ends" até à row e pressionam os nós de hora/minuto).

## Porque assim

- **Opção (B) do issue** (auto-corrigir o picker) já estava implementada; mantive-a em vez de migrar para (A) (bloquear o Save), que exigiria estado de erro novo e contraria o comportamento do iOS Calendar que o próprio issue recomenda.
- **Display `% 24` em vez de normalizar o estado 24→0**: normalizar o estado `endHour` de 24 para 0 rebenta a persistência quando o start também cruza a meia-noite (a guarda corrigiria para `start+1h` no MESMO dia, desfasando mostrado de persistido). A normalização só do display preserva a semântica de dia-seguinte do `setHours(24, ...)` e elimina o único sintoma observável (a hora "24").
- **Correção no `openEditModal`** em vez de na guarda de save: a guarda corrige um `Date` local e não consegue actualizar o estado do picker antes de persistir; corrigir o estado na abertura do modal mantém a invariante "mostrado == persistido" para qualquer fluxo.
- A guarda belt-and-braces em `handleAddEvent` (`:199-202`) foi **mantida** (o issue permite "or keep it as a belt-and-braces guard") — é inalcançável pela UI actual, mas protege dados corrompidos.

## Critérios de aceitação

- [x] **End ≤ start nunca fica mostrado no picker** — os safe setters + a normalização do `openEditModal` garantem que o end mostrado é sempre > start. Testado: cenário do issue (17:30 → 18:15) e legado inválido (17:30 → 18:30).
- [x] **O valor persistido no Save é exactamente o valor mostrado** — o teste `persists exactly the end time shown when Save is tapped` lê o JSON escrito no AsyncStorage e compara hora/minuto com o picker (17:30 → 18:15 em ambos).
- [x] **O picker nunca mostra hora fora de 0-23** — teste de meia-noite: start 23:45 → end mostra "00:00" (antes do fix: "24:00") e persiste no dia seguinte (`getHours() === 0`).
- [x] **O que NÃO mudou:** defaults do modal (09:00 → 10:00) intactos (teste); all-day esconde os pickers sem correção (teste); a guarda de save mantém-se; nenhum outro ecrã/ficheiro tocado (diff limitado a `CalendarScreen.tsx` + o ficheiro de teste novo).

## Testes

- **Passo vermelho:** antes do fix de produção — `Expected: "00:00", Received: "24:00"` (meia-noite) e `Expected: "18:30", Received: "17:15"` (legado inválido).
- **Casos cobertos:** default; cenário do issue; persistência == display; start a ultrapassar end (fronteira de inversão); meia-noite/wrap (fronteira 23:xx → 24); legado inválido (dados corrompidos); all-day (o inverso do fix — pickers escondidos quando a correção não aplica).
- **Sanity-check:** (1) `git stash` do fix → 2 testes falham; `git stash pop` → 7/7. (2) `CalendarScreen.tsx` revertido ao pré-`77d58ad` (sem safe setters) → **5 testes falham**, incluindo o cenário central do issue — prova que os testes prendem a correção pré-existente, não só os meus 2 fixes; restaurado → 7/7.
- `npm run lint`: 0 erros (2 warnings pré-existentes em ficheiros não tocados — CupertinoActionSheet, ClockScreen). `npx tsc --noEmit`: limpo. `npm test`: **9 falhas = exactamente o baseline** (SettingsStore `firstSyncDone`; mesmas 9 em 5 suites), 254 passam, 263 total; os 7 testes novos passam, zero falhas novas.

## Testes

254 passaram, 9 falharam (baseline exacto), 263 total; suite CalendarScreen: 7/7

## Linked Issue

Fixes #202