### PR TITLE
fix/356: HotspotScreen delegates to Android panel; removes cosmetic switch

### DIFF
--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -90,7 +90,7 @@ export function SettingsScreen() {
       case 'airplane': return settings.airplaneMode ? 'On' : undefined;
       case 'wifi': return device.wifi.enabled ? device.wifi.ssid || 'On' : 'Off';
       case 'bluetooth': return device.bluetooth.enabled ? device.bluetooth.name || 'On' : 'Off';
-      case 'hotspot': return settings.hotspotEnabled ? 'On' : 'Off';
+      case 'hotspot': return undefined;
       case 'focus': return settings.focusMode !== 'off' ? settings.focusMode.charAt(0).toUpperCase() + settings.focusMode.slice(1) : undefined;
       case 'screentime': return settings.screenTimeEnabled ? 'On' : 'Off';
       case 'battery': return settings.lowPowerMode ? 'Low Power' : undefined;

--- a/src/screens/settings/HotspotScreen.tsx
+++ b/src/screens/settings/HotspotScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useCallback } from 'react';
 import { View, Text, ScrollView, StyleSheet, Modal, TextInput, Pressable } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
@@ -12,6 +12,7 @@ import {
   CupertinoButton,
 } from '../../components';
 import type { AppNavigationProp } from '../../navigation/types';
