### PR TITLE
Corrige teste MC vácuo em CalculatorScreen (colisão com o botão '0') e traz o fix M+/M- de decimal.js do branch qa/issue-212 para esta PR, com a citação de commit correcta (#335)

### DIFF
--- a/src/screens/CalculatorScreen.tsx
+++ b/src/screens/CalculatorScreen.tsx
@@ -473,12 +473,14 @@ export function CalculatorScreen() {
         setResetOnNext(true);
         break;
       case 'M+':
-        setMemory(prev => prev + current);
+        // Route through performOp so the memory register accumulates with the
+        // same decimal arithmetic as the '=' key, instead of raw IEEE-754.
+        setMemory(prev => performOp(prev, current, '+'));
         setHasMemory(true);
         setResetOnNext(true);
         break;
       case 'M-':
-        setMemory(prev => prev - current);
+        setMemory(prev => performOp(prev, current, '-'));
         setHasMemory(true);
         setResetOnNext(true);
         break;

--- a/src/screens/__tests__/CalculatorScreen.test.tsx
+++ b/src/screens/__tests__/CalculatorScreen.test.tsx
@@ -79,15 +79,153 @@ describe('CalculatorScreen', () => {
   });
 
   it('0.1 + 0.2 equals 0.3 without float artifacts', () => {
-    const { getByText } = render(<CalculatorScreen />);
-    fireEvent.press(getByText('0'));
+    const { getByText, getAllByText } = render(<CalculatorScreen />);
+    // The initial display and the '0' digit button both render the text '0' —
+    // getAllByText('0')[0] is the display (see 'renders calculator display'
+    // above), [1] is the actual pressable button.
+    fireEvent.press(getAllByText('0')[1]);
     fireEvent.press(getByText('.'));
     fireEvent.press(getByText('1'));
     fireEvent.press(getByText('+'));
+    // Display now reads '0.1', so the '0' button is unambiguous again.
     fireEvent.press(getByText('0'));
     fireEvent.press(getByText('.'));
     fireEvent.press(getByText('2'));
     fireEvent.press(getByText('='));
     expect(getByText('0.3')).toBeTruthy();
+  });
+
+  it('large multiplication stays in plain notation under 1e16', () => {
+    const { getByText } = render(<CalculatorScreen />);
+    // Query the '9' button once — after the first press the display itself
+    // reads '9' too, which would make later getByText('9') calls ambiguous.
+    const nineButton = getByText('9');
+    for (let i = 0; i < 9; i++) fireEvent.press(nineButton);
+    fireEvent.press(getByText('×'));
+    fireEvent.press(getByText('1'));
+    fireEvent.press(getByText('0'));
+    fireEvent.press(getByText('0'));
+    fireEvent.press(getByText('0'));
+    fireEvent.press(getByText('='));
+    // 999999999 × 1000 = 999999999000 — must not fall back to scientific
+    // notation or lose digits.
+    expect(getByText('999999999000')).toBeTruthy();
+  });
+
+  it('1e20 × 1e20 = 1e+40 switches to scientific notation', () => {
+    const { getByText, getAllByText } = render(<CalculatorScreen />);
+    // The calculator has no exponent-entry key, so 1e20 is built digit by
+    // digit: '1' followed by twenty '0' presses. At the very start the
+    // display and the '0' button both show '0' (see 'renders calculator
+    // display' above), so the '0' button must be queried via getAllByText —
+    // '1' has no such ambiguity since the display still reads '0'.
+    const oneButton = getByText('1');
+    const zeroButton = getAllByText('0')[1];
+
+    const enterOneE20 = () => {
+      fireEvent.press(oneButton);
+      for (let i = 0; i < 20; i++) fireEvent.press(zeroButton);
+    };
+
+    enterOneE20();
+    fireEvent.press(getByText('×'));
+    enterOneE20();
+    fireEvent.press(getByText('='));
+
+    expect(getByText('1e+40')).toBeTruthy();
+  });
+
+  it('subtracting nearly equal operands keeps the exact decimal difference', () => {
+    const { getByText, getAllByText } = render(<CalculatorScreen />);
+    // Catastrophic cancellation: in IEEE-754 doubles
+    // 100000000.30000001 - 100000000.3 === 1.4901161193847656e-8, and the
+    // relative error survives formatNumber's 10-significant-digit rounding
+    // ('1.490116119e-8'). Only exact decimal arithmetic yields '1e-8'.
+    // Buttons are captured before the first press: once the display echoes a
+    // digit, getByText for that digit becomes ambiguous.
+    const one = getByText('1');
+    const zero = getAllByText('0')[1];
+    const three = getByText('3');
+    const dot = getByText('.');
+
+    const enterHundredMillionPointThree = () => {
+      fireEvent.press(one);
+      for (let i = 0; i < 8; i++) fireEvent.press(zero);
+      fireEvent.press(dot);
+      fireEvent.press(three);
+    };
+
+    enterHundredMillionPointThree();
+    for (let i = 0; i < 6; i++) fireEvent.press(zero);
+    fireEvent.press(one); // 100000000.30000001
+    fireEvent.press(getByText('-'));
+    enterHundredMillionPointThree(); // 100000000.3
+    fireEvent.press(getByText('='));
+
+    expect(getByText('1e-8')).toBeTruthy();
+  });
+
+  it('memory add/subtract keeps the exact decimal difference', () => {
+    const { getByText, getAllByText } = render(<CalculatorScreen />);
+    // Same cancellation, but routed through M+/M- instead of the '=' key —
+    // memory must accumulate with the same decimal arithmetic as performOp.
+    const one = getByText('1');
+    const zero = getAllByText('0')[1];
+    const three = getByText('3');
+    const dot = getByText('.');
+
+    const enterHundredMillionPointThree = () => {
+      fireEvent.press(one);
+      for (let i = 0; i < 8; i++) fireEvent.press(zero);
+      fireEvent.press(dot);
+      fireEvent.press(three);
+    };
+
+    enterHundredMillionPointThree();
+    for (let i = 0; i < 6; i++) fireEvent.press(zero);
+    fireEvent.press(one); // 100000000.30000001
+    fireEvent.press(getByText('M+'));
+    enterHundredMillionPointThree(); // 100000000.3
+    fireEvent.press(getByText('M-'));
+    fireEvent.press(getByText('MR'));
+
+    expect(getByText('1e-8')).toBeTruthy();
+  });
+
+  it('pressing M+ twice adds the displayed value twice', () => {
+    const { getByText } = render(<CalculatorScreen />);
+    const five = getByText('5');
+    fireEvent.press(five);
+    const memoryAdd = getByText('M+');
+    fireEvent.press(memoryAdd);
+    fireEvent.press(memoryAdd);
+    fireEvent.press(getByText('MR'));
+    expect(getByText('10')).toBeTruthy();
+  });
+
+  it('MC empties memory so MR recalls zero', () => {
+    const { getByText, queryByText } = render(<CalculatorScreen />);
+    // Memorize '123' — a value no keyboard button can ever render (every
+    // button label is a single character: '0'-'9', an operator, or a
+    // function name), so its presence/absence in the tree unambiguously
+    // reflects the display, unlike '0' which the digit button also renders.
+    fireEvent.press(getByText('1'));
+    fireEvent.press(getByText('2'));
+    fireEvent.press(getByText('3'));
+    fireEvent.press(getByText('M+')); // memory = 123
+    fireEvent.press(getByText('MC'));
+    fireEvent.press(getByText('MR'));
+    // If MC failed to clear memory, MR would recall 123 and '123' would
+    // still be findable in the tree.
+    expect(queryByText('123')).toBeNull();
+  });
+
+  it('dividing by zero shows Error instead of a numeric result', () => {
+    const { getByText } = render(<CalculatorScreen />);
+    fireEvent.press(getByText('5'));
+    fireEvent.press(getByText('÷'));
+    fireEvent.press(getByText('0'));
+    fireEvent.press(getByText('='));
+    expect(getByText('Error')).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Resumo

Corrige teste MC vácuo em CalculatorScreen (colisão com o botão '0') e traz o fix M+/M- de decimal.js do branch qa/issue-212 para esta PR, com a citação de commit correcta

## Causa raiz

Este issue (L1a) não pedia lógica nova — pedia para destravar a PR #333 (branch `qa/issue-212`), bloqueada 3 vezes por defeitos processuais:

**Problema 1 — teste MC vácuo.** Em `src/screens/__tests__/CalculatorScreen.test.tsx:206-214` (antes desta PR), o teste fazia `getAllByText('0')[0]` depois de MC+MR. O botão dígito `'0'` (`CalculatorScreen.tsx:118`) está sempre presente na árvore, com ou sem o fix de `MC`; `toBeTruthy()` sobre um elemento que já existia antes de qualquer interacção passa sempre. Confirmado empiricamente (ver secção Testes): removendo `setMemory(0)` do case `'MC'` (`CalculatorScreen.tsx:467-470`), o teste antigo continuava verde.

**Problema 2 — descrição da PR desalinhada.** O corpo da PR #333 dizia "nenhuma alteração em CalculatorScreen.tsx", o que era falso: o commit `99f5ab4` (já presente no branch `qa/issue-212`) altera `CalculatorScreen.tsx:475-484`, roteando M+/M- por `performOp` em vez de aritmética IEEE-754 crua. Esta descrição corrige essa afirmação.

**Problema 3 — citação de commit errada.** A secção "Causa raiz" da PR #333 citava `7f4ba95` como o commit que introduziu `decimal.js` em `CalculatorScreen.tsx`. Verificado: `git show 7f4ba95 --stat` toca `CameraScreen.tsx`, `ClockScreen.tsx`, `ConversationScreen.tsx`, `PhotosScreen.tsx`, `ProfileScreen.tsx`, `RemindersScreen.tsx` — nunca `CalculatorScreen.tsx`. É um commit-isco: mesma mensagem ("fix(L1): route arithmetic through decimal.js..."), diff completamente alheio. O commit correcto é `77d58ad`: um squash-merge (PR #237) cujo título de topo é enganador ("fix(C1): surface bridge errors in production"), mas cujo diff real (`git show 77d58ad --stat`) confirma `package.json` (+1, decimal.js) e `CalculatorScreen.tsx` (64 linhas). `git merge-base --is-ancestor 77d58ad HEAD` confirma que é antepassado do branch actual.

## O que mudou

- **`src/screens/CalculatorScreen.tsx`** (+6/-4, trazido do branch `qa/issue-212`, commit `99f5ab4`): `M+`/`M-` (`handleMemory`, linhas 475-484) passam a chamar `performOp(prev, current, '+'|'-')` em vez de `prev + current` / `prev - current`. A memória agora acumula com a mesma aritmética `decimal.js` do `'='`, em vez de IEEE-754 cru — evita que M+/M- reintroduzam artefactos de cancelamento catastrófico que `performOp` já evita no caminho normal.
- **`src/screens/__tests__/CalculatorScreen.test.tsx`** (+142/-4): trouxe os testes já existentes em `qa/issue-212` (regressão `0.1+0.2` com selector corrigido, `1e20×1e20`, cancelamento catastrófico via `=` e via M+/M-, M+ duplo) e substituiu o teste vácuo `'MC empties memory so MR recalls zero'` por uma versão que memoriza `'123'` (valor cujo texto nenhum botão do teclado pode produzir — todos os labels são caracteres únicos: dígitos 0-9, operadores, ou nomes de função como `MC`/`sin`/`π`) e assere `queryByText('123')` como `null` depois de MC+MR.

## Porque assim

Para o teste MC, segui a sugestão do próprio issue (memorizar um valor multi-dígito não colidente) em vez de adicionar `testID` ao nó de display — evita tocar em produção só para tornar um teste testável, e mantém o padrão já usado por outros testes deste ficheiro (ex.: `getByText('123')` em `'pressing numbers updates display'`, linha 17). Alternativa descartada: `getAllByText('0')[1]` (índice do botão) não ajuda porque a ambiguidade está em *qual* '0' é o display, não em quantos existem — testar ausência de `'123'` é a única forma de distinguir memória limpa de memória não limpa sem depender de posição na árvore.

Para o M+/M-, não reimplementei nada: o fix já estava correcto no branch `qa/issue-212` (commit `99f5ab4`) e só precisava de ser trazido para esta PR, tal como o issue instruía.

## Critérios de aceitação

- [x] O teste MC falha se `setMemory(0)` for removido do case `'MC'` — provado abaixo (passo vermelho).
- [x] Esta descrição (corpo da PR) não contém afirmações falsas sobre o diff — cada ficheiro listado em "O que mudou" corresponde a `git diff --name-only origin/main` (ver Testes).
- [x] A secção "Causa raiz" cita `77d58ad`, com nota de que é squash-merge e a prova está no diff (`git show 77d58ad -- src/screens/CalculatorScreen.tsx`), não no título do commit.
- [x] `npm test`: CalculatorScreen 100% verde (17/17) e nenhuma falha nova fora da baseline conhecida (FoldersStore, LockScreen, SettingsScreen, WeatherScreen) — ver Testes.
- [x] Nenhuma alteração a `performOp`/`formatNumber` (`CalculatorScreen.tsx:151-176`, byte-a-byte iguais a `origin/main`) nem à lógica de M+/M- em si (só o teste que a cobre foi reescrito; a lógica de produção já veio pronta de `qa/issue-212`).

## Testes

**Passo vermelho** (teste novo escrito, depois `setMemory(0)` removido manualmente do case `'MC'`, produção revertida com `git stash`):

```
$ npx jest src/screens/__tests__/CalculatorScreen.test.tsx -t "MC empties memory"

  ● CalculatorScreen › MC empties memory so MR recalls zero

    expect(received).toBeNull()

    Received: {"_fiber": {...}}

      218 |     // If MC failed to clear memory, MR would recall 123 and '123' would
      219 |     // still be findable in the tree.
    > 220 |     expect(queryByText('123')).toBeNull();
          |                                ^
      221 |   });

Test Suites: 1 failed, 1 total
Tests:       1 failed, 16 skipped, 17 total
```

Com `setMemory(0)` restaurado, o mesmo teste passa (17/17 no ficheiro).

**Casos cobertos além do caminho feliz:** o teste MC reescrito cobre o inverso do fix (memória que devia ficar vazia continua vazia depois de MC, não só 'memória populada e lida correctamente'). Os restantes testes trazidos de `qa/issue-212` (já escritos nesse branch, não desta corrida) cobrem cancelamento catastrófico via M+/M- e M+ duplicado (repetição da mesma acção).

**Sanity-check obrigatório:** revertido `CalculatorScreen.tsx` para `origin/main` (fix de produção fora, testes mantidos):

```
$ npx jest src/screens/__tests__/CalculatorScreen.test.tsx
  ● CalculatorScreen › memory add/subtract keeps the exact decimal difference
    expect(getByText('1e-8')).toBeTruthy()   → elemento não encontrado
Test Suites: 1 failed, 1 total
Tests:       1 failed, 16 passed, 17 total
```

Restaurado o fix — suite volta a 17/17. Confirma que os testes estão de facto ligados ao código de produção (o teste MC por si não depende do fix M+/M-; o teste de cancelamento catastrófico via memória sim, e falhou como esperado).

**Resultado final das 3 verificações no worktree:**

- `npm run lint`: 0 erros, 1 warning pré-existente e alheio (`ClockScreen.tsx:351`, `tzTick` não usado).
- `npx tsc --noEmit`: limpo, sem output.
- `npm test`: 327 passaram, 8 falharam, 48 suites (44 passaram, 4 falharam). As 8 falhas são exactamente a baseline conhecida (FoldersStore ×2, LockScreen ×3, SettingsScreen ×1, WeatherScreen ×2 — todas por `firstSyncDone` nunca ficar `true` em render síncrono, `SettingsStore.tsx`). Nenhuma falha nova. A falha de baseline `CalculatorScreen › 0.1 + 0.2 equals 0.3 without float artifacts` (selector ambíguo) desaparece porque o branch `qa/issue-212` já a corrigia — dá 1 falha a menos que a baseline registada (9→8 no total do repo).

## Testes

327 passaram, 8 falharam, 48 suites (CalculatorScreen 17/17; as 8 falhas restantes são a baseline pré-existente em FoldersStore/LockScreen/SettingsScreen/WeatherScreen, sem falhas novas)

## Linked Issue

Fixes #335