### PR TITLE
M10: fix syncFromDevice's untestable dynamic import + add missing race-condition test coverage for SettingsStore's first-sync gate (#210)

### DIFF
--- a/src/store/SettingsStore.tsx
+++ b/src/store/SettingsStore.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import { AppState } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import type { LauncherModuleType } from '../../modules/launcher-module/src';
 import { setHapticsEnabled } from '../utils/haptics';
 
 const STORAGE_KEY = '@iostoandroid/settings';
@@ -176,7 +177,15 @@ export function SettingsProvider({
   const syncFromDevice = useCallback(async () => {
     const getLauncherModule = async () => {
       try {
-        return (await import('../../modules/launcher-module/src')).default;
+        // require(), not `await import(...)`: Metro has no real code-splitting
+        // for RN apps, so both compile to the same synchronous module load at
+        // runtime — but a bare `import()` throws under Jest's CommonJS test
+        // environment (ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING_FLAG), which
+        // silently made this catch swallow every call and left syncFromDevice
+        // a permanent no-op in every test in the suite. require() goes through
+        // Jest's normal resolver (and moduleNameMapper), so it's mockable.
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        return (require('../../modules/launcher-module/src') as { default: LauncherModuleType }).default;
       } catch { return null; }
     };
 

--- a/src/store/__tests__/SettingsStore.test.tsx
+++ b/src/store/__tests__/SettingsStore.test.tsx
@@ -1,17 +1,30 @@
 import React from 'react';
-import { renderHook, act } from '@testing-library/react-native';
+import { Text } from 'react-native';
+import { renderHook, render, act, waitFor } from '@testing-library/react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import launcherModule from '../../../modules/launcher-module/src';
 import { SettingsProvider, useSettings, DEFAULT_SETTINGS } from '../SettingsStore';
 
 const wrapper = ({ children }: { children: React.ReactNode }) => (
   <SettingsProvider>{children}</SettingsProvider>
 );
 
+const wifiFixture = { enabled: true, ssid: 'TestWiFi', rssi: -50, ip: '192.168.1.100' };
+const bluetoothFixture = { enabled: true, name: 'TestDevice', address: '', pairedDevices: [] };
+
+/** Renders the raw settings as text so we can assert on what actually painted. */
+function SettingsProbe() {
+  const { settings, isReady } = useSettings();
+  return <Text>{`ready=${isReady} wifiNetwork=${settings.wifiNetwork} bluetoothName=${settings.bluetoothName}`}</Text>;
+}
+
 beforeEach(() => {
   jest.clearAllMocks();
   (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
   (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
   (AsyncStorage.removeItem as jest.Mock).mockResolvedValue(undefined);
+  (launcherModule.getWifiInfo as jest.Mock).mockResolvedValue(wifiFixture);
+  (launcherModule.getBluetoothInfo as jest.Mock).mockResolvedValue(bluetoothFixture);
 });
 
 describe('SettingsStore', () => {
@@ -117,5 +130,105 @@ describe('SettingsStore', () => {
     // Device-independent settings remain at defaults when no stored data
     expect(result.current.settings.airplaneMode).toBe(DEFAULT_SETTINGS.airplaneMode);
     expect(result.current.settings.volume).toBe(DEFAULT_SETTINGS.volume);
+  });
+});
+
+describe('SettingsProvider device sync gate (M10: no stale first render)', () => {
+  it('renders nothing until the first device sync completes, then paints the synced SSID — never the seed value', async () => {
+    // Capture the resolver up front — the Promise (and its resolve fn) must
+    // exist before syncFromDevice ever calls the mock, otherwise a later call
+    // to getWifiInfo() would hand back a *different* pending promise than the
+    // one we hold a resolver for.
+    let resolveWifi: (v: typeof wifiFixture) => void = () => {};
+    const pending = new Promise<typeof wifiFixture>((resolve) => { resolveWifi = resolve; });
+    (launcherModule.getWifiInfo as jest.Mock).mockReturnValueOnce(pending);
+
+    const { queryByText, getByText } = render(
+      <SettingsProvider><SettingsProbe /></SettingsProvider>,
+    );
+
+    // Gate on (default): before the bridge resolves, the provider returns null
+    // for the whole subtree — the seed value ('Home') can never be painted.
+    expect(queryByText(/wifiNetwork=/)).toBeNull();
+
+    // Sanity: the bridge call is genuinely in flight and the gate is still up
+    // right up to the moment it resolves.
+    await waitFor(() => expect(launcherModule.getWifiInfo).toHaveBeenCalled());
+    expect(queryByText(/wifiNetwork=/)).toBeNull();
+
+    await act(async () => { resolveWifi(wifiFixture); });
+
+    // First (and only) painted frame already carries the synced value.
+    await waitFor(() => expect(getByText(/wifiNetwork=TestWiFi/)).toBeTruthy());
+    expect(getByText(/bluetoothName=TestDevice/)).toBeTruthy();
+  });
+
+  it('falls back to seed values after 500ms when the device bridge hangs indefinitely', async () => {
+    jest.useFakeTimers();
+    try {
+      (launcherModule.getWifiInfo as jest.Mock).mockImplementationOnce(() => new Promise(() => {}));
+      (launcherModule.getBluetoothInfo as jest.Mock).mockImplementationOnce(() => new Promise(() => {}));
+
+      const { queryByText, getByText } = render(
+        <SettingsProvider><SettingsProbe /></SettingsProvider>,
+      );
+
+      // Flush the AsyncStorage.getItem() hydration + the dynamic-import hop
+      // inside syncFromDevice (real microtasks, unaffected by fake timers) so
+      // the bridge call is actually in flight and the fallback timer is armed.
+      await waitFor(() => expect(launcherModule.getWifiInfo).toHaveBeenCalled());
+      expect(queryByText(/wifiNetwork=/)).toBeNull();
+
+      await act(async () => { jest.advanceTimersByTime(500); });
+
+      // Bridge never resolved — the UI renders with the seed default instead of
+      // hanging forever.
+      expect(getByText(/wifiNetwork=Home/)).toBeTruthy();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('does not re-invoke the native bridge when the provider re-renders for an unrelated reason', async () => {
+    const { result } = renderHook(() => useSettings(), { wrapper });
+    await waitFor(() => expect(result.current.isReady).toBe(true));
+    await waitFor(() => expect(launcherModule.getWifiInfo).toHaveBeenCalledTimes(1));
+
+    const syncFromDeviceRef = result.current.syncFromDevice;
+    expect(launcherModule.getBluetoothInfo).toHaveBeenCalledTimes(1);
+
+    // Trigger a re-render of the provider that has nothing to do with device sync.
+    await act(async () => {
+      result.current.update('airplaneMode', true);
+    });
+
+    // syncFromDevice is a stable useCallback (empty deps) — its identity does not
+    // change across renders, so the sync effect (deps: [isReady, syncFromDevice])
+    // never re-fires and the bridge is not called again.
+    expect(result.current.syncFromDevice).toBe(syncFromDeviceRef);
+    expect(launcherModule.getWifiInfo).toHaveBeenCalledTimes(1);
+    expect(launcherModule.getBluetoothInfo).toHaveBeenCalledTimes(1);
+  });
+
+  it('mounting and unmounting rapidly while a sync is in flight does not throw or log errors', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    let resolveWifi: (v: typeof wifiFixture) => void = () => {};
+    (launcherModule.getWifiInfo as jest.Mock).mockImplementation(
+      () => new Promise((resolve) => { resolveWifi = resolve; }),
+    );
+
+    for (let i = 0; i < 5; i += 1) {
+      const { unmount } = render(<SettingsProvider><SettingsProbe /></SettingsProvider>);
+      unmount();
+    }
+
+    await act(async () => {
+      resolveWifi(wifiFixture);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(errorSpy).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Resumo

M10: fix syncFromDevice's untestable dynamic import + add missing race-condition test coverage for SettingsStore's first-sync gate

## Causa raiz

O issue descreve um problema de produção ("first render shows seed values before sync completes") que já não existe: o gate (`firstSyncDone` + `mountedRef` + timeout de 500ms) foi implementado num commit squash anterior — `77d58ad` ("fix(C1): surface bridge errors in production (#190) (#237)"), que na verdade agregou dezenas de fixes incluindo o exato diff do M10 (confirmável comparando com o WIP snapshot `0c8008d` referenciado no comentário do issue — os dois diffs são idênticos). O código actual em `src/store/SettingsStore.tsx:154-231` já:
- gate `firstSyncDone` que bloqueia o primeiro render (`src/store/SettingsStore.tsx:274`);
- `mountedRef` que guarda `setSettings` dentro de `syncFromDevice` (linha 207);
- timeout de 500ms como fallback (linha 218);
- prop `gateFirstRender` (default `true`) que o test harness (`src/test-utils.tsx:24`) já desliga para os testes de ecrã síncronos.

**A premissa de "acoplamento com o DeviceStore" no corpo do issue está errada.** `getLauncherModule` dentro de `syncFromDevice` é uma função local definida inline (linha 177), não vem do `DeviceStore` — confirmei com `git log -S DeviceStore -- src/store/SettingsStore.tsx` (zero resultados) e `git log -S getLauncherModule` (só o commit original de #42, anterior ao DeviceStore existir). `SettingsStore` e `DeviceStore` têm cada um a sua própria cópia local do helper; nunca partilharam identidade nem re-render.

**O gap real, e a razão deste PR não ser um no-op:** ao escrever os testes que o issue pede ("mock `syncFromDevice` to resolve after 100ms", "assert children render only after", "SSID vem da bridge mockada"), descobri que `getLauncherModule` (linha 179, antes do fix) usa `await import('../../modules/launcher-module/src')` — um `import()` dinâmico que **rebenta sempre dentro do Jest** com `TypeError: A dynamic import callback was invoked without --experimental-vm-modules` (`ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING_FLAG`). Isto é engolido pelo `catch { return null; }` da própria função e depois outra vez pelo `catch` externo (linha 205), por isso nunca aparecia como erro — `syncFromDevice` ficava silenciosamente um no-op em **todos** os testes da suite (confirmei manualmente invocando `syncFromDevice()` a partir de um teste: `getWifiInfo` nunca era chamado, `wifiNetwork` ficava sempre `'Home'`). Não existia nenhum teste em `SettingsStore.test.tsx`, nem em nenhum outro ficheiro do repo, que alguma vez exercitasse este caminho — daí o critério de aceitação "verificado com um teste que confirma que o SSID vem da bridge mockada" ser literalmente impossível de cumprir sem corrigir isto primeiro.

Em runtime real (Metro/Hermes) isto não é um bug — o Metro não faz code-splitting real para apps RN, por isso `import()` e `require()` compilam para o mesmo carregamento síncrono de módulo. É puramente uma incompatibilidade entre `import()` dinâmico nu e o ambiente CommonJS do Jest.

## O que mudou

- `src/store/SettingsStore.tsx`
  - `getLauncherModule` (dentro de `syncFromDevice`) passa a usar `require('../../modules/launcher-module/src')` em vez de `await import(...)`. Mesma semântica (lazy-load + `try/catch` para degradar graciosamente se o módulo nativo não existir), mas agora passa pelo resolver normal do Jest (e pelo `moduleNameMapper` já configurado em `jest.config.js` para este módulo), tornando o caminho real de sincronização testável.
  - Import de tipo (`import type { LauncherModuleType } from '../../modules/launcher-module/src'`) para tipar o `require()` sem introduzir `any` — apagado em runtime, não força a carga do módulo nativo no import do ficheiro.

- `src/store/__tests__/SettingsStore.test.tsx`
  - Novo `describe('SettingsProvider device sync gate (M10: no stale first render)')` com 4 testes que cobrem os critérios de aceitação do issue (ver abaixo).

## Porque assim

- **Não toquei em `AppsStore.tsx` nem `DeviceStore.tsx`**, que têm o mesmo padrão `await import('../../modules/launcher-module/src')` e portanto o mesmo problema de testabilidade — está fora do âmbito deste issue (que só lista `SettingsStore.tsx`) e não têm testes próprios hoje (não existe `AppsStore.test.tsx` nem `DeviceStore.test.tsx`), por isso o defeito lá é invisível mas não está a bloquear nenhum critério deste issue. Fica como recomendação de follow-up.
- **Não troquei para import estático**: o módulo nativo usa `requireNativeModule(...)` a nível de topo do ficheiro (`modules/launcher-module/src/index.ts`), que pode rebentar de forma síncrona em plataformas/ambientes sem o módulo nativo linkado (ex. Expo Go, iOS). Um import estático executaria isso no load do `SettingsStore.tsx`, que é sempre montado — risco real de crash de arranque. `require()` dentro do `try/catch` preserva o lazy-load e a degradação graciosa que o código já tinha.
- **Critério "DeviceStore re-renders don't cause extra sync cycles" não é aplicável** como descrito (não há esse acoplamento), mas escrevi um teste equivalente e mais forte: confirma que `syncFromDevice` é referencialmente estável entre renders e que um re-render não relacionado (`update('airplaneMode', true)`) não dispara chamadas extra à bridge.
- **"No state-after-unmount warnings" (critério do issue) não é demonstrável por diferença de comportamento nesta versão do React (19.1.0)**: testei empiricamente removendo temporariamente o `mountedRef` guard e confirmei que o React 19 já não emite o aviso "Can't perform a React state update on an unmounted component" para nenhum caminho (nem sequer no efeito de hidratação do `AsyncStorage`, que nunca teve esse guard) — a actualização é silenciosamente descartada pelo próprio React independentemente do guard. Por isso o teste que escrevi para este critério (montar/desmontar 5x com um sync pendente, sem erros/crash) é uma rede de segurança regressiva honesta, não um red-step tied ao `mountedRef` propriamente dito — deixo isto documentado em vez de fingir uma prova que não tenho.

## Critérios de aceitação

- [x] **First paint shows synced values, not seed values** — teste "renders nothing until the first device sync completes, then paints the synced SSID": confirma `queryByText(/wifiNetwork=/)` é `null` enquanto a bridge está em voo, e que o primeiro texto pintado já é `wifiNetwork=TestWiFi` (nunca `Home`).
- [x] **Timeout fallback works (bridge rejection doesn't hang the app)** — teste com `getWifiInfo`/`getBluetoothInfo` mockados para nunca resolver (`new Promise(() => {})`); avança fake timers 500ms; confirma que renderiza com o valor seed (`Home`) em vez de ficar bloqueado.
- [x] **No state-after-unmount warnings** — teste de montar/desmontar 5x com sync pendente, resolvido depois; `console.error` nunca chamado. (Ver nota acima sobre não ser red-step-provável nesta versão do React.)
- [x] **DeviceStore re-renders don't cause extra sync cycles** — não há esse acoplamento (corrigido no texto do issue); teste confirma que `syncFromDevice` mantém a mesma referência e que a bridge não é chamada de novo num re-render não relacionado.
- [x] **O que NÃO devia mudar**: as 7 testes pré-existentes em `SettingsStore.test.tsx` continuam a passar sem alteração de asserts; `gateFirstRender={false}` (usado por `src/test-utils.tsx` e por todos os testes de ecrã) continua a saltar o gate — confirmado pelos 298 testes que passam na suite completa, incluindo todos os ecrãs que consomem `useSettings()` através do harness.

## Testes

**Passo vermelho** (fix de produção revertido via `git stash`, testes mantidos):

```
 SettingsProvider device sync gate (M10: no stale first render)
    ✕ renders nothing until the first device sync completes, then paints the synced SSID — never the seed value (1052 ms)
    ✕ falls back to seed values after 500ms when the device bridge hangs indefinitely (30 ms)
    ✕ does not re-invoke the native bridge when the provider re-renders for an unrelated reason (1059 ms)
    ✓ mounting and unmounting rapidly while a sync is in flight does not throw or log errors (9 ms)

  ● ... renders nothing until the first device sync completes ...
    expect(jest.fn()).toHaveBeenCalled()
    Expected number of calls: >= 1
    Received number of calls:    0
      156 |     await waitFor(() => expect(launcherModule.getWifiInfo).toHaveBeenCalled());

  ● ... falls back to seed values after 500ms ...
    expect(jest.fn()).toHaveBeenCalled()
    Expected number of calls: >= 1
    Received number of calls:    0
      179 |       await waitFor(() => expect(launcherModule.getWifiInfo).toHaveBeenCalled());

  ● ... does not re-invoke the native bridge ...
    expect(jest.fn()).toHaveBeenCalledTimes(expected)
    Expected number of calls: 1
    Received number of calls: 0
      195 |     await waitFor(() => expect(launcherModule.getWifiInfo).toHaveBeenCalledTimes(1));

Test Suites: 1 failed, 1 total
Tests:       3 failed, 8 passed, 11 total
```

Com o fix restaurado, os mesmos 3 testes passam (a 4ª, unmount, já passava mesmo sem o fix — é a tal rede de segurança não red-step-provável explicada acima).

**Casos cobertos além do caminho feliz:**
- **Assíncrono / em voo**: bridge que nunca resolve (hang) — timeout de 500ms.
- **Repetição**: mount/unmount 5x seguidas com sync pendente — sem crash nem `console.error`.
- **Re-render não relacionado**: `update()` de um setting qualquer não deve re-disparar a sincronização com a bridge (guarda contra `useCallback` com deps instáveis).
- **O inverso do fix**: confirmo explicitamente `queryByText(...)` é `null` enquanto a sincronização está em voo — o valor seed nunca chega a pintar.

**Sanity-check:** fiz `git stash push -- src/store/SettingsStore.tsx`, corri a suite (3 dos 4 novos testes falharam, ver acima), `git stash pop` para restaurar, corri de novo — os 11 testes de `SettingsStore.test.tsx` passam.

**Resultado das verificações obrigatórias:**
- `npm run lint`: 0 erros, 1 warning pré-existente em `ClockScreen.tsx` (não tocado por mim).
- `npx tsc --noEmit`: limpo, 0 erros.
- `npm test`: 298 passaram, 9 falharam, 42 suites (37 passaram, 5 falharam) — falhas idênticas à baseline documentada (`FoldersStore`, `CalculatorScreen`, `SettingsScreen`, `LockScreen`, `WeatherScreen`), zero regressões novas, `SettingsStore.test.tsx` 100% verde (11/11).

## Testes

298 passaram, 9 falharam (idênticas à baseline pré-existente, 0 novas), 42 suites (37 passaram, 5 falharam); SettingsStore.test.tsx: 11 passaram, 0 falharam

## Linked Issue

Fixes #210