+import LauncherModule from '../../../modules/launcher-module/src';
 
 function generatePassword(): string {
   // Generate a readable 12-char password
@@ -31,6 +32,10 @@ export function HotspotScreen({ navigation }: { navigation: AppNavigationProp })
   const [showPasswordModal, setShowPasswordModal] = useState(false);
   const [newPassword, setNewPassword] = useState(settings.hotspotPassword || '');
   const [showPassword, setShowPassword] = useState(false);
+
+  const handleHotspotPress = useCallback(() => {
+    LauncherModule.openSystemSettings('hotspot');
+  }, []);
 
   const handleSavePassword = () => {
     if (newPassword.length < 8) {
@@ -62,16 +67,12 @@ export function HotspotScreen({ navigation }: { navigation: AppNavigationProp })
         showsVerticalScrollIndicator={false}
       >
         <View style={{ paddingHorizontal: spacing.md }}>
-          <CupertinoListSection footer="Allow other devices to connect to your hotspot. Enabling requires an active Android tethering permission.">
+          <CupertinoListSection footer="Android restricts hotspot control to system apps. Tap to open the Android hotspot panel where you can enable or disable tethering.">
             <CupertinoListTile
               title="Personal Hotspot"
-              trailing={
-                <CupertinoSwitch
-                  value={settings.hotspotEnabled}
-                  onValueChange={(v) => update('hotspotEnabled', v)}
-                />
-              }
-              showChevron={false}
+              subtitle="Managed by Android"
+              showChevron
+              onPress={handleHotspotPress}
             />
           </CupertinoListSection>
         </View>
@@ -97,25 +98,6 @@ export function HotspotScreen({ navigation }: { navigation: AppNavigationProp })
           </CupertinoListSection>
         </View>
 
-        {settings.hotspotEnabled && (
-          <View style={{ paddingHorizontal: spacing.md }}>
-            <CupertinoListSection
-              header="Connected Devices"
-              footer="The connected-device count is only available when the OS provides it."
-            >
-              <CupertinoListTile
-                title="No Devices Connected"
-                leading={{
-                  name: 'laptop-outline',
-                  color: '#FFFFFF',
-                  backgroundColor: colors.systemGray,
-                }}
-                showChevron={false}
-              />
-            </CupertinoListSection>
-          </View>
-        )}
-
         <View style={{ paddingHorizontal: spacing.md }}>
           <CupertinoListSection
             footer="Maximize Compatibility allows older devices to connect. This may reduce Wi-Fi performance."
@@ -134,7 +116,7 @@ export function HotspotScreen({ navigation }: { navigation: AppNavigationProp })
         </View>
 
         <Text style={[typography.footnote, styles.footer, { color: colors.secondaryLabel }]}>
-          Sharing cellular data as a hotspot is restricted by Android to system apps. Your settings here configure the iOS-style display only; the actual tethering toggle is handled by the system if you enable it at the top.
+          Tapping Personal Hotspot opens the Android tethering panel. Password and compatibility preferences are saved locally for when you enable tethering there.
         </Text>
       </ScrollView>
 

--- a/src/screens/settings/__tests__/HotspotScreen.test.tsx
+++ b/src/screens/settings/__tests__/HotspotScreen.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '../../../test-utils';
+import { HotspotScreen } from '../HotspotScreen';
+
+const mockNavigation = { navigate: jest.fn(), goBack: jest.fn(), push: jest.fn() };
+
+// The launcherModule mock is auto-applied via jest.config.js moduleNameMapper.
+// Import the mock so we can assert on openSystemSettings.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const launcherMock = require('../../../__mocks__/launcherModule').default;
+
+describe('HotspotScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the Personal Hotspot row', () => {
+    const { getByRole } = render(<HotspotScreen navigation={mockNavigation as never} />);
+    // CupertinoListTile has accessibilityRole="button" + accessibilityLabel when onPress is set
+    expect(getByRole('button', { name: 'Personal Hotspot, Managed by Android' })).toBeTruthy();
+  });
+
+  // Red step: before the fix, pressing the hotspot tile only called
+  // update('hotspotEnabled', ...) — openSystemSettings was never called.
+  it('pressing Personal Hotspot row opens Android hotspot settings', async () => {
+    const { getByRole } = render(<HotspotScreen navigation={mockNavigation as never} />);
+
+    fireEvent.press(getByRole('button', { name: 'Personal Hotspot, Managed by Android' }));
+
+    await waitFor(() => {
+      expect(launcherMock.openSystemSettings).toHaveBeenCalledWith('hotspot');
+    });
+  });
+
+  it('does not show an On/Off switch that claims tethering state', () => {
+    const { queryAllByRole } = render(<HotspotScreen navigation={mockNavigation as never} />);
+    // The main Personal Hotspot row must not have a switch.
+    // Other controls (Maximize Compatibility) may still have switches.
+    // We verify the hotspot tile itself is pressable, not a switch toggle.
+    const switches = queryAllByRole('switch');
+    // Maximize Compatibility switch may still exist — we're not asserting zero switches,
+    // just that there are fewer than before (no hotspot switch).
+    // Main check: openSystemSettings is called on press, not a toggle update.
+    expect(switches.length).toBeLessThan(2);
+  });
+});


### PR DESCRIPTION
## Problem

HotspotScreen imported no native bridge. All controls wrote only to SettingsStore — the hotspot switch updated \`settings.hotspotEnabled\` (AsyncStorage), which no system API read. Enabling showed \"On\" in the screen and in SettingsScreen's parent row, but Android tethering was never activated. The footer said tethering was \"handled by the system if you enable it at the top\" — that was false.

## Root Cause

No call to \`LauncherModule.openSystemSettings\`. The Kotlin bridge already maps \`'hotspot' → android.settings.TETHER_SETTINGS\` (LauncherModule.kt:443) but no TS caller existed. Third-party apps cannot programmatically toggle tethering (WifiManager.setWifiApEnabled is hidden since Android 8); delegation to the system panel is the only honest path.

## Fix

- Static import of \`LauncherModule\` (same pattern as App.tsx from #353; dynamic import is unreliable in Jest for this bridge path)
- Personal Hotspot row changed from \`CupertinoSwitch\` → action \`CupertinoListTile\` (chevron, subtitle \"Managed by Android\") — pressing calls \`LauncherModule.openSystemSettings('hotspot')\`
- Removed Connected Devices section — state is unobservable without a system API
- Fixed footer text: describes what the screen actually does
- SettingsScreen: \`case 'hotspot'\` now returns \`undefined\` — no more \"On\"/\"Off\" badge derived from SettingsStore

## Verification

```
npm run lint    → 0 errors (1 pre-existing warning in ClockScreen)
npx tsc --noEmit → clean
npx jest        → 4 failed / 50 passed (same pre-existing failures, 0 regressions)
```

Red step: stashing the fix → 3/3 tests fail (no button with the subtitle selector, openSystemSettings never called, 2 switches remain).
Green step: after fix → 3/3 pass.