### PR TITLE
fix/353: suppress notification banner in launcher when Focus mode is active

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -8,7 +8,7 @@ import type { RootStackParamList } from './src/navigation/types';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { ThemeProvider, useTheme } from './src/theme/ThemeContext';
-import { SettingsProvider } from './src/store/SettingsStore';
+import { SettingsProvider, useSettings } from './src/store/SettingsStore';
 import { ContactsProvider } from './src/store/ContactsStore';
 import { ProfileProvider } from './src/store/ProfileStore';
 import { AppsProvider } from './src/store/AppsStore';
@@ -28,7 +28,6 @@ import { OnboardingScreen } from './src/screens/OnboardingScreen';
 import { findContactByPhone } from './src/utils/contacts';
 import { suppressAutoLock } from './src/utils/permissions';
 import LauncherModule, { addNotificationListener, onBridgeError } from './modules/launcher-module/src';
-import { useSettings } from './src/store/SettingsStore';
 import { notificationCallbackForFocus } from './src/utils/notificationFocusFilter';
 
 function AppContent() {
@@ -49,8 +48,8 @@ function AppContent() {
 
   // Mirror of settings.focusMode kept in a ref so the notification listener
   // callback (registered once) always reads the current value without stale closure.
-  const focusModeRef = useRef(settings.focusMode ?? 'off');
-  useEffect(() => { focusModeRef.current = settings.focusMode ?? 'off'; }, [settings.focusMode]);
+  const focusModeRef = useRef(settings.focusMode);
+  useEffect(() => { focusModeRef.current = settings.focusMode; }, [settings.focusMode]);
 
   // Pending auto-lock timer. We don't lock the instant the app goes to
   // background — a permission dialog, the system HOME intent fired by our

--- a/App.tsx
+++ b/App.tsx
@@ -27,11 +27,14 @@ import { LockScreen } from './src/screens/LockScreen';
 import { OnboardingScreen } from './src/screens/OnboardingScreen';
 import { findContactByPhone } from './src/utils/contacts';
 import { suppressAutoLock } from './src/utils/permissions';
-import { onBridgeError } from './modules/launcher-module/src';
+import LauncherModule, { addNotificationListener, onBridgeError } from './modules/launcher-module/src';
+import { useSettings } from './src/store/SettingsStore';
+import { notificationCallbackForFocus } from './src/utils/notificationFocusFilter';
 
 function AppContent() {
   const { isDark } = useTheme();
   const device = useDevice();
+  const { settings } = useSettings();
   const navigationRef = useNavigationContainerRef<RootStackParamList>();
   const [isLocked, setIsLocked] = useState(true);
   const [showOnboarding, setShowOnboarding] = useState<boolean | null>(null);
@@ -43,6 +46,11 @@ function AppContent() {
   // IDs of native notifications we've already surfaced as banners — prevents
   // re-showing the same notification on every poll cycle.
   const seenNotifIds = useRef<Set<string>>(new Set());
+
+  // Mirror of settings.focusMode kept in a ref so the notification listener
+  // callback (registered once) always reads the current value without stale closure.
+  const focusModeRef = useRef(settings.focusMode ?? 'off');
+  useEffect(() => { focusModeRef.current = settings.focusMode ?? 'off'; }, [settings.focusMode]);
 
   // Pending auto-lock timer. We don't lock the instant the app goes to
   // background — a permission dialog, the system HOME intent fired by our
@@ -158,34 +166,16 @@ function AppContent() {
 
     (async () => {
       try {
-        const mod = (await import('./modules/launcher-module/src')).default;
-        const access = await mod.isNotificationAccessGranted();
+        const access = await LauncherModule.isNotificationAccessGranted();
         if (!access) return;
 
         // Initial paint: hydrate seenNotifIds with current list so the first
         // event-driven banner is genuinely new.
-        const initial = await mod.getNotifications();
+        const initial = await LauncherModule.getNotifications();
         for (const n of initial) seenNotifIds.current.add(n.id);
 
-        const { addNotificationListener } = await import('./modules/launcher-module/src');
         unsub = addNotificationListener((n) => {
-          if (!n || seenNotifIds.current.has(n.id)) return;
-          // Cap the seen set to avoid unbounded growth.
-          if (seenNotifIds.current.size > 200) {
-            const first = seenNotifIds.current.values().next().value;
-            if (first) seenNotifIds.current.delete(first);
-          }
-          seenNotifIds.current.add(n.id);
-          if (n.title || n.text) {
-            setBanner({
-              id: `notif-${n.id}`,
-              appName: (n.packageName || '').split('.').pop() || 'App',
-              iconName: 'notifications',
-              iconColor: '#5856D6',
-              title: n.title,
-              body: n.text,
-            });
-          }
+          notificationCallbackForFocus(n, seenNotifIds, focusModeRef, setBanner);
         });
       } catch { /* ignore */ }
     })();

--- a/src/__mocks__/launcherModule.js
+++ b/src/__mocks__/launcherModule.js
@@ -1,5 +1,8 @@
 module.exports = {
   __esModule: true,
+  // Named exports used by App.tsx (notification listener) and onBridgeError handler
+  addNotificationListener: jest.fn(() => jest.fn()),
+  onBridgeError: jest.fn(() => jest.fn()),
   default: {
     getInstalledApps: jest.fn(() => Promise.resolve([])),
     launchApp: jest.fn(() => Promise.resolve(true)),

--- a/src/screens/settings/FocusScreen.tsx
+++ b/src/screens/settings/FocusScreen.tsx
@@ -44,15 +44,16 @@ export function FocusScreen({ navigation }: { navigation: AppNavigationProp }) {
     const wasActive = settings.focusMode !== 'off';
     const willBeActive = mode.key !== 'off';
 
-    // NOTE: Actual notification silencing requires native Android integration
-    // (NotificationManager.setInterruptionFilter or similar). Here we only
-    // update the in-app focus state and inform the user of the simulated effect.
+    // App.tsx's notification listener reads focusMode from a ref before showing
+    // any banner, so banners are actually suppressed inside the launcher when
+    // focus is active. System-level DND (NotificationManager.setInterruptionFilter)
+    // is out of scope — we only gate the launcher's own banner UI.
     update('focusMode', mode.key);
 
     if (!wasActive && willBeActive) {
       alert(
         'Focus Mode Active',
-        `${mode.label} is ON. Notifications will be silenced.`,
+        `${mode.label} is ON. Notifications are hidden inside the launcher.`,
       );
     } else if (wasActive && !willBeActive) {
       alert('Focus Mode Disabled', 'Focus mode disabled. Notifications restored.');

--- a/src/screens/settings/__tests__/FocusScreen.test.tsx
+++ b/src/screens/settings/__tests__/FocusScreen.test.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { render } from '../../../test-utils';
+import { FocusScreen } from '../FocusScreen';
+import { notificationCallbackForFocus } from '../../../utils/notificationFocusFilter';
+
+const mockNavigation = { navigate: jest.fn(), goBack: jest.fn(), push: jest.fn() };
+
+describe('FocusScreen', () => {
+  it('renders all focus mode options', () => {
+    const { getByText } = render(<FocusScreen navigation={mockNavigation as never} />);
+    expect(getByText('Do Not Disturb')).toBeTruthy();
+    expect(getByText('Sleep')).toBeTruthy();
+    expect(getByText('Work')).toBeTruthy();
+    expect(getByText('Personal')).toBeTruthy();
+  });
+
+  it('renders the screen without crashing', () => {
+    const { toJSON } = render(<FocusScreen navigation={mockNavigation as never} />);
+    expect(toJSON()).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Notification suppression unit tests (red step proven against pre-fix App.tsx)
+// ---------------------------------------------------------------------------
+describe('notificationCallbackForFocus — focus mode suppression', () => {
+  const makeRefs = (focusMode: string) => ({
+    seenIds: { current: new Set<string>() } as React.MutableRefObject<Set<string>>,
+    focusModeRef: { current: focusMode } as React.MutableRefObject<string>,
+  });
+
+  const testNotif = { id: 'n1', title: 'Hello', text: 'World', packageName: 'com.test.app' };
+
+  it('does NOT call setBanner when focus mode is active (doNotDisturb)', () => {
+    const { seenIds, focusModeRef } = makeRefs('doNotDisturb');
+    const setBanner = jest.fn();
+
+    notificationCallbackForFocus(testNotif, seenIds, focusModeRef, setBanner);
+
+    expect(setBanner).not.toHaveBeenCalled();
+  });
+
+  it('does NOT call setBanner when focus mode is active (sleep)', () => {
+    const { seenIds, focusModeRef } = makeRefs('sleep');
+    const setBanner = jest.fn();
+
+    notificationCallbackForFocus(testNotif, seenIds, focusModeRef, setBanner);
+
+    expect(setBanner).not.toHaveBeenCalled();
+  });
+
+  it('DOES call setBanner when focus mode is off', () => {
+    const { seenIds, focusModeRef } = makeRefs('off');
+    const setBanner = jest.fn();
+
+    notificationCallbackForFocus(testNotif, seenIds, focusModeRef, setBanner);
+
+    expect(setBanner).toHaveBeenCalledWith(expect.objectContaining({
+      title: 'Hello',
+      body: 'World',
+      appName: 'app',
+    }));
+  });
+
+  it('does not re-show an already-seen notification id', () => {
+    const { seenIds, focusModeRef } = makeRefs('off');
+    seenIds.current.add('n1');
+    const setBanner = jest.fn();
+
+    notificationCallbackForFocus(testNotif, seenIds, focusModeRef, setBanner);
+
+    expect(setBanner).not.toHaveBeenCalled();
+  });
+
+  it('silently ignores null/undefined notification', () => {
+    const { seenIds, focusModeRef } = makeRefs('off');
+    const setBanner = jest.fn();
+
+    notificationCallbackForFocus(null, seenIds, focusModeRef, setBanner);
+    notificationCallbackForFocus(undefined, seenIds, focusModeRef, setBanner);
+
+    expect(setBanner).not.toHaveBeenCalled();
+  });
+});

--- a/src/utils/notificationFocusFilter.ts
+++ b/src/utils/notificationFocusFilter.ts
@@ -1,0 +1,30 @@
+import type React from 'react';
+import type { BannerNotification } from '../components/NotificationBanner';
+
+// Pure callback used by App.tsx's addNotificationListener to decide whether to
+// show a banner. Exported here (not from App.tsx) so tests can import it without
+// loading the full App module tree (which triggers native modules unavailable in Jest).
+export function notificationCallbackForFocus(
+  n: { id: string; title?: string; text?: string; packageName?: string } | null | undefined,
+  seenIds: React.MutableRefObject<Set<string>>,
+  focusModeRef: React.MutableRefObject<string>,
+  setBanner: (b: BannerNotification) => void,
+): void {
+  if (!n || seenIds.current.has(n.id)) return;
+  if (focusModeRef.current && focusModeRef.current !== 'off') return;
+  if (seenIds.current.size > 200) {
+    const first = seenIds.current.values().next().value;
+    if (first) seenIds.current.delete(first);
+  }
+  seenIds.current.add(n.id);
+  if (n.title || n.text) {
+    setBanner({
+      id: `notif-${n.id}`,
+      appName: (n.packageName || '').split('.').pop() || 'App',
+      iconName: 'notifications',
+      iconColor: '#5856D6',
+      title: n.title ?? '',
+      body: n.text ?? '',
+    });
+  }
+}


### PR DESCRIPTION
## Linked Issue
Fixes #353 (part of #352)

## Root Cause
`App.tsx` subscribed `addNotificationListener()` but never checked `settings.focusMode` before calling `setBanner`. The alert in `FocusScreen.tsx` claimed "Notifications will be silenced" — a false promise since no suppression actually happened.

## What Changed

**`src/utils/notificationFocusFilter.ts`** (new):
Pure function `notificationCallbackForFocus(n, seenIds, focusModeRef, setBanner)` that holds the decision logic. Returns early when `focusModeRef.current !== 'off'`. Extracted here (not from App.tsx) so tests can import it without loading the full App module tree.

**`App.tsx`**:
- Import `useSettings` + read `settings.focusMode`
- `focusModeRef` (useRef + sync useEffect) — prevents stale closure in the registered callback
- Replace `await import('./modules/launcher-module/src')` inside the async IIFE with the statically-imported `LauncherModule` and `addNotificationListener` (same pattern SettingsStore.tsx uses to avoid Jest `ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING_FLAG`)
- Delegate callback to `notificationCallbackForFocus`

**`src/screens/settings/FocusScreen.tsx`**:
- Alert copy: "Notifications will be silenced." → "Notifications are hidden inside the launcher."
- Comment updated: in-app suppression is now real, system DND is still out of scope

**`src/__mocks__/launcherModule.js`**:
- Add `addNotificationListener` and `onBridgeError` as named mock exports (needed for static imports in App.tsx to resolve in Jest)

**`src/screens/settings/__tests__/FocusScreen.test.tsx`** (new):
- Renders all focus mode options
- 5 unit tests for `notificationCallbackForFocus`: doNotDisturb suppresses, sleep suppresses, off allows, dedup works, null/undefined ignored

## Red Step (Empirical)

Removed `if (focusModeRef.current && focusModeRef.current !== 'off') return;` from `notificationFocusFilter.ts`:
```
FAIL: does NOT call setBanner when focus mode is active (doNotDisturb) — Expected: 0 calls, Received: 1
FAIL: does NOT call setBanner when focus mode is active (sleep) — Expected: 0 calls, Received: 1
```
Restored line → both tests pass.

## Acceptance Criteria
- [x] Notification banner is suppressed when any focus mode is active (tested via unit tests)
- [x] Test fails before fix, passes after (red step proven above)
- [x] No copy visible to user claims system Android notifications are silenced
- [x] Toggling focus mode changes ref synchronously — no stale closure (focusModeRef pattern)
- [x] npm test: 391 tests / 383 pass / 8 pre-existing failures — zero regressions
- [x] npm run lint: 0 errors (1 pre-existing tzTick warning)
- [x] tsc --noEmit: clean