### PR TITLE
M7: AssistiveTouch — backdrop volta a montar no reopen durante o fecho + testes de regressão do guard de abertura (#207)

### DIFF
--- a/src/components/AssistiveTouch.tsx
+++ b/src/components/AssistiveTouch.tsx
@@ -146,12 +146,22 @@ export function AssistiveTouch({ navigationRef }: AssistiveTouchProps) {
   // ── Radial menu state ─────────────────────────────────────────────────────
   const [menuOpen, setMenuOpen] = useState(false);
   const [fullyOpen, setFullyOpen] = useState(false);
+  // Timer that mounts the backdrop once the opening animation settles. Owned by
+  // the callbacks (not by an effect on `menuOpen`) so a reopen while the close
+  // animation is still running re-arms it: the effect version skipped it
+  // because `menuOpen` never transitions when the user reopens mid-close, and
+  // the backdrop was then gone for the whole session. `closeMenu` clears it so
+  // the backdrop cannot flash back on during the closing animation.
+  const fullyOpenTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const menuScale = useSharedValue(0);
   const menuOpacity = useSharedValue(0);
 
   const openMenu = useCallback(() => {
     if (hapticFeedback) hapticImpact(Haptics.ImpactFeedbackStyle.Light).catch(() => {});
     setMenuOpen(true);
+    setFullyOpen(false);
+    if (fullyOpenTimer.current) clearTimeout(fullyOpenTimer.current);
+    fullyOpenTimer.current = setTimeout(() => setFullyOpen(true), 150);
     menuScale.value = withSpring(1, { damping: 14, stiffness: 220 });
     menuOpacity.value = withTiming(1, { duration: 160 });
     wake();
@@ -163,15 +173,17 @@ export function AssistiveTouch({ navigationRef }: AssistiveTouchProps) {
       if (finished) runOnJS(setMenuOpen)(false);
     });
     setFullyOpen(false);
+    if (fullyOpenTimer.current) {
+      clearTimeout(fullyOpenTimer.current);
+      fullyOpenTimer.current = null;
+    }
   }, [menuScale, menuOpacity]);
 
   useEffect(() => {
-    if (menuOpen) {
-      const t = setTimeout(() => setFullyOpen(true), 150);
-      return () => clearTimeout(t);
-    }
-    setFullyOpen(false);
-  }, [menuOpen]);
+    return () => {
+      if (fullyOpenTimer.current) clearTimeout(fullyOpenTimer.current);
+    };
+  }, []);
 
   // ── Action execution ──────────────────────────────────────────────────────
   const navigate = useCallback(

--- a/src/components/__tests__/AssistiveTouch.test.tsx
+++ b/src/components/__tests__/AssistiveTouch.test.tsx
@@ -1,0 +1,193 @@
+import React, { useEffect } from 'react';
+import { act, render, fireEvent } from '../../test-utils';
+import { AssistiveTouch } from '../AssistiveTouch';
+import { AssistiveTouchProvider, useAssistiveTouch } from '../../store/AssistiveTouchStore';
+import type { NavigationContainerRefWithCurrent } from '@react-navigation/native';
+import type { RootStackParamList } from '../../navigation/types';
+
+const BACKDROP_LABEL = 'Close AssistiveTouch menu';
+
+// ── Gesture capture ─────────────────────────────────────────────────────────
+// jest.setup.js mocks react-native-gesture-handler with a Gesture API that
+// discards every callback, so the tap that opens the AssistiveTouch menu could
+// never fire in a test. This file re-mocks the module and KEEPS the tap
+// handlers, so tests can drive the floating button's single-tap. The `mock`
+// prefix is required: jest.mock factories may only close over `mock*` names,
+// and the array is only touched at render time, never at module load.
+const mockTapRecords: Array<{ numberOfTaps: number; onEnd: (e: unknown, success: boolean) => void }> = [];
+
+jest.mock('react-native-gesture-handler', () => {
+  const chain = (record: Record<string, unknown>) => {
+    const g: Record<string, unknown> = {};
+    g.numberOfTaps = (n: number) => { record.numberOfTaps = n; return g; };
+    g.minDuration = (n: number) => { record.minDuration = n; return g; };
+    g.maxDuration = (n: number) => { record.maxDuration = n; return g; };
+    ['minDistance', 'maxPointers', 'minPointers', 'enabled', 'hitSlop',
+      'simultaneousWithExternalGesture', 'withRef', 'activeOffsetX',
+      'activeOffsetY', 'failOffsetX', 'failOffsetY', 'averageTouches',
+    ].forEach((m) => { g[m] = () => g; });
+    g.onBegin = (fn: unknown) => { record.onBegin = fn; return g; };
+    g.onStart = (fn: unknown) => { record.onStart = fn; return g; };
+    g.onUpdate = (fn: unknown) => { record.onUpdate = fn; return g; };
+    g.onChange = (fn: unknown) => { record.onChange = fn; return g; };
+    g.onEnd = (fn: unknown) => { record.onEnd = fn; return g; };
+    g.onFinalize = (fn: unknown) => { record.onFinalize = fn; return g; };
+    return g;
+  };
+  const tap = () => {
+    const record = { numberOfTaps: 0, maxDuration: 0 };
+    mockTapRecords.push(record as never);
+    return chain(record);
+  };
+  return {
+    GestureHandlerRootView: 'View',
+    GestureDetector: 'View',
+    Gesture: {
+      Pan: () => chain({}),
+      Tap: tap,
+      LongPress: () => chain({}),
+      Fling: () => chain({}),
+      Exclusive: (...gs: unknown[]) => gs[0],
+      Simultaneous: (...gs: unknown[]) => gs[0],
+      Race: (...gs: unknown[]) => gs[0],
+    },
+    Swipeable: 'View',
+    DrawerLayout: 'View',
+    State: {},
+    PanGestureHandler: 'View',
+    TapGestureHandler: 'View',
+    FlatList: 'FlatList',
+    ScrollView: 'ScrollView',
+  };
+});
+
+// ── Harness ─────────────────────────────────────────────────────────────────
+
+function EnableAssistiveTouch() {
+  const { update } = useAssistiveTouch();
+  useEffect(() => {
+    update({ enabled: true });
+  }, [update]);
+  return null;
+}
+
+function makeNavigationRef() {
+  return {
+    getCurrentRoute: () => ({ name: 'HomeMain', key: 'home', params: undefined }),
+    addListener: jest.fn(() => () => {}),
+    navigate: jest.fn(),
+  } as unknown as NavigationContainerRefWithCurrent<RootStackParamList>;
+}
+
+function renderAssistiveTouch(navigationRef = makeNavigationRef()) {
+  return render(
+    <AssistiveTouchProvider>
+      <EnableAssistiveTouch />
+      <AssistiveTouch navigationRef={navigationRef} />
+    </AssistiveTouchProvider>
+  );
+}
+
+/** Most recently built single-tap gesture (the floating button's tap). */
+const lastSingleTap = () => {
+  for (let i = mockTapRecords.length - 1; i >= 0; i--) {
+    if (mockTapRecords[i].numberOfTaps === 1) return mockTapRecords[i];
+  }
+  throw new Error('no single-tap gesture captured');
+};
+
+/** Simulates a successful tap on the floating button → `openMenu()`. */
+const openMenu = () => {
+  act(() => {
+    lastSingleTap().onEnd({}, true);
+  });
+};
+
+const advance = (ms: number) => {
+  act(() => {
+    jest.advanceTimersByTime(ms);
+  });
+};
+
+describe('AssistiveTouch menu backdrop', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockTapRecords.length = 0;
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('mantém o backdrop desmontado durante a abertura e monta-o aos 150 ms', () => {
+    const { queryByLabelText, getByLabelText } = renderAssistiveTouch();
+    openMenu();
+
+    // 50 ms — a janela do issue: a animar, sem backdrop para roubar o toque.
+    advance(50);
+    expect(queryByLabelText(BACKDROP_LABEL)).toBeNull();
+
+    // 149 ms — borda inferior exacta do guard.
+    advance(99);
+    expect(queryByLabelText(BACKDROP_LABEL)).toBeNull();
+
+    // 150 ms — animação concluída, o backdrop monta.
+    advance(1);
+    expect(getByLabelText(BACKDROP_LABEL)).toBeTruthy();
+  });
+
+  it('tocar num item 50 ms após abrir dispara a ação e não o dismiss', () => {
+    const navigationRef = makeNavigationRef();
+    const { queryByLabelText, getByLabelText } = renderAssistiveTouch(navigationRef);
+    openMenu();
+    advance(50);
+
+    // Sem backdrop montado, o toque no item não pode ser consumido por ele.
+    expect(queryByLabelText(BACKDROP_LABEL)).toBeNull();
+
+    fireEvent.press(getByLabelText('Notifications'));
+    expect(navigationRef.navigate).toHaveBeenCalledWith('NotificationCenter');
+  });
+
+  it('tocar no backdrop depois de assente faz dismiss', () => {
+    const { queryByLabelText, getByLabelText } = renderAssistiveTouch();
+    openMenu();
+    advance(150);
+
+    expect(getByLabelText(BACKDROP_LABEL)).toBeTruthy();
+
+    fireEvent.press(getByLabelText(BACKDROP_LABEL));
+    expect(queryByLabelText(BACKDROP_LABEL)).toBeNull();
+  });
+
+  it('reabrir o menu durante o fecho volta a montar o backdrop', () => {
+    const { queryByLabelText, getByLabelText } = renderAssistiveTouch();
+    openMenu();
+    advance(150);
+    expect(getByLabelText(BACKDROP_LABEL)).toBeTruthy();
+
+    // Tocar num item fecha; `menuOpen` continua true durante a animação de saída.
+    fireEvent.press(getByLabelText('Notifications'));
+    expect(queryByLabelText(BACKDROP_LABEL)).toBeNull();
+
+    // Reabrir antes de o fecho terminar — o `menuOpen` nunca transiciona, por
+    // isso o guard baseado no efeito nunca volta a disparar.
+    openMenu();
+    advance(150);
+
+    // Sem o backdrop, toques fora do menu nunca mais fecham o popover.
+    expect(getByLabelText(BACKDROP_LABEL)).toBeTruthy();
+  });
+
+  it('o backdrop não volta a montar durante o fecho após toque cedo num item', () => {
+    const { queryByLabelText, getByLabelText } = renderAssistiveTouch();
+    openMenu();
+    advance(50); // antes de o guard da abertura disparar
+
+    fireEvent.press(getByLabelText('Notifications')); // fecha o menu
+    expect(queryByLabelText(BACKDROP_LABEL)).toBeNull();
+
+    advance(150); // o timer da abertura original dispararia nesta janela
+    expect(queryByLabelText(BACKDROP_LABEL)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Resumo

M7: AssistiveTouch — backdrop volta a montar no reopen durante o fecho + testes de regressão do guard de abertura

## Causa raiz

O issue descreve um bug que **já não existe em `main`**. Ambos os fixes propostos já estão implementados:

- **(A)** `pointerEvents="box-none"` no wrapper do menu — `src/components/AssistiveTouch.tsx:345`.
- **(B)** Guard `fullyOpen` que atrasa a montagem do backdrop 150ms após `menuOpen` — estado + `setFullyOpen(true)` agendado por efeito, e `{fullyOpen && <Pressable .../>}` no render.

Verificado com `git log -S fullyOpen`: o guard entrou no commit `77d58ad` (ancestral de `origin/main`); o estado pré-fix (`77d58ad~1`) mostra o backdrop `Pressable` montado **incondicionalmente** com `menuOpen` — exactamente o que o issue descreve nas linhas 338-340. O issue estava desactualizado, não o código.

O defeito **real que restava** está no mesmo mecanismo: o guard era agendado por `useEffect(..., [menuOpen])`. Isso tem dois buracos:

1. **Reopen durante o fecho → backdrop permanentemente ausente.** Ao tocar num item, `closeMenu()` corre mas `menuOpen` continua `true` durante a animação de saída (150ms). Se o user volta a tocar no botão nessa janela, `setMenuOpen(true)` é no-op → o efeito não re-corre, o timer da abertura nunca é re-agendado, e o backdrop fica **para sempre** desmontado nessa sessão: toques fora do menu nunca mais fecham o popover. Isto viola o critério 2 do issue num fluxo real.
2. **Flash do backdrop durante o fecho.** Se o item é tocado nos primeiros 150ms da abertura, o timer agendado pelo open original continua pendente (o `closeMenu` não o limpa) → dispara a meio da animação de fecho e o backdrop volta a montar.

## O que mudou

- `src/components/AssistiveTouch.tsx` — o timer que monta o backdrop passa a ser dono dos callbacks, não do efeito: nova ref `fullyOpenTimer`; `openMenu()` faz `setFullyOpen(false)` + limpa + re-agenda o timer de 150ms; `closeMenu()` limpa o timer; o `useEffect([menuOpen])` é substituído por um cleanup de unmount. Timing, `pointerEvents="box-none"` e `accessibilityLabel` inalterados.
- `src/components/__tests__/AssistiveTouch.test.tsx` — **novo**, 5 testes. O mock global de `react-native-gesture-handler` (jest.setup.js) descarta os callbacks dos gestos, pelo que o único caminho para abrir o menu pelo toque real é capturar o handler do single-tap: o ficheiro re-mocka o RNGH e guarda os records de tap; `openMenu()` no teste invoca o `onEnd` do single-tap mais recente. Harness com `AssistiveTouchProvider` + `update({ enabled: true })` + `navigationRef` falso.

## Porque assim

Opção escolhida: timer gerido pelos callbacks (ref). Alternativa descartada: chavear o efeito por um contador de aberturas (`openCount`) — funcionaria, mas não limpa o timer pendente no fecho e deixaria o flash do cenário 2 intacto; a ref limpa no `closeMenu` resolve ambos os buracos com um mecanismo só. O timing de 150ms mantém-se igual ao do código pré-existente e ao proposto no issue.

O `accessibilityLabel` do backdrop é `"Close AssistiveTouch menu"` (não `"Close menu"` como o issue cita). Não é regressão — já era assim no estado pré-fix — e é mais descritivo; não alterado.

## Critérios de aceitação

- [x] **Tocar num item 50ms após abrir dispara a ação, não o dismiss** — já era verdade em `main` (guard pré-existente); travado pelo teste 2, que também verifica que o backdrop está desmontado aos 50ms (nada para roubar o toque).
- [x] **Tocar no backdrop depois de assente ainda faz dismiss** — teste 3; e o caso novo: **reopen durante o fecho volta a montar o backdrop** (teste 4), que falhava antes do fix.
- [x] **Sem regressão de acessibilidade** — o backdrop tem `accessibilityLabel` (asserted nos testes 1/3/4); o label existente `"Close AssistiveTouch menu"` é preservado.
- [x] **O que não devia mudar** — timing de 150ms, itens do menu, ações de navegação, `pointerEvents="box-none"` no wrapper e no Animated.View do menu. Confirmado por diff (só as linhas do timer mudaram) e pela suite completa (zero falhas novas).
- [x] **Inverso do fix** — o backdrop **não** volta a montar durante o fecho após toque cedo num item (teste 5), e continua desmontado antes dos 150ms (teste 1, fronteiras 50/149/150ms).

## Testes

**Passo vermelho** (fix revertido via `git stash push -- src/components/AssistiveTouch.tsx`, testes mantidos):

```
    ✓ mantém o backdrop desmontado durante a abertura e monta-o aos 150 ms (87 ms)
    ✓ tocar num item 50 ms após abrir dispara a ação e não o dismiss (28 ms)
    ✓ tocar no backdrop depois de assente faz dismiss (25 ms)
    ✕ reabrir o menu durante o fecho volta a montar o backdrop (24 ms)
    ✕ o backdrop não volta a montar durante o fecho após toque cedo num item (358 ms)

  ● AssistiveTouch menu backdrop › reabrir o menu durante o fecho volta a montar o backdrop

    Unable to find an element with accessibility label: Close AssistiveTouch menu

      177 |
      178 |     // Sem o backdrop, toques fora do menu nunca mais fecham o popover.
    > 179 |     expect(getByLabelText(BACKDROP_LABEL)).toBeTruthy();
          |            ^

  ● AssistiveTouch menu backdrop › o backdrop não volta a montar durante o fecho após toque cedo num item

    expect(received).toBeNull()

    Received: {"_fiber": {...}, "elementType": "View", ...}

      189 |
      190 |     advance(150); // o timer da abertura original dispararia nesta janela
    > 191 |     expect(queryByLabelText(BACKDROP_LABEL)).toBeNull();
          |                                              ^

Tests:       2 failed, 3 passed, 5 total
```

O guard pré-existente de `main` também foi provado: revertido temporariamente o guard (`{fullyOpen && ...}` → `{true && ...}`), **os 5 testes falham** — os testes 1-3 não são vacuos, exercitam o guard de `main`.

**Casos cobertos:** guard nas fronteiras exactas (50/149/150ms); toque no item a 50ms dispara a ação com o backdrop ausente; dismiss pelo backdrop após assente; o inverso (backdrop não monta antes dos 150ms); repetição (reopen durante o fecho) e assíncrono (o timer da abertura pendente é limpo no fecho).

**Sanity-check:** `git stash push -- src/components/AssistiveTouch.tsx` → suite falha (2 de 5), `git stash pop` → 5/5 passam. Confirmado também com o guard removido (5/5 falham) e restaurado.

**Verificações:**
- `npm run lint`: 0 erros (2 warnings pré-existentes em ficheiros não tocados).
- `npx tsc --noEmit`: limpo.
- `npm test`: 286 passam, 9 falham (exactamente as 9 da baseline — FoldersStore, CalculatorScreen, SettingsScreen, LockScreen, WeatherScreen), 295 total. Zero falhas novas; os 5 testes novos passam.

## Testes

286 passaram, 9 falharam (baseline idêntico), 295 total; AssistiveTouch 5/5

## Linked Issue

Fixes #207