### PR TITLE
M2: RemindersScreen — exporta scheduleReminderNotification e substitui o teste weekday falso (cópia local da fórmula) por um que exercita o caminho real via mock do scheduleNotificationAsync (#203)

### DIFF
--- a/src/screens/RemindersScreen.tsx
+++ b/src/screens/RemindersScreen.tsx
@@ -86,7 +86,7 @@ async function requestNotificationPermissions(): Promise<boolean> {
   }
 }
 
-async function scheduleReminderNotification(reminder: Reminder): Promise<string | undefined> {
+export async function scheduleReminderNotification(reminder: Reminder): Promise<string | undefined> {
   if (!reminder.dueDate) return undefined;
   const dueDate = new Date(reminder.dueDate);
   try {

--- a/src/screens/__tests__/RemindersScreen.weekday.test.ts
+++ b/src/screens/__tests__/RemindersScreen.weekday.test.ts
@@ -1,16 +1,65 @@
 // Unit test for the weekday mapping used when scheduling weekly reminders.
-// Expo WeeklyTriggerInput.weekday: 1 = Sunday ... 7 = Saturday.
+// Expo WeeklyTriggerInput.weekday is 1..7 with 1 = Sunday.
+// Date.getDay() is 0..6 with 0 = Sunday. Hence +1.
+//
+// This exercises the REAL scheduling path (scheduleReminderNotification) and
+// asserts on the trigger actually passed to scheduleNotificationAsync — it does
+// not re-implement the mapping in the test file.
 
-describe('RemindersScreen weekday mapping', () => {
-  const toExpoWeekday = (d: Date) => d.getDay() + 1;
+import * as Notifications from 'expo-notifications';
+import { scheduleReminderNotification } from '../RemindersScreen';
 
-  it('maps Sunday → 1', () => {
-    expect(toExpoWeekday(new Date('2024-01-07T12:00:00Z'))).toBe(1);
+jest.mock('expo-notifications', () => ({
+  getPermissionsAsync: jest.fn(() => Promise.resolve({ status: 'granted' })),
+  requestPermissionsAsync: jest.fn(() => Promise.resolve({ status: 'granted' })),
+  scheduleNotificationAsync: jest.fn(() => Promise.resolve('notification-id')),
+  cancelScheduledNotificationAsync: jest.fn(() => Promise.resolve()),
+  SchedulableTriggerInputTypes: { CALENDAR: 'calendar', DATE: 'date' },
+}));
+
+// Structural match of the screen's internal Reminder type — just the fields
+// scheduleReminderNotification reads.
+function weeklyReminder(dueDate: Date) {
+  return {
+    id: 'test-reminder',
+    title: 'Test reminder',
+    notes: '',
+    completed: false,
+    flagged: false,
+    dueDate: dueDate.getTime(),
+    listName: 'Reminders',
+    createdAt: 1,
+    recurrence: 'weekly' as const,
+  };
+}
+
+function lastScheduledTrigger() {
+  const mock = Notifications.scheduleNotificationAsync as jest.Mock;
+  expect(mock).toHaveBeenCalled();
+  const lastCall = mock.mock.calls[mock.mock.calls.length - 1];
+  return lastCall[0].trigger;
+}
+
+describe('RemindersScreen weekly recurrence — weekday mapping', () => {
+  beforeEach(() => {
+    (Notifications.scheduleNotificationAsync as jest.Mock).mockClear();
   });
-  it('maps Wednesday → 4', () => {
-    expect(toExpoWeekday(new Date('2024-01-10T12:00:00Z'))).toBe(4);
+
+  it('maps a Sunday due date to weekday 1 (Expo 1 = Sunday)', async () => {
+    // 2024-01-07 is a Sunday → Date.getDay() === 0 → weekday 1.
+    await scheduleReminderNotification(weeklyReminder(new Date(2024, 0, 7, 12, 0, 0)));
+    expect(lastScheduledTrigger().weekday).toBe(1);
   });
-  it('maps Saturday → 7', () => {
-    expect(toExpoWeekday(new Date('2024-01-13T12:00:00Z'))).toBe(7);
+
+  it('maps a Wednesday due date to weekday 4', async () => {
+    // 2024-01-10 is a Wednesday → Date.getDay() === 3 → weekday 4.
+    await scheduleReminderNotification(weeklyReminder(new Date(2024, 0, 10, 12, 0, 0)));
+    expect(lastScheduledTrigger().weekday).toBe(4);
+  });
+
+  it('maps a Saturday due date to weekday 7 (Expo 7 = Saturday)', async () => {
+    // 2024-01-13 is a Saturday → Date.getDay() === 6 → weekday 7.
+    await scheduleReminderNotification(weeklyReminder(new Date(2024, 0, 13, 12, 0, 0)));
+    expect(lastScheduledTrigger().weekday).toBe(7);
   });
 });


### PR DESCRIPTION
## Resumo

M2: RemindersScreen — exporta scheduleReminderNotification e substitui o teste weekday falso (cópia local da fórmula) por um que exercita o caminho real via mock do scheduleNotificationAsync

## Causa raiz

O issue descreve o problema como se faltasse o comentário e faltasse o teste. O código contradiz essa descrição em dois pontos:

1. **O comentário já existia** em `src/screens/RemindersScreen.tsx:105-107`, com o link para a doc do Expo (`WeeklyTriggerInput.weekday is 1..7 with 1 = Sunday`). Veio no commit `77d58ad` e está em `main`. Não havia nada a adicionar.

2. **O ficheiro de teste já existia** (`src/screens/__tests__/RemindersScreen.weekday.test.ts`), mas era exactamente o anti-padrão que este pipeline já bloqueou quatro vezes: reimplementava a fórmula dentro do ficheiro de teste (`const toExpoWeekday = (d: Date) => d.getDay() + 1;`) e verificava **essa cópia local**, não o código de produção. Se alguém mudasse o `weekday: dueDate.getDay() + 1` da produção para `getDay()`, o teste continuava a passar — provava zero.

O defeito real era, portanto, de **testabilidade**: `scheduleReminderNotification` (a função de produção que contém o mapeamento) não estava exportada, e o teste existente não a alcançava. O mapeamento em si (Sun→1, Wed→4, Sat→7) estava correcto em produção.

## O que mudou

- `src/screens/RemindersScreen.tsx` — **uma linha**: `scheduleReminderNotification` passou a ser `export`. Sem mudança de comportamento em runtime; só torna a unidade real alcançável pelo teste.
- `src/screens/__tests__/RemindersScreen.weekday.test.ts` — reescrito de raiz: mock de `expo-notifications` (mesmo padrão do `ClockScreen.test.tsx`), chama a **função real** `scheduleReminderNotification` com `recurrence: 'weekly'` e `dueDate` em cada dia, e faz assert no `trigger.weekday` efectivamente passado a `scheduleNotificationAsync`. As datas são construídas com o construtor local (`new Date(2024, 0, 7, 12, 0, 0)`), robusto a timezone da máquina (as ISO strings do teste antigo podiam desviar o dia em timezones extremos).

## Porque assim

- **Exportar a função em vez de factorizar `toExpoWeekday`** (item 3 opcional do issue): testar ao nível do trigger capturado prova o fio todo — que o valor mapeado chega ao objecto `trigger` real enviado ao Expo. Factorizar o helper e testá-lo deixaria o teste passar mesmo que o trigger deixasse de o usar (a armadilha da "cópia paralela", agora a nível de módulo). O comentário inline já documenta o mapeamento; o teste valida-o.
- **Não toquei nos ramos daily/monthly/none** nem em mais nada — o issue pede só o mapeamento weekday.

## Critérios de aceitação

- [x] Comentário com link da spec acima do mapeamento — **já existia** em `RemindersScreen.tsx:105-107` (confirmado via `git log -S`, vem de `main`); o diff não o toca.
- [x] Teste unitário cobre Sun/Wed/Sat e exercita a unidade real — 3 testes que passam por `scheduleReminderNotification` e fazem assert no `trigger.weekday` capturado (1, 4, 7).
- [x] O teste falha quando a unidade real não está exposta — provado no passo vermelho: sem o `export`, os 3 testes falham com `scheduleReminderNotification is not a function`.
- [x] O que NÃO devia mudar: valor do mapeamento (1=Sun…7=Sat), ramos daily/monthly/none, comportamento de runtime do ecrã. Confirmado: o diff de produção é só a keyword `export`; o mapeamento `getDay() + 1` fica intocado.
- [x] `npm test` sem regressão face à baseline — ver Testes abaixo.

## Testes

**Passo vermelho** (teste escrito, produção sem o `export` — output real do jest):

```
● RemindersScreen weekly recurrence — weekday mapping › maps a Wednesday due date to weekday 4

  TypeError: (0 , _RemindersScreen.scheduleReminderNotification) is not a function

    54 |   it('maps a Wednesday due date to weekday 4', async () => {
    55 |     // 2024-01-10 is a Wednesday → Date.getDay() === 3 → weekday 4.
  > 56 |     await scheduleReminderNotification(weeklyReminder(new Date(2024, 0, 10, 12, 0, 0)));
       |                                       ^
    57 |     expect(lastScheduledTrigger().weekday).toBe(4);
    58 |   });

Test Suites: 1 failed, 1 total
Tests:       3 failed, 3 total
```

Depois do fix (`export`):

```
PASS Android src/screens/__tests__/RemindersScreen.weekday.test.ts
  RemindersScreen weekly recurrence — weekday mapping
    ✓ maps a Sunday due date to weekday 1 (Expo 1 = Sunday) (5 ms)
    ✓ maps a Wednesday due date to weekday 4 (1 ms)
    ✓ maps a Saturday due date to weekday 7 (Expo 7 = Saturday) (1 ms)

Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
```

**Casos cobertos:** Sun→1 e Sat→7 são as fronteiras exactas do domínio do mapeamento (getDay 0→weekday 1, getDay 6→weekday 7); Wed→4 cobre o meio do intervalo. Datas locais (`new Date(2024, 0, 7, 12, 0, 0)`) eliminam a dependência da timezone da máquina — cada teste pode falhar por o mapeamento estar errado num dia específico, sem redundância entre si.

**Sanity-check:** `git stash push -- src/screens/RemindersScreen.tsx` (tirar só o fix, deixar o teste) → `npx jest .../RemindersScreen.weekday.test.ts` → `Tests: 3 failed, 3 total`; `git stash pop` → verde. A suite falha sem o fix, prova que o teste está ligado à unidade real.

**Verificações:**
- `npm run lint` → 0 erros, 2 warnings pré-existentes (`CupertinoActionSheet.tsx`, `ClockScreen.tsx` — ficheiros que não toquei).
- `npx tsc --noEmit` → limpo.
- `npm test` → 9 falhados / 254 passados / 263 total. As 9 falhas são **exactamente** as 9 da baseline (mesmas suites: CalculatorScreen, LockScreen, SettingsScreen, WeatherScreen, FoldersStore) — nenhuma falha nova; os 3 testes weekday passam. (O total de testes subiu de 180 para 263 porque a baseline foi medida num ponto anterior; o critério de regressão, número de falhas, não subiu.)

## Testes

263 no total: 254 passaram, 9 falharam (exactamente as 9 da baseline — sem falhas novas); weekday 3/3 passam

## Linked Issue

Fixes #203