### PR TITLE
M6: LockScreen re-fetch de notificações quando a permissão é concedida depois + testes dos 3 estados de notificação (#206)

### DIFF
--- a/src/screens/LockScreen.tsx
+++ b/src/screens/LockScreen.tsx
@@ -39,7 +39,14 @@ const getLauncher = async () => {
   try {
     return (await import('../../modules/launcher-module/src')).default;
   } catch {
-    return null; // Expected: module unavailable on non-Android
+    // Dynamic import is unavailable in some environments (e.g. Jest's VM);
+    // fall back to a synchronous require so the module stays reachable there.
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports -- Metro supports require; fallback for environments without dynamic import
+      return require('../../modules/launcher-module/src').default;
+    } catch {
+      return null; // Expected: module unavailable on non-Android
+    }
   }
 };
 
@@ -404,7 +411,9 @@ export function LockScreen({ navigation, onUnlock }: { navigation?: AppNavigatio
     }, 300);
   };
 
-  // Fetch real notifications
+  // Fetch real notifications. Re-runs when the store's notification-access state
+  // flips to true (e.g. the user grants access in settings and returns to the app),
+  // so the list populates without remounting the screen.
   useEffect(() => {
     let mounted = true;
     (async () => {
@@ -423,7 +432,7 @@ export function LockScreen({ navigation, onUnlock }: { navigation?: AppNavigatio
       } catch { /* Expected: notification access not granted */ }
     })();
     return () => { mounted = false; };
-  }, []);
+  }, [device.notificationAccessGranted]);
 
   // Update clock aligned to minute boundaries (like real iOS)
   useEffect(() => {
@@ -709,8 +718,9 @@ export function LockScreen({ navigation, onUnlock }: { navigation?: AppNavigatio
               <Pressable
                 style={styles.notifPermissionButton}
                 onPress={async () => {
+                  const mod = await getLauncher();
+                  if (!mod) return;
                   try {
-                    const mod = (await import('../../modules/launcher-module/src')).default;
                     await mod.openNotificationAccessSettings();
                   } catch {
                     /* settings intent may be unavailable on some OEM builds */

--- a/src/screens/__tests__/LockScreen.test.tsx
+++ b/src/screens/__tests__/LockScreen.test.tsx
@@ -3,6 +3,8 @@ import { render, fireEvent, waitFor } from '../../test-utils';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as SecureStore from 'expo-secure-store';
 import { LockScreen } from '../LockScreen';
+import { DeviceContext, DeviceContextValue } from '../../store/DeviceStore';
+import launcherModule from '../../../modules/launcher-module/src';
 
 jest.mock('expo-secure-store', () => ({
   getItemAsync: jest.fn(async () => null),
@@ -142,5 +144,158 @@ describe('LockScreen', () => {
     fireEvent.press(getByLabelText('Digit 4'));
 
     await waitFor(() => expect(onUnlock).toHaveBeenCalled());
+  });
+});
+
+// Notification-access CTA + re-fetch behaviour (issue 206).
+
+// The DeviceStore's real launcher-module polling can't run in jest: the dynamic
+// `import()` used by `getLauncher` is not supported by jest's VM, so the store
+// value would stay `null` forever. These tests therefore drive the LockScreen
+// through a controlled DeviceContext value — the same context `useDevice()`
+// reads — so the render branch and the re-fetch reactivity are exercised.
+function MockDeviceProvider({
+  notificationAccessGranted,
+  children,
+}: {
+  notificationAccessGranted: boolean | null;
+  children: React.ReactNode;
+}) {
+  const value: DeviceContextValue = {
+    battery: { level: 0.72, isCharging: false },
+    brightness: 0.5,
+    volume: 0.5,
+    wifi: { enabled: false, ssid: '', rssi: 0, linkSpeed: 0, ip: '', networks: [] },
+    bluetooth: { enabled: false, name: '', address: '', pairedDevices: [] },
+    storage: { totalGB: '0', usedGB: '0', freeGB: '0', usedPercentage: 0 },
+    network: { isConnected: false, isWifi: false, isCellular: false },
+    messages: [],
+    contacts: [],
+    weather: { temp: 0, condition: '', icon: 'cloud', city: '' },
+    notificationAccessGranted,
+    isReady: true,
+    refresh: async () => {},
+    setBrightness: async () => {},
+    setVolume: async () => {},
+    toggleWifi: async () => {},
+    toggleBluetooth: async () => {},
+    openSystemPanel: async () => {},
+    requestContactsPermission: async () => false,
+    requestSmsPermission: async () => false,
+  };
+  return <DeviceContext.Provider value={value}>{children}</DeviceContext.Provider>;
+}
+
+afterEach(() => {
+  // Restore launcher-module defaults so unrelated tests keep the denied-access default.
+  (launcherModule.isNotificationAccessGranted as jest.Mock).mockResolvedValue(false);
+  (launcherModule.getNotifications as jest.Mock).mockResolvedValue([]);
+});
+
+describe('LockScreen notification access', () => {
+  it('shows the CTA when notification access is not granted', () => {
+    const { getByText, getByLabelText } = render(
+      <MockDeviceProvider notificationAccessGranted={false}>
+        <LockScreen />
+      </MockDeviceProvider>
+    );
+    expect(getByText('Notifications are off')).toBeTruthy();
+    expect(getByText('Grant access to see them on the lock screen.')).toBeTruthy();
+    expect(getByLabelText('Open notification access settings')).toBeTruthy();
+  });
+
+  it('opens notification access settings when the CTA button is pressed', async () => {
+    const { getByLabelText } = render(
+      <MockDeviceProvider notificationAccessGranted={false}>
+        <LockScreen />
+      </MockDeviceProvider>
+    );
+    fireEvent.press(getByLabelText('Open notification access settings'));
+    await waitFor(() => expect(launcherModule.openNotificationAccessSettings).toHaveBeenCalled());
+  });
+
+  it('renders notifications and no CTA when access is granted', async () => {
+    (launcherModule.isNotificationAccessGranted as jest.Mock).mockResolvedValue(true);
+    (launcherModule.getNotifications as jest.Mock).mockResolvedValue([
+      { id: 'n1', packageName: 'com.whatsapp', title: 'Hello', text: 'Message body', time: Date.now(), isOngoing: false },
+    ]);
+    const { getByText, queryByText } = render(
+      <MockDeviceProvider notificationAccessGranted={true}>
+        <LockScreen />
+      </MockDeviceProvider>
+    );
+    await waitFor(() => expect(getByText('Hello')).toBeTruthy());
+    expect(queryByText('Notifications are off')).toBeNull();
+  });
+
+  it('keeps the empty state (no CTA) when access is granted but there are no notifications', async () => {
+    (launcherModule.isNotificationAccessGranted as jest.Mock).mockResolvedValue(true);
+    (launcherModule.getNotifications as jest.Mock).mockResolvedValue([]);
+    const { queryByText } = render(
+      <MockDeviceProvider notificationAccessGranted={true}>
+        <LockScreen />
+      </MockDeviceProvider>
+    );
+    // Wait for the fetch to have run so the "empty" state is settled, then
+    // confirm the CTA is NOT shown.
+    await waitFor(() => expect(launcherModule.getNotifications).toHaveBeenCalled());
+    expect(queryByText('Notifications are off')).toBeNull();
+  });
+
+  it('re-fetches notifications after access is granted later (returning from settings)', async () => {
+    // Fresh install / revoked: denied at first.
+    (launcherModule.isNotificationAccessGranted as jest.Mock).mockResolvedValue(false);
+    (launcherModule.getNotifications as jest.Mock).mockResolvedValue([]);
+    const { getByText, queryByText, rerender } = render(
+      <MockDeviceProvider notificationAccessGranted={false}>
+        <LockScreen />
+      </MockDeviceProvider>
+    );
+    expect(getByText('Notifications are off')).toBeTruthy();
+    // Let the mount effect's async body finish reading access=false (no fetch yet)
+    // before flipping the permission state — otherwise the effect reads the new
+    // mock value and this test would pass even without the re-fetch fix.
+    await waitFor(() =>
+      expect(launcherModule.isNotificationAccessGranted).toHaveBeenCalled()
+    );
+
+    // User grants access in the system settings and returns to the app: the store
+    // value flips to true and the LockScreen must re-fetch notifications.
+    (launcherModule.isNotificationAccessGranted as jest.Mock).mockResolvedValue(true);
+    (launcherModule.getNotifications as jest.Mock).mockResolvedValue([
+      { id: 'n1', packageName: 'com.whatsapp', title: 'Granted message', text: 'Body', time: Date.now(), isOngoing: false },
+    ]);
+    rerender(
+      <MockDeviceProvider notificationAccessGranted={true}>
+        <LockScreen />
+      </MockDeviceProvider>
+    );
+
+    await waitFor(() => expect(getByText('Granted message')).toBeTruthy());
+    expect(queryByText('Notifications are off')).toBeNull();
+  });
+
+  it('shows the CTA again and hides notifications when access is revoked', async () => {
+    (launcherModule.isNotificationAccessGranted as jest.Mock).mockResolvedValue(true);
+    (launcherModule.getNotifications as jest.Mock).mockResolvedValue([
+      { id: 'n1', packageName: 'com.whatsapp', title: 'Hello', text: 'Message body', time: Date.now(), isOngoing: false },
+    ]);
+    const { getByText, queryByText, rerender } = render(
+      <MockDeviceProvider notificationAccessGranted={true}>
+        <LockScreen />
+      </MockDeviceProvider>
+    );
+    await waitFor(() => expect(getByText('Hello')).toBeTruthy());
+
+    // Access revoked while the app is open.
+    (launcherModule.isNotificationAccessGranted as jest.Mock).mockResolvedValue(false);
+    rerender(
+      <MockDeviceProvider notificationAccessGranted={false}>
+        <LockScreen />
+      </MockDeviceProvider>
+    );
+
+    await waitFor(() => expect(getByText('Notifications are off')).toBeTruthy());
+    expect(queryByText('Hello')).toBeNull();
   });
 });

--- a/src/store/DeviceStore.tsx
+++ b/src/store/DeviceStore.tsx
@@ -95,6 +95,8 @@ interface DeviceContextValue extends DeviceState {
 
 const DeviceContext = createContext<DeviceContextValue | null>(null);
 
+export { DeviceContext, type DeviceContextValue };
+
 const DEFAULT_STATE: DeviceState = {
   battery: { level: 1, isCharging: false },
   brightness: 0.5,


### PR DESCRIPTION
## Resumo

M6: LockScreen re-fetch de notificações quando a permissão é concedida depois + testes dos 3 estados de notificação

## Causa raiz

O issue descreve um problema que **já estava resolvido em main** e um que **não estava**.

O que o issue alega — "LockScreen renders `device.notifications` straight from the store" (linhas 41-48) — está desactualizado. As linhas 41-48 são o helper `getLauncher()`; as notificações são buscadas localmente pelo LockScreen, não vêm do store. O campo `notificationAccessGranted` no `DeviceStore` e o CTA no LockScreen **já existiam** (adicionados em `77d58ad`, PR #190): o store já faz polling de `isNotificationAccessGranted()` em `src/store/DeviceStore.tsx:273-279` (refresh no mount e no AppState 'active'), e o render já ramifica em `src/screens/LockScreen.tsx:705` com `device.notificationAccessGranted === false` → CTA.

O defeito **real** que restava é o AC3 do issue: o efeito local de fetch de notificações do LockScreen tinha deps `[]` (`src/screens/LockScreen.tsx:426`), portanto corria **uma vez, no mount**. Cenário que falhava:

1. Utilizador nega Notification Access (ou instalação nova saltou o passo).
2. LockScreen monta → efeito lê `isNotificationAccessGranted()` → `false` → não busca. Store: `false` → CTA.
3. Utilizador concede a permissão em Settings e volta à app.
4. `AppState 'active'` → store faz `refresh()` → `notificationAccessGranted` passa a `true` → CTA desaparece.
5. Mas o efeito local **não re-corre** (deps `[]`) → `notifications` continua `[]` → lista vazia para sempre.

Ou seja: o CTA aparecia, mas conceder a permissão não trazia as notificações — exactamente o AC3 que o issue exige. 

## O que mudou

**`src/screens/LockScreen.tsx`**
- O efeito de fetch passa a depender de `device.notificationAccessGranted` (de `[]` para `[device.notificationAccessGranted]`). Quando o store flips para `true` ao voltar de Settings, o efeito re-corre e busca as notificações; quando flips para `false` (permissão revogada), re-corre, o check directo devolve `false` e a lista não é buscada — o CTA substitui o render.
- `getLauncher()` ganhou um fallback a `require` síncrono quando o `import()` dinâmico falha. O Metro suporta `import()`; o VM do jest não (erro "A dynamic import callback was invoked without --experimental-vm-modules"), o que tornava o módulo launcher inalcançável em testes e fazia `getLauncher()` devolver `null` silenciosamente. O fallback só activa quando o `import()` lança; em produção com Metro o comportamento é idêntico.
- O `onPress` do CTA passou a usar `getLauncher()` em vez de `import()` cru — comportamento idêntico em produção (mesmo catch silencioso), e o botão fica testável.

**`src/store/DeviceStore.tsx`**
- Exporta `DeviceContext` e `DeviceContextValue` (aditivo, sem mudança de comportamento) para os testes conseguirem injectar um estado controlado no mesmo contexto que `useDevice()` lê.

**`src/screens/__tests__/LockScreen.test.tsx`**
- 6 testes novos no bloco "LockScreen notification access": CTA quando negado, tap abre settings, lista quando concedido, vazio quando concedido (sem CTA), re-fetch após conceder mais tarde (AC3), e o inverso (revogar → CTA volta).

## Porque assim

- **Não toquei no `DeviceStore` para polling**: o campo `notificationAccessGranted` e o refresh já existiam e estão correctos. Só exportei o contexto para testes.
- **Porque não gate-only no valor do store**: fazer o fetch depender só do valor do store atrasaria a primeira busca atrás do `Promise.all` do `refresh()` (que inclui um fetch de rede ao wttr.in para o clima). Mantive o check directo `isNotificationAccessGranted()` no efeito (busca rápida no mount) e usei o valor do store só como gatilho de re-execução.
- **Alternativa rejeitada — tornar o `import()` dinâmico globalmente testável** (`babel-plugin-dynamic-import-node` ou `--experimental-vm-modules`): blast radius grande. Reactivaria o mock do launcher em todos os ecrãs em teste, mudando defaults (wifi `enabled:true`, bluetooth `true`, storage `'128.0'`) e podia virar testes existentes; exigiria dependência nova ou mudança de script. O fallback local no `getLauncher` alcança o mesmo objectivo com efeito só no LockScreen.
- **Issue estava errado em**: (1) a premissa de que o LockScreen renderiza `device.notifications` do store — as notificações são locais; (2) a ideia de que o CTA/`notificationAccessGranted` não existiam — já existiam desde #190. O trabalho real foi o AC3 (re-fetch) e os testes.

## Critérios de aceitação

- [x] **Fresh install com permissão negada mostra o CTA** — `device.notificationAccessGranted === false` → CTA "Notifications are off" + "Open Settings". Teste: "shows the CTA when notification access is not granted".
- [x] **Tap no CTA abre o Android Notification Listener settings** — `onPress` chama `mod.openNotificationAccessSettings()`. Teste: "opens notification access settings when the CTA button is pressed".
- [x] **Conceder permissão e voltar re-renderiza a lista normal** — era o defeito; o efeito re-corre com o novo dep `[device.notificationAccessGranted]`. Teste: "re-fetches notifications after access is granted later (returning from settings)".
- [x] **Permissão concedida mas sem notificações → estado vazio (não CTA)** — o branch `=== true` renderiza os grupos (vazios), nunca o CTA. Teste: "keeps the empty state (no CTA) when access is granted but there are no notifications".
- [x] **Testes cobrem os três estados** — negado (CTA), concedido+lista, concedido+vazio; + tap, re-fetch e revogação.
- [x] **O que NÃO devia mudar**: a renderização da lista quando concedido (agrupamento, dismiss, expandido intactos), o texto/estilos do CTA, a lógica de polling do store, e nenhuma regressão noutros ecrãs — confirmado porque a suite completa mantém exactamente as 9 falhas de baseline e zero novas.

## Testes

- **Passo vermelho (isolado, só o deps revertido — o fallback já presente):** reverter `[device.notificationAccessGranted]` → `[]` no efeito de fetch e correr o teste AC3:

```
✕ re-fetches notifications after access is granted later (returning from settings) (1106 ms)
Unable to find an element with text: Granted message
> 274 |     await waitFor(() => expect(getByText('Granted message')).toBeTruthy();
     |                             ^
  275 |     expect(queryByText('Notifications are off')).toBeNull();
  276 |   };
      at Object.<anonymous> (src/screens/__tests__/LockScreen.test.tsx:274:18)
Tests:       1 failed, 17 skipped, 18 total
```

  (Nota: este isolamento só é possível com o fallback do `getLauncher` presente; sem ele o `import()` dinâmico lança no VM do jest e nenhuma notificação é alcançável. O passo vermelho completo, com o LockScreen revertido via `git stash`:

```
=== SUITE COM FIX REVERTIDO ===
✕ renders flashlight button (36 ms)
✕ renders camera button (30 ms)
✕ passcode numpad has digit buttons (61 ms)
✕ opens notification access settings when the CTA button is pressed (1006 ms)
✕ renders notifications and no CTA when access is granted (1010 ms)
✕ keeps the empty state (no CTA) when access is granted but there are no notifications (1078 ms)
✕ re-fetches notifications after access is granted later (returning from settings) (1045 ms)
✕ shows the CTA again and hides notifications when access is revoked (1026 ms)
Tests:       8 failed, 10 passed, 18 total
```

  As 3 primeiras são as falhas de baseline (labels desactualizadas); as 5 últimas são os testes novos a falhar porque o módulo launcher é inalcançável em jest sem o fallback. Com o fix completo: 15 passed, só as 3 de baseline.

- **Casos cobertos:** para além do caminho feliz — o inverso do fix (revogar a permissão → CTA volta e a lista esconde, teste "shows the CTA again and hides notifications when access is revoked"); vazio (concedido sem notificações → sem CTA); repetição/transição (negado → concedido → lista, que era o AC3); e o press do CTA. O teste de re-fetch espera explicitamente o efeito de mount terminar antes de simular o grant, para não passar por timing (o `await getLauncher()` deixa o corpo assíncrono ler o mock já trocado).
- **Sanity-check:** `git stash push -- src/screens/LockScreen.tsx` (mantendo os testes) → suite do LockScreen vai de 3 para 8 falhas; `git stash pop` → volta a 3. Os testes estão ligados ao fix.
- **Verificações:** `npm run lint` — 0 erros, 2 warnings pré-existentes (CupertinoActionSheet, ClockScreen). `npx tsc --noEmit` — limpo. `npm test` — 9 falhas / 281 passaram / 41 suites: **exactamente as 9 falhas de baseline** (CalculatorScreen, FoldersStore×2, LockScreen×3, SettingsScreen, WeatherScreen×2), zero falhas novas.

## Testes

281 passaram, 9 falharam (mesmas 9 da baseline), 41 suites; LockScreen notification access: 6/6

## Linked Issue

Fixes #206