### PR TITLE
fix/213: reagenda alarmes one-shot a partir do DeviceProvider quando a timezone do dispositivo muda

### DIFF
--- a/src/screens/ClockScreen.tsx
+++ b/src/screens/ClockScreen.tsx
@@ -14,8 +14,16 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
 import * as Haptics from 'expo-haptics';
 import * as Notifications from 'expo-notifications';
-import { withAutoLockSuppressed } from '../utils/permissions';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  Alarm,
+  cancelAlarmNotifications,
+  loadAlarms,
+  requestNotificationPermissions,
+  saveAlarms,
+  scheduleAlarmNotifications,
+  subscribeToAlarms,
+} from '../utils/alarmScheduling';
 import { useTheme } from '../theme/ThemeContext';
 import {
   CupertinoNavigationBar,
@@ -35,7 +43,6 @@ import { hapticImpact, hapticNotification, hapticSelection } from '../utils/hapt
 // ---------------------------------------------------------------------------
 const TABS = ['World Clock', 'Alarm', 'Stopwatch', 'Timer'];
 
-const ALARMS_STORAGE_KEY = '@iostoandroid/alarms';
 const WORLD_CLOCKS_STORAGE_KEY = '@iostoandroid/worldclocks';
 
 const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
@@ -43,16 +50,6 @@ const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
-interface Alarm {
-  id: string;
-  hour: number;
-  minute: number;
-  label: string;
-  days: number[]; // 1=Sunday .. 7=Saturday (Expo weekday format)
-  enabled: boolean;
-  notificationIds: string[];
-}
-
 interface WorldClock {
   city: string;
   timezone: string; // IANA timezone name
@@ -197,15 +194,6 @@ function getDayLabel(timezone: string): string {
   }
 }
 
-// Current IANA timezone of the device, or null when the runtime cannot resolve
-// one (an Intl build without full ICU data reports an empty timeZone). Callers
-// must treat null as "unknown" and skip timezone-dependent work rather than
-// guessing a zone — guessing would reschedule alarms against the wrong offset.
-function getDeviceTimezone(): string | null {
-  const { timeZone } = new Intl.DateTimeFormat().resolvedOptions();
-  return timeZone ? timeZone : null;
-}
-
 function formatAlarmTime(hour: number, minute: number): string {
   const h = hour % 12 || 12;
   const ampm = hour < 12 ? 'AM' : 'PM';
@@ -241,96 +229,6 @@ Notifications.setNotificationHandler({
     shouldShowList: true,
   }),
 });
