### PR TITLE
fix/354: Auto-Lock picker setting now drives the lock timer duration

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -27,6 +27,7 @@ import { LockScreen } from './src/screens/LockScreen';
 import { OnboardingScreen } from './src/screens/OnboardingScreen';
 import { findContactByPhone } from './src/utils/contacts';
 import { suppressAutoLock } from './src/utils/permissions';
+import { resolveAutoLockDelay } from './src/utils/autoLockUtils';
 import LauncherModule, { addNotificationListener, onBridgeError } from './modules/launcher-module/src';
 import { notificationCallbackForFocus } from './src/utils/notificationFocusFilter';
 
@@ -57,7 +58,7 @@ function AppContent() {
   // background the activity for a fraction of a second. Only lock if we're
   // still backgrounded after a short grace period.
   const lockTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const AUTO_LOCK_GRACE_MS = 5000;
+  const autoLockDelay = resolveAutoLockDelay(settings.autoLock);
 
   // Surface native bridge errors as notification banners
   useEffect(() => {
@@ -100,10 +101,12 @@ function AppContent() {
       if (state === 'background') {
         if (suppressAutoLock()) return; // a permission dialog is showing — ignore background
         if (lockTimer.current) clearTimeout(lockTimer.current);
-        lockTimer.current = setTimeout(() => {
-          setIsLocked(true);
-          lockTimer.current = null;
-        }, AUTO_LOCK_GRACE_MS);
+        if (autoLockDelay !== null) {
+          lockTimer.current = setTimeout(() => {
+            setIsLocked(true);
+            lockTimer.current = null;
+          }, autoLockDelay);
+        }
       } else if (state === 'active') {
         // Returning within the grace period — cancel pending lock.
         if (lockTimer.current) {
@@ -121,7 +124,7 @@ function AppContent() {
       sub.remove();
       if (lockTimer.current) clearTimeout(lockTimer.current);
     };
-  }, []);
+  }, [autoLockDelay]);
 
   // Monitor for new messages and show banner
   useEffect(() => {

--- a/src/utils/__tests__/autoLockUtils.test.ts
+++ b/src/utils/__tests__/autoLockUtils.test.ts
@@ -1,0 +1,38 @@
+import { resolveAutoLockDelay, AUTO_LOCK_MS } from '../autoLockUtils';
+
+// Red step: before the fix, App.tsx had `const AUTO_LOCK_GRACE_MS = 5000` hardcoded.
+// resolveAutoLockDelay did not exist — these tests would all fail (import error / wrong value).
+
+describe('resolveAutoLockDelay', () => {
+  it("returns null for 'Never' — no timer should be scheduled", () => {
+    expect(resolveAutoLockDelay('Never')).toBeNull();
+  });
+
+  it("returns 30000 for '30 Seconds', not the old hardcoded 5000", () => {
+    expect(resolveAutoLockDelay('30 Seconds')).toBe(30_000);
+  });
+
+  it("returns 60000 for '1 Minute'", () => {
+    expect(resolveAutoLockDelay('1 Minute')).toBe(60_000);
+  });
+
+  it("returns 120000 for '2 Minutes'", () => {
+    expect(resolveAutoLockDelay('2 Minutes')).toBe(120_000);
+  });
+
+  it("returns 300000 for '5 Minutes'", () => {
+    expect(resolveAutoLockDelay('5 Minutes')).toBe(300_000);
+  });
+
+  it('returns 5000 fallback for unknown/legacy values', () => {
+    expect(resolveAutoLockDelay('unknown')).toBe(5_000);
+    expect(resolveAutoLockDelay('')).toBe(5_000);
+  });
+
+  it('AUTO_LOCK_MS map covers all picker options from DisplayBrightnessScreen', () => {
+    const pickerOptions = ['30 Seconds', '1 Minute', '2 Minutes', '3 Minutes', '5 Minutes', 'Never'];
+    for (const option of pickerOptions) {
+      expect(option in AUTO_LOCK_MS).toBe(true);
+    }
+  });
+});

--- a/src/utils/autoLockUtils.ts
+++ b/src/utils/autoLockUtils.ts
@@ -1,0 +1,15 @@
+export const AUTO_LOCK_MS: Record<string, number | null> = {
+  '30 Seconds': 30_000,
+  '1 Minute': 60_000,
+  '2 Minutes': 120_000,
+  '3 Minutes': 180_000,
+  '5 Minutes': 300_000,
+  Never: null,
+};
+
+// Returns the lock delay in ms for the given autoLock setting string,
+// or 5000 as a fallback for unknown/legacy values.
+// Returns null when the setting means "never lock".
+export function resolveAutoLockDelay(setting: string): number | null {
+  return setting in AUTO_LOCK_MS ? AUTO_LOCK_MS[setting] : 5_000;
+}


### PR DESCRIPTION
## Problem

`App.tsx` had `const AUTO_LOCK_GRACE_MS = 5000` hardcoded. `settings.autoLock` (persisted by the picker in DisplayBrightnessScreen) was stored but never consumed — selecting '30 Seconds', '1 Minute', etc. had no effect; the app always locked after 5 s. Selecting 'Never' also had no effect.

## Root Cause

The AppState listener scheduled `setTimeout(..., AUTO_LOCK_GRACE_MS)` unconditionally, ignoring `settings.autoLock` entirely.

## Fix

- `src/utils/autoLockUtils.ts` — new file: `AUTO_LOCK_MS` record mapping every picker label to its ms value (`'Never' → null`), and `resolveAutoLockDelay(setting)` returning the mapped value or 5 000 ms for unknown/legacy entries.
- `App.tsx` — replaced `AUTO_LOCK_GRACE_MS` with `autoLockDelay = resolveAutoLockDelay(settings.autoLock)`; added `autoLockDelay` to the `useEffect` deps so the listener re-registers on setting change; wrapped `setTimeout` in `if (autoLockDelay !== null)` so 'Never' skips scheduling entirely.

## Tests

`src/utils/__tests__/autoLockUtils.test.ts` — 7 unit tests:
- **Red step proven**: without `autoLockUtils.ts`, import fails → all tests error.
- `'Never'` returns `null` (no timer scheduled)
- `'30 Seconds'` returns `30 000`, not the old hardcoded `5 000`
- All 6 picker options covered
- Unknown/legacy values fall back to `5 000`

## Verification

```
npm run lint    → 0 errors (1 pre-existing warning in ClockScreen, unrelated)
npx tsc --noEmit → clean
npx jest        → 4 failed / 48 passed (same pre-existing failures, 0 regressions)
```