### PR TITLE
fix(pipeline): circuit breaker for PRs, and surface stale ones in --status

### DIFF
--- a/scripts/team/orchestrator.sh
+++ b/scripts/team/orchestrator.sh
@@ -279,6 +279,9 @@ pick_pr() {
   while IFS= read -r line; do
     [ -n "$line" ] || continue
     num=${line%% *}; sha=${line##* }
+    # Deferred PRs are skipped for the same reason deferred issues are: an unjudged
+    # PR returns every cycle, and if the engine is what failed that is a spin.
+    is_deferred "pr-$num" && continue
     if ! grep -qxF "$num $sha" "$REVIEWED_STATE" 2>/dev/null; then
       echo "$num"; return 0
     fi

--- a/scripts/team/review.sh
+++ b/scripts/team/review.sh
@@ -183,6 +183,35 @@ AGENT_SLOT=main CLAUDE_MODEL="$MODEL" \
   bash "$SCRIPT_DIR/run-agent.sh" "$PROMPT" "$WT" "${REVIEW_TIMEOUT:-1800}" \
   >> "$LOG_DIR/review-$PR.log" 2>&1; AGENT_RC=$?
 
+# THE SAME CIRCUIT BREAKER THE ISSUES HAVE, FOR PULL REQUESTS.
+#
+# Not marking an unjudged PR as reviewed is what stops it being stranded — and it
+# is also what makes it come back EVERY cycle. If the engine is what is failing,
+# that is a spin: #342 was reviewed five times before this existed.
+#
+# So consecutive verdict-less reviews are counted per PR and, after a couple, the
+# PR is parked until the subscription returns. Keys are namespaced `pr-N` so they
+# never collide with an issue of the same number.
+review_noverdict_breaker() {
+  local n until_ts
+  n=$(bump_noverdict "pr-$PR")
+  if [ "$n" -ge "$TEAM_DEFER_AFTER" ]; then
+    until_ts=$(defer_issue "pr-$PR")
+    log "PR #$PR adiado até $(date -d "@$until_ts" '+%H:%M') após $n reviews sem veredicto"
+    gh pr comment "$PR" --repo "$REPO" --body "## Reviewer: adiado após $n corridas sem veredicto
+
+O motor não concluiu a review $n vezes seguidas, sempre por razões alheias a este
+PR — subscrição esgotada e fallback a não terminar. Como um PR não julgado volta à
+fila em cada ciclo, isto passaria a tempo gasto sem nada decidido.
+
+Fica adiado até **$(date -d "@$until_ts" '+%H:%M')**, quando a subscrição volta, e
+a fila segue para o resto. O PR não foi julgado nem aprovado — está apenas à espera
+de um motor que consiga julgá-lo." >/dev/null 2>&1 || true
+  else
+    log "PR #$PR: $n review(s) seguidas sem veredicto"
+  fi
+}
+
 if ! verdict_readable "$VERDICT_FILE"; then
   if ! no_verdict_is_real_failure main "$AGENT_RC"; then
     log "SEM VEREDICTO (corrida degradada ou não arrancada) — PR fica para nova review"
@@ -191,6 +220,7 @@ if ! verdict_readable "$VERDICT_FILE"; then
 A corrida não produziu veredicto por uma razão alheia ao PR: ou o slot estava
 ocupado, ou a subscrição estava esgotada e o fallback não conseguiu concluir. O PR
 fica como está e será revisto de novo." >/dev/null 2>&1 || true
+    review_noverdict_breaker
     exit 78   # <- "não julguei este PR": o orquestrador NÃO pode marcá-lo como revisto
   fi
   # A failed run must not consume the PR: leave it open so the next cycle picks it
@@ -200,8 +230,11 @@ fica como está e será revisto de novo." >/dev/null 2>&1 || true
 
 A corrida terminou sem escrever veredicto (ver \`$LOG_DIR/review-$PR.log\`). Falha
 da corrida, não do PR — será revisto de novo." >/dev/null 2>&1 || true
+  review_noverdict_breaker
   exit 78
 fi
+
+clear_noverdict "pr-$PR"   # judged: the streak is over
 
 VERDICT=$(jqv "$VERDICT_FILE" '.verdict' 'blocked-impl')
 SUMMARY=$(jqv "$VERDICT_FILE" '.summary' '(sem resumo)'); SUMMARY="${SUMMARY:0:1500}"

--- a/scripts/team/start.sh
+++ b/scripts/team/start.sh
@@ -85,6 +85,35 @@ case "$ACTION" in
       2>/dev/null || echo "?"
     echo "fechados até agora: $(gh issue list --repo "$REPO" --label qa:done --state closed --limit 300 --json number --jq 'length' 2>/dev/null || echo '?')"
 
+    # PRs QUE PARARAM DE SER OLHADOS.
+    #
+    # A ausência de actividade num sítio específico é o que nenhum monitor apanha:
+    # o board mostra "em review" e ninguém repara que ninguém está a rever. Quatro
+    # PRs ficaram assim, o mais antigo catorze horas, e foi o utilizador que deu por
+    # isso — duas vezes.
+    #
+    # Um PR aberto há mais de uma hora sem actualização é, na prática, sempre um
+    # destes casos: sha marcado como revisto sem ter sido julgado, ou adiado à
+    # espera de motor.
+    # `gh --jq` does not take `--arg`, so the cutoff is interpolated into the
+    # filter instead. The first version passed --arg and silently produced nothing:
+    # a check for silent failures that itself failed silently.
+    CUT=$(date -u -d '1 hour ago' +%Y-%m-%dT%H:%M:%SZ)
+    STALE=$(gh pr list --repo "$REPO" --base "$BASE_BRANCH" --state open --limit 100 \
+      --json number,updatedAt,headRefName \
+      --jq "[.[] | select(.headRefName|startswith(\"qa/\")) | select(.updatedAt < \"$CUT\") | .number] | join(\",\")" \
+      2>/dev/null || echo "")
+    if [ -n "${STALE//[[:space:]]/}" ]; then
+      echo "⚠️  PRs parados há >1h: #${STALE//,/, #}"
+      for p in ${STALE//,/ }; do
+        if is_deferred "pr-$p"; then
+          echo "    #$p adiado até $(date -d "@$(cat "$DEFER_DIR/pr-$p")" '+%H:%M') (à espera de motor)"
+        else
+          echo "    #$p sem adiamento — verifica se a sha está em reviewed-shas sem ter sido julgado"
+        fi
+      done
+    fi
+
     # FECHOS ACIDENTAIS.
     #
     # Um issue fechado que ainda traz uma etiqueta de TRABALHO (ready/wip/review/


### PR DESCRIPTION
Fixing the stranding exposed its twin. Not marking an unjudged PR as reviewed stops it disappearing — and also brings it back **every cycle**. When the engine is what failed, that is a spin: **#342 was reviewed five times**, and with the quota out until 23:01 it would have kept going for two more hours.

PRs now get the breaker the issues already had: consecutive verdict-less reviews are counted per PR and after a couple it is parked until the subscription returns, with the reason posted — stating explicitly that it was neither judged nor approved, only postponed. Keys namespaced `pr-N`. A real verdict clears the streak.

`--status` now reports PRs open >1h without an update, saying for each whether it is deferred (waiting for an engine) or unexplained (likely a sha marked reviewed without being judged).

That check exists because **absence of activity is what no monitor catches** — the board says "in review" and nobody notices that nobody is reviewing. Four PRs sat like that, the oldest fourteen hours, and the user spotted it twice.

Its first version passed `--arg` to `gh --jq`, which gh does not accept, so it produced nothing — a check for silent failures that failed silently. Fixed; it now correctly reports #338 and #324.