### PR TITLE
fix(pipeline): a PR is only 'reviewed' if it was judged; close orphaned PRs

### DIFF
--- a/scripts/team/orchestrator.sh
+++ b/scripts/team/orchestrator.sh
@@ -333,6 +333,43 @@ cleanup_stale() {
   fi
 }
 
+# ── PRs whose issue no longer exists ──────────────────────────────────────
+#
+# The curator's `split` closes the parent issue and opens children. If that parent
+# already had an open PR, the PR is orphaned: its `Fixes #N` points at a closed
+# issue, no rework will ever touch its branch, and the reviewer would spend a full
+# run judging work whose contract was withdrawn.
+#
+# PR #333 sat like that — issue #212 closed as qa:done by a split into #335/#336/
+# #337, the PR still open hours later.
+#
+# Closing it is not throwing work away: the children carry the scope forward, and
+# the branch stays on the remote if anyone wants the diff.
+close_orphan_prs() {
+  local list num issue state
+  list=$(gh pr list --repo "$REPO" --base "$BASE_BRANCH" --state open \
+           --json number,headRefName,body \
+           --jq '.[] | select(.headRefName | startswith("qa/")) | "\(.number)\t\(.body // "" | gsub("\n"; " "))"' \
+           2>/dev/null) || return 0
+  [ -n "$list" ] || return 0
+  while IFS=$'\t' read -r num body; do
+    [ -n "$num" ] || continue
+    issue=$(printf '%s' "$body" | grep -oiE '(Fixes|Closes|Resolves)[[:space:]]+#[0-9]+' | grep -oE '[0-9]+' | head -1)
+    [ -n "$issue" ] || continue
+    state=$(gh issue view "$issue" --repo "$REPO" --json state --jq .state 2>/dev/null || echo "")
+    [ "$state" = "CLOSED" ] || continue
+    log "PR #$num órfão: o issue #$issue está fechado — a fechar o PR"
+    gh pr comment "$num" --repo "$REPO" --body "## Orquestrador: PR órfão
+
+O issue #$issue que este PR resolvia foi **fechado** — tipicamente porque o curator
+o partiu em sub-issues, que levam o âmbito daqui para a frente.
+
+Um PR cujo contrato foi retirado não é revisível, e deixá-lo aberto só gasta uma
+corrida de review. Fechado. O branch fica no remoto se alguém quiser o diff." >/dev/null 2>&1 || true
+    gh pr close "$num" --repo "$REPO" >/dev/null 2>&1 || true
+  done <<< "$list"
+}
+
 # An issue stuck in qa:wip with no agent alive means the implementer died. Left
 # alone it blocks that issue forever, because nothing dispatches on qa:wip.
 rescue_stuck_wip() {
@@ -369,7 +406,30 @@ Devolvido a \`$L_READY\` para nova tentativa."
 
 # ── Role dispatch ──────────────────────────────────────────────────────────
 run_implement() { log "IMPLEMENTADOR -> #$1"; bash "$SCRIPT_DIR/implement.sh" "$1" || log "implement falhou #$1"; }
-run_review()    { log "REVIEWER -> PR #$1"; bash "$SCRIPT_DIR/review.sh" "$1" || log "review falhou PR #$1"; mark_reviewed "$1"; }
+# A PR IS ONLY "REVIEWED" IF IT WAS ACTUALLY JUDGED.
+#
+# mark_reviewed used to run unconditionally, so a review that produced NO verdict —
+# quota exhausted, slot busy, engine died — still recorded the head sha. pick_pr
+# only re-reviews a PR whose head MOVED, and nothing pushes to a branch whose issue
+# is sitting in qa:review, so the PR was never looked at again.
+#
+# Four PRs were stranded exactly that way (#324, #333, #338, #342), the oldest for
+# fourteen hours, while the board showed them as "in review". review.sh's own
+# comment claimed "no reviewed-sha record was written" — it was wrong, because the
+# orchestrator wrote it.
+#
+# review.sh now exits 78 for "I did not judge this", and only a real verdict marks
+# the sha.
+run_review() {
+  log "REVIEWER -> PR #$1"
+  bash "$SCRIPT_DIR/review.sh" "$1"; local rc=$?
+  if [ "$rc" = "78" ]; then
+    log "PR #$1 não foi julgado (rc=78) — NÃO marco como revisto, volta na próxima"
+    return 0
+  fi
+  [ "$rc" -ne 0 ] && log "review falhou PR #$1 (rc=$rc)"
+  mark_reviewed "$1"
+}
 
 # The curator runs DETACHED on its own slot. It writes only GitHub comments and
 # labels — no git, no build, no push — so it costs nothing to run alongside the
@@ -452,6 +512,7 @@ while true; do
   fi
 
   rescue_stuck_wip
+  close_orphan_prs
 
   # Repair analysis runs alongside delivery, never in front of it.
   launch_curator_if_needed

--- a/scripts/team/review.sh
+++ b/scripts/team/review.sh
@@ -191,7 +191,7 @@ if ! verdict_readable "$VERDICT_FILE"; then
 A corrida não produziu veredicto por uma razão alheia ao PR: ou o slot estava
 ocupado, ou a subscrição estava esgotada e o fallback não conseguiu concluir. O PR
 fica como está e será revisto de novo." >/dev/null 2>&1 || true
-    exit 0
+    exit 78   # <- "não julguei este PR": o orquestrador NÃO pode marcá-lo como revisto
   fi
   # A failed run must not consume the PR: leave it open so the next cycle picks it
   # up again (its head sha is unchanged, and no reviewed-sha record was written).
@@ -200,7 +200,7 @@ fica como está e será revisto de novo." >/dev/null 2>&1 || true
 
 A corrida terminou sem escrever veredicto (ver \`$LOG_DIR/review-$PR.log\`). Falha
 da corrida, não do PR — será revisto de novo." >/dev/null 2>&1 || true
-  exit 0
+  exit 78
 fi
 
 VERDICT=$(jqv "$VERDICT_FILE" '.verdict' 'blocked-impl')


### PR DESCRIPTION
**1. `mark_reviewed` ran unconditionally.** `pick_pr` only re-reviews a PR whose head *moved*; `mark_reviewed` recorded the sha after every review call — including ones that produced **no verdict** (quota spent, slot busy, engine died). Nothing pushes to a branch whose issue sits in `qa:review`, so the sha never moves and the PR is never looked at again.

Four PRs stranded that way — **#324, #333, #338, #342** — the oldest for **fourteen hours**, while the board showed them as "in review". `review.sh`'s own comment claimed *"no reviewed-sha record was written"* — wrong, the orchestrator wrote it. Two files disagreed and the silent one won.

`review.sh` now exits **78** for "I did not judge this"; only a real verdict marks the sha.

**2. Nothing closed a PR whose issue was split away.** The curator's `split` closes the parent and opens children, orphaning the parent's PR — `Fixes #N` points at a closed issue and no rework will ever touch that branch. PR #333 sat like that after #212 became #335/#336/#337. `close_orphan_prs` now closes them each cycle with the reason posted.