### PR TITLE
Documenta em docs/BUNDLE_SIZE_NOTES.md o delta de bundle size da dependência decimal.js, medido via npx expo export real neste repositório (#337)

### DIFF
--- a/docs/BUNDLE_SIZE_NOTES.md
+++ b/docs/BUNDLE_SIZE_NOTES.md
@@ -1,0 +1,52 @@
+# Bundle Size Notes
+
+Nota de acompanhamento ao GAP_ANALYSIS_V2.md — impacto de dependências no tamanho do bundle JS.
+
+## N6. Delta de bundle size da dependência `decimal.js` (issue #337, AC5 de #212)
+
+- **Commit medido**: `1f2c2c9` (branch `qa/issue-337`, `main` na data abaixo)
+- **Data**: 2026-08-19
+- **Versão de `decimal.js`**: `10.6.0` (declarada como `^10.4.3` em `package.json:17`)
+
+### Metodologia
+
+`npx expo export` produz por omissão bytecode Hermes (`.hbc`), que não é legível
+por ferramentas de análise de bundle. Para medir a contribuição real de
+`decimal.js`, foi gerado também um bundle JS plano (não-Hermes) com source map,
+e analisado com `source-map-explorer`, que atribui bytes do bundle final a cada
+ficheiro-fonte via o source map — não é uma estimativa, é medição directa do
+artefacto gerado neste repositório.
+
+```bash
+# Bundle de produção real (Hermes bytecode, o que é embutido no APK)
+npx expo export --platform android --output-dir /tmp/expo-export-test
+
+# Bundle JS plano + source map, só para análise (mesmo grafo de módulos)
+npx expo export --platform android --output-dir /tmp/expo-export-nobc \
+  --no-bytecode --source-maps
+
+npx source-map-explorer \
+  _expo/static/js/android/index-*.js \
+  _expo/static/js/android/index-*.js.map \
+  --json analysis.json --no-border-checks
+```
+
+### Resultados medidos
+
+| Artefacto | Tamanho |
+|---|---|
+| Bundle Android — Hermes bytecode (`.hbc`, o que entra no APK) | **5.300.335 bytes** (5,1 MiB / 5,3 MB) |
+| Bundle Android — JS minificado plano (usado só para análise) | 3.742.658 bytes (3,6 MiB) |
+| Contribuição de `decimal.js/decimal.mjs` no JS minificado (via source map) | **31.962 bytes** (≈31,2 KB), **0,85%** do bundle JS |
+| `node_modules/decimal.js` em disco (fonte não empacotada) | 300 KB (`decimal.js` principal: 136.673 bytes não minificado) |
+| `decimal.mjs` gzip -9 isolado (referência cruzada, não é o número do bundle real) | 31.643 bytes |
+
+### Conclusão
+
+`decimal.js` acrescenta **~32 KB minificados (~0,85% do bundle JS)** ao bundle
+Android desta app — negligível face aos ~3,6 MB do bundle JS total (ou aos
+5,3 MB do `.hbc` final). Não há impacto material no tempo de arranque ou no
+tamanho do APK que justifique reconsiderar a dependência introduzida em
+`77d58ad` (PR #237) e usada em `295fb97` (#340) para rotear operações
+aritméticas (`sin`/`cos`/`tan`/`log`/`ln`/`√`/`x²`/`x³`/`1÷x`/`|x|`) por
+`decimal.js` em vez de `Math.*` nativo.


### PR DESCRIPTION
## Resumo

Documenta em docs/BUNDLE_SIZE_NOTES.md o delta de bundle size da dependência decimal.js, medido via npx expo export real neste repositório

## Causa raiz

Não é um bug de código — é uma lacuna de documentação. O issue #212 original tinha AC5 ("documentar impacto de bundle size de decimal.js") por cumprir há 3 rondas; `decimal.js` já está em produção desde `77d58ad` (PR #237) e é usado activamente em `295fb97` (#340) para rotear operações trigonométricas/logarítmicas por `decimal.js` em vez de `Math.*` nativo. Nunca existiu, em nenhum ficheiro do repositório, uma medição real do custo desta dependência no bundle.

## O que mudou

- **`docs/BUNDLE_SIZE_NOTES.md`** (novo): nota "N6" (seguindo o padrão de numeração de `docs/GAP_ANALYSIS_V2.md`) com:
  - Metodologia usada (porque `npx expo export` por omissão gera bytecode Hermes ilegível por ferramentas de análise, e como se contornou isso).
  - Tamanho real do bundle Android de produção (`.hbc`, o que entra no APK): **5.300.335 bytes** (5,1 MiB).
  - Tamanho do bundle JS plano minificado usado só para análise: 3.742.658 bytes.
  - Contribuição real de `decimal.js/decimal.mjs`, atribuída via source map com `source-map-explorer`: **31.962 bytes (~0,85% do bundle JS)**.
  - Tamanho em disco de `node_modules/decimal.js` (300 KB) e gzip isolado do `decimal.mjs` (31.643 bytes) como referências cruzadas.
  - Commit e data da medição.

Nenhum ficheiro em `src/` foi tocado.

## Porque assim

`npx expo export` por omissão produz bytecode Hermes (`.hbc`), que `source-map-explorer` e ferramentas semelhantes não conseguem atribuir por ficheiro-fonte. Para obter um número real (não uma estimativa da internet, conforme exigido pela AC3), gerei também um export com `--no-bytecode --source-maps`, que partilha o mesmo grafo de módulos e minificação, e usei `source-map-explorer` para atribuir bytes do bundle real a `decimal.js` via o source map gerado nesta corrida — não uma reimplementação nem um número copiado de bundlephobia. O valor de bundlephobia/gzip isolado aparece só como referência cruzada secundária, como o issue sugeria, nunca como fonte primária.

Alternativa descartada: usar apenas `du -sh node_modules/decimal.js` (300 KB) como proxy do custo no bundle — rejeitada porque inclui ficheiros nunca empacotados (`.d.ts`, `README.md`, `LICENCE.md`, e a variante `decimal.js` não-ESM não usada), sobrestimando o custo real em ~9x face ao que efectivamente entra no bundle minificado.

## Critérios de aceitação

- [x] Existe `docs/BUNDLE_SIZE_NOTES.md` com o tamanho do bundle JS (`npx expo export`) e uma estimativa do custo de `decimal.js` — ambos números medidos, não estimados.
- [x] Nenhuma alteração a código de produção (`src/`) — confirmado por `git diff --stat origin/main...HEAD`, que só lista `docs/BUNDLE_SIZE_NOTES.md`.
- [x] O número reportado vem de uma corrida real de `npx expo export` neste repositório (commit `1f2c2c9`, branch `qa/issue-337`), com os comandos exactos documentados no próprio ficheiro para reprodutibilidade.

## Testes

Tarefa de documentação — não há teste automático aplicável (confirmado no próprio issue, secção "Como testar"). Verificação manual feita:

- `git status --porcelain` e `git diff --name-only origin/main...HEAD` só mostram `docs/BUNDLE_SIZE_NOTES.md` — nenhum ficheiro em `src/` alterado.
- O ficheiro contém números concretos (bytes, não "pequeno"/"aceitável") e o commit+data da medição.

**Sanity-check**: não aplicável no sentido do fluxo TDD (não há fix de produção a reverter) — a verificação equivalente foi confirmar que `docs/BUNDLE_SIZE_NOTES.md` é o único artefacto novo e que os números nele batem com os comandos que gerei e corri nesta sessão (não copiados de memória).

**Verificações obrigatórias** (worktree `qa/issue-337`, comparadas com a linha de base de `main`):
- `npm run lint`: 0 erros, 1 warning pré-existente em `src/screens/ClockScreen.tsx:351` (não tocado por este trabalho) — igual à baseline (0 erros).
- `npx tsc --noEmit`: limpo, sem output — igual à baseline.
- `npm test`: 9 falhas em 5 suites (`FoldersStore`, `SettingsScreen`, `LockScreen`, `CalculatorScreen`, `WeatherScreen`), 330 a passar em 339 totais. As 9 falhas correspondem exactamente, nome a nome, à lista de `baseline.json` (mesma causa: `SettingsStore` devolve `null` até `firstSyncDone` resolver de forma assíncrona). Sem falhas novas — sem regressão.

## Testes

339 testes totais: 330 passaram, 9 falharam (as mesmas 9 pré-existentes da linha de base, mesmas 5 suites), 48 suites (43 passaram, 5 falharam)

## Linked Issue

Fixes #337