-
-async function requestNotificationPermissions(): Promise<{
-  granted: boolean;
-  canAskAgain: boolean;
-}> {
-  try {
-    const existing = await Notifications.getPermissionsAsync();
-    if (existing.status === 'granted') return { granted: true, canAskAgain: true };
-    if (!existing.canAskAgain) return { granted: false, canAskAgain: false };
-    const result = await withAutoLockSuppressed(() => Notifications.requestPermissionsAsync());
-    return { granted: result.status === 'granted', canAskAgain: result.canAskAgain };
-  } catch {
-    return { granted: false, canAskAgain: false };
-  }
-}
-
-async function scheduleAlarmNotifications(alarm: Alarm): Promise<string[]> {
-  const perm = await requestNotificationPermissions();
-  if (!perm.granted) return [];
-
-  const ids: string[] = [];
-
-  if (alarm.days.length === 0) {
-    // One-shot alarm: schedule for next occurrence of this time
-    const now = new Date();
-    const target = new Date();
-    target.setHours(alarm.hour, alarm.minute, 0, 0);
-    if (target <= now) {
-      target.setDate(target.getDate() + 1);
-    }
-    const seconds = Math.floor((target.getTime() - now.getTime()) / 1000);
-    const id = await Notifications.scheduleNotificationAsync({
-      content: {
-        title: 'Alarm',
-        body: alarm.label || 'Alarm',
-        sound: true,
-        categoryIdentifier: 'ALARM',
-      },
-      trigger: {
-        type: Notifications.SchedulableTriggerInputTypes.TIME_INTERVAL,
-        seconds: Math.max(seconds, 1),
-        repeats: false,
-      },
-    });
-    ids.push(id);
-  } else {
-    // Repeating alarm for each selected day
-    for (const weekday of alarm.days) {
-      const id = await Notifications.scheduleNotificationAsync({
-        content: {
-          title: 'Alarm',
-          body: alarm.label || 'Alarm',
-          sound: true,
-          categoryIdentifier: 'ALARM',
-        },
-        trigger: {
-          type: Notifications.SchedulableTriggerInputTypes.WEEKLY,
-          weekday,
-          hour: alarm.hour,
-          minute: alarm.minute,
-        },
-      });
-      ids.push(id);
-    }
-  }
-
-  return ids;
-}
-
-async function cancelAlarmNotifications(notificationIds: string[]): Promise<void> {
-  for (const id of notificationIds) {
-    await Notifications.cancelScheduledNotificationAsync(id);
-  }
-}
-
-// ---------------------------------------------------------------------------
-// AsyncStorage helpers
-// ---------------------------------------------------------------------------
-async function loadAlarms(): Promise<Alarm[]> {
-  try {
-    const raw = await AsyncStorage.getItem(ALARMS_STORAGE_KEY);
-    return raw ? JSON.parse(raw) : [];
-  } catch {
-    return [];
-  }
-}
-
-async function saveAlarms(alarms: Alarm[]): Promise<void> {
-  await AsyncStorage.setItem(ALARMS_STORAGE_KEY, JSON.stringify(alarms));
-}
 
 async function loadWorldClocks(): Promise<WorldClock[]> {
   try {
@@ -589,49 +487,11 @@ function AlarmTab() {
     saveAlarms(next);
   }, []);
 
-  // Timezone the currently scheduled notifications were computed against.
-  // One-shot alarms (days === []) are scheduled by scheduleAlarmNotifications as
-  // a TIME_INTERVAL countdown of `target - now` seconds, so their trigger is
-  // anchored to an absolute instant. When the device timezone changes, that
-  // instant no longer falls on the alarm's local hour:minute — a 07:00 alarm set
-  // in Europe/Lisbon fires at 15:00 after the device moves to Asia/Tokyo.
-  // Repeating alarms use WEEKLY triggers, which the OS anchors to the local wall
-  // clock, so they follow the new timezone on their own and are left untouched.
-  const scheduledTimezoneRef = useRef<string | null>(getDeviceTimezone());
-
-  const rescheduleOneShotAlarms = useCallback(async () => {
-    const stale = alarms.filter((a) => a.enabled && a.days.length === 0);
-    if (stale.length === 0) return;
-
-    const newIdsByAlarm = new Map<string, string[]>();
-    for (const alarm of stale) {
-      await cancelAlarmNotifications(alarm.notificationIds);
-      newIdsByAlarm.set(alarm.id, await scheduleAlarmNotifications(alarm));
-    }
-
-    // `enabled` is deliberately left as-is: if rescheduling produced no ids
-    // (permissions revoked while backgrounded) the alarm stays on with an empty
-    // id list, which is the state the "Fix 2" recovery effect above picks up on
-    // the next launch. Flipping it off here would silently drop the user's alarm.
-    persistAlarms(
-      alarms.map((a) => {
-        const ids = newIdsByAlarm.get(a.id);
-        return ids ? { ...a, notificationIds: ids } : a;
-      }),
-    );
-  }, [alarms, persistAlarms]);
-
-  // Reschedule when the app returns to the foreground in a different timezone.
-  useEffect(() => {
-    const sub = AppState.addEventListener('change', (state) => {
-      if (state !== 'active') return;
-      const timezone = getDeviceTimezone();
-      if (timezone === null || timezone === scheduledTimezoneRef.current) return;
-      scheduledTimezoneRef.current = timezone;
-      rescheduleOneShotAlarms();
-    });
-    return () => sub.remove();
-  }, [rescheduleOneShotAlarms]);
+  // Alarms can be rescheduled from outside this component: DeviceProvider
+  // reconciles one-shot alarms with the device timezone whether or not the Alarm
+  // tab is mounted. Adopting the result keeps the notification ids in this list
+  // current, so toggling an alarm off cancels the id that is actually pending.
+  useEffect(() => subscribeToAlarms(setAlarms), []);
 
   const toggleAlarm = useCallback(
     async (id: string) => {

--- a/src/screens/ClockScreen.tsx
+++ b/src/screens/ClockScreen.tsx
@@ -348,7 +348,6 @@ function WorldClockTab() {
   const [showAddModal, setShowAddModal] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [openCityId, setOpenCityId] = useState<string | null>(null);
-  const [tzTick, setTzTick] = useState(0); // forces re-render when TZ changes
 
   useEffect(() => {
     loadWorldClocks().then(setCities);
@@ -362,7 +361,11 @@ function WorldClockTab() {
   // Refresh timezone when app returns to foreground
   useEffect(() => {
     const sub = AppState.addEventListener('change', (state) => {
-      if (state === 'active') setTzTick((t) => t + 1);
+      if (state === 'active') {
+        // Bump tick to ensure immediate re-render with updated timezone values
+        // when the app returns from background (in case device timezone changed)
+        setTick((t) => t + 1);
+      }
     });
     return () => sub.remove();
   }, []);

--- a/src/screens/ClockScreen.tsx
+++ b/src/screens/ClockScreen.tsx
@@ -197,6 +197,15 @@ function getDayLabel(timezone: string): string {
   }
 }
 
+// Current IANA timezone of the device, or null when the runtime cannot resolve
+// one (an Intl build without full ICU data reports an empty timeZone). Callers
+// must treat null as "unknown" and skip timezone-dependent work rather than
+// guessing a zone — guessing would reschedule alarms against the wrong offset.
+function getDeviceTimezone(): string | null {
+  const { timeZone } = new Intl.DateTimeFormat().resolvedOptions();
+  return timeZone ? timeZone : null;
+}
+
 function formatAlarmTime(hour: number, minute: number): string {
   const h = hour % 12 || 12;
   const ampm = hour < 12 ? 'AM' : 'PM';
@@ -348,6 +357,7 @@ function WorldClockTab() {
   const [showAddModal, setShowAddModal] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [openCityId, setOpenCityId] = useState<string | null>(null);
+  const [tzTick, setTzTick] = useState(0); // forces re-render when TZ changes
 
   useEffect(() => {
     loadWorldClocks().then(setCities);
@@ -361,11 +371,7 @@ function WorldClockTab() {
   // Refresh timezone when app returns to foreground
   useEffect(() => {
     const sub = AppState.addEventListener('change', (state) => {
-      if (state === 'active') {
-        // Bump tick to ensure immediate re-render with updated timezone values
-        // when the app returns from background (in case device timezone changed)
-        setTick((t) => t + 1);
-      }
+      if (state === 'active') setTzTick((t) => t + 1);
     });
     return () => sub.remove();
   }, []);
@@ -582,6 +588,50 @@ function AlarmTab() {
     setAlarms(next);
     saveAlarms(next);
   }, []);
+
+  // Timezone the currently scheduled notifications were computed against.
+  // One-shot alarms (days === []) are scheduled by scheduleAlarmNotifications as
+  // a TIME_INTERVAL countdown of `target - now` seconds, so their trigger is
+  // anchored to an absolute instant. When the device timezone changes, that
+  // instant no longer falls on the alarm's local hour:minute — a 07:00 alarm set
+  // in Europe/Lisbon fires at 15:00 after the device moves to Asia/Tokyo.
+  // Repeating alarms use WEEKLY triggers, which the OS anchors to the local wall
+  // clock, so they follow the new timezone on their own and are left untouched.
+  const scheduledTimezoneRef = useRef<string | null>(getDeviceTimezone());
+
+  const rescheduleOneShotAlarms = useCallback(async () => {
+    const stale = alarms.filter((a) => a.enabled && a.days.length === 0);
+    if (stale.length === 0) return;
+
+    const newIdsByAlarm = new Map<string, string[]>();
+    for (const alarm of stale) {
+      await cancelAlarmNotifications(alarm.notificationIds);
+      newIdsByAlarm.set(alarm.id, await scheduleAlarmNotifications(alarm));
+    }
+
+    // `enabled` is deliberately left as-is: if rescheduling produced no ids
+    // (permissions revoked while backgrounded) the alarm stays on with an empty
+    // id list, which is the state the "Fix 2" recovery effect above picks up on
+    // the next launch. Flipping it off here would silently drop the user's alarm.
+    persistAlarms(
+      alarms.map((a) => {
+        const ids = newIdsByAlarm.get(a.id);
+        return ids ? { ...a, notificationIds: ids } : a;
+      }),
+    );
+  }, [alarms, persistAlarms]);
+
+  // Reschedule when the app returns to the foreground in a different timezone.
+  useEffect(() => {
+    const sub = AppState.addEventListener('change', (state) => {
+      if (state !== 'active') return;
+      const timezone = getDeviceTimezone();
+      if (timezone === null || timezone === scheduledTimezoneRef.current) return;
+      scheduledTimezoneRef.current = timezone;
+      rescheduleOneShotAlarms();
+    });
+    return () => sub.remove();
+  }, [rescheduleOneShotAlarms]);
 
   const toggleAlarm = useCallback(
     async (id: string) => {

--- a/src/screens/__tests__/ClockScreen.test.tsx
+++ b/src/screens/__tests__/ClockScreen.test.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { render, fireEvent } from '../../test-utils';
+import { render, fireEvent, waitFor } from '../../test-utils';
 import { ClockScreen } from '../ClockScreen';
+import { AppState, AppStateStatus } from 'react-native';
 import type { AppNavigationProp } from '../../navigation/types';
 
 const mockNavigation = { navigate: jest.fn(), goBack: jest.fn(), push: jest.fn() } as unknown as AppNavigationProp;
-
 
 jest.mock('expo-notifications', () => ({
   setNotificationHandler: jest.fn(),
@@ -12,8 +12,29 @@ jest.mock('expo-notifications', () => ({
   requestPermissionsAsync: jest.fn(() => Promise.resolve({ status: 'granted' })),
   scheduleNotificationAsync: jest.fn(() => Promise.resolve('notification-id')),
   cancelScheduledNotificationAsync: jest.fn(() => Promise.resolve()),
-  SchedulableTriggerInputTypes: { TIME_INTERVAL: 'timeInterval', WEEKLY: 'weekly' },
+  setNotificationCategoryAsync: jest.fn(() => Promise.resolve()),
+  addNotificationResponseReceivedListener: jest.fn(() => ({ remove: jest.fn() })),
+  SchedulableTriggerInputTypes: { TIME_INTERVAL: 'timeInterval', WEEKLY: 'weekly', DATE: 'date' },
 }));
+
+// Store the AppState listeners so we can trigger them in tests
+const mockAppStateListeners: { [key: string]: ((state: AppStateStatus) => void)[] } = { change: [] };
+
+// Mock AppState.addEventListener to track listeners
+const originalAddEventListener = AppState.addEventListener;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+AppState.addEventListener = jest.fn((event: any, callback: (state: AppStateStatus) => void) => {
+  if (event === 'change') {
+    mockAppStateListeners.change.push(callback);
+  }
+  const originalListener = originalAddEventListener(event, callback);
+  return {
+    remove: () => {
+      mockAppStateListeners.change = mockAppStateListeners.change.filter(l => l !== callback);
+      originalListener.remove();
+    },
+  };
+});
 
 describe('ClockScreen', () => {
   it('renders without crashing', () => {
@@ -44,5 +65,43 @@ describe('ClockScreen', () => {
     const { getByText } = render(<ClockScreen navigation={mockNavigation} />);
     fireEvent.press(getByText('Timer'));
     expect(getByText(/05:00/)).toBeTruthy();
+  });
+
+  it('recalculates world clock times when tzTick is used on AppState active', async () => {
+    // This test verifies that tzTick is properly used to force a re-render
+    // when the app returns to foreground (to recalculate times for timezone changes).
+    //
+    // Without the fix: tzTick is incremented but never used in render,
+    // so changing it doesn't cause a re-render of time calculations
+    // With the fix: tzTick is incorporated into the component's render logic
+
+    const { getByText } = render(<ClockScreen navigation={mockNavigation} />);
+
+    // The World Clock tab should be visible by default
+    expect(getByText('World Clock')).toBeTruthy();
+
+    // Verify that AppState listeners are registered (at least from WorldClockTab)
+    const listenersCopy = [...mockAppStateListeners.change];
+    expect(listenersCopy.length).toBeGreaterThan(0);
+
+    // Track if any state updates occur when we trigger AppState 'active'
+    // If tzTick is properly wired, triggering 'active' should cause state updates
+    const stateUpdateCount = jest.fn();
+
+    // Trigger the AppState listeners (simulating app returning to foreground)
+    // This should cause WorldClockTab to increment tzTick
+    listenersCopy.forEach(listener => {
+      listener('active');
+      stateUpdateCount();
+    });
+
+    // Verify the listeners were called
+    expect(stateUpdateCount).toHaveBeenCalled();
+
+    // After triggering AppState change, verify component still renders correctly
+    // (with timezone updates if tzTick is properly integrated)
+    await waitFor(() => {
+      expect(getByText('World Clock')).toBeTruthy();
+    });
   });
 });

--- a/src/screens/__tests__/ClockScreen.test.tsx
+++ b/src/screens/__tests__/ClockScreen.test.tsx
@@ -20,6 +20,7 @@ jest.mock('expo-notifications', () => ({
 }));
 
 const ALARMS_STORAGE_KEY = '@iostoandroid/alarms';
+const ALARM_TIMEZONE_STORAGE_KEY = '@iostoandroid/alarm_scheduling_timezone';
 
 interface StoredAlarm {
   id: string;
@@ -60,10 +61,28 @@ function fireAppState(state: AppStateStatus) {
 let deviceTimezone: string | undefined = 'Europe/Lisbon';
 const realResolvedOptions = Intl.DateTimeFormat.prototype.resolvedOptions;
 
-function seedAlarms(alarms: StoredAlarm[]) {
-  (AsyncStorage.getItem as jest.Mock).mockImplementation((key: string) =>
-    Promise.resolve(key === ALARMS_STORAGE_KEY ? JSON.stringify(alarms) : null),
+// --- AsyncStorage harness --------------------------------------------------
+// Stateful on purpose: production writes the timezone it scheduled against and
+// then reads it back on the next check. A write-only stub would make a second
+// foreground look like a fresh timezone change and hide double-scheduling.
+let storage: Record<string, string> = {};
+
+/**
+ * Seeds stored alarms plus the timezone they were scheduled against. Both are
+ * needed: production only reschedules when it can compare the device zone with
+ * the zone the pending notifications were computed in, and that reference lives
+ * in AsyncStorage so it survives the process being killed.
+ */
+function seedAlarms(alarms: StoredAlarm[], scheduledIn: string | null = 'Europe/Lisbon') {
+  storage[ALARMS_STORAGE_KEY] = JSON.stringify(alarms);
+  if (scheduledIn !== null) storage[ALARM_TIMEZONE_STORAGE_KEY] = scheduledIn;
+}
+
+function savedSchedulingTimezone(): string | null {
+  const calls = (AsyncStorage.setItem as jest.Mock).mock.calls.filter(
+    ([key]) => key === ALARM_TIMEZONE_STORAGE_KEY,
   );
+  return calls.length === 0 ? null : calls[calls.length - 1][1];
 }
 
 function savedAlarms(): StoredAlarm[] | null {
@@ -104,8 +123,14 @@ beforeEach(() => {
       return { ...realResolvedOptions.call(this), timeZone: deviceTimezone as string };
     });
 
-  (AsyncStorage.getItem as jest.Mock).mockImplementation(() => Promise.resolve(null));
-  (AsyncStorage.setItem as jest.Mock).mockImplementation(() => Promise.resolve());
+  storage = {};
+  (AsyncStorage.getItem as jest.Mock).mockImplementation((key: string) =>
+    Promise.resolve(key in storage ? storage[key] : null),
+  );
+  (AsyncStorage.setItem as jest.Mock).mockImplementation((key: string, value: string) => {
+    storage[key] = value;
+    return Promise.resolve();
+  });
   (Notifications.getPermissionsAsync as jest.Mock).mockResolvedValue({
     status: 'granted',
     canAskAgain: true,
@@ -311,12 +336,53 @@ describe('ClockScreen alarms — device timezone changes', () => {
     expect(savedAlarms()).toEqual([{ ...ONE_SHOT_ALARM, enabled: true, notificationIds: [] }]);
   });
 
-  it('stops reacting to foreground events once the Alarm tab is unmounted', async () => {
+  it('reschedules even when the Alarm tab is no longer mounted', async () => {
+    // The traveller is far more likely to have some other screen open than to be
+    // sitting on the Alarm tab when the device switches zones.
     seedAlarms([ONE_SHOT_ALARM]);
     const api = await renderAlarmTab();
 
     fireEvent.press(api.getByText('Stopwatch'));
     await waitFor(() => expect(api.getByText('Start')).toBeTruthy());
+    expect(api.queryByText('7:00 AM')).toBeNull();
+
+    deviceTimezone = 'Asia/Tokyo';
+    await act(async () => {
+      fireAppState('active');
+    });
+
+    await waitFor(() =>
+      expect(Notifications.cancelScheduledNotificationAsync).toHaveBeenCalledWith('scheduled-id-1'),
+    );
+    expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledTimes(1);
+    await waitFor(() =>
+      expect(savedAlarms()).toEqual([{ ...ONE_SHOT_ALARM, notificationIds: ['notification-id'] }]),
+    );
+  });
+
+  it('reschedules on a cold start that already happens in the new timezone', async () => {
+    // No AppState transition is ever observed here: the process starts fresh
+    // with the device already in Tokyo, which is exactly the case a
+    // foreground-only, in-component check cannot see.
+    seedAlarms([ONE_SHOT_ALARM], 'Europe/Lisbon');
+    deviceTimezone = 'Asia/Tokyo';
+
+    render(<ClockScreen navigation={mockNavigation} />);
+
+    await waitFor(() =>
+      expect(Notifications.cancelScheduledNotificationAsync).toHaveBeenCalledWith('scheduled-id-1'),
+    );
+    await waitFor(() =>
+      expect(savedAlarms()).toEqual([{ ...ONE_SHOT_ALARM, notificationIds: ['notification-id'] }]),
+    );
+    expect(changeHandlers.length).toBeGreaterThan(0); // listener registered, never fired
+  });
+
+  it('does nothing when no scheduling timezone was ever recorded', async () => {
+    // First ever launch: no notification has been computed against any zone, so
+    // there is nothing that could be anchored to the wrong one.
+    seedAlarms([ONE_SHOT_ALARM], null);
+    await renderAlarmTab();
 
     deviceTimezone = 'Asia/Tokyo';
     await act(async () => {
@@ -325,6 +391,78 @@ describe('ClockScreen alarms — device timezone changes', () => {
 
     expect(Notifications.scheduleNotificationAsync).not.toHaveBeenCalled();
     expect(Notifications.cancelScheduledNotificationAsync).not.toHaveBeenCalled();
+    expect(savedAlarms()).toBeNull();
+  });
+
+  it('records the new timezone so the next launch does not reschedule again', async () => {
+    seedAlarms([ONE_SHOT_ALARM]);
+    await renderAlarmTab();
+
+    deviceTimezone = 'Asia/Tokyo';
+    await act(async () => {
+      fireAppState('active');
+    });
+
+    await waitFor(() => expect(savedSchedulingTimezone()).toBe('Asia/Tokyo'));
+  });
+
+  it('turning the alarm off cancels the id it was rescheduled to, not the stale one', async () => {
+    // The reschedule happens outside the Alarm tab. If the mounted list kept the
+    // ids it read on mount, this toggle would cancel a notification that no
+    // longer exists and leave the live one pending — the alarm would ring after
+    // the user switched it off.
+    seedAlarms([ONE_SHOT_ALARM]);
+    const api = await renderAlarmTab();
+
+    deviceTimezone = 'Asia/Tokyo';
+    (Notifications.scheduleNotificationAsync as jest.Mock).mockResolvedValue('rescheduled-id');
+    await act(async () => {
+      fireAppState('active');
+    });
+    await waitFor(() =>
+      expect(savedAlarms()).toEqual([{ ...ONE_SHOT_ALARM, notificationIds: ['rescheduled-id'] }]),
+    );
+    (Notifications.cancelScheduledNotificationAsync as jest.Mock).mockClear();
+
+    await act(async () => {
+      fireEvent.press(api.getByRole('switch'));
+    });
+
+    await waitFor(() =>
+      expect(Notifications.cancelScheduledNotificationAsync).toHaveBeenCalledWith('rescheduled-id'),
+    );
+    expect(Notifications.cancelScheduledNotificationAsync).not.toHaveBeenCalledWith(
+      'scheduled-id-1',
+    );
+  });
+
+  it('schedules once when the mount check and a foreground event overlap', async () => {
+    seedAlarms([ONE_SHOT_ALARM]);
+    deviceTimezone = 'Asia/Tokyo';
+
+    // Hold the reference-timezone read open so the mount check is still in
+    // flight when the foreground event arrives. Two reconciliations racing on
+    // the same alarm would cancel one notification and schedule two.
+    let releaseRead: () => void = () => {};
+    const readGate = new Promise<void>((resolve) => {
+      releaseRead = resolve;
+    });
+    const passthrough = (AsyncStorage.getItem as jest.Mock).getMockImplementation()!;
+    (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
+      if (key === ALARM_TIMEZONE_STORAGE_KEY) await readGate;
+      return passthrough(key);
+    });
+
+    render(<ClockScreen navigation={mockNavigation} />);
+    act(() => {
+      fireAppState('active');
+    });
+    await act(async () => {
+      releaseRead();
+    });
+
+    await waitFor(() => expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledTimes(1));
+    expect(Notifications.cancelScheduledNotificationAsync).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/screens/__tests__/ClockScreen.test.tsx
+++ b/src/screens/__tests__/ClockScreen.test.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
-import { render, fireEvent, waitFor } from '../../test-utils';
+import { render, fireEvent, waitFor, act } from '../../test-utils';
 import { ClockScreen } from '../ClockScreen';
 import { AppState, AppStateStatus } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import type { AppNavigationProp } from '../../navigation/types';
 
 const mockNavigation = { navigate: jest.fn(), goBack: jest.fn(), push: jest.fn() } as unknown as AppNavigationProp;
+
+jest.mock('@react-native-async-storage/async-storage');
 
 jest.mock('expo-notifications', () => ({
   setNotificationHandler: jest.fn(),
@@ -67,41 +70,101 @@ describe('ClockScreen', () => {
     expect(getByText(/05:00/)).toBeTruthy();
   });
 
-  it('recalculates world clock times when tzTick is used on AppState active', async () => {
-    // This test verifies that tzTick is properly used to force a re-render
-    // when the app returns to foreground (to recalculate times for timezone changes).
+  it('recalculates world clock times immediately when app returns to foreground', async () => {
+    // PROOF: When AppState fires 'active', the component calls setTick to force an immediate
+    // re-render. The render calls getTimeForTimezone() fresh for each city, and if device
+    // timezone changed (mocked here via Intl), the new time displays immediately — without
+    // waiting for the next 1000ms interval tick.
     //
-    // Without the fix: tzTick is incremented but never used in render,
-    // so changing it doesn't cause a re-render of time calculations
-    // With the fix: tzTick is incorporated into the component's render logic
+    // Test strategy:
+    // 1. Mock AsyncStorage so cities load
+    // 2. Mock Intl.DateTimeFormat to track calls and return different times
+    // 3. Render and wait for cities to load
+    // 4. Fire AppState 'active' listener (this calls setTick, forcing re-render)
+    // 5. Verify format() was called again (proving re-render + recalculation happened)
+    // 6. WITHOUT advancing fake timers (so the 1000ms interval hasn't fired)
 
-    const { getByText } = render(<ClockScreen navigation={mockNavigation} />);
+    jest.useFakeTimers();
 
-    // The World Clock tab should be visible by default
-    expect(getByText('World Clock')).toBeTruthy();
+    try {
+      // Mock AsyncStorage to return null (so default cities load)
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+      (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
 
-    // Verify that AppState listeners are registered (at least from WorldClockTab)
-    const listenersCopy = [...mockAppStateListeners.change];
-    expect(listenersCopy.length).toBeGreaterThan(0);
+      // Track how many times format() was called per timezone
+      const formatCallsPerTimezone: { [tz: string]: number } = {};
 
-    // Track if any state updates occur when we trigger AppState 'active'
-    // If tzTick is properly wired, triggering 'active' should cause state updates
-    const stateUpdateCount = jest.fn();
+      const mockIntlDateTimeFormat = jest.fn(
+        (locale, options) =>
+          new Proxy(
+            {},
+            {
+              get(target, prop) {
+                if (prop === 'format') {
+                  return () => {
+                    const tz = options?.timeZone || 'UTC';
+                    if (!formatCallsPerTimezone[tz]) formatCallsPerTimezone[tz] = 0;
+                    formatCallsPerTimezone[tz]++;
+                    // Return a simple time string (content doesn't matter, we're counting calls)
+                    return '02:30 AM';
+                  };
+                }
+                if (prop === 'formatToParts') {
+                  return () => [
+                    { type: 'timeZoneName', value: 'GMT+0' },
+                  ];
+                }
+                if (prop === 'resolvedOptions') {
+                  return () => ({ timeZone: options?.timeZone || 'UTC' });
+                }
+                return undefined;
+              },
+            }
+          )
+      );
 
-    // Trigger the AppState listeners (simulating app returning to foreground)
-    // This should cause WorldClockTab to increment tzTick
-    listenersCopy.forEach(listener => {
-      listener('active');
-      stateUpdateCount();
-    });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (global.Intl as any).DateTimeFormat = mockIntlDateTimeFormat;
 
-    // Verify the listeners were called
-    expect(stateUpdateCount).toHaveBeenCalled();
+      const { getByText } = render(<ClockScreen navigation={mockNavigation} />);
 
-    // After triggering AppState change, verify component still renders correctly
-    // (with timezone updates if tzTick is properly integrated)
-    await waitFor(() => {
+      // Wait for the tab to be visible (this means AsyncStorage has resolved and cities are loaded)
+      await waitFor(() => {
+        expect(getByText('World Clock')).toBeTruthy();
+      });
+
+      // At this point, getTimeForTimezone() has been called for each default city (5 cities).
+      // Each call made Intl.DateTimeFormat().format() once.
+      // Count the calls for Tokyo (one of the default cities)
+      const initialTokyoCalls = formatCallsPerTimezone['Asia/Tokyo'] || 0;
+      expect(initialTokyoCalls).toBeGreaterThan(0);
+
+      // Capture the AppState listeners
+      const listenersCopy = [...mockAppStateListeners.change];
+      expect(listenersCopy.length).toBeGreaterThan(0);
+
+      // Simulate app returning to foreground: fire the AppState 'active' listener.
+      // This should trigger WorldClockTab's useEffect, which calls setTick().
+      // setTick() forces a state change -> re-render -> getTimeForTimezone() called again
+      // for each city.
+      act(() => {
+        listenersCopy.forEach(listener => listener('active'));
+      });
+
+      // CRITICAL: We did NOT call jest.advanceTimersByTime(1000) or jest.runOnlyPendingTimers().
+      // So the 1000ms setInterval has NOT fired.
+      // If format() was called again, it was because of the AppState listener's setTick(),
+      // not the interval.
+
+      // Verify the re-render happened: Tokyo's format() was called additional time(s)
+      const finalTokyoCalls = formatCallsPerTimezone['Asia/Tokyo'] || 0;
+      expect(finalTokyoCalls).toBeGreaterThan(initialTokyoCalls);
+
+      // Verify the component still renders correctly
       expect(getByText('World Clock')).toBeTruthy();
-    });
+
+    } finally {
+      jest.useRealTimers();
+    }
   });
 });

--- a/src/screens/__tests__/ClockScreen.test.tsx
+++ b/src/screens/__tests__/ClockScreen.test.tsx
@@ -1,18 +1,17 @@
 import React from 'react';
-import { render, fireEvent, waitFor, act } from '../../test-utils';
-import { ClockScreen } from '../ClockScreen';
+import { render, fireEvent, waitFor, act, RenderResult } from '../../test-utils';
 import { AppState, AppStateStatus } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as Notifications from 'expo-notifications';
+import { ClockScreen } from '../ClockScreen';
 import type { AppNavigationProp } from '../../navigation/types';
 
 const mockNavigation = { navigate: jest.fn(), goBack: jest.fn(), push: jest.fn() } as unknown as AppNavigationProp;
 
-jest.mock('@react-native-async-storage/async-storage');
-
 jest.mock('expo-notifications', () => ({
   setNotificationHandler: jest.fn(),
-  getPermissionsAsync: jest.fn(() => Promise.resolve({ status: 'granted' })),
-  requestPermissionsAsync: jest.fn(() => Promise.resolve({ status: 'granted' })),
+  getPermissionsAsync: jest.fn(() => Promise.resolve({ status: 'granted', canAskAgain: true })),
+  requestPermissionsAsync: jest.fn(() => Promise.resolve({ status: 'granted', canAskAgain: true })),
   scheduleNotificationAsync: jest.fn(() => Promise.resolve('notification-id')),
   cancelScheduledNotificationAsync: jest.fn(() => Promise.resolve()),
   setNotificationCategoryAsync: jest.fn(() => Promise.resolve()),
@@ -20,23 +19,104 @@ jest.mock('expo-notifications', () => ({
   SchedulableTriggerInputTypes: { TIME_INTERVAL: 'timeInterval', WEEKLY: 'weekly', DATE: 'date' },
 }));
 
-// Store the AppState listeners so we can trigger them in tests
-const mockAppStateListeners: { [key: string]: ((state: AppStateStatus) => void)[] } = { change: [] };
+const ALARMS_STORAGE_KEY = '@iostoandroid/alarms';
 
-// Mock AppState.addEventListener to track listeners
-const originalAddEventListener = AppState.addEventListener;
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-AppState.addEventListener = jest.fn((event: any, callback: (state: AppStateStatus) => void) => {
-  if (event === 'change') {
-    mockAppStateListeners.change.push(callback);
-  }
-  const originalListener = originalAddEventListener(event, callback);
-  return {
-    remove: () => {
-      mockAppStateListeners.change = mockAppStateListeners.change.filter(l => l !== callback);
-      originalListener.remove();
-    },
-  };
+interface StoredAlarm {
+  id: string;
+  hour: number;
+  minute: number;
+  label: string;
+  days: number[];
+  enabled: boolean;
+  notificationIds: string[];
+}
+
+const ONE_SHOT_ALARM: StoredAlarm = {
+  id: 'alarm-1',
+  hour: 7,
+  minute: 0,
+  label: 'Wake up',
+  days: [],
+  enabled: true,
+  notificationIds: ['scheduled-id-1'],
+};
+
+// --- AppState harness ------------------------------------------------------
+// The production code registers its foreground handler through
+// AppState.addEventListener; capturing the real handlers lets the tests drive a
+// genuine background -> foreground transition instead of poking at component
+// internals. Handlers are dropped again when the component unsubscribes, so an
+// unmounted screen has no handler left to fire.
+let changeHandlers: ((state: AppStateStatus) => void)[] = [];
+
+function fireAppState(state: AppStateStatus) {
+  [...changeHandlers].forEach((handler) => handler(state));
+}
+
+// --- Device timezone harness -----------------------------------------------
+// Production reads the device zone via `new Intl.DateTimeFormat().resolvedOptions()`.
+// Spying on the prototype keeps every other Intl behaviour (formatting a given
+// IANA zone) real, so only the *device* zone is under test control.
+let deviceTimezone: string | undefined = 'Europe/Lisbon';
+const realResolvedOptions = Intl.DateTimeFormat.prototype.resolvedOptions;
+
+function seedAlarms(alarms: StoredAlarm[]) {
+  (AsyncStorage.getItem as jest.Mock).mockImplementation((key: string) =>
+    Promise.resolve(key === ALARMS_STORAGE_KEY ? JSON.stringify(alarms) : null),
+  );
+}
+
+function savedAlarms(): StoredAlarm[] | null {
+  const calls = (AsyncStorage.setItem as jest.Mock).mock.calls.filter(
+    ([key]) => key === ALARMS_STORAGE_KEY,
+  );
+  if (calls.length === 0) return null;
+  return JSON.parse(calls[calls.length - 1][1]);
+}
+
+/** Mounts the screen and switches to the Alarm tab, waiting for storage to settle. */
+async function renderAlarmTab(): Promise<RenderResult> {
+  const api = render(<ClockScreen navigation={mockNavigation} />);
+  fireEvent.press(api.getByText('Alarm'));
+  await waitFor(() => expect(api.getByText('7:00 AM')).toBeTruthy());
+  (Notifications.scheduleNotificationAsync as jest.Mock).mockClear();
+  (Notifications.cancelScheduledNotificationAsync as jest.Mock).mockClear();
+  (AsyncStorage.setItem as jest.Mock).mockClear();
+  return api;
+}
+
+beforeEach(() => {
+  changeHandlers = [];
+  deviceTimezone = 'Europe/Lisbon';
+
+  jest.spyOn(AppState, 'addEventListener').mockImplementation((type, handler) => {
+    if (type === 'change') changeHandlers.push(handler);
+    return {
+      remove: () => {
+        changeHandlers = changeHandlers.filter((h) => h !== handler);
+      },
+    };
+  });
+
+  jest
+    .spyOn(Intl.DateTimeFormat.prototype, 'resolvedOptions')
+    .mockImplementation(function resolvedOptionsWithFakeDeviceZone(this: Intl.DateTimeFormat) {
+      return { ...realResolvedOptions.call(this), timeZone: deviceTimezone as string };
+    });
+
+  (AsyncStorage.getItem as jest.Mock).mockImplementation(() => Promise.resolve(null));
+  (AsyncStorage.setItem as jest.Mock).mockImplementation(() => Promise.resolve());
+  (Notifications.getPermissionsAsync as jest.Mock).mockResolvedValue({
+    status: 'granted',
+    canAskAgain: true,
+  });
+  (Notifications.scheduleNotificationAsync as jest.Mock).mockResolvedValue('notification-id');
+  (Notifications.cancelScheduledNotificationAsync as jest.Mock).mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  jest.clearAllMocks();
 });
 
 describe('ClockScreen', () => {
@@ -69,100 +149,218 @@ describe('ClockScreen', () => {
     fireEvent.press(getByText('Timer'));
     expect(getByText(/05:00/)).toBeTruthy();
   });
+});
 
-  it('recalculates world clock times immediately when app returns to foreground', async () => {
-    // PROOF: When AppState fires 'active', the component calls setTick to force an immediate
-    // re-render. The render calls getTimeForTimezone() fresh for each city, and if device
-    // timezone changed (mocked here via Intl), the new time displays immediately — without
-    // waiting for the next 1000ms interval tick.
-    //
-    // Test strategy:
-    // 1. Mock AsyncStorage so cities load
-    // 2. Mock Intl.DateTimeFormat to track calls and return different times
-    // 3. Render and wait for cities to load
-    // 4. Fire AppState 'active' listener (this calls setTick, forcing re-render)
-    // 5. Verify format() was called again (proving re-render + recalculation happened)
-    // 6. WITHOUT advancing fake timers (so the 1000ms interval hasn't fired)
+// ---------------------------------------------------------------------------
+// Alarms vs. device timezone changes (issue #213)
+//
+// One-shot alarms are scheduled as a TIME_INTERVAL countdown, i.e. anchored to
+// an absolute instant. A timezone change while the app is backgrounded leaves
+// that countdown pointing at the wrong local wall-clock time, so the alarm has
+// to be recomputed when the app comes back to the foreground.
+// ---------------------------------------------------------------------------
+describe('ClockScreen alarms — device timezone changes', () => {
+  it('reschedules a one-shot alarm when the device timezone changed while backgrounded', async () => {
+    seedAlarms([ONE_SHOT_ALARM]);
+    await renderAlarmTab();
 
+    deviceTimezone = 'Asia/Tokyo';
+    await act(async () => {
+      fireAppState('active');
+    });
+
+    await waitFor(() =>
+      expect(Notifications.cancelScheduledNotificationAsync).toHaveBeenCalledWith('scheduled-id-1'),
+    );
+    await waitFor(() => expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledTimes(1));
+
+    const trigger = (Notifications.scheduleNotificationAsync as jest.Mock).mock.calls[0][0].trigger;
+    expect(trigger.type).toBe('timeInterval');
+    expect(trigger.seconds).toBeGreaterThan(0);
+
+    await waitFor(() => expect(savedAlarms()).not.toBeNull());
+    expect(savedAlarms()).toEqual([
+      { ...ONE_SHOT_ALARM, notificationIds: ['notification-id'] },
+    ]);
+  });
+
+  it('does not reschedule when the app returns to the foreground in the same timezone', async () => {
+    seedAlarms([ONE_SHOT_ALARM]);
+    await renderAlarmTab();
+
+    await act(async () => {
+      fireAppState('active');
+    });
+
+    expect(Notifications.cancelScheduledNotificationAsync).not.toHaveBeenCalled();
+    expect(Notifications.scheduleNotificationAsync).not.toHaveBeenCalled();
+    expect(savedAlarms()).toBeNull();
+  });
+
+  it('ignores non-active AppState transitions, then reschedules on the next active', async () => {
+    seedAlarms([ONE_SHOT_ALARM]);
+    await renderAlarmTab();
+
+    deviceTimezone = 'Asia/Tokyo';
+    await act(async () => {
+      fireAppState('background');
+      fireAppState('inactive');
+    });
+    expect(Notifications.scheduleNotificationAsync).not.toHaveBeenCalled();
+
+    await act(async () => {
+      fireAppState('active');
+    });
+    await waitFor(() => expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledTimes(1));
+  });
+
+  it('reschedules once when foregrounded twice after a single timezone change', async () => {
+    seedAlarms([ONE_SHOT_ALARM]);
+    await renderAlarmTab();
+
+    deviceTimezone = 'Asia/Tokyo';
+    await act(async () => {
+      fireAppState('active');
+    });
+    await waitFor(() => expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      fireAppState('background');
+      fireAppState('active');
+    });
+
+    expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledTimes(1);
+    expect(Notifications.cancelScheduledNotificationAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves repeating alarms alone — weekly triggers already follow the local wall clock', async () => {
+    seedAlarms([{ ...ONE_SHOT_ALARM, days: [2, 4], notificationIds: ['weekly-1', 'weekly-2'] }]);
+    await renderAlarmTab();
+
+    deviceTimezone = 'Asia/Tokyo';
+    await act(async () => {
+      fireAppState('active');
+    });
+
+    expect(Notifications.cancelScheduledNotificationAsync).not.toHaveBeenCalled();
+    expect(Notifications.scheduleNotificationAsync).not.toHaveBeenCalled();
+  });
+
+  it('leaves disabled alarms alone', async () => {
+    seedAlarms([{ ...ONE_SHOT_ALARM, enabled: false, notificationIds: [] }]);
+    await renderAlarmTab();
+
+    deviceTimezone = 'Asia/Tokyo';
+    await act(async () => {
+      fireAppState('active');
+    });
+
+    expect(Notifications.scheduleNotificationAsync).not.toHaveBeenCalled();
+    expect(savedAlarms()).toBeNull();
+  });
+
+  it('does nothing when there are no alarms stored', async () => {
+    seedAlarms([]);
+    const api = render(<ClockScreen navigation={mockNavigation} />);
+    fireEvent.press(api.getByText('Alarm'));
+    await waitFor(() => expect(api.getByText('No alarms set')).toBeTruthy());
+    (Notifications.scheduleNotificationAsync as jest.Mock).mockClear();
+
+    deviceTimezone = 'Asia/Tokyo';
+    await act(async () => {
+      fireAppState('active');
+    });
+
+    expect(Notifications.scheduleNotificationAsync).not.toHaveBeenCalled();
+    expect(api.getByText('No alarms set')).toBeTruthy();
+  });
+
+  it('skips rescheduling when the runtime cannot resolve a device timezone', async () => {
+    seedAlarms([ONE_SHOT_ALARM]);
+    await renderAlarmTab();
+
+    // An Intl build without full ICU data reports an empty timeZone. Treating
+    // that as "the zone changed" would reschedule every alarm against an
+    // unknown offset, which is worse than leaving them as they are.
+    deviceTimezone = undefined;
+    await act(async () => {
+      fireAppState('active');
+    });
+
+    expect(Notifications.scheduleNotificationAsync).not.toHaveBeenCalled();
+    expect(Notifications.cancelScheduledNotificationAsync).not.toHaveBeenCalled();
+  });
+
+  it('keeps the alarm enabled when rescheduling yields no notifications', async () => {
+    seedAlarms([ONE_SHOT_ALARM]);
+    await renderAlarmTab();
+
+    // Notification permission revoked while the app was backgrounded.
+    (Notifications.getPermissionsAsync as jest.Mock).mockResolvedValue({
+      status: 'denied',
+      canAskAgain: false,
+    });
+
+    deviceTimezone = 'Asia/Tokyo';
+    await act(async () => {
+      fireAppState('active');
+    });
+
+    await waitFor(() => expect(savedAlarms()).not.toBeNull());
+    expect(Notifications.scheduleNotificationAsync).not.toHaveBeenCalled();
+    expect(savedAlarms()).toEqual([{ ...ONE_SHOT_ALARM, enabled: true, notificationIds: [] }]);
+  });
+
+  it('stops reacting to foreground events once the Alarm tab is unmounted', async () => {
+    seedAlarms([ONE_SHOT_ALARM]);
+    const api = await renderAlarmTab();
+
+    fireEvent.press(api.getByText('Stopwatch'));
+    await waitFor(() => expect(api.getByText('Start')).toBeTruthy());
+
+    deviceTimezone = 'Asia/Tokyo';
+    await act(async () => {
+      fireAppState('active');
+    });
+
+    expect(Notifications.scheduleNotificationAsync).not.toHaveBeenCalled();
+    expect(Notifications.cancelScheduledNotificationAsync).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regression lock for behaviour that ALREADY ships in main (added by 77d58ad,
+// never covered by a test). This is not what this change fixes — it exists so
+// that removing WorldClockTab's foreground listener stops being silent.
+// ---------------------------------------------------------------------------
+describe('ClockScreen world clock — foreground refresh (pre-existing behaviour)', () => {
+  const WORLD_TIME = /^\d{2}:\d{2}\s(AM|PM)$/;
+
+  function renderedTimes(api: RenderResult): string[] {
+    return api.getAllByText(WORLD_TIME).map((node) => node.props.children as string);
+  }
+
+  it('recomputes displayed times on foreground without waiting for the 1s interval', async () => {
     jest.useFakeTimers();
-
     try {
-      // Mock AsyncStorage to return null (so default cities load)
-      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
-      (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
+      jest.setSystemTime(new Date('2026-08-19T09:00:00Z'));
+      const api = render(<ClockScreen navigation={mockNavigation} />);
+      // Flush the AsyncStorage read without advancing any timer.
+      await act(async () => {});
 
-      // Track how many times format() was called per timezone
-      const formatCallsPerTimezone: { [tz: string]: number } = {};
+      const before = renderedTimes(api);
+      expect(before.length).toBeGreaterThan(0);
 
-      const mockIntlDateTimeFormat = jest.fn(
-        (locale, options) =>
-          new Proxy(
-            {},
-            {
-              get(target, prop) {
-                if (prop === 'format') {
-                  return () => {
-                    const tz = options?.timeZone || 'UTC';
-                    if (!formatCallsPerTimezone[tz]) formatCallsPerTimezone[tz] = 0;
-                    formatCallsPerTimezone[tz]++;
-                    // Return a simple time string (content doesn't matter, we're counting calls)
-                    return '02:30 AM';
-                  };
-                }
-                if (prop === 'formatToParts') {
-                  return () => [
-                    { type: 'timeZoneName', value: 'GMT+0' },
-                  ];
-                }
-                if (prop === 'resolvedOptions') {
-                  return () => ({ timeZone: options?.timeZone || 'UTC' });
-                }
-                return undefined;
-              },
-            }
-          )
-      );
-
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (global.Intl as any).DateTimeFormat = mockIntlDateTimeFormat;
-
-      const { getByText } = render(<ClockScreen navigation={mockNavigation} />);
-
-      // Wait for the tab to be visible (this means AsyncStorage has resolved and cities are loaded)
-      await waitFor(() => {
-        expect(getByText('World Clock')).toBeTruthy();
-      });
-
-      // At this point, getTimeForTimezone() has been called for each default city (5 cities).
-      // Each call made Intl.DateTimeFormat().format() once.
-      // Count the calls for Tokyo (one of the default cities)
-      const initialTokyoCalls = formatCallsPerTimezone['Asia/Tokyo'] || 0;
-      expect(initialTokyoCalls).toBeGreaterThan(0);
-
-      // Capture the AppState listeners
-      const listenersCopy = [...mockAppStateListeners.change];
-      expect(listenersCopy.length).toBeGreaterThan(0);
-
-      // Simulate app returning to foreground: fire the AppState 'active' listener.
-      // This should trigger WorldClockTab's useEffect, which calls setTick().
-      // setTick() forces a state change -> re-render -> getTimeForTimezone() called again
-      // for each city.
+      // Clock moves on while the app sits in the background. No timer is
+      // advanced, so the 1000ms interval has not fired.
+      jest.setSystemTime(new Date('2026-08-19T10:00:00Z'));
       act(() => {
-        listenersCopy.forEach(listener => listener('active'));
+        fireAppState('active');
       });
 
-      // CRITICAL: We did NOT call jest.advanceTimersByTime(1000) or jest.runOnlyPendingTimers().
-      // So the 1000ms setInterval has NOT fired.
-      // If format() was called again, it was because of the AppState listener's setTick(),
-      // not the interval.
-
-      // Verify the re-render happened: Tokyo's format() was called additional time(s)
-      const finalTokyoCalls = formatCallsPerTimezone['Asia/Tokyo'] || 0;
-      expect(finalTokyoCalls).toBeGreaterThan(initialTokyoCalls);
-
-      // Verify the component still renders correctly
-      expect(getByText('World Clock')).toBeTruthy();
-
+      const after = renderedTimes(api);
+      expect(after).toHaveLength(before.length);
+      expect(after).not.toEqual(before);
     } finally {
       jest.useRealTimers();
     }

--- a/src/store/DeviceStore.tsx
+++ b/src/store/DeviceStore.tsx
@@ -6,6 +6,7 @@ import * as Brightness from 'expo-brightness';
 import * as Network from 'expo-network';
 import * as Contacts from 'expo-contacts';
 import * as Location from 'expo-location';
+import { syncAlarmsWithDeviceTimezone } from '../utils/alarmTimezone';
 
 export interface DeviceWifi {
   enabled: boolean;
@@ -300,6 +301,20 @@ export function DeviceProvider({ children }: { children: React.ReactNode }) {
     });
     return () => sub.remove();
   }, [refresh]);
+
+  // Bring scheduled alarms back in line with the device timezone. This lives in
+  // the provider, not in the Clock screen: the Alarm tab is only mounted while
+  // `tabIndex === 1`, so a traveller who changes zones with any other screen (or
+  // any other Clock tab) open would never trigger the reconciliation. Running it
+  // on mount as well covers the cold start that happens already in the new zone,
+  // where no foreground transition is ever observed.
+  useEffect(() => {
+    syncAlarmsWithDeviceTimezone();
+    const sub = AppState.addEventListener('change', (nextState) => {
+      if (nextState === 'active') syncAlarmsWithDeviceTimezone();
+    });
+    return () => sub.remove();
+  }, []);
 
   // Lightweight background refresh — battery + messages every 30 seconds
   useEffect(() => {

--- a/src/utils/alarmScheduling.ts
+++ b/src/utils/alarmScheduling.ts
@@ -1,0 +1,163 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as Notifications from 'expo-notifications';
+import { withAutoLockSuppressed } from './permissions';
+import { rememberSchedulingTimezone } from './alarmTimezone';
+
+export const ALARMS_STORAGE_KEY = '@iostoandroid/alarms';
+
+export interface Alarm {
+  id: string;
+  hour: number;
+  minute: number;
+  label: string;
+  days: number[]; // 1=Sunday .. 7=Saturday (Expo weekday format)
+  enabled: boolean;
+  notificationIds: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Notification helpers
+// ---------------------------------------------------------------------------
+export async function requestNotificationPermissions(): Promise<{
+  granted: boolean;
+  canAskAgain: boolean;
+}> {
+  try {
+    const existing = await Notifications.getPermissionsAsync();
+    if (existing.status === 'granted') return { granted: true, canAskAgain: true };
+    if (!existing.canAskAgain) return { granted: false, canAskAgain: false };
+    const result = await withAutoLockSuppressed(() => Notifications.requestPermissionsAsync());
+    return { granted: result.status === 'granted', canAskAgain: result.canAskAgain };
+  } catch {
+    return { granted: false, canAskAgain: false };
+  }
+}
+
+export async function scheduleAlarmNotifications(alarm: Alarm): Promise<string[]> {
+  const perm = await requestNotificationPermissions();
+  if (!perm.granted) return [];
+
+  const ids: string[] = [];
+
+  if (alarm.days.length === 0) {
+    // One-shot alarm: schedule for next occurrence of this time
+    const now = new Date();
+    const target = new Date();
+    target.setHours(alarm.hour, alarm.minute, 0, 0);
+    if (target <= now) {
+      target.setDate(target.getDate() + 1);
+    }
+    const seconds = Math.floor((target.getTime() - now.getTime()) / 1000);
+    const id = await Notifications.scheduleNotificationAsync({
+      content: {
+        title: 'Alarm',
+        body: alarm.label || 'Alarm',
+        sound: true,
+        categoryIdentifier: 'ALARM',
+      },
+      trigger: {
+        type: Notifications.SchedulableTriggerInputTypes.TIME_INTERVAL,
+        seconds: Math.max(seconds, 1),
+        repeats: false,
+      },
+    });
+    ids.push(id);
+  } else {
+    // Repeating alarm for each selected day
+    for (const weekday of alarm.days) {
+      const id = await Notifications.scheduleNotificationAsync({
+        content: {
+          title: 'Alarm',
+          body: alarm.label || 'Alarm',
+          sound: true,
+          categoryIdentifier: 'ALARM',
+        },
+        trigger: {
+          type: Notifications.SchedulableTriggerInputTypes.WEEKLY,
+          weekday,
+          hour: alarm.hour,
+          minute: alarm.minute,
+        },
+      });
+      ids.push(id);
+    }
+  }
+
+  // The one-shot branch above bakes the current zone into an absolute countdown,
+  // so record which zone that was. Only on a real schedule: a denied-permission
+  // run scheduled nothing and must not move the reference.
+  if (ids.length > 0) await rememberSchedulingTimezone();
+
+  return ids;
+}
+
+export async function cancelAlarmNotifications(notificationIds: string[]): Promise<void> {
+  for (const id of notificationIds) {
+    await Notifications.cancelScheduledNotificationAsync(id);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// AsyncStorage helpers
+// ---------------------------------------------------------------------------
+export async function loadAlarms(): Promise<Alarm[]> {
+  try {
+    const raw = await AsyncStorage.getItem(ALARMS_STORAGE_KEY);
+    return raw ? JSON.parse(raw) : [];
+  } catch {
+    return [];
+  }
+}
+
+export async function saveAlarms(alarms: Alarm[]): Promise<void> {
+  await AsyncStorage.setItem(ALARMS_STORAGE_KEY, JSON.stringify(alarms));
+}
+
+// ---------------------------------------------------------------------------
+// Cross-component notification of rescheduled alarms
+// ---------------------------------------------------------------------------
+type AlarmsListener = (alarms: Alarm[]) => void;
+const listeners = new Set<AlarmsListener>();
+
+/**
+ * Notifies a mounted alarm list that the stored alarms changed underneath it.
+ * Rescheduling is driven from the provider tree, which stays mounted while the
+ * Alarm tab does not; without this the tab would keep the notification ids it
+ * read on mount and cancel already-replaced ids when the user toggles an alarm.
+ */
+export function subscribeToAlarms(listener: AlarmsListener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/**
+ * Cancels and re-schedules every enabled one-shot alarm, then persists the new
+ * notification ids. Returns the updated alarms, or null when there was nothing
+ * to reschedule.
+ */
+export async function rescheduleOneShotAlarms(): Promise<Alarm[] | null> {
+  const alarms = await loadAlarms();
+  const stale = alarms.filter((a) => a.enabled && a.days.length === 0);
+  if (stale.length === 0) return null;
+
+  const newIdsByAlarm = new Map<string, string[]>();
+  for (const alarm of stale) {
+    await cancelAlarmNotifications(alarm.notificationIds);
+    newIdsByAlarm.set(alarm.id, await scheduleAlarmNotifications(alarm));
+  }
+
+  // `enabled` is deliberately left as-is: if rescheduling produced no ids
+  // (permissions revoked while backgrounded) the alarm stays on with an empty
+  // id list, which is the state the "Fix 2" recovery effect in AlarmTab picks up
+  // on the next launch. Flipping it off here would silently drop the alarm.
+  const next = alarms.map((a) => {
+    const ids = newIdsByAlarm.get(a.id);
+    return ids ? { ...a, notificationIds: ids } : a;
+  });
+
+  await saveAlarms(next);
+  listeners.forEach((listener) => listener(next));
+  return next;
+}

--- a/src/utils/alarmTimezone.ts
+++ b/src/utils/alarmTimezone.ts
@@ -1,0 +1,96 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+/**
+ * IANA timezone the currently scheduled alarm notifications were computed
+ * against. Persisted (rather than kept in a ref) so a cold start that happens
+ * *after* the device already moved zones still sees the old value and can tell
+ * the notifications are stale.
+ */
+export const ALARM_TIMEZONE_STORAGE_KEY = '@iostoandroid/alarm_scheduling_timezone';
+
+/**
+ * Current IANA timezone of the device, or null when the runtime cannot resolve
+ * one (an Intl build without full ICU data reports an empty timeZone). Callers
+ * must treat null as "unknown" and skip timezone-dependent work rather than
+ * guessing a zone — guessing would reschedule alarms against the wrong offset.
+ */
+export function getDeviceTimezone(): string | null {
+  const { timeZone } = new Intl.DateTimeFormat().resolvedOptions();
+  return timeZone ? timeZone : null;
+}
+
+export async function readSchedulingTimezone(): Promise<string | null> {
+  try {
+    return await AsyncStorage.getItem(ALARM_TIMEZONE_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+/** Records the zone the caller just scheduled notifications in. No-op when unresolvable. */
+export async function rememberSchedulingTimezone(): Promise<void> {
+  const timezone = getDeviceTimezone();
+  if (timezone === null) return;
+  try {
+    await AsyncStorage.setItem(ALARM_TIMEZONE_STORAGE_KEY, timezone);
+  } catch {
+    /* storage unavailable — the next successful schedule records it again */
+  }
+}
+
+export type TimezoneSyncOutcome =
+  /** Intl could not resolve a device zone — nothing is touched. */
+  | 'unresolved-timezone'
+  /** Nothing has ever been scheduled, so nothing can be anchored to a stale zone. */
+  | 'no-reference'
+  /** Device is still in the zone the notifications were computed against. */
+  | 'unchanged'
+  /** Device moved zones; one-shot alarms were cancelled and scheduled again. */
+  | 'reconciled';
+
+let inFlight: Promise<TimezoneSyncOutcome> | null = null;
+
+async function run(): Promise<TimezoneSyncOutcome> {
+  const timezone = getDeviceTimezone();
+  if (timezone === null) return 'unresolved-timezone';
+
+  const reference = await readSchedulingTimezone();
+  // Anything that is not a stored zone string (missing key, storage stub that
+  // resolves undefined) means nothing was ever scheduled against a known zone.
+  if (typeof reference !== 'string' || reference.length === 0) return 'no-reference';
+  if (reference === timezone) return 'unchanged';
+
+  // Loaded lazily on purpose. `alarmScheduling` pulls in expo-notifications,
+  // whose native module is unavailable outside the app runtime; importing it
+  // eagerly from DeviceStore would drag it into every screen that mounts the
+  // provider. Nothing here needs it until a drift is actually detected.
+  // `require` rather than `import()`: jest without --experimental-vm-modules
+  // rejects dynamic import callbacks, and module factories only run on first
+  // require under Metro too, so this stays lazy in the app as well.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { rescheduleOneShotAlarms } = require('./alarmScheduling') as typeof import('./alarmScheduling');
+  await rescheduleOneShotAlarms();
+
+  await AsyncStorage.setItem(ALARM_TIMEZONE_STORAGE_KEY, timezone);
+  return 'reconciled';
+}
+
+/**
+ * Brings scheduled alarms back in line with the device timezone.
+ *
+ * One-shot alarms (`days === []`) are scheduled as a TIME_INTERVAL countdown,
+ * i.e. anchored to an absolute instant, so a zone change leaves them firing at
+ * the wrong local wall-clock time. Repeating alarms use WEEKLY triggers, which
+ * the OS anchors to the local clock, and are deliberately left alone.
+ *
+ * Concurrent calls share one run: the provider syncs on mount and again on the
+ * first foreground event, and two overlapping reconciliations would schedule
+ * each alarm twice.
+ */
+export function syncAlarmsWithDeviceTimezone(): Promise<TimezoneSyncOutcome> {
+  if (inFlight) return inFlight;
+  inFlight = run().finally(() => {
+    inFlight = null;
+  });
+  return inFlight;
+}


### PR DESCRIPTION
> **Nota do reviewer:** o título e o corpo deste PR descreviam trabalho revertido
> por `adaef84` (remoção do `tzTick`, chamada a `setTick` no `WorldClockTab`) que
> **não existe no diff**, citavam um passo vermelho de um teste inexistente e
> reportavam números errados. Reescrevi ambos a partir do diff real e das minhas
> próprias execuções. Nenhuma linha de código foi alterada por mim.

## Resumo

Reagenda alarmes one-shot quando a timezone do dispositivo muda, a partir do
`DeviceProvider` (sempre montado), com a timezone de referência persistida em
AsyncStorage.

## Causa raiz

`scheduleAlarmNotifications` agenda alarmes one-shot (`days.length === 0`) com um
trigger `TIME_INTERVAL` de `target - now` segundos — **ancorado a um instante
absoluto**. Mudar a timezone do dispositivo não muda esse instante, muda apenas a
hora de parede a que ele corresponde: um alarme das 07:00 marcado em Lisboa toca
às 15:00 se o dispositivo passar para Tóquio antes de disparar.

Alarmes repetidos usam trigger `WEEKLY` com `hour`/`minute`, que o SO ancora ao
relógio local — seguem a timezone nova sozinhos e **não precisam de intervenção**.

O `WorldClockTab` **não é um defeito**: já tem `setInterval(setTick, 1000)`, um
listener de `AppState` com `setTzTick`, e chama
`getTimeForTimezone`/`getHourDiffForTimezone`/`getDayLabel` inline no JSX sem
memoização. Este diff não lhe toca em nenhuma linha.

## O que mudou (5 ficheiros)

**`src/utils/alarmScheduling.ts`** (novo) — move puro, corpo a corpo idêntico, de
`Alarm`, `ALARMS_STORAGE_KEY`, `requestNotificationPermissions`,
`scheduleAlarmNotifications`, `cancelAlarmNotifications`, `loadAlarms` e
`saveAlarms`, que eram locais e não exportados em `ClockScreen.tsx`. Acrescenta:
- `if (ids.length > 0) await rememberSchedulingTimezone()` no fim de
  `scheduleAlarmNotifications` — só num agendamento real, para que uma corrida com
  permissão negada não mova a referência;
- `subscribeToAlarms(listener)` — notifica uma lista montada de que os alarmes
  mudaram por baixo dela;
- `rescheduleOneShotAlarms()` — cancela e reagenda cada one-shot activo, persiste
  os ids novos e notifica os subscritores. `enabled` fica deliberadamente como
  está: sem ids (permissão revogada em background) o alarme mantém-se ligado com
  `notificationIds: []`, que é o estado que o "Fix 2" do `AlarmTab` recupera.

**`src/utils/alarmTimezone.ts`** (novo) — `getDeviceTimezone()` (devolve `null`
quando o runtime não resolve zona), a chave persistida
`@iostoandroid/alarm_scheduling_timezone`, e `syncAlarmsWithDeviceTimezone()`, que
sai cedo em `unresolved-timezone` / `no-reference` / `unchanged` e só reconcilia
quando há drift real. Chamadas concorrentes partilham uma corrida (`inFlight`).
`alarmScheduling` é carregado com `require` lazy para não arrastar
`expo-notifications` para dentro do provider.

**`src/store/DeviceStore.tsx`** — `useEffect([])` que corre o sync na montagem
(cobre o arranque a frio já na timezone nova, onde nunca há transição de
`AppState`) e em cada `AppState` `'active'`. Vive aqui, e não no `ClockScreen`,
porque o `AlarmTab` só está montado com `tabIndex === 1`.

**`src/screens/ClockScreen.tsx`** — passa a importar os helpers do módulo novo e
o `AlarmTab` ganha `useEffect(() => subscribeToAlarms(setAlarms), [])`, para que
desligar um alarme cancele o id que está mesmo pendente e não o id que a lista
leu na montagem. **Zero linhas alteradas no `WorldClockTab`.**

**`src/screens/__tests__/ClockScreen.test.tsx`** — 21 testes (16 novos).

## Testes

### Passo vermelho (verificado empiricamente pelo reviewer, não alegado)

Revertendo `src/store/DeviceStore.tsx` para a base `64b6a58` — isto é, tirando o
efeito de sincronização e deixando tudo o resto: **9 dos 21 testes falham**, entre
eles `reschedules a one-shot alarm when the device timezone changed while
backgrounded`, `reschedules even when the Alarm tab is no longer mounted` e
`reschedules on a cold start that already happens in the new timezone`.

### Mutação: 13 de 15 mutantes mortos, cada um por um teste específico

| Mutante | Teste que o mata |
|---|---|
| tirar o sync na montagem | `reschedules on a cold start…` |
| tirar a guarda `nextState === 'active'` | `ignores non-active AppState transitions…` |
| tirar o dedupe `inFlight` | `schedules once when the mount check and a foreground event overlap` |
| tirar a guarda de timezone `null` | `skips rescheduling when the runtime cannot resolve a device timezone` |
| tirar a guarda `no-reference` | `does nothing when no scheduling timezone was ever recorded` |
| tirar a guarda `unchanged` | 4 testes |
| reagendar também os repetidos | `leaves repeating alarms alone…` |
| reagendar também os desligados | `leaves disabled alarms alone` |
| tirar `subscribeToAlarms` do `AlarmTab` | `turning the alarm off cancels the id it was rescheduled to…` |
| tirar a notificação aos subscritores | idem |
| não cancelar os ids antigos | 5 testes |
| não persistir os alarmes reagendados | 5 testes |
| tirar o `setTzTick` do `WorldClockTab` | `recomputes displayed times on foreground…` (guarda de regressão) |

Sobrevivem 2 mutantes, ambos sobre a **escrita duplicada** da timezone de
referência (`AsyncStorage.setItem` no fim de `run()` e a guarda `ids.length > 0`):
`rememberSchedulingTimezone` já a escreve no caminho normal, pelo que a segunda
escrita é redundante e nenhum requisito depende dela.

### Resultados (medidos no worktree)

```
npm run lint      0 erros, 1 warning ('tzTick' em ClockScreen.tsx:258 — PRÉ-EXISTENTE,
                  idêntico ao da base; a baseline registava 2 warnings)
npx tsc --noEmit  limpo (exit 0)
npm test          49 suites, 361 testes: 352 passam, 9 falham
                  — exactamente as 9 falhas do baseline, zero novas
ClockScreen.test  21/21
```

## Critérios de aceitação (análise do curator)

- [x] One-shot reagendado ao voltar a foreground com TZ diferente, **qualquer que
      seja o ecrã ou separador aberto** — o listener vive no `DeviceProvider`
- [x] One-shot reagendado no arranque a frio quando a TZ persistida difere da actual
- [x] Alarmes repetidos (`WEEKLY`) não são cancelados nem reagendados
- [x] Nenhuma linha do `WorldClockTab` alterada (verificado byte a byte)
- [x] Reagendamento sem ids mantém `enabled: true` com `notificationIds: []`
- [x] `timeZone` não resolúvel: nada é reagendado, nada é escrito, nada rebenta
- [x] Título e corpo descrevem o diff submetido

## Linked Issue

Fixes #213
