### PR TITLE
fix/issue-359: restrict export to EXPORTABLE_KEYS allow-list; add disclosure dialog

### DIFF
--- a/src/screens/settings/BackupRestoreScreen.tsx
+++ b/src/screens/settings/BackupRestoreScreen.tsx
@@ -22,6 +22,45 @@ import {
 } from '../../components';
 import type { AppNavigationProp } from '../../navigation/types';
 
+// Explicit allow-list derived from SettingsStore.tsx, ThemeContext.tsx, and
+// each settings screen that writes its own AsyncStorage keys.
+// Intentionally excludes non-settings data: messages, notes, contacts, reminders,
+// home layout, Spotlight history, and any future non-settings keys.
+const EXPORTABLE_KEYS = [
+  // Main settings blob (SettingsStore)
+  '@iostoandroid/settings',
+  // ThemeContext — display mode, accent colour, high-contrast
+  '@iostoandroid/theme_preference',
+  '@iostoandroid/accent_color',
+  '@iostoandroid/high_contrast',
+  // AccessibilityScreen — text scale, bold, reduce motion
+  '@iostoandroid/a11y_textscale',
+  '@iostoandroid/a11y_bold',
+  '@iostoandroid/a11y_reduce_motion',
+  // DisplayBrightnessScreen — night shift preference
+  '@iostoandroid/night_shift',
+  // KeyboardScreen — keyboard preferences
+  '@iostoandroid/kbd_autocap',
+  '@iostoandroid/kbd_autocorrect',
+  '@iostoandroid/kbd_clicks',
+  '@iostoandroid/kbd_predictive',
+  // CellularScreen — cellular and data-roaming preferences
+  '@iostoandroid/cellular_data',
+  '@iostoandroid/data_roaming',
+  // DateTimeScreen — timezone preference
+  '@iostoandroid/timezone',
+  // LanguageRegionScreen — locale preferences
+  '@iostoandroid/language',
+  '@iostoandroid/region',
+  // SoundsHapticsScreen — ringtone and text-tone labels
+  '@iostoandroid/ringtone',
+  '@iostoandroid/text_tone',
+  // WallpaperScreen — custom wallpaper URI
+  '@iostoandroid/custom_wallpaper',
+] as const;
+
+const EXPORTABLE_SET = new Set<string>(EXPORTABLE_KEYS);
+
 export function BackupRestoreScreen({ navigation }: { navigation: AppNavigationProp }) {
   const { theme, typography, spacing } = useTheme();
   const { colors } = theme;
@@ -32,16 +71,16 @@ export function BackupRestoreScreen({ navigation }: { navigation: AppNavigationP
   const [importText, setImportText] = useState('');
   const [showImportModal, setShowImportModal] = useState(false);
   const [showResetConfirm, setShowResetConfirm] = useState(false);
+  const [showExportConfirm, setShowExportConfirm] = useState(false);
   const [busy, setBusy] = useState(false);
   const alert = useAlert();
 
-  const handleExport = useCallback(async () => {
+  const doExport = useCallback(async () => {
     try {
       setBusy(true);
-      const keys = await AsyncStorage.getAllKeys();
-      const rawEntries = await AsyncStorage.getMany(keys);
+      const entries = await AsyncStorage.getMany([...EXPORTABLE_KEYS]);
       const backup: Record<string, string> = {};
-      for (const [k, v] of Object.entries(rawEntries)) {
+      for (const [k, v] of Object.entries(entries)) {
         if (v !== null) backup[k] = v;
       }
       const json = JSON.stringify(backup, null, 2);
@@ -56,6 +95,10 @@ export function BackupRestoreScreen({ navigation }: { navigation: AppNavigationP
     }
   }, [alert]);
 
+  const handleExport = useCallback(() => {
+    setShowExportConfirm(true);
+  }, []);
+
   const handleImportConfirm = useCallback(async () => {
     if (!importText.trim()) {
       alert('Error', 'Paste your backup JSON first.');
@@ -67,11 +110,13 @@ export function BackupRestoreScreen({ navigation }: { navigation: AppNavigationP
       if (typeof data !== 'object' || Array.isArray(data)) {
         throw new Error('Expected a JSON object');
       }
-      const entries: Record<string, string> = {};
+      const filtered: Record<string, string> = {};
       for (const [k, v] of Object.entries(data)) {
-        entries[k] = String(v);
+        if (EXPORTABLE_SET.has(k)) {
+          filtered[k] = String(v);
+        }
       }
-      await AsyncStorage.setMany(entries);
+      await AsyncStorage.setMany(filtered);
       setShowImportModal(false);
       setImportText('');
       alert('Restored', 'Settings imported successfully. Restart the app to apply all changes.');
@@ -119,7 +164,7 @@ export function BackupRestoreScreen({ navigation }: { navigation: AppNavigationP
           <CupertinoListSection>
             <CupertinoListTile
               title="Export Settings"
-              subtitle="Copy all settings to clipboard as JSON"
+              subtitle="Copy app preferences to clipboard as JSON"
               onPress={handleExport}
               trailing={busy ? <ActivityIndicator size="small" color={colors.systemBlue} /> : undefined}
             />
@@ -223,6 +268,25 @@ export function BackupRestoreScreen({ navigation }: { navigation: AppNavigationP
           </View>
         </View>
       </Modal>
+
+      {/* Export Disclosure Dialog */}
+      <CupertinoAlertDialog
+        visible={showExportConfirm}
+        title="Export Settings"
+        message="This copies your app preferences (display, sounds, keyboard, accessibility, and similar settings) to the clipboard. The clipboard is readable by any app in the foreground."
+        actions={[
+          { label: 'Cancel', style: 'cancel', onPress: () => setShowExportConfirm(false) },
+          {
+            label: 'Export',
+            style: 'default',
+            onPress: () => {
+              setShowExportConfirm(false);
+              doExport();
+            },
+          },
+        ]}
+        onClose={() => setShowExportConfirm(false)}
+      />
 
       {/* Reset Confirm Dialog */}
       <CupertinoAlertDialog

--- a/src/screens/settings/__tests__/BackupRestoreScreen.test.tsx
+++ b/src/screens/settings/__tests__/BackupRestoreScreen.test.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '../../../test-utils';
+import { BackupRestoreScreen } from '../BackupRestoreScreen';
+
+const mockSetStringAsync = jest.fn<Promise<void>, [string]>();
+jest.mock('expo-clipboard', () => ({
+  setStringAsync: jest.fn((s: string) => mockSetStringAsync(s)),
+  getStringAsync: jest.fn().mockResolvedValue(''),
+}));
+
+// ALL_DATA contains both settings and non-settings keys.
+// getMany is called with an explicit EXPORTABLE_KEYS list — only those keys are fetched.
+const ALL_DATA: Record<string, string> = {
+  '@iostoandroid/settings': '{"vibration":true}',
+  '@iostoandroid/theme_preference': 'dark',
+  '@iostoandroid/sms_messages': '[{"id":"1","body":"secret"}]',  // non-settings
+  '@iostoandroid/notes': 'My private note',                       // non-settings
+};
+
+const mockGetMany = jest.fn<Promise<Record<string, string | null>>, [string[]]>();
+const mockSetMany = jest.fn<Promise<void>, [Record<string, string>]>();
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(() => Promise.resolve(null)),
+    setItem: jest.fn(() => Promise.resolve()),
+    removeItem: jest.fn(() => Promise.resolve()),
+    getAllKeys: jest.fn(() => Promise.resolve(Object.keys(ALL_DATA))),
+    getMany: jest.fn((keys: string[]) => mockGetMany(keys)),
+    setMany: (entries: Record<string, string>) => mockSetMany(entries),
+    clear: jest.fn(() => Promise.resolve()),
+  },
+}));
+
+const mockNavigation = { navigate: jest.fn(), goBack: jest.fn(), push: jest.fn() };
+
+describe('BackupRestoreScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetMany.mockImplementation((keys: string[]) => {
+      const result: Record<string, string | null> = {};
+      for (const k of keys) {
+        result[k] = ALL_DATA[k] ?? null;
+      }
+      return Promise.resolve(result);
+    });
+  });
+
+  it('renders without crashing', () => {
+    const { toJSON } = render(<BackupRestoreScreen navigation={mockNavigation as never} />);
+    expect(toJSON()).toBeTruthy();
+  });
+
+  // Red step: before fix, pressing Export immediately calls getAllKeys() and writes ALL
+  // data (including SMS/notes) to clipboard with no disclosure.
+  // After fix: disclosure dialog appears first; on confirm, only EXPORTABLE_KEYS are exported.
+  it('exports only settings keys — no SMS or notes in clipboard', async () => {
+    const { getByText } = render(<BackupRestoreScreen navigation={mockNavigation as never} />);
+
+    fireEvent.press(getByText('Export Settings'));
+
+    // Disclosure dialog should appear before clipboard is written
+    await waitFor(() => expect(getByText('Export')).toBeTruthy());
+    fireEvent.press(getByText('Export'));
+
+    await waitFor(() => expect(mockSetStringAsync).toHaveBeenCalled());
+
+    const rawArg = (mockSetStringAsync.mock.calls[0] as [string])[0];
+    const exported = JSON.parse(rawArg) as Record<string, unknown>;
+
+    expect(exported['@iostoandroid/settings']).toBe('{"vibration":true}');
+    expect(exported['@iostoandroid/theme_preference']).toBe('dark');
+    expect(exported['@iostoandroid/sms_messages']).toBeUndefined();
+    expect(exported['@iostoandroid/notes']).toBeUndefined();
+  });
+
+  it('does not call getAllKeys during export', async () => {
+    const AsyncStorageMock = jest.requireMock('@react-native-async-storage/async-storage').default;
+    const { getByText } = render(<BackupRestoreScreen navigation={mockNavigation as never} />);
+
+    fireEvent.press(getByText('Export Settings'));
+    await waitFor(() => expect(getByText('Export')).toBeTruthy());
+    fireEvent.press(getByText('Export'));
+    await waitFor(() => expect(mockSetStringAsync).toHaveBeenCalled());
+
+    expect(AsyncStorageMock.getAllKeys).not.toHaveBeenCalled();
+  });
+
+  // Red step for import: before fix, ALL keys from the JSON blob are written to storage,
+  // including non-settings keys. After fix, only keys in EXPORTABLE_KEYS are written.
+  it('import ignores keys outside the allow-list', async () => {
+    const { getByText, getByPlaceholderText } = render(
+      <BackupRestoreScreen navigation={mockNavigation as never} />,
+    );
+
+    fireEvent.press(getByText('Import Settings'));
+    const textarea = getByPlaceholderText('{"@iostoandroid/...": "..."}');
+
+    const maliciousBackup = JSON.stringify({
+      '@iostoandroid/settings': '{"vibration":false}',
+      '@iostoandroid/sms_messages': 'injected',
+      '@iostoandroid/notes': 'injected',
+    });
+
+    fireEvent.changeText(textarea, maliciousBackup);
+    fireEvent.press(getByText('Import'));
+
+    await waitFor(() => expect(mockSetMany).toHaveBeenCalled());
+
+    const writtenEntries = mockSetMany.mock.calls[0][0];
+    expect(writtenEntries['@iostoandroid/settings']).toBe('{"vibration":false}');
+    expect(writtenEntries['@iostoandroid/sms_messages']).toBeUndefined();
+    expect(writtenEntries['@iostoandroid/notes']).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What

Closes #359.

## Changes

**`src/screens/settings/BackupRestoreScreen.tsx`**
- Added `EXPORTABLE_KEYS` constant (20 entries derived from `SettingsStore.tsx`, `ThemeContext.tsx`, and each settings screen that writes its own AsyncStorage key). Not inferred from prefix — `@iostoandroid/sms_messages` and similar non-settings keys share the prefix
- Added `EXPORTABLE_SET` for O(1) lookup
- Replaced `getAllKeys() → getMany(all)` with `getMany([...EXPORTABLE_KEYS])`: SMS messages, notes, contacts, reminders, home layout, Spotlight history never fetched or placed in clipboard
- Added `showExportConfirm` state + `CupertinoAlertDialog` disclosure: dialog lists what's included (display, sounds, keyboard, accessibility...) and warns clipboard is readable by foreground apps. Clipboard is only written after the user presses "Export"
- `handleImportConfirm`: parses JSON, filters through `EXPORTABLE_SET`, writes only matching keys via `setMany`. Old backups made with the previous `getAllKeys` export cannot re-inject out-of-scope data
- Subtitle updated from "Copy all settings" → "Copy app preferences" to match scope

**`src/screens/settings/__tests__/BackupRestoreScreen.test.tsx`** (new)
- 4 tests seeding both settings (`@iostoandroid/settings`, `@iostoandroid/theme_preference`) and non-settings (`@iostoandroid/sms_messages`, `@iostoandroid/notes`) keys
- Red step proven: 3 failures before fix
- After fix: all 4 pass

## Verification

- `grep -n "getAllKeys" src/screens/settings/BackupRestoreScreen.tsx` → 0 results
- `npx tsc --noEmit` — clean (0 errors)
- `npm run lint` — 0 new errors (1 pre-existing warning)
- `npm test` — 4 suites/8 tests failing (same baseline; 0 regressions; +4 new passing tests)