### PR TITLE
fix/issue-357: remove dead controls from SoundsHapticsScreen; wire volume to DeviceStore

### DIFF
--- a/src/screens/settings/SoundsHapticsScreen.tsx
+++ b/src/screens/settings/SoundsHapticsScreen.tsx
@@ -5,6 +5,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
 import { useTheme } from '../../theme/ThemeContext';
 import { useSettings } from '../../store/SettingsStore';
+import { useDevice } from '../../store/DeviceStore';
 import {
   CupertinoNavigationBar,
   CupertinoListSection,
@@ -20,30 +21,25 @@ const TEXT_TONES = ['Note (Default)', 'Aurora', 'Bamboo', 'Chord', 'Circles', 'C
 
 const RINGTONE_STORAGE_KEY = '@iostoandroid/ringtone';
 const TEXT_TONE_STORAGE_KEY = '@iostoandroid/text_tone';
-const SYSTEM_HAPTICS_STORAGE_KEY = '@iostoandroid/system_haptics';
 
 export function SoundsHapticsScreen({ navigation }: { navigation: AppNavigationProp }) {
   const { theme, typography, spacing } = useTheme();
   const { colors } = theme;
   const insets = useSafeAreaInsets();
   const { settings, update } = useSettings();
+  const { volume, setVolume } = useDevice();
   const [showRingtonePicker, setShowRingtonePicker] = useState(false);
   const [showTextTonePicker, setShowTextTonePicker] = useState(false);
-  const [systemHaptics, setSystemHaptics] = useState(true);
-  // Local ringtone/text tone state (backed by AsyncStorage)
   const [ringtone, setRingtone] = useState(settings.ringtone || 'Reflection');
   const [textTone, setTextTone] = useState(settings.textTone || 'Note');
 
-  // Load persisted values on mount
   useEffect(() => {
     Promise.all([
       AsyncStorage.getItem(RINGTONE_STORAGE_KEY),
       AsyncStorage.getItem(TEXT_TONE_STORAGE_KEY),
-      AsyncStorage.getItem(SYSTEM_HAPTICS_STORAGE_KEY),
-    ]).then(([rt, tt, haptics]) => {
+    ]).then(([rt, tt]) => {
       if (rt) { setRingtone(rt); update('ringtone', rt); }
       if (tt) { setTextTone(tt); update('textTone', tt); }
-      if (haptics !== null) setSystemHaptics(haptics !== 'false');
     }).catch(() => {});
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -60,11 +56,6 @@ export function SoundsHapticsScreen({ navigation }: { navigation: AppNavigationP
     update('textTone', t);
     AsyncStorage.setItem(TEXT_TONE_STORAGE_KEY, t).catch(() => {});
     setShowTextTonePicker(false);
-  };
-
-  const handleSystemHapticsToggle = (val: boolean) => {
-    setSystemHaptics(val);
-    AsyncStorage.setItem(SYSTEM_HAPTICS_STORAGE_KEY, val ? 'true' : 'false').catch(() => {});
   };
 
   return (
@@ -86,14 +77,17 @@ export function SoundsHapticsScreen({ navigation }: { navigation: AppNavigationP
       >
         {/* Ringtone & Vibration section */}
         <View style={{ paddingHorizontal: spacing.md }}>
-          <CupertinoListSection header="Ringtone & Vibration">
+          <CupertinoListSection
+            header="Ringtone & Vibration"
+            footer="Ringtone and text tone playback depends on Android app audio permissions. Sounds play through the Notification channel."
+          >
             {/* Volume slider */}
             <View style={styles.sliderRow}>
               <Ionicons name="volume-low-outline" size={20} color={colors.secondaryLabel} />
               <View style={styles.sliderTrack}>
                 <CupertinoSlider
-                  value={settings.volume}
-                  onValueChange={(v) => update('volume', v)}
+                  value={volume}
+                  onValueChange={setVolume}
                   minimumValue={0}
                   maximumValue={1}
                 />
@@ -128,38 +122,8 @@ export function SoundsHapticsScreen({ navigation }: { navigation: AppNavigationP
               title="System Haptics"
               trailing={
                 <CupertinoSwitch
-                  value={systemHaptics}
-                  onValueChange={handleSystemHapticsToggle}
-                />
-              }
-              showChevron={false}
-            />
-            <CupertinoListTile
-              title="Vibration"
-              trailing={
-                <CupertinoSwitch
                   value={settings.vibration}
                   onValueChange={(v) => update('vibration', v)}
-                />
-              }
-              showChevron={false}
-            />
-            <CupertinoListTile
-              title="Keyboard Clicks"
-              trailing={
-                <CupertinoSwitch
-                  value={settings.keyboardClicks}
-                  onValueChange={(v) => update('keyboardClicks', v)}
-                />
-              }
-              showChevron={false}
-            />
-            <CupertinoListTile
-              title="Lock Sound"
-              trailing={
-                <CupertinoSwitch
-                  value={settings.lockSound}
-                  onValueChange={(v) => update('lockSound', v)}
                 />
               }
               showChevron={false}

--- a/src/screens/settings/__tests__/SoundsHapticsScreen.test.tsx
+++ b/src/screens/settings/__tests__/SoundsHapticsScreen.test.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { render } from '../../../test-utils';
+import { SoundsHapticsScreen } from '../SoundsHapticsScreen';
+import { CupertinoSlider } from '../../../components/CupertinoSlider';
+
+const mockSetVolume = jest.fn();
+const mockUpdate = jest.fn();
+
+jest.mock('../../../store/DeviceStore', () => ({
+  useDevice: () => ({
+    volume: 0.5,
+    setVolume: mockSetVolume,
+    battery: { level: 1, isCharging: false },
+    brightness: 0.5,
+    wifi: { enabled: false, ssid: '', rssi: 0, linkSpeed: 0, ip: '', networks: [] },
+    bluetooth: { enabled: false, name: '', address: '', pairedDevices: [] },
+    storage: { totalGB: '64', usedGB: '32', freeGB: '32', usedPercentage: 50 },
+    network: { isConnected: true, isWifi: true, isCellular: false },
+    messages: [],
+    contacts: [],
+    weather: { temp: 20, condition: 'Sunny', icon: 'sunny', city: 'Lisbon' },
+    notificationAccessGranted: true,
+    isReady: true,
+    refresh: jest.fn(),
+    setBrightness: jest.fn(),
+    toggleWifi: jest.fn(),
+    toggleBluetooth: jest.fn(),
+    openSystemPanel: jest.fn(),
+    requestContactsPermission: jest.fn(),
+    requestSmsPermission: jest.fn(),
+  }),
+  DeviceProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  DeviceContext: null,
+}));
+
+jest.mock('../../../store/SettingsStore', () => ({
+  useSettings: () => ({
+    settings: {
+      vibration: true,
+      ringtone: 'Reflection',
+      textTone: 'Note',
+    },
+    update: mockUpdate,
+  }),
+  SettingsProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(() => Promise.resolve(null)),
+    setItem: jest.fn(() => Promise.resolve()),
+    removeItem: jest.fn(() => Promise.resolve()),
+    getMany: jest.fn(() => Promise.resolve({})),
+  },
+}));
+
+const mockNavigation = { navigate: jest.fn(), goBack: jest.fn(), push: jest.fn() };
+
+describe('SoundsHapticsScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders without crashing', () => {
+    const { toJSON } = render(<SoundsHapticsScreen navigation={mockNavigation as never} />);
+    expect(toJSON()).toBeTruthy();
+  });
+
+  // Red step: before fix there were TWO haptics switches (System Haptics orphan + Vibration real).
+  // After fix there is exactly ONE (renamed to System Haptics, backed by settings.vibration).
+  it('has exactly one haptics switch', () => {
+    const { getAllByRole, getByText } = render(<SoundsHapticsScreen navigation={mockNavigation as never} />);
+    expect(getByText('System Haptics')).toBeTruthy();
+    const switches = getAllByRole('switch');
+    expect(switches).toHaveLength(1);
+  });
+
+  it('does not show Keyboard Clicks or Lock Sound', () => {
+    const { queryByText } = render(<SoundsHapticsScreen navigation={mockNavigation as never} />);
+    expect(queryByText('Keyboard Clicks')).toBeNull();
+    expect(queryByText('Lock Sound')).toBeNull();
+  });
+
+  // Red step: before fix slider fires update('volume', v) on SettingsStore (dead key),
+  // never calls device.setVolume. After fix it calls device.setVolume.
+  it('volume slider calls device.setVolume, not settings.update', () => {
+    const { UNSAFE_getAllByType } = render(<SoundsHapticsScreen navigation={mockNavigation as never} />);
+    const sliders = UNSAFE_getAllByType(CupertinoSlider);
+    expect(sliders.length).toBeGreaterThan(0);
+
+    // Directly invoke the onValueChange prop — simulates gesture completion
+    sliders[0].props.onValueChange(0.7);
+
+    expect(mockSetVolume).toHaveBeenCalledWith(0.7);
+    expect(mockUpdate).not.toHaveBeenCalledWith('volume', expect.anything());
+  });
+});


### PR DESCRIPTION
## What

Closes #357.

## Changes

**`src/screens/settings/SoundsHapticsScreen.tsx`**
- Removed `systemHaptics` local state, `SYSTEM_HAPTICS_STORAGE_KEY`, and `handleSystemHapticsToggle` — orphaned local state that never wired to any consumer
- Removed `System Haptics` switch (the orphan) from the Haptics section
- Renamed `Vibration` → `System Haptics` — this toggle is backed by `settings.vibration`, which `src/utils/haptics.ts` reads to gate all vibration calls; label now matches iOS semantics
- Removed `Keyboard Clicks` and `Lock Sound` switches — `settings.keyboardClicks` and `settings.lockSound` are unused dead keys in SettingsStore; no audio API backs them on Android
- Removed `AsyncStorage.getItem(SYSTEM_HAPTICS_STORAGE_KEY)` from mount effect
- Added `import { useDevice }` — destructures `{ volume, setVolume }` from DeviceStore
- Changed volume slider: `value={settings.volume}` (dead key) → `value={volume}` (live DeviceStore); `onValueChange={(v) => update('volume', v)}` → `onValueChange={setVolume}` (calls native bridge via LauncherModule)
- Added footer disclosure to Ringtone & Vibration section explaining Android audio channel constraint

**`src/screens/settings/__tests__/SoundsHapticsScreen.test.tsx`** (new)
- 4 tests; mocks `useDevice` and `SettingsStore` to control bridge calls
- Red step proven: before fix, `has exactly one haptics switch` fails (4 switches), `does not show Keyboard Clicks or Lock Sound` fails (both present), `volume slider calls device.setVolume` fails (calls dead `update('volume', ...)` instead)
- After fix: all 4 pass

## Verification

- `npm run lint` — 0 new errors (1 pre-existing warning in unrelated file)
- `npx tsc --noEmit` — clean
- `npm test` — 4 suites failing, 8 tests failing (same baseline as `main`; 0 regressions)