### PR TITLE
fix(pipeline): detect the fallback's own quota limit

### DIFF
--- a/scripts/team/lib.sh
+++ b/scripts/team/lib.sh
@@ -184,10 +184,41 @@ defer_issue() {
   printf '%s' "$until_ts"
 }
 
+# THE FALLBACK HAS ITS OWN QUOTA, AND IT RUNS OUT TOO.
+#
+# Ollama Cloud enforces a WEEKLY limit, and when it is spent every run dies in
+# seconds with
+#
+#   API Error: ... you have reached your weekly usage limit, upgrade for higher
+#   limits: https://ollama.com/upgrade
+#
+# The harness used to read that as a generic failed run and retry it forever: 47 of
+# those on 2026-08-19, the first at 07:27, while I spent the day measuring "success
+# rates" and concluding the model was weak. It was not weak, it was locked out —
+# and every measurement I took after 07:27 was of a wall, not of capability.
+#
+# So the fallback gets a cooldown of its own. A weekly limit does not clear in
+# minutes, hence the long default: retry occasionally in case it was a soft limit,
+# and otherwise leave it alone.
+FALLBACK_COOLDOWN_FILE="$STATE_DIR/ollama-usage-cooldown"
+TEAM_FALLBACK_COOLDOWN_H="${TEAM_FALLBACK_COOLDOWN_H:-6}"
+
+fallback_cooldown_remaining() {
+  [ -f "$FALLBACK_COOLDOWN_FILE" ] || { echo 0; return; }
+  local until_ts now
+  until_ts=$(cat "$FALLBACK_COOLDOWN_FILE" 2>/dev/null || echo 0)
+  now=$(date +%s)
+  if [ "$now" -lt "$until_ts" ]; then echo $(( until_ts - now )); else echo 0; fi
+}
+
+fallback_exhausted() { [ "$(fallback_cooldown_remaining)" -gt 0 ]; }
+
 # True when the next agent run will land on the fallback engine rather than the
-# subscription: the quota is spent and the fallback is enabled.
+# subscription: the subscription quota is spent, the fallback is enabled, and the
+# fallback still has quota of its own.
 on_fallback() {
   [ "${TEAM_USE_FALLBACK:-1}" = "1" ] || return 1
+  fallback_exhausted && return 1
   [ "$(cooldown_remaining)" -gt 0 ]
 }
 

--- a/scripts/team/orchestrator.sh
+++ b/scripts/team/orchestrator.sh
@@ -492,9 +492,10 @@ while true; do
   #
   # Sleep to the reset instead, in chunks, so the pipeline picks straight back up
   # and a `--stop` still lands promptly.
-  if [ "${TEAM_USE_FALLBACK:-0}" != "1" ]; then
+  if [ "${TEAM_USE_FALLBACK:-1}" != "1" ] || fallback_exhausted; then
     REMAIN=$(cooldown_remaining)
     if [ "$REMAIN" -gt 0 ]; then
+      fallback_exhausted && log "o fallback tambem esta sem quota (Ollama Cloud, ~$(( $(fallback_cooldown_remaining) / 60 ))min)"
       log "subscrição esgotada — volta às $(date -d "@$(( $(date +%s) + REMAIN ))" +%H:%M). A aguardar (fallback desligado)."
       if [ "$ONCE" = "1" ]; then exit 0; fi
       while [ "$(cooldown_remaining)" -gt 0 ]; do sleep 60; done

--- a/scripts/team/run-agent.sh
+++ b/scripts/team/run-agent.sh
@@ -261,6 +261,13 @@ else
 fi
 
 # ── 2. Fallback (Ollama Cloud model behind the same harness) ───────────────
+# The fallback has its own quota. If a previous run found it spent, do not spend a
+# further 3 minutes rediscovering that.
+if [ -z "$USED" ] && [ "${TEAM_USE_FALLBACK:-1}" = "1" ] && fallback_exhausted; then
+  echo "[run-agent] fallback tambem sem quota (volta em ~$(( $(fallback_cooldown_remaining) / 60 ))min) — nao corro" >&2
+  exit 77
+fi
+
 if [ -z "$USED" ] && [ "${TEAM_USE_FALLBACK:-0}" != "1" ]; then
   # Measured not to work for these roles on this repo — see the comment on
   # TEAM_USE_FALLBACK in lib.sh. Exit 77 so the caller can tell "we deliberately
@@ -302,9 +309,18 @@ if [ -z "$USED" ]; then
       --allowedTools "$ALLOWED_TOOLS" \
       --strict-mcp-config --mcp-config '{"mcpServers":{}}'
   RC=$?
+
+  # Same detection as the subscription path, applied to the fallback: a usage limit
+  # is not a failed task, and retrying it every 45 seconds achieves nothing.
+  if [ "$RC" -ne 0 ] && is_usage_exhausted "${AGENT_OUTPUT:-}"; then
+    echo $(( $(date +%s) + TEAM_FALLBACK_COOLDOWN_H * 3600 )) > "$FALLBACK_COOLDOWN_FILE"
+    echo "[run-agent] fallback SEM QUOTA (limite do Ollama Cloud) — em pausa ${TEAM_FALLBACK_COOLDOWN_H}h" >&2
+    USED=""
+    RC=77
+  fi
 fi
 
-echo "[run-agent] fim: motor=$USED rc=$RC" >&2
+echo "[run-agent] fim: motor=${USED:-nenhum} rc=$RC" >&2
 
 # Record which engine actually ran, so the caller can tell a DEGRADED run from a
 # genuine failure. Without this marker "no verdict" reads as "this issue defeated


### PR DESCRIPTION
The answer to "why does the fallback keep failing" was not the model, the prompt size, or a bad window. **Ollama Cloud enforces a weekly limit and it was spent:**

```
API Error: ... you have reached your weekly usage limit,
upgrade for higher limits: https://ollama.com/upgrade
```

**47 runs died on exactly that message today**, out of 52 failed fallback runs — the first at **07:27**, before every measurement I took. The "56% success rate", the "this window is worse than average", and the disable/re-enable decisions were all reasoning about a variable that had already been pinned. I measured a wall and called it capability.

The harness read it as a generic failed run and retried every cycle, ~3 min each, all day.

- `is_usage_exhausted` (which already existed and already matches this text) now applies to the fallback path too;
- hitting it parks the fallback for `TEAM_FALLBACK_COOLDOWN_H` (default 6h) — a weekly limit does not clear in minutes;
- `on_fallback()` reports false while parked, so easy-issues-first stops pretending there is an engine;
- the orchestrator waits for the subscription and says both quotas are gone.