### PR TITLE
Migra @draft_* e @lock_pin (chaves AsyncStorage sem namespace) para @iostoandroid/ com migracao one-shot e testes (#205)

### DIFF
--- a/src/screens/ConversationScreen.tsx
+++ b/src/screens/ConversationScreen.tsx
@@ -29,6 +29,7 @@ import Animated, {
 import * as Haptics from 'expo-haptics';
 import { useTheme } from '../theme/ThemeContext';
 import { useDevice, DeviceSms } from '../store/DeviceStore';
+import { migrateAsyncStorageKey, draftStorageKey, draftLegacyStorageKey } from '../store/storage';
 import { CupertinoTextField, useAlert } from '../components';
 import { findContactByPhone } from '../utils/contacts';
 import type { AppNavigationProp, AppRouteProp } from '../navigation/types';
@@ -311,7 +312,8 @@ export function ConversationScreen({ navigation, route }: ConversationScreenProp
   const [selectedMsgId, setSelectedMsgId] = useState<string | null>(null);
   const [localImageMessages, setLocalImageMessages] = useState<LocalImageMessage[]>([]);
   const listRef = useRef<FlatList>(null);
-  const draftKey = `@draft_${address}`;
+  const draftKey = draftStorageKey(address);
+  const legacyDraftKey = draftLegacyStorageKey(address);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Load reactions from storage
@@ -358,12 +360,14 @@ export function ConversationScreen({ navigation, route }: ConversationScreenProp
     }
   }, [selectedMsgId]);
 
-  // Load draft on mount
+  // Load draft on mount — migrate the legacy key first so existing users keep their drafts
   useEffect(() => {
-    AsyncStorage.getItem(draftKey).then((value) => {
+    (async () => {
+      await migrateAsyncStorageKey(legacyDraftKey, draftKey);
+      const value = await AsyncStorage.getItem(draftKey);
       if (value) setInputText(value);
-    }).catch(() => {});
-  }, [draftKey]);
+    })().catch(() => {});
+  }, [draftKey, legacyDraftKey]);
 
   // Debounced draft save on text change
   const handleInputChange = useCallback((text: string) => {

--- a/src/screens/LauncherSettingsScreen.tsx
+++ b/src/screens/LauncherSettingsScreen.tsx
@@ -28,6 +28,12 @@ const DEFAULT_DOCK = [
   'com.iostoandroid.settings',
 ];
 
+// Passcode storage: SecureStore is primary; AsyncStorage is a fallback when
+// SecureStore is unavailable. The legacy key predates the @iostoandroid/ namespace.
+const LOCK_PIN_KEY = 'lock_pin';
+const LOCK_PIN_STORAGE_KEY = '@iostoandroid/lock_pin';
+const LOCK_PIN_LEGACY_KEY = '@lock_pin';
+
 const DOCK_LABELS: Record<string, string> = {
   'com.iostoandroid.phone': 'Phone',
   'com.iostoandroid.messages': 'Messages',
@@ -63,11 +69,14 @@ export function LauncherSettingsScreen() {
       return;
     }
     if (pinStep === 'current') {
-      // Read PIN from SecureStore (fall back to legacy AsyncStorage)
+      // Read PIN from SecureStore (fall back to namespaced AsyncStorage key, then legacy)
       let current: string | null = null;
-      try { current = await SecureStore.getItemAsync('lock_pin'); } catch { /* ignore */ }
+      try { current = await SecureStore.getItemAsync(LOCK_PIN_KEY); } catch { /* ignore */ }
       if (!current) {
-        try { current = await AsyncStorage.getItem('@lock_pin'); } catch { /* ignore */ }
+        try { current = await AsyncStorage.getItem(LOCK_PIN_STORAGE_KEY); } catch { /* ignore */ }
+      }
+      if (!current) {
+        try { current = await AsyncStorage.getItem(LOCK_PIN_LEGACY_KEY); } catch { /* ignore */ }
       }
       if (current && pinInput !== current) {
         alert('Incorrect PIN', 'The current PIN you entered is wrong.');
@@ -90,12 +99,13 @@ export function LauncherSettingsScreen() {
       }
       // Store PIN securely
       try {
-        await SecureStore.setItemAsync('lock_pin', pinInput);
-        // Remove legacy key if it exists
-        await AsyncStorage.removeItem('@lock_pin');
+        await SecureStore.setItemAsync(LOCK_PIN_KEY, pinInput);
+        // Remove AsyncStorage copies if they exist
+        await AsyncStorage.removeItem(LOCK_PIN_STORAGE_KEY);
+        await AsyncStorage.removeItem(LOCK_PIN_LEGACY_KEY);
       } catch {
-        // Fallback to AsyncStorage if SecureStore unavailable
-        await AsyncStorage.setItem('@lock_pin', pinInput);
+        // Fallback to AsyncStorage if SecureStore unavailable (namespaced key only)
+        await AsyncStorage.setItem(LOCK_PIN_STORAGE_KEY, pinInput);
       }
       setShowPinModal(false);
       alert('Success', 'Your passcode has been changed.');

--- a/src/screens/LockScreen.tsx
+++ b/src/screens/LockScreen.tsx
@@ -70,6 +70,7 @@ import { WALLPAPERS, darkenHex } from '../utils/wallpapers';
 import { hapticImpact, hapticNotification } from '../utils/haptics';
 
 const LOCK_PIN_KEY = 'lock_pin';
+const LOCK_PIN_STORAGE_KEY = '@iostoandroid/lock_pin';
 const LOCK_PIN_LEGACY_KEY = '@lock_pin';
 
 const { height: SCREEN_HEIGHT } = Dimensions.get('window');
@@ -438,16 +439,26 @@ export function LockScreen({ navigation, onUnlock }: { navigation?: AppNavigatio
     };
   }, []);
 
-  // Migrate PIN from AsyncStorage to SecureStore if needed
+  // Migrate PIN from AsyncStorage (namespaced fallback or legacy) to SecureStore if needed
   useEffect(() => {
     (async () => {
       try {
         const securePin = await SecureStore.getItemAsync(LOCK_PIN_KEY);
-        if (securePin) return; // Already in SecureStore
-        // Check for legacy AsyncStorage PIN
-        const legacyPin = await AsyncStorage.getItem(LOCK_PIN_LEGACY_KEY);
-        if (legacyPin) {
-          await SecureStore.setItemAsync(LOCK_PIN_KEY, legacyPin);
+        if (securePin) {
+          // SecureStore is authoritative — drop any AsyncStorage copies
+          await AsyncStorage.removeItem(LOCK_PIN_STORAGE_KEY);
+          await AsyncStorage.removeItem(LOCK_PIN_LEGACY_KEY);
+          return;
+        }
+        // Check the namespaced AsyncStorage key first, then the legacy key
+        let storedPin: string | null = null;
+        try { storedPin = await AsyncStorage.getItem(LOCK_PIN_STORAGE_KEY); } catch { /* ignore */ }
+        if (!storedPin) {
+          try { storedPin = await AsyncStorage.getItem(LOCK_PIN_LEGACY_KEY); } catch { /* ignore */ }
+        }
+        if (storedPin) {
+          await SecureStore.setItemAsync(LOCK_PIN_KEY, storedPin);
+          await AsyncStorage.removeItem(LOCK_PIN_STORAGE_KEY);
           await AsyncStorage.removeItem(LOCK_PIN_LEGACY_KEY);
         }
         // No default PIN is set automatically - user must set one in settings
@@ -469,19 +480,16 @@ export function LockScreen({ navigation, onUnlock }: { navigation?: AppNavigatio
       if (prev.length >= 4) return prev;
       const next = prev + digit;
       if (next.length === 4) {
-        // Verify PIN from SecureStore (fall back to AsyncStorage for legacy)
+        // Verify PIN from SecureStore (fall back to namespaced AsyncStorage key, then legacy)
         (async () => {
           let pin: string | null = null;
-          let storeAvailable = false;
           try {
             pin = await SecureStore.getItemAsync(LOCK_PIN_KEY);
-            storeAvailable = true;
           } catch { /* SecureStore unavailable */ }
-          if (!pin && !storeAvailable) {
-            // SecureStore failed — try legacy AsyncStorage as last resort
-            try { pin = await AsyncStorage.getItem(LOCK_PIN_LEGACY_KEY); } catch { /* ignore */ }
-          } else if (!pin) {
-            // SecureStore is available but no PIN set — try legacy migration
+          if (!pin) {
+            try { pin = await AsyncStorage.getItem(LOCK_PIN_STORAGE_KEY); } catch { /* ignore */ }
+          }
+          if (!pin) {
             try { pin = await AsyncStorage.getItem(LOCK_PIN_LEGACY_KEY); } catch { /* ignore */ }
           }
           // If no PIN is set anywhere, allow unlock (first-time user)

--- a/src/screens/MessagesScreen.tsx
+++ b/src/screens/MessagesScreen.tsx
@@ -20,6 +20,7 @@ import { Typography } from '../theme/CupertinoTheme';
 import type { AppNavigationProp } from '../navigation/types';
 import * as Haptics from 'expo-haptics';
 import { useDevice, DeviceSms, DeviceContact } from '../store/DeviceStore';
+import { migrateAsyncStorageKey, draftStorageKey, draftLegacyStorageKey } from '../store/storage';
 import { CupertinoButton, CupertinoSwipeableRow, useAlert, SkeletonListRow } from '../components';
 import { findContactByPhone } from '../utils/contacts';
 import { logger } from '../utils/logger';
@@ -328,7 +329,9 @@ export function MessagesScreen() {
         const loaded: Record<string, string> = {};
         await Promise.all(
           allConvs.map(async (c) => {
-            const value = await AsyncStorage.getItem(`@draft_${c.address}`);
+            // Migrate the legacy draft key before reading so existing drafts survive
+            await migrateAsyncStorageKey(draftLegacyStorageKey(c.address), draftStorageKey(c.address));
+            const value = await AsyncStorage.getItem(draftStorageKey(c.address));
             if (value) loaded[c.address] = value;
           }),
         );

--- a/src/screens/__tests__/ConversationScreen.test.tsx
+++ b/src/screens/__tests__/ConversationScreen.test.tsx
@@ -1,9 +1,31 @@
 import React from 'react';
-import { render } from '../../test-utils';
+import { render, fireEvent, waitFor } from '../../test-utils';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { ConversationScreen } from '../ConversationScreen';
 
 const mockNavigation = { navigate: jest.fn(), goBack: jest.fn(), push: jest.fn() };
 const mockRoute = { params: { address: '+15551234567' } };
+
+// Stateful in-memory AsyncStorage mock: setItem persists so a subsequent
+// getItem returns what was written — unlike the stateless default mock.
+function setupMemoryAsyncStorage(initial: Record<string, string> = {}) {
+  const store = new Map<string, string>(Object.entries(initial));
+  (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) =>
+    store.has(key) ? store.get(key) : null,
+  );
+  (AsyncStorage.setItem as jest.Mock).mockImplementation(async (key: string, value: string) => {
+    store.set(key, value);
+  });
+  (AsyncStorage.removeItem as jest.Mock).mockImplementation(async (key: string) => {
+    store.delete(key);
+  });
+  return store;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  setupMemoryAsyncStorage();
+});
 
 describe('ConversationScreen', () => {
   it('renders without crashing', () => {
@@ -33,5 +55,70 @@ describe('ConversationScreen', () => {
       <ConversationScreen navigation={mockNavigation as never} route={mockRoute as never} />
     );
     expect(getByLabelText('Back to Messages')).toBeTruthy();
+  });
+
+  it('migrates a legacy draft to the namespaced key on mount', async () => {
+    const store = setupMemoryAsyncStorage({
+      '@draft_+15551234567': 'Hello legacy draft',
+    });
+
+    const { getByDisplayValue } = render(
+      <ConversationScreen navigation={mockNavigation as never} route={mockRoute as never} />
+    );
+
+    await waitFor(() => {
+      expect(getByDisplayValue('Hello legacy draft')).toBeTruthy();
+    });
+    // Legacy value copied to the namespaced key and legacy key removed
+    expect(store.get('@iostoandroid/draft_+15551234567')).toBe('Hello legacy draft');
+    expect(store.has('@draft_+15551234567')).toBe(false);
+  });
+
+  it('keeps the new-key draft when BOTH keys exist (no overwrite)', async () => {
+    const store = setupMemoryAsyncStorage({
+      '@draft_+15551234567': 'legacy value',
+      '@iostoandroid/draft_+15551234567': 'newer value',
+    });
+
+    const { getByDisplayValue } = render(
+      <ConversationScreen navigation={mockNavigation as never} route={mockRoute as never} />
+    );
+
+    await waitFor(() => {
+      expect(getByDisplayValue('newer value')).toBeTruthy();
+    });
+    expect(store.get('@iostoandroid/draft_+15551234567')).toBe('newer value');
+    expect(store.has('@draft_+15551234567')).toBe(false);
+  });
+
+  it('loads a draft already stored under the namespaced key', async () => {
+    const store = setupMemoryAsyncStorage({
+      '@iostoandroid/draft_+15551234567': 'already namespaced',
+    });
+
+    const { getByDisplayValue } = render(
+      <ConversationScreen navigation={mockNavigation as never} route={mockRoute as never} />
+    );
+
+    await waitFor(() => {
+      expect(getByDisplayValue('already namespaced')).toBeTruthy();
+    });
+    // No legacy key involved, nothing else written
+    expect(store.has('@draft_+15551234567')).toBe(false);
+  });
+
+  it('saves drafts under the namespaced key only (never re-creates legacy)', async () => {
+    const store = setupMemoryAsyncStorage();
+
+    const { getByPlaceholderText } = render(
+      <ConversationScreen navigation={mockNavigation as never} route={mockRoute as never} />
+    );
+
+    fireEvent.changeText(getByPlaceholderText('Message'), 'Draft being typed');
+
+    await waitFor(() => {
+      expect(store.get('@iostoandroid/draft_+15551234567')).toBe('Draft being typed');
+    });
+    expect(store.has('@draft_+15551234567')).toBe(false);
   });
 });

--- a/src/screens/__tests__/LauncherSettingsScreen.test.tsx
+++ b/src/screens/__tests__/LauncherSettingsScreen.test.tsx
@@ -1,0 +1,113 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '../../test-utils';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as SecureStore from 'expo-secure-store';
+import { LauncherSettingsScreen } from '../LauncherSettingsScreen';
+
+jest.mock('expo-secure-store', () => ({
+  getItemAsync: jest.fn(async () => null),
+  setItemAsync: jest.fn(async () => {}),
+  deleteItemAsync: jest.fn(async () => {}),
+}));
+
+// Stateful in-memory AsyncStorage mock: setItem persists so a subsequent
+// getItem returns what was written — unlike the stateless default mock.
+function setupMemoryAsyncStorage(initial: Record<string, string> = {}) {
+  const store = new Map<string, string>(Object.entries(initial));
+  (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) =>
+    store.has(key) ? store.get(key) : null,
+  );
+  (AsyncStorage.setItem as jest.Mock).mockImplementation(async (key: string, value: string) => {
+    store.set(key, value);
+  });
+  (AsyncStorage.removeItem as jest.Mock).mockImplementation(async (key: string) => {
+    store.delete(key);
+  });
+  return store;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  setupMemoryAsyncStorage();
+  (SecureStore.getItemAsync as jest.Mock).mockResolvedValue(null);
+  (SecureStore.setItemAsync as jest.Mock).mockResolvedValue(undefined);
+});
+
+async function submitPinFlow(getByText: (t: string) => unknown, getByPlaceholderText: (t: string) => unknown) {
+  fireEvent.press(getByText('Change Passcode'));
+  // Each step transition is async (the handler awaits SecureStore/AsyncStorage),
+  // so wait for the modal title to change before driving the next step.
+  // Step 1 — current passcode (none set, proceeds)
+  fireEvent.changeText(getByPlaceholderText('••••'), '1234');
+  fireEvent.press(getByText('Next'));
+  await waitFor(() => expect(getByText('Enter New Passcode')).toBeTruthy());
+  // Step 2 — new passcode
+  fireEvent.changeText(getByPlaceholderText('••••'), '5678');
+  fireEvent.press(getByText('Next'));
+  await waitFor(() => expect(getByText('Confirm New Passcode')).toBeTruthy());
+  // Step 3 — confirm new passcode
+  fireEvent.changeText(getByPlaceholderText('••••'), '5678');
+  fireEvent.press(getByText('Next'));
+}
+
+describe('LauncherSettingsScreen', () => {
+  it('falls back to the NAMESPACED AsyncStorage key when SecureStore is unavailable', async () => {
+    (SecureStore.setItemAsync as jest.Mock).mockRejectedValue(new Error('SecureStore unavailable'));
+    const store = setupMemoryAsyncStorage();
+
+    const { getByText, getByPlaceholderText } = render(<LauncherSettingsScreen />);
+    await submitPinFlow(getByText, getByPlaceholderText);
+
+    await waitFor(() => {
+      expect(store.get('@iostoandroid/lock_pin')).toBe('5678');
+    });
+    // The legacy key must never be written again
+    expect(store.has('@lock_pin')).toBe(false);
+  });
+
+  it('removes BOTH AsyncStorage PIN keys when the PIN is stored in SecureStore', async () => {
+    const store = setupMemoryAsyncStorage({
+      '@iostoandroid/lock_pin': '1111',
+      '@lock_pin': '2222',
+    });
+
+    const { getByText, getByPlaceholderText } = render(<LauncherSettingsScreen />);
+    fireEvent.press(getByText('Change Passcode'));
+    // Step 1 — current passcode lives in the namespaced key (1111)
+    fireEvent.changeText(getByPlaceholderText('••••'), '1111');
+    fireEvent.press(getByText('Next'));
+    await waitFor(() => expect(getByText('Enter New Passcode')).toBeTruthy());
+    // Step 2 — new passcode
+    fireEvent.changeText(getByPlaceholderText('••••'), '5678');
+    fireEvent.press(getByText('Next'));
+    await waitFor(() => expect(getByText('Confirm New Passcode')).toBeTruthy());
+    // Step 3 — confirm new passcode → stored in SecureStore, AsyncStorage copies dropped
+    fireEvent.changeText(getByPlaceholderText('••••'), '5678');
+    fireEvent.press(getByText('Next'));
+
+    await waitFor(() => {
+      expect(SecureStore.setItemAsync).toHaveBeenCalledWith('lock_pin', '5678');
+    });
+    expect(store.has('@iostoandroid/lock_pin')).toBe(false);
+    expect(store.has('@lock_pin')).toBe(false);
+  });
+
+  it('accepts the current PIN stored in the namespaced key (read order: SecureStore → new → legacy)', async () => {
+    const store = setupMemoryAsyncStorage({
+      '@iostoandroid/lock_pin': '1234',
+      '@lock_pin': '9999',
+    });
+
+    const { getByText, getByPlaceholderText } = render(<LauncherSettingsScreen />);
+    fireEvent.press(getByText('Change Passcode'));
+
+    // Enter the PIN from the namespaced key — it must be accepted (advances to "new" step)
+    fireEvent.changeText(getByPlaceholderText('••••'), '1234');
+    fireEvent.press(getByText('Next'));
+
+    await waitFor(() => {
+      expect(getByText('Enter New Passcode')).toBeTruthy();
+    });
+    expect(store.has('@iostoandroid/lock_pin')).toBe(true);
+  });
+});

--- a/src/screens/__tests__/LockScreen.test.tsx
+++ b/src/screens/__tests__/LockScreen.test.tsx
@@ -1,6 +1,37 @@
 import React from 'react';
-import { render, fireEvent } from '../../test-utils';
+import { render, fireEvent, waitFor } from '../../test-utils';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as SecureStore from 'expo-secure-store';
 import { LockScreen } from '../LockScreen';
+
+jest.mock('expo-secure-store', () => ({
+  getItemAsync: jest.fn(async () => null),
+  setItemAsync: jest.fn(async () => {}),
+  deleteItemAsync: jest.fn(async () => {}),
+}));
+
+// Stateful in-memory AsyncStorage mock: setItem persists so a subsequent
+// getItem returns what was written — unlike the stateless default mock.
+function setupMemoryAsyncStorage(initial: Record<string, string> = {}) {
+  const store = new Map<string, string>(Object.entries(initial));
+  (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) =>
+    store.has(key) ? store.get(key) : null,
+  );
+  (AsyncStorage.setItem as jest.Mock).mockImplementation(async (key: string, value: string) => {
+    store.set(key, value);
+  });
+  (AsyncStorage.removeItem as jest.Mock).mockImplementation(async (key: string) => {
+    store.delete(key);
+  });
+  return store;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  setupMemoryAsyncStorage();
+  (SecureStore.getItemAsync as jest.Mock).mockResolvedValue(null);
+  (SecureStore.setItemAsync as jest.Mock).mockResolvedValue(undefined);
+});
 
 describe('LockScreen', () => {
   it('renders without crashing', () => {
@@ -56,5 +87,60 @@ describe('LockScreen', () => {
     fireEvent.press(getByLabelText('Use passcode to unlock'));
     fireEvent.press(getByLabelText('Cancel passcode entry'));
     expect(queryByText('Enter Passcode')).toBeNull();
+  });
+
+  it('migrates a PIN from the namespaced AsyncStorage key to SecureStore on mount', async () => {
+    const store = setupMemoryAsyncStorage({ '@iostoandroid/lock_pin': '1234' });
+
+    render(<LockScreen />);
+
+    await waitFor(() => {
+      expect(SecureStore.setItemAsync).toHaveBeenCalledWith('lock_pin', '1234');
+    });
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('@iostoandroid/lock_pin');
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('@lock_pin');
+    expect(store.has('@iostoandroid/lock_pin')).toBe(false);
+    expect(store.has('@lock_pin')).toBe(false);
+  });
+
+  it('migrates a PIN from the legacy AsyncStorage key to SecureStore on mount', async () => {
+    const store = setupMemoryAsyncStorage({ '@lock_pin': '4321' });
+
+    render(<LockScreen />);
+
+    await waitFor(() => {
+      expect(SecureStore.setItemAsync).toHaveBeenCalledWith('lock_pin', '4321');
+    });
+    expect(store.has('@lock_pin')).toBe(false);
+  });
+
+  it('does not overwrite a SecureStore PIN when a stored copy exists', async () => {
+    setupMemoryAsyncStorage({ '@iostoandroid/lock_pin': '1111' });
+    (SecureStore.getItemAsync as jest.Mock).mockResolvedValue('9999');
+
+    render(<LockScreen />);
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(SecureStore.setItemAsync).not.toHaveBeenCalled();
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('@iostoandroid/lock_pin');
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('@lock_pin');
+  });
+
+  it('unlocks with a PIN stored only in the namespaced key when SecureStore is unavailable', async () => {
+    // Fully-broken SecureStore: reads and writes both throw, so the AsyncStorage
+    // copy is the only PIN source and the mount-migration cannot run.
+    setupMemoryAsyncStorage({ '@iostoandroid/lock_pin': '1234', '@lock_pin': '9999' });
+    (SecureStore.getItemAsync as jest.Mock).mockRejectedValue(new Error('SecureStore unavailable'));
+    (SecureStore.setItemAsync as jest.Mock).mockRejectedValue(new Error('SecureStore unavailable'));
+    const onUnlock = jest.fn();
+
+    const { getByLabelText } = render(<LockScreen onUnlock={onUnlock} />);
+    fireEvent.press(getByLabelText('Use passcode to unlock'));
+    fireEvent.press(getByLabelText('Digit 1'));
+    fireEvent.press(getByLabelText('Digit 2'));
+    fireEvent.press(getByLabelText('Digit 3'));
+    fireEvent.press(getByLabelText('Digit 4'));
+
+    await waitFor(() => expect(onUnlock).toHaveBeenCalled());
   });
 });

--- a/src/store/__tests__/storage.test.ts
+++ b/src/store/__tests__/storage.test.ts
@@ -1,0 +1,87 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { migrateAsyncStorageKey, draftStorageKey, draftLegacyStorageKey } from '../storage';
+
+// Stateful in-memory AsyncStorage mock: setItem persists so a subsequent
+// getItem returns what was written — unlike the stateless default mock.
+function setupMemoryAsyncStorage(initial: Record<string, string> = {}) {
+  const store = new Map<string, string>(Object.entries(initial));
+  (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) =>
+    store.has(key) ? store.get(key) : null,
+  );
+  (AsyncStorage.setItem as jest.Mock).mockImplementation(async (key: string, value: string) => {
+    store.set(key, value);
+  });
+  (AsyncStorage.removeItem as jest.Mock).mockImplementation(async (key: string) => {
+    store.delete(key);
+  });
+  return store;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  setupMemoryAsyncStorage();
+});
+
+describe('migrateAsyncStorageKey', () => {
+  it('copies the legacy value to the new key and removes the legacy key', async () => {
+    setupMemoryAsyncStorage({ '@folders': '["legacy-data"]' });
+
+    await migrateAsyncStorageKey('@folders', '@iostoandroid/folders');
+
+    expect(await AsyncStorage.getItem('@iostoandroid/folders')).toBe('["legacy-data"]');
+    expect(await AsyncStorage.getItem('@folders')).toBeNull();
+  });
+
+  it('preserves the new-key value when BOTH keys exist (no overwrite)', async () => {
+    setupMemoryAsyncStorage({
+      '@folders': '["legacy-data"]',
+      '@iostoandroid/folders': '["newer-data"]',
+    });
+
+    await migrateAsyncStorageKey('@folders', '@iostoandroid/folders');
+
+    expect(await AsyncStorage.getItem('@iostoandroid/folders')).toBe('["newer-data"]');
+    expect(await AsyncStorage.getItem('@folders')).toBeNull();
+  });
+
+  it('leaves the new key untouched when only the new key exists', async () => {
+    setupMemoryAsyncStorage({ '@iostoandroid/folders': '["new-only"]' });
+
+    await migrateAsyncStorageKey('@folders', '@iostoandroid/folders');
+
+    expect(await AsyncStorage.getItem('@iostoandroid/folders')).toBe('["new-only"]');
+    expect(await AsyncStorage.getItem('@folders')).toBeNull();
+  });
+
+  it('is a no-op on a fresh install (no legacy, no new)', async () => {
+    await migrateAsyncStorageKey('@folders', '@iostoandroid/folders');
+
+    expect(await AsyncStorage.getItem('@iostoandroid/folders')).toBeNull();
+    expect(await AsyncStorage.getItem('@folders')).toBeNull();
+  });
+
+  it('is idempotent when called twice in a row', async () => {
+    setupMemoryAsyncStorage({ '@folders': '["data"]' });
+
+    await migrateAsyncStorageKey('@folders', '@iostoandroid/folders');
+    await migrateAsyncStorageKey('@folders', '@iostoandroid/folders');
+
+    expect(await AsyncStorage.getItem('@iostoandroid/folders')).toBe('["data"]');
+    expect(await AsyncStorage.getItem('@folders')).toBeNull();
+  });
+
+  it('does not throw when storage access fails (best-effort migration)', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockRejectedValue(new Error('storage unavailable'));
+
+    await expect(
+      migrateAsyncStorageKey('@folders', '@iostoandroid/folders'),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe('draft key helpers', () => {
+  it('builds namespaced and legacy draft keys from an address', () => {
+    expect(draftStorageKey('+15551234567')).toBe('@iostoandroid/draft_+15551234567');
+    expect(draftLegacyStorageKey('+15551234567')).toBe('@draft_+15551234567');
+  });
+});

--- a/src/store/storage.ts
+++ b/src/store/storage.ts
@@ -17,3 +17,13 @@ export async function migrateAsyncStorageKey(legacy: string, next: string): Prom
     /* best-effort migration — ignore failures */
   }
 }
+
+// Per-address message draft keys. The legacy form (`@draft_<address>`) predates
+// the @iostoandroid/ namespace and is only read as a migration source.
+export function draftStorageKey(address: string): string {
+  return `@iostoandroid/draft_${address}`;
+}
+
+export function draftLegacyStorageKey(address: string): string {
+  return `@draft_${address}`;
+}


### PR DESCRIPTION
## Resumo

Migra @draft_* e @lock_pin (chaves AsyncStorage sem namespace) para @iostoandroid/ com migracao one-shot e testes

## Causa raiz

O issue apontava `AppsStore` (`@recent_apps`) e `FoldersStore` (`@folders`) como chaves nao-namespaced. A investigacao mostrou que `main` **ja os migrou** (commit `77d58ad` "fix(C1): surface bridge errors in production (#190) (#237)"), incluindo o helper `migrateAsyncStorageKey` em `src/store/storage.ts` e o teste de migracao em `FoldersStore.test.tsx`. As chaves genuinamente nao-namespaced que restavam em `src/` eram duas:

- **`@draft_<address>`** — rascunhos de mensagem por conversa. `src/screens/ConversationScreen.tsx` construia `draftKey = `@draft_${address}`` e lia/escrevia/removia com essa chave; `src/screens/MessagesScreen.tsx:331` lia ``@draft_${c.address}`` para mostrar o badge de rascunho. Como a chave de escrita activa nao era namespaced, o backup/restauro (que enumera `@iostoandroid/`) e o wipe por prefixo nao a apanhavam.
- **`@lock_pin`** — fallback do PIN em AsyncStorage quando o SecureStore falha. `LauncherSettingsScreen.tsx` escrevia literalmente `AsyncStorage.setItem('@lock_pin', pinInput)` no fallback (linha 98) e lia literais nas linhas 70/95; `LockScreen.tsx` lia/removia a chave legacy. Ao contrario de `@recent_apps`/`@folders` (que em `main` so aparecem como constante legacy passada ao helper de migracao), `@lock_pin` era ainda **alvo de escrita activo** — recriado a cada gravacao quando o SecureStore falhava.

Nota sobre o grep do issue: a expressao `AsyncStorage\.(get|set|remove)Item\(.['\"\\]\@[^/]` exige **dois** caracteres entre `(` e `@` (`.` + uma aspa), por isso nao apanha `getItem('@lock_pin')` nem template strings como ``getItem(`@draft_${addr}`)`` — devolve 0 mesmo com chaves nao-namespaced. Usei um grep corrigido (aspas simples e backtick) para a enumeracao.

## O que mudou

- `src/store/storage.ts` — adiciona `draftStorageKey(address)` -> `@iostoandroid/draft_<addr>` e `draftLegacyStorageKey(address)` -> `@draft_<addr>`, ao lado do `migrateAsyncStorageKey` ja existente.
- `src/screens/ConversationScreen.tsx` — `draftKey` passa a ser `draftStorageKey(address)`; novo `legacyDraftKey`. O efeito de montagem migra primeiro (`migrateAsyncStorageKey(legacyDraftKey, draftKey)`) e so depois le a chave nova. As escritas/remocoes de rascunho continuam a usar `draftKey`, agora namespaced.
- `src/screens/MessagesScreen.tsx` — `loadDrafts` migra a chave legacy de cada conversa antes de ler a chave nova.
- `src/screens/LockScreen.tsx` — nova constante `LOCK_PIN_STORAGE_KEY = '@iostoandroid/lock_pin'`. O efeito de migracao le a chave nova e depois a legacy, migra para o SecureStore e remove ambas; se o SecureStore ja tem PIN, remove as copias em AsyncStorage. O caminho de verificacao le SecureStore -> chave nova -> legacy (removeu a flag `storeAvailable`, cujos dois ramos eram identicos).
- `src/screens/LauncherSettingsScreen.tsx` — constantes `LOCK_PIN_KEY`/`LOCK_PIN_STORAGE_KEY`/`LOCK_PIN_LEGACY_KEY`. O fallback quando o SecureStore falha escreve na chave **nova**; o sucesso remove ambas as copias AsyncStorage; a leitura do PIN actual tenta SecureStore -> nova -> legacy.
- Testes: `src/store/__tests__/storage.test.ts` (unit do helper + helpers de draft, com mock AsyncStorage stateful), `src/screens/__tests__/ConversationScreen.test.tsx` (migracao de rascunho), `src/screens/__tests__/LockScreen.test.tsx` (migracao do PIN), `src/screens/__tests__/LauncherSettingsScreen.test.tsx` (escrita de fallback + remocao + ordem de leitura).

## Porque assim

Segui o padrao que `main` ja estabelecera para `@recent_apps`/`@folders`: a chave nova e o unico alvo de escrita; a chave legacy existe apenas como fonte de migracao (ler + remover). Para o PIN, o SecureStore mantem-se autoritativo; o AsyncStorage e apenas fallback, agora sob o namespace — o que faz com que o wipe/reset por prefixo e o backup/restauro o apanhem.

Alternativas descartadas: (a) ignorar `@lock_pin` por ser "legacy" — descartada porque e ainda um alvo de escrita activo (o fallback recriava a chave legacy a cada gravacao); (b) migrar os rascunhos em lote no arranque — descartada porque a lista de conversas so existe em runtime e o custo e uma leitura por conversa; a migracao na leitura cobre ambos os ecrans com o mesmo helper.

## Criterios de aceitacao

- [x] Zero chaves nao-namespaced em `src/`: o grep literal do issue devolve 0; o grep corrigido de literais em chamadas AsyncStorage devolve apenas `@iostoandroid/...`. As unicas strings nao-namespaced que restam sao constantes legacy usadas **apenas** como fonte de migracao (`@recent_apps`, `@folders` ja em `main`; `@lock_pin`/`@draft_` agora) — o mesmo padrao pos-migracao de `main`.
- [x] Utilizadores existentes nao perdem dados: testes de migracao confirmam copia do valor legacy para a chave nova + remocao da legacy.
- [x] Com AMBAS as chaves, o valor da nova prevalece (sem overwrite): testado em `storage.test.ts` e `ConversationScreen.test.tsx`.
- [x] Instalacoes novas usam chaves namespaced desde o dia 1: o save de rascunho escreve apenas `@iostoandroid/draft_...`; o fallback do PIN escreve apenas `@iostoandroid/lock_pin`; nenhum teste re-cria a chave legacy (o inverso do fix).
- [x] O que NAO devia mudar: desbloqueio com PIN correcto continua a funcionar (teste existente passa); o SecureStore nao e sobrescrito quando ja tem PIN (testado); a lista de ficheiros `git status` contem apenas os 9 ficheiros abaixo.

## Testes

**Passo vermelho** — com o fix de producao revertido (`git stash push` dos 5 ficheiros de producao, testes mantidos), outputs reais do jest:

ConversationScreen:
```
● ConversationScreen › migrates a legacy draft to the namespaced key on mount

  expect(received).toBe(expected) // Object.is equality

  Expected: "Hello legacy draft"
  Received: undefined
```

LockScreen:
```
● LockScreen › migrates a PIN from the namespaced AsyncStorage key to SecureStore on mount

  expect(jest.fn()).toHaveBeenCalledWith(...expected)

  Expected: "lock_pin", "1234"

  Number of calls: 0
```

LauncherSettingsScreen:
```
● LauncherSettingsScreen › falls back to the NAMESPACED AsyncStorage key when SecureStore is unavailable

  expect(received).toBe(expected) // Object.is equality

  Expected: "5678"
  Received: undefined
```

**Sanity-check completo**: `git stash push` do fix (5 ficheiros de producao) -> nos 4 suites novos/alterados: **14 falham, 16 passam**; `git stash pop` -> **30 passam, 3 falham** (apenas baseline). Os testes falham sem o fix e passam com ele — provam que estao ligados ao comportamento.

**Casos cobertos** (alem do caminho feliz):
- Estado vazio/instalacao nova: sem legacy nem nova -> no-op; sem legacy -> sem migracao (`storage.test.ts`, ConversationScreen).
- Ambos existem -> a nova prevalece (sem overwrite) e a legacy e removida (`storage.test.ts`, ConversationScreen).
- Repeticao: migracao chamada duas vezes seguidas (idempotente).
- Assincrono/erro: `getItem` a lancar -> o helper nao rebenta (best-effort).
- O inverso do fix: save de rascunho NAO re-cria `@draft_...`; fallback do PIN NAO re-cria `@lock_pin` (mock stateful verifica ausencia da chave legacy).
- Seguranca: PIN guardado so na chave nova e aceite no desbloqueio quando o SecureStore esta indisponivel; SecureStore com PIN nao e sobrescrito e as copias AsyncStorage sao limpas.

**Resultados**: `npm run lint` -> 0 erros, 2 warnings pre-existentes em ficheiros nao tocados (CupertinoActionSheet, ClockScreen). `npx tsc --noEmit` -> limpo. `npm test` -> **9 falharam, 275 passaram, 284 total, 41 suites** — exactamente o conjunto do baseline (mesmos 9 testes, mesmas 5 suites; nenhuma falha nova, nenhuma nos ficheiros tocados). Os 3 LockScreen a falhar sao baseline (`renders flashlight button`, `renders camera button`, `passcode numpad has digit buttons`) — confirmado com `git stash` do meu fix + run + `git stash pop`.

Nota de cobertura: a alteracao de 3 linhas no `MessagesScreen.tsx` (migrar antes de ler no `loadDrafts`) nao tem teste directo proprio — o `DeviceProvider` carrega mensagens via dynamic import do modulo nativo e o override do mock no ficheiro de teste nao intercepta essa instancia (probe comprovou 0 chamadas a `getRecentMessages`). Esta coberta indirectamente pelos testes unitarios dos mesmos helpers que chama (`migrateAsyncStorageKey`, `draftStorageKey`/`draftLegacyStorageKey`) e pelos testes de integracao do ConversationScreen com o mesmo fluxo migracao->leitura.

## Testes

275 passaram, 9 falharam (todas baseline), 5 suites com falhas de 41; 36 suites verdes

## Linked Issue

Fixes #205