### PR TITLE
fix(pipeline): stop one failing issue from pinning the whole queue

### DIFF
--- a/scripts/team/implement.sh
+++ b/scripts/team/implement.sh
@@ -196,13 +196,31 @@ AGENT_SLOT=main CLAUDE_MODEL="$MODEL" \
 
 if ! verdict_readable "$VERDICT_FILE"; then
   if ! no_verdict_is_real_failure main "$AGENT_RC"; then
-    log "SEM VEREDICTO (corrida degradada ou não arrancada) — issue volta a $PREV_STATE"
-    comment_issue "$ISSUE" "## Implementador: corrida degradada, sem veredicto
+    NV=$(bump_noverdict "$ISSUE")
+    log "SEM VEREDICTO (corrida degradada ou não arrancada) — $NV seguidas — issue volta a $PREV_STATE"
+    if [ "$NV" -ge "$TEAM_DEFER_AFTER" ]; then
+      # Circuit breaker: the issue keeps coming back to the head of the queue and
+      # pinning the pipeline on a failure that is not its fault. Park it until the
+      # subscription returns — the stronger engine is what it was missing.
+      UNTIL=$(defer_issue "$ISSUE")
+      log "#$ISSUE adiado até $(date -d "@$UNTIL" '+%H:%M') — a fila segue para o próximo"
+      comment_issue "$ISSUE" "## Implementador: adiado após $NV corridas sem veredicto
+
+O motor não concluiu $NV vezes seguidas, sempre por razões alheias ao issue
+(subscrição esgotada, fallback a não terminar). Cada tentativa devolvia o issue à
+cabeça da fila e voltava a ser despachada, o que prendia o pipeline inteiro num
+problema que não é deste issue.
+
+Fica adiado até **$(date -d "@$UNTIL" '+%H:%M')** — o momento em que a subscrição
+volta — e a fila segue para o próximo. Nada se perdeu."
+    else
+      comment_issue "$ISSUE" "## Implementador: corrida degradada, sem veredicto
 
 A corrida não produziu veredicto por uma razão alheia ao issue: ou o slot estava
 ocupado, ou a subscrição estava esgotada e o modelo de fallback não conseguiu
