### PR TITLE
Rotear sin/cos/tan/log/ln/√/x²/x³/1÷x/|x| por decimal.js em vez de Math.* nativo (#336)

### DIFF
--- a/src/screens/CalculatorScreen.tsx
+++ b/src/screens/CalculatorScreen.tsx
@@ -142,6 +142,10 @@ const SCIENTIFIC_ROWS: ButtonDef[][] = [
     { label: 'π', type: 'scientific' },
     { label: 'e', type: 'scientific' },
   ],
+  [
+    { label: '1/x', type: 'scientific' },
+    { label: '|x|', type: 'scientific' },
+  ],
 ];
 
 // ---------------------------------------------------------------------------
@@ -526,34 +530,38 @@ export function CalculatorScreen() {
 
     if (resetIfError()) return;
     const current = parseFloat(display);
-    let result: number;
+    const currentD = new Decimal(current);
+    let result: Decimal;
 
-    const toRad = (deg: number) => deg * (Math.PI / 180);
+    // Degrees→radians conversion also goes through Decimal (Decimal.acos(-1)
+    // at the configured 20-digit precision) instead of mixing in native
+    // Math.PI, so the whole sin/cos/tan chain stays at one precision level.
+    const toRad = (deg: Decimal) => deg.times(Decimal.acos(-1)).div(180);
 
     switch (label) {
       case 'sin':
-        result = isDeg ? Math.sin(toRad(current)) : Math.sin(current);
+        result = isDeg ? toRad(currentD).sin() : currentD.sin();
         break;
       case 'cos':
-        result = isDeg ? Math.cos(toRad(current)) : Math.cos(current);
+        result = isDeg ? toRad(currentD).cos() : currentD.cos();
         break;
       case 'tan':
-        result = isDeg ? Math.tan(toRad(current)) : Math.tan(current);
+        result = isDeg ? toRad(currentD).tan() : currentD.tan();
         break;
       case 'log':
-        result = Math.log10(current);
+        result = currentD.log();
         break;
       case 'ln':
-        result = Math.log(current);
+        result = currentD.ln();
         break;
       case '√':
-        result = Math.sqrt(current);
+        result = currentD.sqrt();
         break;
       case 'x²':
-        result = Math.pow(current, 2);
+        result = currentD.pow(2);
         break;
       case 'x³':
-        result = Math.pow(current, 3);
+        result = currentD.pow(3);
         break;
       case 'π':
         setDisplay(formatNumber(Math.PI));
@@ -565,16 +573,16 @@ export function CalculatorScreen() {
         return;
       case '1/x':
         if (current === 0) { setDisplay('Error'); setResetOnNext(true); return; }
-        result = 1 / current;
+        result = new Decimal(1).div(currentD);
         break;
       case '|x|':
-        result = Math.abs(current);
+        result = currentD.abs();
         break;
       default:
         return;
     }
 
-    setDisplay(formatNumber(result));
+    setDisplay(formatNumber(result.toNumber()));
     setResetOnNext(true);
   };
 

--- a/src/screens/__tests__/CalculatorScreen.test.tsx
+++ b/src/screens/__tests__/CalculatorScreen.test.tsx
@@ -1,6 +1,26 @@
 import React from 'react';
+import { Dimensions } from 'react-native';
+import Decimal from 'decimal.js';
 import { render, fireEvent } from '../../test-utils';
 import { CalculatorScreen } from '../CalculatorScreen';
+
+// Scientific buttons only render in the landscape SCIENTIFIC_ROWS grid
+// (CalculatorScreen.tsx:774), so these helpers flip useWindowDimensions'
+// underlying source between tests.
+const PORTRAIT = { width: 750, height: 1334, scale: 2, fontScale: 2 };
+const LANDSCAPE = { width: 1334, height: 750, scale: 2, fontScale: 2 };
+const goLandscape = () => Dimensions.set({ window: LANDSCAPE, screen: LANDSCAPE });
+const goPortrait = () => Dimensions.set({ window: PORTRAIT, screen: PORTRAIT });
+
+// Digit/decimal buttons collide in text with the display once it shows the
+// same character (e.g. display "5" + button "5"), so entry goes through the
+// accessibility role instead of getByText.
+function typeNumber(getByRole: (role: 'button', opts: { name: string }) => unknown, numStr: string) {
+  for (const ch of numStr) {
+    const name = ch === '.' ? 'decimal point' : ch;
+    fireEvent.press(getByRole('button', { name }) as never);
+  }
+}
 
 describe('CalculatorScreen', () => {
   it('renders calculator display', () => {
@@ -89,5 +109,144 @@ describe('CalculatorScreen', () => {
     fireEvent.press(getByText('2'));
     fireEvent.press(getByText('='));
     expect(getByText('0.3')).toBeTruthy();
+  });
+
+  describe('scientific functions route through decimal.js (issue #336)', () => {
+    afterEach(() => {
+      goPortrait();
+    });
+
+    // sin(180°) is mathematically 0. Native `Math.sin(180 * Math.PI/180)`
+    // carries the double-precision error of Math.PI itself and lands on
+    // 1.224646799e-16. Routing the degree conversion through Decimal's
+    // 20-digit Decimal.acos(-1) lands on a value ~4 orders of magnitude
+    // closer to zero — a difference formatNumber's 10-significant-digit
+    // trim does NOT wash out.
+    it('sin uses Decimal-precision degree conversion', () => {
+      goLandscape();
+      const { getByRole, getByText, getAllByText } = render(<CalculatorScreen />);
+      typeNumber(getByRole, '180');
+      fireEvent.press(getByText('sin'));
+      expect(getAllByText('-3.735661672e-20')[0]).toBeTruthy();
+    });
+
+    // Same reasoning as sin, at cos(90°).
+    it('cos uses Decimal-precision degree conversion', () => {
+      goLandscape();
+      const { getByRole, getByText, getAllByText } = render(<CalculatorScreen />);
+      typeNumber(getByRole, '90');
+      fireEvent.press(getByText('cos'));
+      expect(getAllByText('-6.867830836e-20')[0]).toBeTruthy();
+    });
+
+    // tan(90°) sits on tangent's discontinuity — both native and Decimal
+    // produce large garbage values near the asymptote, but they diverge
+    // sharply because they approach it from opposite sides of the true
+    // singularity (native ends up positive ~1.63e16, Decimal negative
+    // ~-7.07e14). A visible, deterministic 10-digit-display divergence.
+    it('tan diverges sharply from native Math near its 90° discontinuity', () => {
+      goLandscape();
+      const { getByRole, getByText, getAllByText } = render(<CalculatorScreen />);
+      typeNumber(getByRole, '90');
+      fireEvent.press(getByText('tan'));
+      expect(getAllByText('-707106781200000')[0]).toBeTruthy();
+    });
+
+    // log10(x) for x just below 1 is a textbook catastrophic-cancellation
+    // case: Math.log10 computes log(x)/LN10 in double precision, Decimal's
+    // log() carries 20 digits through the whole computation.
+    it('log (base 10) resolves catastrophic cancellation near 1', () => {
+      goLandscape();
+      const { getByRole, getByText, getAllByText } = render(<CalculatorScreen />);
+      typeNumber(getByRole, '0.9999999999999998');
+      fireEvent.press(getByText('log'));
+      expect(getAllByText('-8.685889638e-17')[0]).toBeTruthy();
+    });
+
+    // Same cancellation case for ln, just above 1.
+    it('ln resolves catastrophic cancellation near 1', () => {
+      goLandscape();
+      const { getByRole, getByText, getAllByText } = render(<CalculatorScreen />);
+      typeNumber(getByRole, '1.0000000000000002');
+      fireEvent.press(getByText('ln'));
+      expect(getAllByText('2e-16')[0]).toBeTruthy();
+    });
+
+    // 81619578.08945106² is a crafted 1-ULP boundary: Math.pow and
+    // Decimal.pow round the last significant digit differently
+    // (...27000000 vs ...28000000), which survives formatNumber's
+    // 10-significant-digit trim.
+    it('x² routes through Decimal.pow, not Math.pow', () => {
+      goLandscape();
+      const { getByRole, getByText, getAllByText } = render(<CalculatorScreen />);
+      typeNumber(getByRole, '81619578.08945106');
+      fireEvent.press(getByText('x²'));
+      expect(getAllByText('6661755528000000')[0]).toBeTruthy();
+    });
+
+    // √, x³, 1/x and |x| are correctly-rounded double operations already —
+    // native Math and Decimal.toNumber() agree bit-for-bit on virtually
+    // every input, so there is no display-visible value to assert on.
+    // These assert the routing directly: the Decimal method must be the
+    // one actually invoked.
+    it('√ calls Decimal.prototype.sqrt, not Math.sqrt', () => {
+      goLandscape();
+      const spy = jest.spyOn(Decimal.prototype, 'sqrt');
+      const { getByRole, getByText } = render(<CalculatorScreen />);
+      typeNumber(getByRole, '2');
+      fireEvent.press(getByText('√'));
+      expect(spy).toHaveBeenCalled();
+      spy.mockRestore();
+    });
+
+    it('x³ calls Decimal.prototype.pow with exponent 3, not Math.pow', () => {
+      goLandscape();
+      const spy = jest.spyOn(Decimal.prototype, 'pow');
+      const { getByRole, getByText } = render(<CalculatorScreen />);
+      typeNumber(getByRole, '5');
+      fireEvent.press(getByText('x³'));
+      expect(spy).toHaveBeenCalledWith(3);
+      spy.mockRestore();
+    });
+
+    it('1/x calls Decimal.prototype.div, not native division', () => {
+      goLandscape();
+      const spy = jest.spyOn(Decimal.prototype, 'div');
+      const { getByRole, getByText } = render(<CalculatorScreen />);
+      typeNumber(getByRole, '4');
+      fireEvent.press(getByText('1/x'));
+      expect(spy).toHaveBeenCalled();
+      spy.mockRestore();
+    });
+
+    it('1/x still guards against division by zero', () => {
+      goLandscape();
+      const { getByText, getAllByText } = render(<CalculatorScreen />);
+      fireEvent.press(getByText('1/x'));
+      expect(getAllByText('Error')[0]).toBeTruthy();
+    });
+
+    // formatNumber() (CalculatorScreen.tsx:153-154) always calls
+    // Decimal(...).abs() internally on the *result*, so a bare
+    // "was abs() called" spy passes even when the |x| case itself still
+    // uses Math.abs — it's satisfied by formatNumber alone. Assert
+    // instead that abs() was called on an instance holding the *negative
+    // input* (-7), which can only come from the |x| case computing on the
+    // Decimal-wrapped current value, not from formatting the (already
+    // positive) result.
+    it('|x| calls Decimal.prototype.abs on the input, not Math.abs', () => {
+      goLandscape();
+      const spy = jest.spyOn(Decimal.prototype, 'abs');
+      const { getByRole, getByText } = render(<CalculatorScreen />);
+      typeNumber(getByRole, '7');
+      fireEvent.press(getByText('+/-'));
+      spy.mockClear();
+      fireEvent.press(getByText('|x|'));
+      const calledOnNegativeInput = spy.mock.instances.some(
+        inst => (inst as Decimal).toNumber() === -7,
+      );
+      expect(calledOnNegativeInput).toBe(true);
+      spy.mockRestore();
+    });
   });
 });


### PR DESCRIPTION
## Resumo

Rotear sin/cos/tan/log/ln/√/x²/x³/1÷x/|x| por decimal.js em vez de Math.* nativo

## Causa raiz

`src/screens/CalculatorScreen.tsx:531-579` (`handleScientific`, na versão anterior ao fix) fazia `const current = parseFloat(display)` e depois `Math.sin`/`Math.cos`/`Math.tan`/`Math.log10`/`Math.log`/`Math.sqrt`/`Math.pow`/`Math.abs`/divisão nativa sobre esse `number`. A aritmética básica (`=`, `performOp`) e a memória já passavam por `Decimal` desde a ronda anterior (#212), mas as funções científicas nunca foram tocadas — exatamente o sintoma que este issue descreve.

Durante a investigação encontrei uma segunda causa raiz não mencionada no issue: os `case '1/x'` e `case '|x|'` já existiam no `switch` desde a implementação original (`git log -S"'1/x'"` mostra que só apareceram em dois commits antigos, nunca alterados depois), mas **nenhum botão os disparava** — `SCIENTIFIC_ROWS` (o array que gera os botões científicos, só renderizado em paisagem) tinha apenas 10 entradas (`( ) x² sin cos x³ tan log √ ln π e`), faltando `1/x` e `|x|`. Eram código morto. Sem um botão, não há forma de os exercitar via `fireEvent.press`, e o próprio issue exige "pelo menos um teste por função científica" para as 10 funções. Corrigi isto adicionando os dois botões em falta a `SCIENTIFIC_ROWS` — é a mesma estrutura de dados já usada para as outras 10 entradas, não um redesenho.

## O que mudou

**`src/screens/CalculatorScreen.tsx`**
- `SCIENTIFIC_ROWS`: adicionada uma 5ª linha com `{ label: '1/x' }` e `{ label: '|x|' }`, que já tinham handler no switch mas nenhum botão.
- `handleScientific`: `current` continua `parseFloat(display)` (para o guard `current === 0` do `1/x`, inalterado), mas passa a existir `currentD = new Decimal(current)`, e cada `case` científico usa métodos de instância `Decimal` (`.sin()`, `.cos()`, `.tan()`, `.log()`, `.ln()`, `.sqrt()`, `.pow(2)`, `.pow(3)`, `.abs()`, `new Decimal(1).div(currentD)`) em vez do `Math.*` equivalente. `result` passa a ser `Decimal`, convertido para `number` só no fim com `.toNumber()` antes de `formatNumber(...)` — `formatNumber` não mudou.
- `toRad`: a conversão graus→radianos para `sin/cos/tan` passou a `deg.times(Decimal.acos(-1)).div(180)` em vez de `deg * (Math.PI/180)`, para não misturar precisão dupla nativa com o resto da cadeia Decimal — escolha explícita pedida pelo issue.
- `π`/`e` continuam `Math.PI`/`Math.E` (não tocados, como o issue pede).

**`src/screens/__tests__/CalculatorScreen.test.tsx`** — novo `describe('scientific functions route through decimal.js (issue #336)')` com 10 testes, um por função, mais um de regressão do guard de divisão por zero.

## Porque assim

- **Guard de `1/x` inalterado**: mantive `if (current === 0)` (não `currentD.isZero()`) para não tocar em código que já funcionava e não estava no escopo do issue.
- **`parseFloat(display)` mantido antes de envolver em Decimal**: em vez de `new Decimal(display)` diretamente, para preservar exatamente o comportamento de parsing anterior (ex.: strings como `"5."` já validadas por `parseFloat` sem risco de `Decimal` rejeitar formatos de display que `parseFloat` tolera).
- **Testes de valor vs. testes de spy**: procurei por divergência numérica visível a 10 dígitos (o método sugerido no issue) para `sin/cos/tan/log/ln/x²` — todas têm casos reais onde `Decimal` e `Math` nativo divergem (cancelamento catastrófico perto de 1 para log/ln, erro de `Math.PI` perto de zeros de sin/cos, descontinuidade de tan a 90°, 1-ULP de arredondamento em `x²`). Para `√/x³/1÷x/|x|` fiz uma busca aleatória de ~200k-1M valores por função e **não encontrei nenhuma divergência**: são operações de dupla precisão corretamente arredondadas (raiz quadrada, divisão simples e valor absoluto são exatas ou corretamente arredondadas em IEEE754; `x*x*x` empiricamente também nunca divergiu a 10 dígitos no intervalo testado). Para essas 4 usei `jest.spyOn(Decimal.prototype, <método>)` a verificar que o método `Decimal` foi mesmo chamado — é a única prova de mutação fiável quando não existe divergência de valor observável.
- **Armadilha encontrada e evitada**: o `spy` inicial em `Decimal.prototype.abs` passava mesmo sem o fix, porque `formatNumber` (linha 154) já chama `.abs()` internamente sobre o **resultado** para decidir notação exponencial — o spy "apanhava" essa chamada e mascarava a ausência do fix. Troquei para verificar que `abs()` foi chamado numa instância com o valor **negativo de entrada** (ex. `-7`), que só pode vir do `case '|x|'` em si, não de `formatNumber`.

## Critérios de aceitação

- [x] `sin`, `cos`, `tan`, `log`, `ln`, `√`, `x²`, `x³`, `1/x`, `|x|` calculam via `Decimal`, não via `Math.*` — confirmado por leitura do diff e pelos 10 testes.
- [x] Pelo menos um teste por função científica morre se a chamada `Decimal` for revertida para `Math.*` equivalente — confirmado por mutação individual das 10 chamadas (ver secção Testes).
- [x] `formatNumber`/`performOp` continuam inalterados — confirmado por `git diff`, nenhuma linha tocada nessas funções.
- [x] Sem novas falhas fora da baseline conhecida — confirmado: os 9 testes a falhar depois do fix são exatamente os 9 da baseline (FoldersStore ×2, SettingsScreen ×1, LockScreen ×3, WeatherScreen ×2, mais `CalculatorScreen › 0.1 + 0.2 equals 0.3 without float artifacts`, que já falhava em `main` por colisão de texto `getByText('0')` entre o dígito do display e o botão — não relacionado com este fix, não tocado).

## Testes

**Passo vermelho** (com `SCIENTIFIC_ROWS` já com os botões `1/x`/`|x|` adicionados, mas `handleScientific` ainda com `Math.*` nativo):

```
 npx jest src/screens/__tests__/CalculatorScreen.test.tsx -t "scientific functions route through decimal.js" --verbose

 ✕ sin uses Decimal-precision degree conversion (129 ms)
 ✕ cos uses Decimal-precision degree conversion (57 ms)
 ✕ tan diverges sharply from native Math near its 90° discontinuity (54 ms)
 ✕ log (base 10) resolves catastrophic cancellation near 1 (147 ms)
 ✕ ln resolves catastrophic cancellation near 1 (97 ms)
 ✕ x² routes through Decimal.pow, not Math.pow (81 ms)
 ✕ √ calls Decimal.prototype.sqrt, not Math.sqrt (121 ms)
 ✕ x³ calls Decimal.prototype.pow with exponent 3, not Math.pow (43 ms)
 ✕ 1/x calls Decimal.prototype.div, not native division (25 ms)
 ✓ 1/x still guards against division by zero (19 ms)
 ✕ |x| calls Decimal.prototype.abs on the input, not Math.abs (26 ms)

 Test Suites: 1 failed, 1 total
 Tests:       10 failed, 10 skipped, 1 passed, 21 total
```

Exemplo de falha detalhada (`sin`):
```
 ● CalculatorScreen › scientific functions route through decimal.js (issue #336) › sin uses Decimal-precision degree conversion

   Unable to find an element with text: -3.735661672e-20
     > 184 | expect(getAllByText('-3.735661672e-20')[0]).toBeTruthy();
```

Depois do fix, os mesmos 10 testes passam (`10 passed`).

**Casos cobertos** (um por função, valor escolhido para ser um mutation-kill determinístico, não caminho feliz genérico):
- `sin(180°)` — erro de `Math.PI` nativo perto de um zero-crossing (native `1.224646799e-16` vs Decimal `-3.735661672e-20`).
- `cos(90°)` — mesmo mecanismo (native `6.123233996e-17` vs Decimal `-6.867830836e-20`).
- `tan(90°)` — descontinuidade da tangente: native e Decimal divergem de lado oposto do assíntota (`1.633123935e+16` vs `-707106781200000`), prova visual forte.
- `log(0.9999999999999998)` / `ln(1.0000000000000002)` — cancelamento catastrófico perto de 1, clássico em `Math.log`/`Math.log10` de precisão dupla.
- `x²` de `81619578.08945106` — fronteira de arredondamento de 1 ULP entre `Math.pow` e `Decimal.pow` que sobrevive ao corte de 10 dígitos significativos do `formatNumber`.
- `√`, `x³`, `1/x`, `|x|` — sem divergência de valor encontrada (são operações corretamente arredondadas em dupla precisão); testados por `jest.spyOn` a confirmar que o método `Decimal` correspondente foi chamado.
- **Inverso do fix**: teste dedicado que o guard de divisão por zero em `1/x` (`current === 0` → `'Error'`) continua ativo, inalterado.
- **Mutação individual**: reverti cada uma das 10 chamadas Decimal para o `Math.*` equivalente, uma de cada vez (via `sed` + `git diff` a confirmar restauro exato entre iterações), e corri a suite — cada reversão matou exatamente o teste correspondente e mais nenhum:
  ```
  mutation: sin        -> ✕ sin uses Decimal-precision degree conversion
  mutation: cos        -> ✕ cos uses Decimal-precision degree conversion
  mutation: tan        -> ✕ tan diverges sharply from native Math near its 90° discontinuity
  mutation: log        -> ✕ log (base 10) resolves catastrophic cancellation near 1
  mutation: ln          -> ✕ ln resolves catastrophic cancellation near 1
  mutation: sqrt        -> ✕ √ calls Decimal.prototype.sqrt, not Math.sqrt
  mutation: pow2        -> ✕ x² routes through Decimal.pow, not Math.pow
  mutation: pow3        -> ✕ x³ calls Decimal.prototype.pow with exponent 3, not Math.pow
  mutation: reciprocal  -> ✕ 1/x calls Decimal.prototype.div, not native division
  mutation: abs         -> ✕ |x| calls Decimal.prototype.abs on the input, not Math.abs
  ```

**Sanity-check**: `git stash push -- src/screens/CalculatorScreen.tsx` (revertendo TODO o fix de produção, mantendo os testes), corri a suite — os 10 testes científicos falharam (mais `1/x still guards...` que passou a falhar também, porque o stash também reverteu a adição dos botões `1/x`/`|x|`, esperado), `12 failed, 9 passed, 21 total`. `git stash pop` restaurou o fix; suite voltou a `10 passed` nos testes científicos.

**Resultado das verificações obrigatórias:**
- `npm run lint`: `0 erro(s), 1 warning` (o warning é pré-existente em `ClockScreen.tsx:351`, não tocado por este PR).
- `npx tsc --noEmit`: limpo, sem output.
- `npm test`: `9 failed, 330 passed, 339 total` (48 suites, 5 falhadas). Os 9 testes a falhar são, nome a nome, exatamente os 9 da baseline (`FoldersStore` ×2, `SettingsScreen` ×1, `LockScreen` ×3, `WeatherScreen` ×2, `CalculatorScreen › 0.1 + 0.2 equals 0.3 without float artifacts`) — confirmado por comparação direta das listas de nomes falhados, não apenas pela contagem (a contagem total de testes/suites da baseline registada, 180/30, já estava desatualizada face ao estado atual do repo, mas a lista de falhas nomeadas coincide 1:1). Nenhuma falha nova.

## Testes

339 testes correram, 330 passaram, 9 falharam (5 de 48 suites) — as 9 falhas são exatamente as da baseline (FoldersStore, SettingsScreen, LockScreen, WeatherScreen, CalculatorScreen 0.1+0.2), sem nenhuma falha nova. Os 10 testes científicos novos (mais o de regressão do guard 1/x=0) passam todos: '11 passed' no describe 'scientific functions route through decimal.js (issue #336)'.

## Linked Issue

Fixes #336