### PR TITLE
fix(M3): cancel pending onDismiss in NotificationBanner exit window (track delayed timeout in timerRef) (#204)

### DIFF
--- a/src/components/NotificationBanner.tsx
+++ b/src/components/NotificationBanner.tsx
@@ -49,7 +49,10 @@ export function NotificationBanner({ notification, onDismiss }: Props) {
     translateY.value = withTiming(-150, { duration: 200 });
     scale.value = withTiming(0.95, { duration: 200 });
     opacity.value = withTiming(0, { duration: 200 });
-    setTimeout(onDismiss, 250);
+    timerRef.current = setTimeout(() => {
+      timerRef.current = null;
+      onDismiss();
+    }, 250);
   }, [onDismiss, translateY, scale, opacity]);
 
   // Show animation

--- a/src/components/__tests__/NotificationBanner.test.tsx
+++ b/src/components/__tests__/NotificationBanner.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Pressable, Text } from 'react-native';
-import { render, fireEvent } from '../../test-utils';
+import { render, fireEvent, act } from '../../test-utils';
 import { NotificationBanner, BannerNotification } from '../NotificationBanner';
 import * as Haptics from 'expo-haptics';
 import { setHapticsEnabled } from '../../utils/haptics';
@@ -136,5 +136,74 @@ describe('NotificationBanner haptics (H5)', () => {
 
     expect(Haptics.notificationAsync).toHaveBeenCalled();
     expect(unhandled).toEqual([]);
+  });
+});
+
+// The full provider tree from test-utils is required: ThemeProvider itself calls
+// useSettings. DeviceStore/SettingsStore install timers on mount, but with fake
+// timers they only fire inside the act() blocks below (their state updates are
+// flushed there), so they don't interfere with the banner's own timer window.
+describe('NotificationBanner auto-dismiss (M3)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('auto-dismisses after the timer, calling onDismiss exactly once', () => {
+    const onDismiss = jest.fn();
+    render(<NotificationBanner notification={makeNotification()} onDismiss={onDismiss} />);
+
+    act(() => {
+      jest.advanceTimersByTime(5000); // auto-dismiss timer fires → dismiss() schedules onDismiss in 250ms
+    });
+    act(() => {
+      jest.advanceTimersByTime(250); // exit-animation window → onDismiss
+    });
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels the pending onDismiss when a new banner replaces the old one during the exit animation', () => {
+    const onDismiss = jest.fn();
+    const { rerender } = render(
+      <NotificationBanner notification={makeNotification({ id: 'n1' })} onDismiss={onDismiss} />,
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(5000); // old banner auto-dismisses → onDismiss scheduled in 250ms
+    });
+
+    // A new banner arrives before the old one's delayed onDismiss runs.
+    rerender(<NotificationBanner notification={makeNotification({ id: 'n2' })} onDismiss={onDismiss} />);
+
+    act(() => {
+      jest.advanceTimersByTime(250);
+    });
+
+    // The old banner's stale onDismiss must not clear the new banner.
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it('does not call onDismiss after the banner unmounts while the exit animation is pending', () => {
+    const onDismiss = jest.fn();
+    const { unmount } = render(
+      <NotificationBanner notification={makeNotification()} onDismiss={onDismiss} />,
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(5000); // dismiss() schedules onDismiss in 250ms
+    });
+
+    unmount(); // banner goes away inside the 250ms exit window
+
+    act(() => {
+      jest.advanceTimersByTime(250);
+    });
+
+    expect(onDismiss).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Resumo

fix(M3): cancel pending onDismiss in NotificationBanner exit window (track delayed timeout in timerRef)

## Causa raiz

O issue afirma que o timer de auto-dismiss não é limpo no dismiss manual, causando duplo `onDismiss`. Essa parte **já estava corrigida em `main`**: o commit `77d58ad` (PR #237, batch H7) — e o commit dedicado `b2a1772` na branch `claude/find-bugs-gaps-wEhJ0` — introduziram `timerRef` e fazem `dismiss()` limpar o timer de 5s antes de agendar `onDismiss` (`src/components/NotificationBanner.tsx:44-53`).

O que **não** estava corrigido é o atraso de saída: `dismiss()` agendava o `onDismiss` com `setTimeout(onDismiss, 250)` **não-trastreado**. Esse timeout:

- dispara `onDismiss` mesmo depois de o componente desmontar durante a janela de 250ms;
- dispara `onDismiss` depois de um banner novo substituir o antigo dentro da mesma janela — o cenário exacto do issue: "new banner accidentally cleared";
- duplica `onDismiss` se `dismiss()` for invocado duas vezes dentro da janela (ex.: auto-dismiss + toque durante a saída).

O fix guarda esse timeout no mesmo `timerRef`, para que a limpeza do efeito (unmount ou troca de notification) o cancele como já cancela o timer de 5s.

## O que mudou

- `src/components/NotificationBanner.tsx`: `dismiss()` passa a guardar o `setTimeout(onDismiss, 250)` em `timerRef.current`, com o callback a limpar o ref antes de chamar `onDismiss`. A limpeza do `useEffect` de exibição já limpa o que estiver no ref — passa a cobrir também o atraso de saída.
- `src/components/__tests__/NotificationBanner.test.tsx`: novo describe "NotificationBanner auto-dismiss (M3)" com 3 testes (ver Testes).

## Porque assim

O issue propunha exactamente este mecanismo (guardar o timer num ref e limpar no dismiss), e esse núcleo já existia em `main`; implementá-lo de novo não seria um passo vermelho. O defeito real remanescente era o timeout de 250ms não-trastreado. A alternativa de um guard `dismissingRef` (ignorar segundos dismisses) foi descartada: guardar o timeout de 250ms no ref resolve os três sintomas com menos estado e mantém as animações intactas. Os gestos (swipe/tap) não são exercitáveis em jest — o mock de `react-native-gesture-handler` em `jest.setup.js` descarta os callbacks —, mas todos os caminhos (timer, swipe, tap) convergem no mesmo `dismiss()`, que é o que os testes accionam através do timer real de 5s.

## Critérios de aceitação

- [x] Manual dismiss + elapsed timer → `onDismiss` exactamente uma vez: já era garantido pelo fix pré-existente (dismiss limpa o timer de 5s); travado pelo teste nominal "auto-dismisses after the timer, calling onDismiss exactly once".
- [x] Banner novo a chegar durante a janela de saída → `onDismiss` pendente do banner antigo é cancelado (não limpa o banner novo). Teste "cancels the pending onDismiss when a new banner replaces the old one during the exit animation".
- [x] Unmount durante a janela de saída → nenhum callback pendente. Teste "does not call onDismiss after the banner unmounts while the exit animation is pending".
- [x] Animações de mostrar/esconder inalteradas: o fix só troca o alvo do timeout, não toca nos `withTiming`/`withSpring`.
- [x] O que NÃO devia mudar: nenhum outro ficheiro alterado; os 6 testes H5 existentes continuam a passar.

## Testes

- **Passo vermelho:** com o fix de produção revertido (`git stash push -- src/components/NotificationBanner.tsx`):

```
$ npx jest --color=false src/components/__tests__/NotificationBanner.test.tsx
  NotificationBanner auto-dismiss (M3)
    ✓ auto-dismisses after the timer, calling onDismiss exactly once
    ✕ cancels the pending onDismiss when a new banner replaces the old one during the exit animation
    ✕ does not call onDismiss after the banner unmounts while the exit animation is pending

  ● NotificationBanner auto-dismiss (M3) › cancels the pending onDismiss when a new banner replaces the old one during the exit animation
    expect(jest.fn()).not.toHaveBeenCalled()
    Expected number of calls: 0
    Received number of calls: 1

    > 188 |     expect(onDismiss).not.toHaveBeenCalled();

  ● NotificationBanner auto-dismiss (M3) › does not call onDismiss after the banner unmounts while the exit animation is pending
    expect(jest.fn()).not.toHaveBeenCalled()
    Expected number of calls: 0
    Received number of calls: 1

    > 207 |     expect(onDismiss).not.toHaveBeenCalled();

Test Suites: 1 failed, 1 total
Tests:       2 failed, 7 passed, 9 total
```

- **Casos cobertos:** caminho feliz (auto-dismiss → exactamente uma chamada), o inverso do fix (banner novo durante a saída NÃO é limpo pelo `onDismiss` antigo), e o assíncrono/pending (sem `onDismiss` após unmount durante a janela de 250ms). Fronteiras de tempo: 5000ms exactos + os 250ms da janela de saída.
- **Sanity-check:** revertido o fix, a suite falha (2 falhas, output acima); restaurado, os 9 testes passam.
- Resultado final: `npm run lint` → 0 erros (2 warnings pré-existentes noutros ficheiros); `npx tsc --noEmit` → limpo; `npm test` → 257 passaram, 9 falharam (as 9 da baseline, em 5 suites), 39 suites. Nenhuma falha nova em ficheiros tocados.

## Testes

NotificationBanner.test.tsx: 9 passaram, 0 falharam; suite completa: 257 passaram, 9 falharam (as 9 da baseline), 39 suites

## Linked Issue

Fixes #204