-concluir. **Isto não é um problema do issue** — volta a \`$L_READY\` para nova
+concluir. **Isto não é um problema do issue** — volta a \`$PREV_STATE\` para nova
 tentativa."
+    fi
     set_state "$ISSUE" "$PREV_STATE"
     wt_remove "$WT"
     exit 0
@@ -216,6 +234,8 @@ corrida, não do issue — volta à fila."
   wt_remove "$WT"
   exit 0
 fi
+
+clear_noverdict "$ISSUE"   # a verdict arrived: the streak is over
 
 OUTCOME=$(jqv "$VERDICT_FILE" '.outcome' 'blocked')
 SUMMARY=$(jqv "$VERDICT_FILE" '.summary' 'correção automática'); SUMMARY="${SUMMARY:0:200}"

--- a/scripts/team/lib.sh
+++ b/scripts/team/lib.sh
@@ -139,6 +139,61 @@ attempts_of() { cat "$ATTEMPTS_DIR/${1}" 2>/dev/null || echo 0; }
 
 clear_attempts() { rm -f "$ATTEMPTS_DIR/${1}" 2>/dev/null || true; }
 
+# ── Circuit breaker for runs that keep dying without a verdict ─────────────
+#
+# A run that produces no verdict is not the issue's fault, so it does not count as a
+# rejection and the issue goes straight back in the queue. Correct in isolation, and
+# a trap in aggregate: the issue returns to the SAME position — the head of the
+# queue — and is dispatched again immediately. If the cause is the engine rather
+# than the issue, that repeats forever.
+#
+# Measured: with the subscription exhausted, #318 failed three times in a row on the
+# fallback, ~3 minutes each, and the orchestrator dispatched nothing else in
+# between. The whole pipeline was pinned on one issue, and from the log every cycle
+# looked like work starting.
+#
+# So after a couple of consecutive verdict-less runs the issue is DEFERRED — parked
+# with a timestamp and skipped by the dispatcher until it passes. When the cause is
+# a quota outage the natural deadline is the moment the subscription returns: the
+# stronger engine is exactly what it was missing.
+NOVERDICT_DIR="$STATE_DIR/noverdict"
+DEFER_DIR="$STATE_DIR/deferred"
+mkdir -p "$NOVERDICT_DIR" "$DEFER_DIR" 2>/dev/null || true
+
+TEAM_DEFER_AFTER="${TEAM_DEFER_AFTER:-2}"
+
+bump_noverdict() {
+  local issue="$1" n
+  n=$(( $(cat "$NOVERDICT_DIR/$issue" 2>/dev/null || echo 0) + 1 ))
+  echo "$n" > "$NOVERDICT_DIR/$issue"
+  printf '%s' "$n"
+}
+
+clear_noverdict() { rm -f "$NOVERDICT_DIR/${1}" 2>/dev/null || true; }
+
+# Park an issue until $2 (epoch seconds). Defaults to the end of the current quota
+# cooldown, or 30 minutes when there is none.
+defer_issue() {
+  local issue="$1" until_ts="${2:-}" cd now
+  if [ -z "$until_ts" ]; then
+    cd=$(cat "$COOLDOWN_FILE" 2>/dev/null || echo 0)
+    now=$(date +%s)
+    if [ "$cd" -gt "$now" ]; then until_ts=$(( cd + 120 )); else until_ts=$(( now + 1800 )); fi
+  fi
+  echo "$until_ts" > "$DEFER_DIR/$issue"
+  printf '%s' "$until_ts"
+}
+
+is_deferred() {
+  local issue="$1" until_ts now
+  [ -f "$DEFER_DIR/$issue" ] || return 1
+  until_ts=$(cat "$DEFER_DIR/$issue" 2>/dev/null || echo 0)
+  now=$(date +%s)
+  if [ "$now" -lt "$until_ts" ]; then return 0; fi
+  rm -f "$DEFER_DIR/$issue" 2>/dev/null || true   # expired
+  return 1
+}
+
 # After this many failed attempts an issue is promoted to the strong tier. This is
 # the "only if it needs it" rule made mechanical: nobody guesses up front which
 # issue is hard, the issue demonstrates it by defeating the cheaper model.

--- a/scripts/team/orchestrator.sh
+++ b/scripts/team/orchestrator.sh
@@ -131,7 +131,20 @@ issues_with() {
       2>/dev/null
 }
 
-first_with() { issues_with "$1" | head -1; }
+# First actionable issue for a label, SKIPPING anything currently deferred.
+#
+# Without the skip, a deferred issue keeps being returned as the head of the queue
+# and the dispatcher pins itself on it — which is the exact failure the deferral
+# exists to break.
+first_with() {
+  local n
+  while IFS= read -r n; do
+    [ -n "$n" ] || continue
+    is_deferred "$n" && continue
+    echo "$n"; return 0
+  done < <(issues_with "$1")
+  return 0
+}
 
 # Labels on one issue, straight from the cache.
 labels_of() {


### PR DESCRIPTION
A verdict-less run is not the issue's fault, so it doesn't count as a rejection and the issue goes back in the queue — **at the same position, the head**, and is dispatched again immediately. When the cause is the engine, that repeats forever.

Measured this morning: subscription ran out again (back at 13:01), everything fell to the Ollama fallback, and **#318 failed three times in a row**, ~3 min each, with nothing else dispatched in between. The whole pipeline was pinned on one issue while 14 filed bugs waited — and every cycle in the log read as work starting.

Consecutive verdict-less runs are now counted separately from rejections. After two, the issue is **deferred**: parked with a timestamp, skipped by the dispatcher until it passes. With a quota outage the deadline is when the subscription returns, since the stronger engine is exactly what the run was missing. Any real verdict clears the streak.

`first_with()` skips deferred issues itself — filtering afterwards would keep handing back the same head of queue, which is the failure the deferral exists to break.