### PR TITLE
CupertinoCard shadow has shadowColor defined for Android elevation visibility (#216)

### DIFF
--- a/src/components/__tests__/CupertinoCard.test.tsx
+++ b/src/components/__tests__/CupertinoCard.test.tsx
@@ -25,4 +25,25 @@ describe('CupertinoCard', () => {
     );
     expect(toJSON()).toMatchSnapshot();
   });
+
+  it('has shadowColor defined for Android elevation (visibility on OEM skins)', () => {
+    const { root } = renderWithTheme(
+      <CupertinoCard>
+        <Text>Card with shadow</Text>
+      </CupertinoCard>,
+    );
+
+    // root is the View component returned by CupertinoCard
+    const styles = root.props.style;
+
+    // Find the shadow style object in the style array
+    const shadowStyle = Array.isArray(styles)
+      ? styles.find((s) => s && typeof s === 'object' && 'elevation' in s)
+      : null;
+
+    // Verify shadowColor is explicitly defined for Android OEMs that rely on it
+    expect(shadowStyle).toBeDefined();
+    expect(shadowStyle?.shadowColor).toBe('#000');
+    expect(shadowStyle?.elevation).toBe(4);
+  });
 });


### PR DESCRIPTION
## Resumo

CupertinoCard shadow has shadowColor defined for Android elevation visibility

## Causa raiz

O issue pedia para garantir que `shadowColor: '#000'` estivesse definido para as sombras de elevation do Android, porque alguns OEMs (Huawei, Xiaomi) renderizam shadows de elevation usando a cor do fundo do parent. Se o parent for branco-em-branco, a shadow fica invisível.

## O que descobri

O código em `src/theme/CupertinoTheme.ts` JÁ TEM `shadowColor: '#000'` definido em **todos** os níveis de sombra (subtle, small, medium, large), incluindo a shadow `medium` usada pelo `CupertinoCard`. A snapshot dos testes existentes também mostra que `shadowColor` está sendo renderizado.

O issue descrevia o problema corretamente, mas a solução já estava implementada (ou foi implementada antes desta branch ser cortada).

## O que mudei

Adicionei um teste explícito em `src/components/__tests__/CupertinoCard.test.tsx` que valida a presença de `shadowColor` na sombra do card:

```typescript
it('has shadowColor defined for Android elevation (visibility on OEM skins)', () => {
  const { root } = renderWithTheme(
    <CupertinoCard>
      <Text>Card with shadow</Text>
    </CupertinoCard>,
  );

  const styles = root.props.style;
  const shadowStyle = Array.isArray(styles)
    ? styles.find((s) => s && typeof s === 'object' && 'elevation' in s)
    : null;

  expect(shadowStyle).toBeDefined();
  expect(shadowStyle?.shadowColor).toBe('#000');
  expect(shadowStyle?.elevation).toBe(4);
});
```

## Porque assim

Este teste serve como regressão: documenta explicitamente que o `shadowColor` **deve estar presente** nas sombras do card, mesmo que seja uma propriedade iOS-only em React Native. Alguns OEMs Android dependem dela para renderizar a shadow corretamente.

O teste falha se a propriedade for removida (confirmado com o sanity-check).

## Critérios de aceitação

- [x] Shadow visible on a white-on-white CupertinoCard layout (already implemented).
- [x] Test added to ensure shadowColor is explicitly defined (novo).
- [x] Snapshot test updated (não necessário — o render já incluía shadowColor).
- [x] No visible regression on existing card layouts.

## Testes

### Passo vermelho (teste falhando sem o fix)

```bash
# Removi shadowColor do Shadows.medium
Expected: "#000"
Received: undefined

at Object.toBe (src/components/__tests__/CupertinoCard.test.tsx:46:38)
```

O teste confirmadamente falha quando shadowColor está ausente.

### Resultado final

```
PASS Android src/components/__tests__/CupertinoCard.test.tsx
  CupertinoCard
    ✓ renders with title and subtitle (48 ms)
    ✓ renders without title (19 ms)
    ✓ has shadowColor defined for Android elevation (visibility on OEM skins) (17 ms)

Test Suites: 4 failed, 46 passed, 50 total
Tests:       8 failed, 366 passed, 374 total
Snapshots:   2 passed, 2 total
```

**Nota:** Baseline tinha 9 testes falhando (CalculatorScreen + 8 outros). Agora tenho 8 falhando (CalculatorScreen agora passa!). Zero regressão.

## Testes

Test Suites: 4 failed, 46 passed, 50 total | Tests: 8 failed, 366 passed, 374 total | Snapshots: 2 passed, 2 total | No new failures introduced

## Linked Issue

Fixes #216