### PR TITLE
M11: wrap the 6 permission-dialog call sites that still bypassed withAutoLockSuppressed, closing the auto-lock race the issue was reopened for (#211)

### DIFF
--- a/src/screens/CameraScreen.tsx
+++ b/src/screens/CameraScreen.tsx
@@ -59,10 +59,12 @@ export function CameraScreen({ navigation }: { navigation: AppNavigationProp }) 
   // Camera permissions (uses real hook or stub depending on expo-camera availability)
   const [permission, requestPermission] = useCamPerms();
 
-  // Request permission on mount
+  // Request permission on mount. Showing the native camera-permission dialog
+  // backgrounds the app (it's a separate Activity), so this must go through
+  // withAutoLockSuppressed or a slow reader gets auto-locked out mid-prompt.
   useEffect(() => {
     if (useCameraPermissionsHook && permission && !permission.granted && permission.canAskAgain) {
-      requestPermission();
+      withAutoLockSuppressed(requestPermission).catch(() => {});
     }
   }, [permission, requestPermission]);
 
@@ -214,7 +216,7 @@ export function CameraScreen({ navigation }: { navigation: AppNavigationProp }) 
           </Text>
           {permission?.canAskAgain && (
             <Pressable
-              onPress={requestPermission}
+              onPress={() => { withAutoLockSuppressed(requestPermission).catch(() => {}); }}
               style={styles.permissionBtn}
               accessibilityLabel="Grant camera permission"
               accessibilityRole="button"

--- a/src/screens/ConversationScreen.tsx
+++ b/src/screens/ConversationScreen.tsx
@@ -486,7 +486,7 @@ export function ConversationScreen({ navigation, route }: ConversationScreenProp
           PermissionsAndroid.PERMISSIONS.SEND_SMS,
         );
         if (!already) {
-          const result = await PermissionsAndroid.request(
+          const result = await withAutoLockSuppressed(() => PermissionsAndroid.request(
             PermissionsAndroid.PERMISSIONS.SEND_SMS,
             {
               title: 'Send Messages',
@@ -494,7 +494,7 @@ export function ConversationScreen({ navigation, route }: ConversationScreenProp
               buttonPositive: 'Allow',
               buttonNegative: 'Deny',
             },
-          );
+          ));
           if (result !== PermissionsAndroid.RESULTS.GRANTED) {
             alert(
               'Permission Needed',

--- a/src/screens/LauncherHomeScreen.tsx
+++ b/src/screens/LauncherHomeScreen.tsx
@@ -48,6 +48,7 @@ import {
 import type { BannerNotification } from '../components';
 import type { RootStackParamList } from '../navigation/types';
 import { WALLPAPERS, darkenHex } from '../utils/wallpapers';
+import { withAutoLockSuppressed } from '../utils/permissions';
 import { ControlCenterOverlay } from '../components/ControlCenterOverlay';
 import { NotificationCenterOverlay } from '../components/NotificationCenterOverlay';
 import { SpotlightReveal } from '../components/SpotlightReveal';
@@ -644,7 +645,10 @@ export function LauncherHomeScreen() {
         const perms = await mod.checkPermissions();
         const needsPermission = Object.values(perms).some(v => !v);
         if (needsPermission) {
-          await mod.requestAllPermissions();
+          // Requests every missing category one after another — each native
+          // dialog backgrounds the app, so the whole batch must be
+          // suppressed or a slow reader gets auto-locked on first launch.
+          await withAutoLockSuppressed(() => mod.requestAllPermissions());
         }
       } catch { /* Expected: permissions check may fail on non-Android or first install */ }
     })();

--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -13,10 +13,21 @@ import { Ionicons } from '@expo/vector-icons';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { LinearGradient } from 'expo-linear-gradient';
 import { SystemColors } from '../theme/CupertinoTheme';
+import { withAutoLockSuppressed } from '../utils/permissions';
+import type { LauncherModuleType } from '../../modules/launcher-module/src';
 
 const getLauncher = async () => {
   try {
-    return (await import('../../modules/launcher-module/src')).default;
+    // require(), not `await import(...)`: Metro has no real code-splitting
+    // for RN apps, so both compile to the same synchronous module load at
+    // runtime — but a bare `import()` throws under Jest's CommonJS test
+    // environment (ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING_FLAG), silently
+    // swallowed by this catch, which made handleGrantPermissions a permanent
+    // no-op in every test (see #210's identical fix in SettingsStore.tsx).
+    // require() goes through Jest's normal resolver (and moduleNameMapper),
+    // so it's mockable.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    return (require('../../modules/launcher-module/src') as { default: LauncherModuleType }).default;
   } catch {
     return null; // Expected: module unavailable on non-Android
   }
@@ -78,7 +89,10 @@ export function OnboardingScreen({ onDone }: OnboardingScreenProps) {
     if (mod) {
       try {
         setPermissionError(null);
-        await mod.requestAllPermissions();
+        // Requests Camera, Microphone, Storage etc. one after another — each
+        // native dialog backgrounds the app, so the whole batch must be
+        // suppressed or a slow reader gets auto-locked mid-onboarding.
+        await withAutoLockSuppressed(() => mod.requestAllPermissions());
         const results = await mod.checkPermissions();
         setPermissionResults(results);
       } catch (e: unknown) {

--- a/src/screens/__tests__/CameraScreen.autolock.test.tsx
+++ b/src/screens/__tests__/CameraScreen.autolock.test.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { act } from '@testing-library/react-native';
+import { render, fireEvent } from '../../test-utils';
+import { CameraScreen } from '../CameraScreen';
+import { suppressAutoLock } from '../../utils/permissions';
+import type { AppNavigationProp } from '../../navigation/types';
+
+// This suite exercises the REAL expo-camera permission hook (unlike
+// CameraScreen.test.tsx, which relies on expo-camera being unavailable in
+// the test env). It proves App.tsx's auto-lock suppression actually engages
+// while the native camera-permission dialog is up — the M11 defect.
+let resolveRequest: (value: { granted: boolean; canAskAgain: boolean }) => void;
+const mockRequestPermission = jest.fn(
+  () =>
+    new Promise<{ granted: boolean; canAskAgain: boolean }>((resolve) => {
+      resolveRequest = resolve;
+    }),
+);
+
+jest.mock('expo-media-library', () => ({
+  requestPermissionsAsync: jest.fn(() => Promise.resolve({ status: 'granted' })),
+  saveToLibraryAsync: jest.fn(() => Promise.resolve()),
+}));
+
+// Stable object identity across re-renders (mirrors the real hook, which
+// only produces a new permission object when the underlying value changes).
+// A fresh literal every render would re-trigger the mount effect on every
+// re-render via the [permission, requestPermission] dependency array.
+const mockPermission = { granted: false, canAskAgain: true };
+
+jest.mock('expo-camera', () => ({
+  CameraView: 'CameraView',
+  useCameraPermissions: () => [mockPermission, mockRequestPermission],
+}));
+
+const mockNavigation = { navigate: jest.fn(), goBack: jest.fn(), push: jest.fn() } as unknown as AppNavigationProp;
+
+describe('CameraScreen auto-lock suppression (M11)', () => {
+  beforeEach(() => {
+    mockRequestPermission.mockClear();
+  });
+
+  it('suppresses auto-lock while the camera permission dialog requested on mount is pending', async () => {
+    render(<CameraScreen navigation={mockNavigation} />);
+
+    expect(mockRequestPermission).toHaveBeenCalledTimes(1);
+    expect(suppressAutoLock()).toBe(true);
+
+    await act(async () => {
+      resolveRequest({ granted: true, canAskAgain: true });
+    });
+
+    expect(suppressAutoLock()).toBe(false);
+  });
+
+  it('suppresses auto-lock while the "Grant Permission" button retry is pending', async () => {
+    // canAskAgain stays true so the mount effect also fires once; settle it
+    // first so only the button press is under test.
+    const { getByLabelText } = render(<CameraScreen navigation={mockNavigation} />);
+    await act(async () => {
+      resolveRequest({ granted: false, canAskAgain: true });
+    });
+    mockRequestPermission.mockClear();
+    expect(suppressAutoLock()).toBe(false);
+
+    fireEvent.press(getByLabelText('Grant camera permission'));
+
+    expect(mockRequestPermission).toHaveBeenCalledTimes(1);
+    expect(suppressAutoLock()).toBe(true);
+
+    await act(async () => {
+      resolveRequest({ granted: true, canAskAgain: true });
+    });
+
+    expect(suppressAutoLock()).toBe(false);
+  });
+});

--- a/src/screens/__tests__/ConversationScreen.autolock.test.tsx
+++ b/src/screens/__tests__/ConversationScreen.autolock.test.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { PermissionsAndroid } from 'react-native';
+import type { PermissionStatus } from 'react-native/Libraries/PermissionsAndroid/PermissionsAndroid';
+import { act } from '@testing-library/react-native';
+import { render, fireEvent } from '../../test-utils';
+import { ConversationScreen } from '../ConversationScreen';
+import { suppressAutoLock } from '../../utils/permissions';
+
+// Proves App.tsx's auto-lock suppression engages while the native SEND_SMS
+// permission dialog is up — the M11 defect: handleSend called
+// PermissionsAndroid.request directly, bypassing withAutoLockSuppressed,
+// even though the same file already wraps its camera/photo-library requests.
+const mockNavigation = { navigate: jest.fn(), goBack: jest.fn(), push: jest.fn() };
+const mockRoute = { params: { address: '+15551234567' } };
+
+describe('ConversationScreen auto-lock suppression (M11)', () => {
+  it('suppresses auto-lock while the SEND_SMS permission dialog is pending', async () => {
+    jest.spyOn(PermissionsAndroid, 'check').mockResolvedValue(false);
+    let resolveRequest: (v: PermissionStatus) => void;
+    jest.spyOn(PermissionsAndroid, 'request').mockImplementation(
+      () => new Promise((resolve) => { resolveRequest = resolve; }),
+    );
+
+    const { getByPlaceholderText, getByLabelText } = render(
+      <ConversationScreen navigation={mockNavigation as never} route={mockRoute as never} />
+    );
+
+    fireEvent.changeText(getByPlaceholderText('Message'), 'Hi there');
+
+    // handleSend awaits PermissionsAndroid.check() before it ever reaches the
+    // withAutoLockSuppressed(...request...) call under test, so flush that
+    // microtask before asserting suppression state.
+    await act(async () => {
+      fireEvent.press(getByLabelText('Send message'));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(suppressAutoLock()).toBe(true);
+
+    await act(async () => {
+      resolveRequest(PermissionsAndroid.RESULTS.GRANTED);
+    });
+
+    expect(suppressAutoLock()).toBe(false);
+  });
+});

--- a/src/screens/__tests__/OnboardingScreen.autolock.test.tsx
+++ b/src/screens/__tests__/OnboardingScreen.autolock.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { act } from '@testing-library/react-native';
+import { render, fireEvent } from '../../test-utils';
+import { OnboardingScreen } from '../OnboardingScreen';
+import { suppressAutoLock } from '../../utils/permissions';
+// Mapped by jest.config.js moduleNameMapper to src/__mocks__/launcherModule.js —
+// the same module instance OnboardingScreen's dynamic import resolves to.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const LauncherModule = require('../../../modules/launcher-module/src').default;
+
+// Proves App.tsx's auto-lock suppression engages while the native module's
+// batch requestAllPermissions() call is in flight — the exact "nested
+// prompts (Camera + Microphone + Storage one after the other)" scenario
+// called out by the M11 issue. OnboardingScreen.handleGrantPermissions
+// called mod.requestAllPermissions() directly, bypassing
+// withAutoLockSuppressed entirely.
+describe('OnboardingScreen auto-lock suppression (M11)', () => {
+  it('suppresses auto-lock while requestAllPermissions() is pending on the Permissions page', async () => {
+    let resolveRequest: (v: boolean) => void;
+    (LauncherModule.requestAllPermissions as jest.Mock).mockImplementation(
+      () => new Promise((resolve) => { resolveRequest = resolve; }),
+    );
+
+    const { getByText } = render(<OnboardingScreen onDone={jest.fn()} />);
+    await act(async () => { fireEvent.press(getByText('Get Started')); });
+
+    await act(async () => {
+      fireEvent.press(getByText('Grant Permissions'));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(suppressAutoLock()).toBe(true);
+
+    await act(async () => {
+      resolveRequest(true);
+    });
+
+    expect(suppressAutoLock()).toBe(false);
+  });
+});

--- a/src/screens/settings/PrivacyScreen.tsx
+++ b/src/screens/settings/PrivacyScreen.tsx
@@ -4,6 +4,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTheme } from '../../theme/ThemeContext';
 import { useSettings } from '../../store/SettingsStore';
 import LauncherModule from '../../../modules/launcher-module/src';
+import { withAutoLockSuppressed } from '../../utils/permissions';
 import {
   CupertinoNavigationBar,
   CupertinoListSection,
@@ -54,7 +55,10 @@ export function PrivacyScreen({ navigation }: { navigation: AppNavigationProp })
   const handleRequestPermissions = useCallback(async () => {
     setRequestingPermissions(true);
     try {
-      await LauncherModule.requestAllPermissions();
+      // Requests every category one after another — each native dialog
+      // backgrounds the app, so the whole batch must be suppressed or a
+      // slow reader gets auto-locked mid-flow.
+      await withAutoLockSuppressed(() => LauncherModule.requestAllPermissions());
       // Re-check after requesting
       await checkPermissions();
       alert('Permissions Updated', 'Permission status has been refreshed.');

--- a/src/screens/settings/__tests__/PrivacyScreen.autolock.test.tsx
+++ b/src/screens/settings/__tests__/PrivacyScreen.autolock.test.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { act } from '@testing-library/react-native';
+import { render, fireEvent, waitFor } from '../../../test-utils';
+import { PrivacyScreen } from '../PrivacyScreen';
+import { suppressAutoLock } from '../../../utils/permissions';
+// Statically imported by PrivacyScreen.tsx, mapped by jest.config.js
+// moduleNameMapper to src/__mocks__/launcherModule.js — same instance.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const LauncherModule = require('../../../../modules/launcher-module/src').default;
+
+const mockNavigation = { navigate: jest.fn(), goBack: jest.fn(), push: jest.fn() };
+
+// Proves App.tsx's auto-lock suppression engages while the native module's
+// batch requestAllPermissions() call (triggered by the "Request" button) is
+// in flight — the M11 defect. PrivacyScreen.handleRequestPermissions called
+// LauncherModule.requestAllPermissions() directly, bypassing
+// withAutoLockSuppressed entirely.
+describe('PrivacyScreen auto-lock suppression (M11)', () => {
+  it('suppresses auto-lock while requestAllPermissions() is pending', async () => {
+    (LauncherModule.checkPermissions as jest.Mock).mockResolvedValue({ camera: false });
+
+    const { getByText } = render(<PrivacyScreen navigation={mockNavigation as never} />);
+
+    await waitFor(() => expect(getByText('Request')).toBeTruthy());
+
+    let resolveRequest: (v: boolean) => void;
+    (LauncherModule.requestAllPermissions as jest.Mock).mockImplementation(
+      () => new Promise((resolve) => { resolveRequest = resolve; }),
+    );
+
+    await act(async () => {
+      fireEvent.press(getByText('Request'));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(suppressAutoLock()).toBe(true);
+
+    await act(async () => {
+      resolveRequest(true);
+    });
+
+    expect(suppressAutoLock()).toBe(false);
+  });
+});

--- a/src/store/DeviceStore.tsx
+++ b/src/store/DeviceStore.tsx
@@ -382,7 +382,7 @@ export function DeviceProvider({ children }: { children: React.ReactNode }) {
   const requestSmsPermission = useCallback(async () => {
     if (Platform.OS === 'android') {
       try {
-        const granted = await PermissionsAndroid.request(
+        const granted = await withAutoLockSuppressed(() => PermissionsAndroid.request(
           PermissionsAndroid.PERMISSIONS.READ_SMS,
           {
             title: 'SMS Access',
@@ -390,7 +390,7 @@ export function DeviceProvider({ children }: { children: React.ReactNode }) {
             buttonPositive: 'Allow',
             buttonNegative: 'Deny',
           },
-        );
+        ));
         if (granted !== PermissionsAndroid.RESULTS.GRANTED) return false;
       } catch { return false; }
     }

--- a/src/store/__tests__/DeviceStore.autolock.test.tsx
+++ b/src/store/__tests__/DeviceStore.autolock.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Platform, PermissionsAndroid } from 'react-native';
+import type { PermissionStatus } from 'react-native/Libraries/PermissionsAndroid/PermissionsAndroid';
+import { renderHook, act } from '@testing-library/react-native';
+import { DeviceProvider, useDevice } from '../DeviceStore';
+import { suppressAutoLock } from '../../utils/permissions';
+
+// Proves App.tsx's auto-lock suppression engages while the native
+// READ_SMS permission dialog (PermissionsAndroid.request) is up — the M11
+// defect: DeviceStore.requestSmsPermission called PermissionsAndroid.request
+// directly, bypassing withAutoLockSuppressed entirely.
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <DeviceProvider>{children}</DeviceProvider>
+);
+
+describe('DeviceStore requestSmsPermission auto-lock suppression (M11)', () => {
+  it('platform is android in this test env', () => {
+    expect(Platform.OS).toBe('android');
+  });
+
+  it('suppresses auto-lock while the READ_SMS permission dialog is pending', async () => {
+    let resolveRequest: (v: PermissionStatus) => void;
+    jest.spyOn(PermissionsAndroid, 'request').mockImplementation(
+      () => new Promise((resolve) => { resolveRequest = resolve; }),
+    );
+
+    const { result } = renderHook(() => useDevice(), { wrapper });
+    await act(async () => {});
+
+    let requestPromise!: Promise<boolean>;
+    act(() => {
+      requestPromise = result.current.requestSmsPermission();
+    });
+
+    expect(suppressAutoLock()).toBe(true);
+
+    await act(async () => {
+      resolveRequest(PermissionsAndroid.RESULTS.GRANTED);
+      await requestPromise;
+    });
+
+    expect(suppressAutoLock()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Resumo

M11: wrap the 6 permission-dialog call sites that still bypassed withAutoLockSuppressed, closing the auto-lock race the issue was reopened for

## Causa raiz

A issue #211 já tinha sido "fechada" por um commit WIP anterior que introduziu `src/utils/permissions.ts` (`suppressAutoLock()` + `withAutoLockSuppressed(fn)`, contador para chamadas aninhadas, cap de segurança de 30s) e ligou-o em `App.tsx:94` (`if (suppressAutoLock()) return;` antes de agendar o timer de auto-lock). Essa parte está correta e não foi tocada.

Mas o comentário de fecho da issue lista apenas 9 chamadas de permissão envolvidas — e a auditoria pedida explicitamente pela própria issue ("grep for requestPermissionsAsync, requestCameraPermissionsAsync, ... etc.") nunca foi completada. Encontrei **6 pontos de pedido de permissão nativa que continuavam por envolver**, cada um deles capaz de disparar o mesmo mecanismo de corrida descrito na issue (o diálogo nativo do Android corre numa Activity separada → a app entra em `background` → o timer de 5s começa a contar):

1. `src/screens/CameraScreen.tsx:65` — `requestPermission()` do hook `useCameraPermissions()` do `expo-camera`, disparado automaticamente no `useEffect` de montagem. **Este é literalmente o pedido de permissão da Câmara** — o ficheiro só tinha o `MediaLibrary.requestPermissionsAsync()` (guardar a foto) envolvido, não o pedido de acesso à câmara em si.
2. `src/screens/CameraScreen.tsx:219` — o mesmo `requestPermission` no botão "Grant Permission" do ecrã de permissão negada.
3. `src/store/DeviceStore.tsx:385` — `PermissionsAndroid.request(READ_SMS, …)` dentro de `requestSmsPermission`. Só o `Contacts.requestPermissionsAsync()` estava envolvido nesse ficheiro; o pedido de SMS (usado por `MessagesScreen`) não.
4. `src/screens/ConversationScreen.tsx:489` — `PermissionsAndroid.request(SEND_SMS, …)` dentro de `handleSend`. Inconsistente com o resto do próprio ficheiro, que já envolvia os pedidos de Câmara/Galeria (linhas 438/452) mas não este.
5. `src/screens/OnboardingScreen.tsx:81` (agora 95) — `mod.requestAllPermissions()` no botão "Grant Permissions" do onboarding. É exactamente o cenário de "nested prompts (Camera + Microphone + Storage one after the other)" que a issue descreve — pede todas as permissões em sequência, é o caso com maior probabilidade real de ultrapassar os 5s.
6. `src/screens/settings/PrivacyScreen.tsx:57` — `LauncherModule.requestAllPermissions()` no botão "Request" do ecrã de Privacidade.
7. `src/screens/LauncherHomeScreen.tsx:647` — `mod.requestAllPermissions()` no efeito de primeiro arranque ("Request permissions on first launch"). É o caminho mais provável de acontecer na prática: primeira instalação, o launcher pede tudo de uma vez.

Além disso, a auditoria acima descobriu que `OnboardingScreen.tsx`'s `getLauncher()` usava `await import(...)` em vez de `require(...)` — o mesmo defeito de testabilidade já identificado e corrigido na issue #210 para `SettingsStore.syncFromDevice` (`ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING_FLAG` sob Jest CJS faz o `catch` engolir sempre a chamada, deixando `handleGrantPermissions` um no-op permanente em testes). Sem esta correção pontual não era possível montar um teste real que exercitasse o caminho que estava a corrigir, por isso apliquei o mesmo padrão já aceite em #210, só a este ficheiro.

## O que mudou

- `src/screens/CameraScreen.tsx` — os dois disparos de `requestPermission()` (montagem + botão "Grant Permission") passam a `withAutoLockSuppressed(requestPermission)`.
- `src/store/DeviceStore.tsx` — `PermissionsAndroid.request(READ_SMS, …)` em `requestSmsPermission` envolvido em `withAutoLockSuppressed`.
- `src/screens/ConversationScreen.tsx` — `PermissionsAndroid.request(SEND_SMS, …)` em `handleSend` envolvido em `withAutoLockSuppressed`.
- `src/screens/OnboardingScreen.tsx` — `mod.requestAllPermissions()` em `handleGrantPermissions` envolvido em `withAutoLockSuppressed`; `getLauncher()` passa de `await import(...)` para `require(...)` (mesma correção de testabilidade da #210).
- `src/screens/settings/PrivacyScreen.tsx` — `LauncherModule.requestAllPermissions()` em `handleRequestPermissions` envolvido em `withAutoLockSuppressed`.
- `src/screens/LauncherHomeScreen.tsx` — `mod.requestAllPermissions()` no efeito de primeiro arranque envolvido em `withAutoLockSuppressed`.
- 5 novos ficheiros de teste (`*.autolock.test.tsx`) que montam o componente/hook real e provam que `suppressAutoLock()` está `true` enquanto o pedido nativo está pendente e `false` depois de resolver.

Não toquei em `src/utils/permissions.ts` nem em `App.tsx` — a lógica de suppressão e o cap de 30s já estavam correctos; o problema era só nos pontos de chamada não auditados.

## Porque assim

- Segui o mesmo padrão (`withAutoLockSuppressed(() => chamada())`) já usado nos 9 pontos que a issue tinha corrigido, em vez de inventar uma variante nova — mantém o ficheiro consistente consigo mesmo (era isso, aliás, que denunciava o `ConversationScreen.tsx`: tinha dois pedidos envolvidos e um ao lado não).
- Para `LauncherHomeScreen.tsx` apliquei o fix de produção mas **não escrevi um teste dedicado**: o componente já tem uma instabilidade de render pré-existente e não relacionada ("Rendered more hooks than during the previous render" ao forçar múltiplos ticks de microtask extra durante o efeito de primeiro arranque) que só aparece com a sequência de `act()` que o teste precisava. Investigar essa instabilidade está fora do âmbito desta issue; corrigi o ponto de chamada (padrão idêntico, baixo risco) e confirmei que a suite existente (`LauncherHomeScreen.test.tsx`, 5 testes) continua toda verde.
- Não toquei em `LockScreen.tsx`'s biometric prompt (`expo-local-authentication`): não é um pedido de *permissão* Android (não é `requestPermissionsAsync`-like, não aparece no grep da issue) e o `BiometricPrompt` nativo não faz a Activity ir a background da mesma forma — é um mecanismo diferente do descrito na issue.

## Critérios de aceitação

- [x] Pedir a permissão da Câmara e demorar 10s a responder NÃO bloqueia a app — coberto por `CameraScreen.autolock.test.tsx` (prova `suppressAutoLock()===true` enquanto `requestPermission()` está pendente).
- [x] Backgrounding normal (botão home) continua a bloquear ao fim de 5s — não tocado; `App.tsx`'s `AUTO_LOCK_GRACE_MS=5000` e o `setTimeout` ficam exactamente iguais.
- [x] Cap de segurança de 30s aplicado — não tocado; `MAX_SUPPRESSION_MS=30_000` em `permissions.ts` já existia e continua a decrementar o contador ao fim desse tempo mesmo que `fn()` nunca resolva.
- [x] Todos os pontos de pedido de permissão passam pelo wrapper — confirmado por grep final (ver bloco de Testes abaixo): zero chamadas a `requestPermissionsAsync`, `PermissionsAndroid.request(`, `requestAllPermissions()` ou ao `requestPermission` do `useCameraPermissions` fora de `withAutoLockSuppressed`.
- [x] Testes cobrem: bloqueio normal (pré-existente, não regredido), bloqueio suprimido durante permissão (5 novos testes, um por mecanismo: hook do `expo-camera`, `PermissionsAndroid.request` em dois ficheiros distintos, `requestAllPermissions()` em dois ficheiros distintos), cap de segurança (já coberto implicitamente pelo `finally`+`setTimeout` em `permissions.ts`, não modificado nesta PR).

## Testes

### Passo vermelho (um por ficheiro de produção tocado)

**CameraScreen** — com o wrap removido (`requestPermission()` sem `withAutoLockSuppressed`):
```
CameraScreen auto-lock suppression (M11)
  ✕ suppresses auto-lock while the camera permission dialog requested on mount is pending
  ✕ suppresses auto-lock while the "Grant Permission" button retry is pending

  ● suppresses auto-lock while the camera permission dialog requested on mount is pending
    expect(received).toBe(expected)
    Expected: true
    Received: false
      44 |     expect(suppressAutoLock()).toBe(true);
```

**DeviceStore.requestSmsPermission** — com `PermissionsAndroid.request` não envolvido:
```
DeviceStore requestSmsPermission auto-lock suppression (M11)
  ✕ suppresses auto-lock while the READ_SMS permission dialog is pending

  ● suppresses auto-lock while the READ_SMS permission dialog is pending
    expect(received).toBe(expected)
    Expected: true
    Received: false
      34 |     expect(suppressAutoLock()).toBe(true);
```

**ConversationScreen.handleSend** — com `PermissionsAndroid.request(SEND_SMS)` não envolvido:
```
ConversationScreen auto-lock suppression (M11)
  ✕ suppresses auto-lock while the SEND_SMS permission dialog is pending

  ● suppresses auto-lock while the SEND_SMS permission dialog is pending
    expect(received).toBe(expected)
    Expected: true
    Received: false
      33 |     expect(suppressAutoLock()).toBe(true);
```

**OnboardingScreen.handleGrantPermissions** — com o wrap removido mas o fix de `require()` já presente (isola exactamente a suppressão, não o bug de dynamic import):
```
OnboardingScreen auto-lock suppression (M11)
  ✕ suppresses auto-lock while requestAllPermissions() is pending on the Permissions page

  ● suppresses auto-lock while requestAllPermissions() is pending on the Permissions page
    expect(received).toBe(expected)
    Expected: true
    Received: false
      33 |     expect(suppressAutoLock()).toBe(true);
```

**PrivacyScreen.handleRequestPermissions** — com o wrap removido:
```
PrivacyScreen auto-lock suppression (M11)
  ✕ suppresses auto-lock while requestAllPermissions() is pending

  ● suppresses auto-lock while requestAllPermissions() is pending
    expect(received).toBe(expected)
    Expected: true
    Received: false
      37 |     expect(suppressAutoLock()).toBe(true);
```

Confirmação agregada (todos os 6 fixes de produção revertidos de uma vez via `git stash`, todos os 5 ficheiros de teste novos correndo contra o código pré-fix):
```
Test Suites: 5 failed, 5 total
Tests:       6 failed, 1 passed, 7 total   (o 1 passou é um teste trivial "Platform.OS is android", sem relação com o fix)
```

### Casos cobertos

- **Mecanismo do hook (`expo-camera`)** vs **`PermissionsAndroid.request`** vs **chamada de bridge nativa (`requestAllPermissions`)** — três mecanismos de disparo de diálogo distintos, cada um testado no mínimo uma vez.
- **Disparo automático (mount effect)** vs **disparo por interacção (botão)** — CameraScreen cobre ambos.
- **Estado suprimido → resolvido**: cada teste confirma `suppressAutoLock()===true` durante o pendente e `===false` depois de resolver a promise — prova que o contador não fica preso (regressão do inverso: se ficasse preso, a app nunca mais voltaria a bloquear).
- Não escrevi um teste novo para o cap de 30s nem para o comportamento normal de bloqueio: ambos já existiam intocados em `permissions.ts`/`App.tsx` e não há linha nova a proteger ali.

### Sanity-check

Revertidos os 6 ficheiros de produção em bloco (`git stash push -- <6 ficheiros>`), mantendo os 5 ficheiros de teste novos: a suite completa dos 5 novos ficheiros falhou com 6/7 falhas (a razão certa, mostrado acima). `git stash pop` restaurou os fixes; a suite voltou a verde.

### Resultado dos comandos obrigatórios

`npm run lint`: 0 erros (1 warning pré-existente em `ClockScreen.tsx`, ficheiro não tocado por esta PR).

`npx tsc --noEmit`: limpo.

`npm test`: 305 passaram, 9 falharam, 47 suites (5 falharam) — **as mesmas 9 falhas da linha de base** (`CalculatorScreen`, `FoldersStore`×2, `LockScreen`×3, `SettingsScreen`, `WeatherScreen`×2), confirmadas por comparação directa com `baseline.json`. Nenhuma falha nova. Os 134 testes adicionais (180→314) incluem os 7 novos testes desta PR, todos verdes.

## Testes

305 passaram, 9 falharam (mesmas 9 da linha de base, nenhuma nova), 47 suites (5 falharam, mesmas da linha de base)

## Linked Issue

Fixes #211