### PR TITLE
fix/issue-358: remove dead privacy toggles; wire locationServices as permission gate

### DIFF
--- a/src/screens/settings/PrivacyScreen.tsx
+++ b/src/screens/settings/PrivacyScreen.tsx
@@ -31,7 +31,6 @@ export function PrivacyScreen({ navigation }: { navigation: AppNavigationProp })
 
   const alert = useAlert();
 
-  const [allowTracking, setAllowTracking] = useState(false);
   const [permissions, setPermissions] = useState<Record<string, boolean>>({});
   const [loadingPermissions, setLoadingPermissions] = useState(false);
   const [requestingPermissions, setRequestingPermissions] = useState(false);
@@ -70,7 +69,9 @@ export function PrivacyScreen({ navigation }: { navigation: AppNavigationProp })
 
   const totalPermissions = PERMISSION_CATEGORIES.length;
   const grantedCount = PERMISSION_CATEGORIES.filter(
-    (p) => permissions[p.key] === true
+    (p) => p.key === 'location'
+      ? settings.locationServices && permissions[p.key] === true
+      : permissions[p.key] === true
   ).length;
 
   return (
@@ -138,22 +139,6 @@ export function PrivacyScreen({ navigation }: { navigation: AppNavigationProp })
           </CupertinoListSection>
         </View>
 
-        {/* Tracking */}
-        <View style={{ paddingHorizontal: spacing.md }}>
-          <CupertinoListSection header="Tracking">
-            <CupertinoListTile
-              title="Allow Apps to Request to Track"
-              trailing={
-                <CupertinoSwitch
-                  value={allowTracking}
-                  onValueChange={setAllowTracking}
-                />
-              }
-              showChevron={false}
-            />
-          </CupertinoListSection>
-        </View>
-
         {/* App Privacy with real permission status */}
         <View style={{ paddingHorizontal: spacing.md }}>
           <View style={[styles.sectionHeaderRow, { paddingHorizontal: 16, paddingBottom: 6, paddingTop: 22 }]}>
@@ -170,6 +155,8 @@ export function PrivacyScreen({ navigation }: { navigation: AppNavigationProp })
           </View>
           <CupertinoListSection>
             {PERMISSION_CATEGORIES.map((item) => {
+              // Location row is gated by the Location Services toggle above
+              const locationDisabled = item.key === 'location' && !settings.locationServices;
               const isGranted = permissions[item.key] === true;
               const hasData = item.key in permissions;
               return (
@@ -183,7 +170,11 @@ export function PrivacyScreen({ navigation }: { navigation: AppNavigationProp })
                   }}
                   trailing={
                     <View style={styles.trailingRow}>
-                      {hasData ? (
+                      {locationDisabled ? (
+                        <Text style={[typography.body, { color: colors.secondaryLabel }]}>
+                          Disabled by user
+                        </Text>
+                      ) : hasData ? (
                         <>
                           <View
                             style={[
@@ -234,32 +225,6 @@ export function PrivacyScreen({ navigation }: { navigation: AppNavigationProp })
                 />
               );
             })}
-          </CupertinoListSection>
-        </View>
-
-        {/* Analytics & Improvements */}
-        <View style={{ paddingHorizontal: spacing.md }}>
-          <CupertinoListSection header="Analytics & Improvements">
-            <CupertinoListTile
-              title="Share Analytics"
-              trailing={
-                <CupertinoSwitch
-                  value={settings.analyticsEnabled}
-                  onValueChange={(v) => update('analyticsEnabled', v)}
-                />
-              }
-              showChevron={false}
-            />
-            <CupertinoListTile
-              title="Personalized Ads"
-              trailing={
-                <CupertinoSwitch
-                  value={settings.personalizedAds}
-                  onValueChange={(v) => update('personalizedAds', v)}
-                />
-              }
-              showChevron={false}
-            />
           </CupertinoListSection>
         </View>
 

--- a/src/screens/settings/__tests__/PrivacyScreen.test.tsx
+++ b/src/screens/settings/__tests__/PrivacyScreen.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { render, waitFor } from '../../../test-utils';
+import { PrivacyScreen } from '../PrivacyScreen';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const launcherMock = require('../../../__mocks__/launcherModule').default;
+
+const mockUpdate = jest.fn();
+
+jest.mock('../../../store/SettingsStore', () => ({
+  useSettings: () => ({
+    settings: {
+      locationServices: false,
+    },
+    update: mockUpdate,
+  }),
+  SettingsProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const mockNavigation = { navigate: jest.fn(), goBack: jest.fn(), push: jest.fn() };
+
+describe('PrivacyScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Report location as denied so any "Request" button logic is triggered
+    launcherMock.checkPermissions.mockResolvedValue({ location: false });
+  });
+
+  it('renders without crashing', async () => {
+    const { toJSON } = render(<PrivacyScreen navigation={mockNavigation as never} />);
+    expect(toJSON()).toBeTruthy();
+  });
+
+  it('does not show Share Analytics or Personalized Ads toggles', () => {
+    const { queryByText } = render(<PrivacyScreen navigation={mockNavigation as never} />);
+    expect(queryByText('Share Analytics')).toBeNull();
+    expect(queryByText('Personalized Ads')).toBeNull();
+  });
+
+  it('does not show Allow Apps to Request to Track toggle', () => {
+    const { queryByText } = render(<PrivacyScreen navigation={mockNavigation as never} />);
+    expect(queryByText('Allow Apps to Request to Track')).toBeNull();
+  });
+
+  // Red step: before fix, with locationServices=false the location row still shows
+  // a "Request" button and shows "Denied" status — the toggle has no effect on the UI.
+  // After fix: location row shows "Disabled by user" and has no Request button.
+  it('hides Request button for location when locationServices is off', async () => {
+    const { queryAllByText, queryByText } = render(<PrivacyScreen navigation={mockNavigation as never} />);
+
+    // Wait for checkPermissions to resolve (location: false → row gets real data)
+    await waitFor(() => {
+      expect(launcherMock.checkPermissions).toHaveBeenCalled();
+    });
+
+    // With locationServices=false: no "Denied" for location and no "Request" for location
+    // The row should show "Disabled by user" (controlled by the toggle gate)
+    expect(queryByText('Denied')).toBeNull();
+    // And no Request buttons should be visible for the location row
+    const requestButtons = queryAllByText('Request');
+    expect(requestButtons).toHaveLength(0);
+  });
+});

--- a/src/store/SettingsStore.tsx
+++ b/src/store/SettingsStore.tsx
@@ -51,8 +51,6 @@ export interface SettingsState {
   lowPowerMode: boolean;
   batteryPercentage: boolean;
   locationServices: boolean;
-  analyticsEnabled: boolean;
-  personalizedAds: boolean;
   wallpaperIndex: number;
   reduceMotion: boolean;
   boldText: boolean;
@@ -108,8 +106,6 @@ export const DEFAULT_SETTINGS: SettingsState = {
   lowPowerMode: false,
   batteryPercentage: true,
   locationServices: true,
-  analyticsEnabled: false,
-  personalizedAds: false,
   wallpaperIndex: 0,
   reduceMotion: false,
   boldText: false,


### PR DESCRIPTION
## What

Closes #358.

## Changes

**`src/store/SettingsStore.tsx`**
- Removed `analyticsEnabled` and `personalizedAds` from `SettingsState` interface and `DEFAULT_SETTINGS` — no analytics/ads SDK exists in the project; toggles were advertising false behaviour on a privacy screen

**`src/screens/settings/PrivacyScreen.tsx`**
- Removed `allowTracking` local state and the entire "Tracking" section — iOS ATT concept; no Android equivalent; state didn't persist across navigation
- Removed "Analytics & Improvements" section (`Share Analytics`, `Personalized Ads`)
- Wired `settings.locationServices` as a gate for the location permission row: when off, the row shows "Disabled by user" (no dot, no Granted/Denied text, no Request button); `grantedCount` also excludes location when the toggle is off
- All functional code untouched: `checkPermissions`, `requestAllPermissions`, `PERMISSION_CATEGORIES`, permission status display, Refresh button

**`src/screens/settings/__tests__/PrivacyScreen.test.tsx`** (new)
- 4 tests with `settings.locationServices = false` and `checkPermissions` returning `{ location: false }`
- Red step proven: before fix, `does not show Share Analytics` fails, `does not show Allow Apps to Request to Track` fails, and `hides Request button for location when locationServices is off` fails (Denied + Request button appears regardless of toggle)
- After fix: all 4 pass

## Verification

- `grep -rn "analyticsEnabled|personalizedAds|allowTracking" src` → 0 results
- `npx tsc --noEmit` — clean
- `npm run lint` — 0 new errors (1 pre-existing warning in unrelated file)
- `npm test` — 4 suites/8 tests failing (same baseline; 0 regressions; +4 new passing tests)