### PR TITLE
Add test coverage for CallScreen: caller-name fallback, mute/speaker toggles, and End Call navigation (#287)

### DIFF
--- a/src/screens/__tests__/CallScreen.test.tsx
+++ b/src/screens/__tests__/CallScreen.test.tsx
@@ -1,0 +1,175 @@
+import React from 'react';
+import { render, fireEvent } from '../../test-utils';
+import { CallScreen } from '../CallScreen';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const navigation = { navigate: jest.fn(), goBack: jest.fn() } as any;
+
+function renderCall(params: { number?: string; name?: string }) {
+  return render(
+    <CallScreen navigation={navigation} route={{ params } as any} />
+  );
+}
+
+// CallScreen kicks off a native dialer call and starts a 10s fallback timeout
+// on mount (see CallScreen.tsx's post-mount effect). Fake timers keep that
+// timeout from firing mid-test/leaking across tests, and unmounting after
+// each test clears its AppState listener + timeout.
+beforeEach(() => {
+  jest.useFakeTimers();
+  navigation.navigate.mockClear();
+  navigation.goBack.mockClear();
+});
+
+afterEach(() => {
+  jest.clearAllTimers();
+  jest.useRealTimers();
+});
+
+describe('CallScreen', () => {
+  describe('caller identity', () => {
+    it('renders the caller name from route params', () => {
+      const { getByText } = renderCall({ number: '+15551234567', name: 'Jane Doe' });
+      expect(getByText('Jane Doe')).toBeTruthy();
+    });
+
+    it('derives avatar initials from the caller name', () => {
+      const { getByText } = renderCall({ number: '+15551234567', name: 'Jane Doe' });
+      expect(getByText('JD')).toBeTruthy();
+    });
+
+    it('falls back to the number when name is absent from params', () => {
+      const { getByText, queryByText } = renderCall({ number: '+15551234567' });
+      expect(getByText('+15551234567')).toBeTruthy();
+      expect(queryByText('Jane Doe')).toBeNull();
+    });
+
+    it('falls back to the number when name is an empty string', () => {
+      // Matches how PhoneScreen navigates here for numbers with no saved
+      // contact: navigation.navigate('CallScreen', { number, name: name ?? '' })
+      const { getByText } = renderCall({ number: '+15551234567', name: '' });
+      expect(getByText('+15551234567')).toBeTruthy();
+    });
+
+    it("falls back to 'Unknown' when neither name nor number is present", () => {
+      const { getByText, queryByText } = renderCall({});
+      expect(getByText('Unknown')).toBeTruthy();
+      expect(queryByText('+15551234567')).toBeNull();
+    });
+  });
+
+  describe('mute toggle', () => {
+    it('pressing Mute switches the icon from mic to mic-off', () => {
+      const { getByLabelText, UNSAFE_getByProps, UNSAFE_queryByProps } = renderCall({
+        number: '+15551234567',
+        name: 'Jane Doe',
+      });
+
+      expect(UNSAFE_getByProps({ name: 'mic' })).toBeTruthy();
+      expect(UNSAFE_queryByProps({ name: 'mic-off' })).toBeNull();
+
+      fireEvent.press(getByLabelText('Mute'));
+
+      expect(UNSAFE_getByProps({ name: 'mic-off' })).toBeTruthy();
+      expect(UNSAFE_queryByProps({ name: 'mic' })).toBeNull();
+    });
+
+    it('pressing Mute twice returns to the unmuted icon', () => {
+      const { getByLabelText, UNSAFE_getByProps, UNSAFE_queryByProps } = renderCall({
+        number: '+15551234567',
+        name: 'Jane Doe',
+      });
+
+      const mute = getByLabelText('Mute');
+      fireEvent.press(mute);
+      fireEvent.press(mute);
+
+      expect(UNSAFE_getByProps({ name: 'mic' })).toBeTruthy();
+      expect(UNSAFE_queryByProps({ name: 'mic-off' })).toBeNull();
+    });
+
+    it('toggling Mute does not affect the Speaker icon', () => {
+      const { getByLabelText, UNSAFE_getByProps } = renderCall({
+        number: '+15551234567',
+        name: 'Jane Doe',
+      });
+
+      fireEvent.press(getByLabelText('Mute'));
+
+      expect(UNSAFE_getByProps({ name: 'volume-medium' })).toBeTruthy();
+    });
+  });
+
+  describe('speaker toggle', () => {
+    it('pressing Speaker switches the icon from volume-medium to volume-high', () => {
+      const { getByLabelText, UNSAFE_getByProps, UNSAFE_queryByProps } = renderCall({
+        number: '+15551234567',
+        name: 'Jane Doe',
+      });
+
+      expect(UNSAFE_getByProps({ name: 'volume-medium' })).toBeTruthy();
+      expect(UNSAFE_queryByProps({ name: 'volume-high' })).toBeNull();
+
+      fireEvent.press(getByLabelText('Speaker'));
+
+      expect(UNSAFE_getByProps({ name: 'volume-high' })).toBeTruthy();
+      expect(UNSAFE_queryByProps({ name: 'volume-medium' })).toBeNull();
+    });
+
+    it('pressing Speaker twice returns to the non-speaker icon', () => {
+      const { getByLabelText, UNSAFE_getByProps, UNSAFE_queryByProps } = renderCall({
+        number: '+15551234567',
+        name: 'Jane Doe',
+      });
+
+      const speaker = getByLabelText('Speaker');
+      fireEvent.press(speaker);
+      fireEvent.press(speaker);
+
+      expect(UNSAFE_getByProps({ name: 'volume-medium' })).toBeTruthy();
+      expect(UNSAFE_queryByProps({ name: 'volume-high' })).toBeNull();
+    });
+
+    it('pressing Mute and Speaker both flips both icons independently', () => {
+      const { getByLabelText, UNSAFE_getByProps } = renderCall({
+        number: '+15551234567',
+        name: 'Jane Doe',
+      });
+
+      fireEvent.press(getByLabelText('Mute'));
+      fireEvent.press(getByLabelText('Speaker'));
+
+      expect(UNSAFE_getByProps({ name: 'mic-off' })).toBeTruthy();
+      expect(UNSAFE_getByProps({ name: 'volume-high' })).toBeTruthy();
+    });
+  });
+
+  describe('end call', () => {
+    it('pressing End Call navigates back', () => {
+      const { getByLabelText } = renderCall({ number: '+15551234567', name: 'Jane Doe' });
+
+      fireEvent.press(getByLabelText('End Call'));
+
+      expect(navigation.goBack).toHaveBeenCalledTimes(1);
+      expect(navigation.navigate).not.toHaveBeenCalled();
+    });
+
+    it('pressing Mute or Speaker does not navigate away from the call', () => {
+      const { getByLabelText } = renderCall({ number: '+15551234567', name: 'Jane Doe' });
+
+      fireEvent.press(getByLabelText('Mute'));
+      fireEvent.press(getByLabelText('Speaker'));
+
+      expect(navigation.goBack).not.toHaveBeenCalled();
+      expect(navigation.navigate).not.toHaveBeenCalled();
+    });
+  });
+
+  it('exposes accessible labels for all three call controls', () => {
+    const { getByLabelText } = renderCall({ number: '+15551234567', name: 'Jane Doe' });
+
+    expect(getByLabelText('Mute')).toBeTruthy();
+    expect(getByLabelText('Speaker')).toBeTruthy();
+    expect(getByLabelText('End Call')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Resumo

Add test coverage for CallScreen: caller-name fallback, mute/speaker toggles, and End Call navigation

## Causa raiz

`src/screens/CallScreen.tsx` não tinha nenhum ficheiro de teste em `src/screens/__tests__/` — confirmado por `Grep`/`Glob`, e é o único ecrã do épico #52 nessa situação (LockScreen, LauncherHomeScreen, ControlCenterScreen, etc. já têm testes). Não há um defeito de comportamento: o ecrã já implementa corretamente o que o issue descreve — verifiquei o código linha a linha antes de escrever qualquer teste:

- `src/screens/CallScreen.tsx:83-85` — `const displayName = name || number || 'Unknown';` implementa exatamente a cadeia de fallback name → number → 'Unknown'.
- `src/screens/CallScreen.tsx:161-165` — `toggleMute` faz `setIsMuted((v) => !v)`; `ControlButton` (linha 51-69) usa `active={isMuted}` para aplicar `styles.controlBtnActive` e troca o ícone (`mic` ↔ `mic-off`, linha 195-200).
- `src/screens/CallScreen.tsx:167-170` — `toggleSpeaker` é o análogo para `isSpeaker` / `volume-medium` ↔ `volume-high`.
- `src/screens/CallScreen.tsx:154-157` — `handleEndCall` chama `navigation.goBack()` (não `navigate`).

Este issue é portanto puramente de cobertura de teste, não de correção de defeito — não há código de produção a mudar. Registo isto explicitamente porque o processo padrão deste pipeline pede um "passo vermelho" via reversão do fix; não havendo fix, substituí esse passo por uma prova equivalente (ver secção Testes).

## O que mudou

- **`src/screens/__tests__/CallScreen.test.tsx`** (novo) — 14 testes que montam `CallScreen` com `navigation`/`route` mockados via `render`/`fireEvent` de `test-utils`, cobrindo:
  - identidade do chamador: nome presente, fallback para número (params sem `name`, e com `name: ''` — o caso real usado por `PhoneScreen.tsx:574` ao ligar para um número sem nome de contacto), fallback para `'Unknown'` quando nada existe, e iniciais do avatar;
  - mute: toggle simples, duplo toggle (idempotência do duplo toque), e que mutar não afeta o ícone do Speaker;
  - speaker: toggle simples, duplo toggle, e que Mute+Speaker são independentes (ambos ativos ao mesmo tempo);
  - end call: chama `navigation.goBack()` exatamente uma vez e nunca `navigate`; e o inverso — que mutar/altifalante NÃO navega para fora do ecrã;
  - smoke test de que os três `accessibilityLabel` (`Mute`, `Speaker`, `End Call`) existem.

Nenhum ficheiro de produção foi alterado.

## Porque assim

- Assercões usam `getByText`/`getByLabelText`/`toHaveBeenCalledTimes`/`UNSAFE_getByProps` (para ler o `name` do `Ionicons` real, já que o ícone visualmente muda com o estado) — nunca `toJSON()`/snapshot, conforme pedido no issue.
- Usei `jest.useFakeTimers()` (padrão já usado em `LauncherHomeScreen.test.tsx`) porque `CallScreen` arranca um `setTimeout` de 10s e um listener de `AppState` no `useEffect` de montagem (linha 133-150) para simular o retorno do dialer nativo; sem fake timers o handle fica aberto entre testes.
- Testei o fallback `name: ''` (não só `name` ausente) porque é o caminho real de `PhoneScreen.tsx:574` — o tipo `AppNavigationProp` declara `name`/`number` como `string` obrigatórios, mas na prática pode chegar `''`.

## Critérios de aceitação

- [x] `CallScreen` tem um ficheiro de teste que o renderiza com `navigation`/`route` mockados.
- [x] O nome do chamador (fallback name → number → 'Unknown') é verificado com `getByText`, não snapshot — 4 testes cobrem os 3 ramos + o caso `name: ''`.
- [x] Mute e Speaker são exercitados com `fireEvent.press` e o estado resultante é verificado (troca de ícone via `UNSAFE_getByProps`, não apenas `toBeTruthy()`).
- [x] End Call é exercitado com `fireEvent.press` e verifica-se `navigation.goBack` (não `navigate`) — confirmei o handler real antes de escrever o teste, como pedido no issue.
- [x] Todas as asserções comportamentais usam `getByText`/`getByLabelText`/`toHaveBeenCalledTimes`/`UNSAFE_getByProps`, não `toJSON()`/`toBeTruthy()` isolado.
- [x] As 9 falhas pré-existentes (`CalculatorScreen`, `FoldersStore` ×2, `LockScreen` ×3, `SettingsScreen`, `WeatherScreen` ×2) continuam exatamente as mesmas — não corrigidas nem mascaradas (não toquei nesses ficheiros).
- [x] `npm test` não mostra falhas NOVAS — confirmado por comparação nominal com `baseline.json`.

## Testes

**Passo vermelho (adaptado):** este issue não corrige um defeito — o comportamento já estava correto em `CallScreen.tsx`, por isso não há "fix de produção" para reverter. Para provar que os testes estão ligados ao comportamento real (e não são decorativos), parti temporariamente os 4 mecanismos que os testes verificam — fallback de nome, toggle de mute, toggle de speaker, e `goBack` — corri a suite, e restaurei com `git checkout`:

```
# CallScreen.tsx temporariamente alterado:
#   displayName sempre 'Unknown'
#   toggleMute/toggleSpeaker sem setState (no-op)
#   handleEndCall chama navigation.navigate(...) em vez de goBack()

$ npx jest src/screens/__tests__/CallScreen.test.tsx
  CallScreen
    ✓ exposes accessible labels for all three call controls (13 ms)
    caller identity
      ✕ renders the caller name from route params (70 ms)
      ✕ derives avatar initials from the caller name (19 ms)
      ✕ falls back to the number when name is absent from params (17 ms)
      ✕ falls back to the number when name is an empty string (16 ms)
      ✓ falls back to 'Unknown' when neither name nor number is present (17 ms)
    mute toggle
      ✕ pressing Mute switches the icon from mic to mic-off (16 ms)
      ...
    speaker toggle
      ✕ pressing Speaker switches the icon from volume-medium to volume-high (11 ms)
      ✕ pressing Mute and Speaker both flips both icons independently (13 ms)
    end call
      ✕ pressing End Call navigates back (10 ms)

  ● CallScreen › end call › pressing End Call navigates back
    expect(jest.fn()).toHaveBeenCalledTimes(expected)
    Expected number of calls: 1
    Received number of calls: 0
      153 |       expect(navigation.goBack).toHaveBeenCalledTimes(1);

Tests: 8 failed, 6 passed, 14 total
```

8 dos 14 falharam exatamente nos mecanismos que a alteração partiu (os 6 restantes — ex. duplo-toggle que fica trivialmente igual a `false→false`, ou o smoke-test de labels — não dependem desses mecanismos e continuam corretos por não terem sido tocados). Depois de `git checkout -- src/screens/CallScreen.tsx`, a suite voltou a 14/14 verde.

**Casos cobertos além do caminho feliz:** name ausente vs. name vazio (2 formas distintas de "sem nome"); ausência total (número + nome) → 'Unknown'; duplo toque em Mute e em Speaker (idempotência); toggles cruzados (mutar não mexe no Speaker e vice-versa); o inverso do fix — mutar/altifalante não deve navegar para fora da chamada.

**Sanity-check:** feito via o mesmo procedimento do passo vermelho acima (não há fix de produção a reverter separadamente — a reversão *é* a prova).

**Resultado das verificações** (branch `qa/issue-287`, comparado com a baseline de `main`):
- `npm run lint`: 0 erros (1 warning pré-existente em `ClockScreen.tsx`, não relacionado).
- `npx tsc --noEmit`: limpo.
- `npm test`: 319 passaram, 9 falharam, 48 suites — as mesmas 9 falhas pré-existentes da baseline (`CalculatorScreen`, `FoldersStore` ×2, `LockScreen` ×3, `SettingsScreen`, `WeatherScreen` ×2), zero falhas novas.

## Testes

319 passaram, 9 falharam (as mesmas 9 pré-existentes da baseline em main — nenhuma nova), 48 suites; os 14 testes novos de CallScreen.test.tsx passam todos

## Linked Issue

Fixes #287