### PR TITLE
fix/355: wire High Contrast toggle to ThemeContext; remove shadow state

### DIFF
--- a/src/screens/settings/AccessibilityScreen.tsx
+++ b/src/screens/settings/AccessibilityScreen.tsx
@@ -21,11 +21,10 @@ const A11Y_KEYS = {
   textscale: '@iostoandroid/a11y_textscale',
   bold: '@iostoandroid/a11y_bold',
   reduceMotion: '@iostoandroid/a11y_reduce_motion',
-  contrast: '@iostoandroid/a11y_contrast',
 } as const;
 
 export function AccessibilityScreen({ navigation }: { navigation: AppNavigationProp }) {
-  const { theme, typography, spacing, textScale } = useTheme();
+  const { theme, typography, spacing, textScale, highContrast, setHighContrast } = useTheme();
   const { colors } = theme;
   const insets = useSafeAreaInsets();
   const { settings, update } = useSettings();
@@ -39,7 +38,6 @@ export function AccessibilityScreen({ navigation }: { navigation: AppNavigationP
   const [largerTextScale, setLargerTextScale] = useState(1.0);
   const [boldTextLocal, setBoldTextLocal] = useState(false);
   const [reduceMotionLocal, setReduceMotionLocal] = useState(false);
-  const [highContrast, setHighContrast] = useState(false);
 
   useEffect(() => {
     AsyncStorage.getMany(Object.values(A11Y_KEYS)).then((map) => {
@@ -50,7 +48,6 @@ export function AccessibilityScreen({ navigation }: { navigation: AppNavigationP
       }
       if (map[A11Y_KEYS.bold] !== null) setBoldTextLocal(map[A11Y_KEYS.bold] === 'true');
       if (map[A11Y_KEYS.reduceMotion] !== null) setReduceMotionLocal(map[A11Y_KEYS.reduceMotion] === 'true');
-      if (map[A11Y_KEYS.contrast] !== null) setHighContrast(map[A11Y_KEYS.contrast] === 'true');
     });
   }, []);
 
@@ -79,10 +76,6 @@ export function AccessibilityScreen({ navigation }: { navigation: AppNavigationP
     AsyncStorage.setItem(A11Y_KEYS.reduceMotion, String(v));
   }, [update]);
 
-  const toggleHighContrast = useCallback((v: boolean) => {
-    setHighContrast(v);
-    AsyncStorage.setItem(A11Y_KEYS.contrast, String(v));
-  }, []);
 
   return (
     <View style={[styles.container, { backgroundColor: colors.systemGroupedBackground }]}>
@@ -129,7 +122,7 @@ export function AccessibilityScreen({ navigation }: { navigation: AppNavigationP
               trailing={
                 <CupertinoSwitch
                   value={highContrast}
-                  onValueChange={toggleHighContrast}
+                  onValueChange={setHighContrast}
                 />
               }
               showChevron={false}

--- a/src/screens/settings/__tests__/AccessibilityScreen.test.tsx
+++ b/src/screens/settings/__tests__/AccessibilityScreen.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { Text } from 'react-native';
+import { render, fireEvent } from '../../../test-utils';
+import { useTheme } from '../../../theme/ThemeContext';
+import { AccessibilityScreen } from '../AccessibilityScreen';
+
+// AccessibilityScreen uses useAssistiveTouch which requires AssistiveTouchProvider.
+// Provide a minimal stub so the screen renders without the full provider tree.
+jest.mock('../../../store/AssistiveTouchStore', () => ({
+  useAssistiveTouch: () => ({ enabled: false }),
+}));
+
+// AccessibilityScreen calls AsyncStorage.getMany (non-standard); mock it
+// here so the useEffect doesn't throw in tests.
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(() => Promise.resolve(null)),
+    setItem: jest.fn(() => Promise.resolve()),
+    removeItem: jest.fn(() => Promise.resolve()),
+    getMany: jest.fn(() => Promise.resolve({})),
+  },
+}));
+
+const mockNavigation = { navigate: jest.fn(), goBack: jest.fn(), push: jest.fn() };
+
+// Reads highContrast directly from ThemeContext — proves the toggle reached
+// the context, not just the screen's local state.
+function HighContrastReader() {
+  const { highContrast } = useTheme();
+  return <Text testID="hc-value">{String(highContrast)}</Text>;
+}
+
+describe('AccessibilityScreen', () => {
+  it('renders the High Contrast toggle', () => {
+    const { getByText } = render(<AccessibilityScreen navigation={mockNavigation as never} />);
+    expect(getByText('High Contrast')).toBeTruthy();
+  });
+
+  it('renders Bold Text and Reduce Motion toggles unchanged', () => {
+    const { getByText } = render(<AccessibilityScreen navigation={mockNavigation as never} />);
+    expect(getByText('Bold Text')).toBeTruthy();
+    expect(getByText('Reduce Motion')).toBeTruthy();
+  });
+
+  // Red step: with the old shadow state, pressing the switch only updated local
+  // React state — ThemeContext.highContrast stayed false. This test fails before
+  // the fix and passes after.
+  it('toggling High Contrast updates ThemeContext, not just local state', () => {
+    const { getAllByRole, getByTestId } = render(
+      <>
+        <AccessibilityScreen navigation={mockNavigation as never} />
+        <HighContrastReader />
+      </>,
+    );
+
+    expect(getByTestId('hc-value').props.children).toBe('false');
+
+    // Switch order in the Vision section: [0] Bold Text, [1] Reduce Motion, [2] High Contrast
+    const switches = getAllByRole('switch');
+    fireEvent.press(switches[2]);
+
+    expect(getByTestId('hc-value').props.children).toBe('true');
+  });
+});


### PR DESCRIPTION
## Problem

`AccessibilityScreen.tsx` had a shadow `useState(false)` for `highContrast` that was never consumed by `ThemeContext`. Toggling "High Contrast" wrote to a dead `@iostoandroid/a11y_contrast` AsyncStorage key — no pixel changed. The real implementation (`ThemeContext.setHighContrast` → `getTheme(isDark, accentColor, highContrast)` → `CupertinoTheme.ts:311`) was unreachable from the UI.

## Root Cause

`AccessibilityScreen` imported `useTheme()` but never destructured `highContrast` or `setHighContrast` from it. The shadow `useState` + `toggleHighContrast` callback masked the missing wire-up.

## Fix

- Removed `contrast` from `A11Y_KEYS` and the dead AsyncStorage read/write
- Removed `const [highContrast, setHighContrast] = useState(false)` and `toggleHighContrast` callback
- Added `highContrast, setHighContrast` to the `useTheme()` destructure
- Wired `onValueChange={setHighContrast}` directly on the High Contrast `CupertinoSwitch`
- `ThemeContext` already persists the value; no duplicate persistence needed

## Verification

```
grep -rn "a11y_contrast" src  → 0 results ✓
grep -n "useState" AccessibilityScreen.tsx  → no highContrast state ✓
npm run lint   → 0 errors ✓
npx tsc --noEmit → clean ✓
npx jest       → 4 failed / 49 passed (same pre-existing failures, 0 regressions) ✓
```

## Tests (`AccessibilityScreen.test.tsx`)

- **Red step** (before fix): pressing the switch left `ThemeContext.highContrast === false`; `HighContrastReader` received `'false'` → test fails with `Expected: "true", Received: "false"`
- **Green step** (after fix): pressing the switch calls `ThemeContext.setHighContrast(true)` → `HighContrastReader` receives `'true'` → test passes
- Other toggles (Bold Text, Reduce Motion) render unchanged