### PR TITLE
Adiciona teste de integração ponta-a-ponta que prova a wiring de Auto-Lock em App.tsx (o fix em si já estava mergeado) (#354)

### DIFF
--- a/__tests__/App.autolock.test.tsx
+++ b/__tests__/App.autolock.test.tsx
@@ -1,0 +1,253 @@
+import React from 'react';
+import { AppState, AppStateStatus } from 'react-native';
+import { render, act, fireEvent } from '@testing-library/react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import App from '../App';
+import { withAutoLockSuppressed } from '../src/utils/permissions';
+
+// Issue #354: the Auto-Lock picker (DisplayBrightnessScreen) persisted
+// `settings.autoLock`, but App.tsx locked the screen off a hardcoded
+// `AUTO_LOCK_GRACE_MS = 5000`, so the picker had no effect at all.
+//
+// These tests exercise the REAL App.tsx AppState wiring end to end: mount
+// the real component tree, unlock through the real LockScreen passcode
+// flow (no PIN is set, so any 4 digits succeed — see LockScreen.test.tsx
+// for the same pattern), background the app via a captured AppState
+// handler, and advance real (faked) timers to prove the delay that's
+// actually scheduled matches `settings.autoLock`, not the old constant.
+
+jest.mock('expo-secure-store', () => ({
+  getItemAsync: jest.fn(async () => null),
+  setItemAsync: jest.fn(async () => {}),
+  deleteItemAsync: jest.fn(async () => {}),
+}));
+
+// jest.setup.js mocks './modules/launcher-module/src' (relative to the setup
+// file, at repo root) via an explicit jest.mock() without the
+// addNotificationListener/onBridgeError named exports App.tsx needs — every
+// other test reaches the module through a differently-worded relative path
+// that resolves through the moduleNameMapper entry to
+// src/__mocks__/launcherModule.js instead, which does have them. App.tsx is
+// the only caller that shares jest.setup.js's exact specifier, so it's the
+// only place this gap is visible. Overriding locally (same resolved file)
+// keeps the fix scoped to this test file.
+jest.mock('../modules/launcher-module/src', () => ({
+  __esModule: true,
+  addNotificationListener: jest.fn(() => jest.fn()),
+  onBridgeError: jest.fn(() => jest.fn()),
+  default: {
+    getInstalledApps: jest.fn(() => Promise.resolve([])),
+    launchApp: jest.fn(() => Promise.resolve(true)),
+    getAppIcon: jest.fn(() => Promise.resolve('')),
+    isDefaultLauncher: jest.fn(() => Promise.resolve(false)),
+    openLauncherSettings: jest.fn(() => Promise.resolve(true)),
+    getWifiInfo: jest.fn(() => Promise.resolve({ enabled: true, ssid: 'TestWiFi', rssi: -50, ip: '192.168.1.100' })),
+    setWifiEnabled: jest.fn(() => Promise.resolve(true)),
+    getWifiNetworks: jest.fn(() => Promise.resolve([{ ssid: 'TestWiFi', level: -50, isSecure: true }])),
+    getBluetoothInfo: jest.fn(() => Promise.resolve({ enabled: true, name: 'TestDevice', address: '', pairedDevices: [] })),
+    setBluetoothEnabled: jest.fn(() => Promise.resolve(true)),
+    getStorageInfo: jest.fn(() => Promise.resolve({ totalGB: '128.0', usedGB: '89.3', freeGB: '38.7', usedPercentage: 70 })),
+    getRecentMessages: jest.fn(() => Promise.resolve([])),
+    getVolume: jest.fn(() => Promise.resolve(0.5)),
+    setVolume: jest.fn(() => Promise.resolve(true)),
+    openSystemSettings: jest.fn(() => Promise.resolve(true)),
+    getNetworkInfo: jest.fn(() => Promise.resolve({ isConnected: true, isWifi: true, isCellular: false, isVpn: false })),
+    setFlashlight: jest.fn(() => Promise.resolve(true)),
+    isFlashlightOn: jest.fn(() => Promise.resolve(false)),
+    getCallLog: jest.fn(() => Promise.resolve([])),
+    makeCall: jest.fn(() => Promise.resolve(true)),
+    getNotifications: jest.fn(() => Promise.resolve([])),
+    clearNotification: jest.fn(() => Promise.resolve(true)),
+    clearAllNotifications: jest.fn(() => Promise.resolve(true)),
+    isNotificationAccessGranted: jest.fn(() => Promise.resolve(false)),
+    openNotificationAccessSettings: jest.fn(() => Promise.resolve(true)),
+    sendSms: jest.fn(() => Promise.resolve(true)),
+    requestAllPermissions: jest.fn(() => Promise.resolve(true)),
+    checkPermissions: jest.fn(() => Promise.resolve({})),
+    getCalendarEvents: jest.fn(() => Promise.resolve([])),
+    getNowPlaying: jest.fn(() => Promise.resolve({ title: '', artist: '', album: '', isPlaying: false, packageName: '' })),
+    uninstallApp: jest.fn(() => Promise.resolve(true)),
+  },
+}));
+
+// jest.setup.js's @react-navigation/native mock doesn't export
+// useNavigationContainerRef (no other test renders App.tsx directly, which is
+// the only caller). Extend it locally rather than touching the shared mock.
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({
+    navigate: jest.fn(),
+    goBack: jest.fn(),
+    canGoBack: jest.fn(() => false),
+    getParent: () => ({ navigate: jest.fn() }),
+  }),
+  useRoute: () => ({ params: {} }),
+  // AssistiveTouch/HomeIndicator call methods directly on the ref returned by
+  // useNavigationContainerRef (getCurrentRoute, addListener, navigate) — not
+  // just `.current`, mirroring the real NavigationContainerRefWithCurrent.
+  useNavigationContainerRef: () => ({
+    current: null,
+    getCurrentRoute: jest.fn(() => undefined),
+    addListener: jest.fn(() => jest.fn()),
+    navigate: jest.fn(),
+    isReady: jest.fn(() => true),
+  }),
+  NavigationContainer: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+// TabNavigator statically imports every screen, including ClockScreen, which
+// imports expo-notifications — unavailable as a native module under Jest.
+jest.mock('expo-notifications', () => ({
+  setNotificationHandler: jest.fn(),
+  getPermissionsAsync: jest.fn(() => Promise.resolve({ status: 'granted', canAskAgain: true })),
+  requestPermissionsAsync: jest.fn(() => Promise.resolve({ status: 'granted', canAskAgain: true })),
+  scheduleNotificationAsync: jest.fn(() => Promise.resolve('notification-id')),
+  cancelScheduledNotificationAsync: jest.fn(() => Promise.resolve()),
+  setNotificationCategoryAsync: jest.fn(() => Promise.resolve()),
+  addNotificationResponseReceivedListener: jest.fn(() => ({ remove: jest.fn() })),
+  SchedulableTriggerInputTypes: { TIME_INTERVAL: 'timeInterval', WEEKLY: 'weekly', DATE: 'date' },
+}));
+
+const ONBOARDING_KEY = '@iostoandroid/onboarding_done';
+const SETTINGS_KEY = '@iostoandroid/settings';
+
+let changeHandlers: ((state: AppStateStatus) => void)[] = [];
+
+function fireAppState(state: AppStateStatus) {
+  [...changeHandlers].forEach((handler) => handler(state));
+}
+
+function mockPersistedAutoLock(autoLock: string) {
+  (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) => {
+    if (key === ONBOARDING_KEY) return 'true'; // skip onboarding
+    if (key === SETTINGS_KEY) return JSON.stringify({ autoLock });
+    return null;
+  });
+}
+
+beforeEach(() => {
+  changeHandlers = [];
+  jest.spyOn(AppState, 'addEventListener').mockImplementation((type, handler) => {
+    if (type === 'change') changeHandlers.push(handler as (state: AppStateStatus) => void);
+    return {
+      remove: () => {
+        changeHandlers = changeHandlers.filter((h) => h !== handler);
+      },
+    } as unknown as ReturnType<typeof AppState.addEventListener>;
+  });
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+/** Mounts <App/>, flushes past the onboarding/settings/theme async gates
+ *  landing on the (always-shown-first) LockScreen, then unlocks through the
+ *  real passcode flow so the AppState background/foreground wiring can be
+ *  exercised against the post-unlock app. */
+async function renderUnlockedApp() {
+  const api = render(<App />);
+
+  // Flush AsyncStorage reads for onboarding, SettingsProvider (+ device
+  // sync fallback) and ThemeProvider, each of which gates the next
+  // provider's mount — see SettingsStore.tsx / ThemeContext.tsx.
+  for (let i = 0; i < 4; i++) {
+    // eslint-disable-next-line no-await-in-loop
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(600);
+    });
+  }
+
+  // expo-local-authentication isn't mocked (no biometric hardware under
+  // Jest), so LockScreen's mount-time triggerBiometric() always rejects and
+  // falls straight through to the passcode numpad — no need to press "Use
+  // passcode to unlock" first.
+  expect(api.queryByLabelText('Digit 1')).toBeTruthy();
+
+  await act(async () => {
+    fireEvent.press(api.getByLabelText('Digit 1'));
+    fireEvent.press(api.getByLabelText('Digit 2'));
+    fireEvent.press(api.getByLabelText('Digit 3'));
+    fireEvent.press(api.getByLabelText('Digit 4'));
+    await jest.advanceTimersByTimeAsync(0);
+  });
+
+  expect(api.queryByLabelText('Digit 1')).toBeNull();
+
+  return api;
+}
+
+describe('App auto-lock delay (issue #354)', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("'Never' — backgrounding and advancing timers far past 5s never re-locks", async () => {
+    mockPersistedAutoLock('Never');
+    const api = await renderUnlockedApp();
+
+    await act(async () => {
+      fireAppState('background');
+    });
+
+    // Ten minutes — an order of magnitude past the old hardcoded 5s grace
+    // period, and well past every timed option except 'Never'.
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(10 * 60_000);
+    });
+
+    expect(api.queryByLabelText('Swipe up to unlock')).toBeNull();
+    api.unmount();
+  });
+
+  it("'30 Seconds' — does not lock at the old 5s, locks at 30s", async () => {
+    mockPersistedAutoLock('30 Seconds');
+    const api = await renderUnlockedApp();
+
+    await act(async () => {
+      fireAppState('background');
+    });
+
+    // Old hardcoded AUTO_LOCK_GRACE_MS: must NOT have locked yet.
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(5_000);
+    });
+    expect(api.queryByLabelText('Swipe up to unlock')).toBeNull();
+
+    // Cross the configured 30s threshold.
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(25_001);
+    });
+    expect(api.queryByLabelText('Swipe up to unlock')).toBeTruthy();
+    api.unmount();
+  });
+
+  it('auto-lock suppression (#211) still wins over a configured delay', async () => {
+    mockPersistedAutoLock('30 Seconds');
+    const api = await renderUnlockedApp();
+
+    let releaseSuppression: () => void = () => {};
+    const suppressed = withAutoLockSuppressed(
+      () => new Promise<void>((resolve) => { releaseSuppression = resolve; }),
+    );
+
+    await act(async () => {
+      fireAppState('background');
+    });
+
+    // Well past the 30s configured delay while suppression is still held.
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(60_000);
+    });
+    expect(api.queryByLabelText('Swipe up to unlock')).toBeNull();
+
+    await act(async () => {
+      releaseSuppression();
+      await suppressed;
+    });
+    api.unmount();
+  });
+});


### PR DESCRIPTION
## Resumo

Adiciona teste de integração ponta-a-ponta que prova a wiring de Auto-Lock em App.tsx (o fix em si já estava mergeado)

## Causa raiz

O defeito descrito no issue (`App.tsx` a usar `AUTO_LOCK_GRACE_MS = 5000` fixo, ignorando `settings.autoLock`) **já não existe no branch de partida**. Confirmei via `git log -S` e `git merge-base --is-ancestor`: o commit `9a4b5c86` ("fix/354: Auto-Lock picker setting now drives the lock timer duration (#392)") já está mergeado em `main` e é ancestral de `HEAD` deste worktree (`03ff14e`). Esse commit já:

- extraiu `AUTO_LOCK_MS`/`resolveAutoLockDelay()` para `src/utils/autoLockUtils.ts:1-15`, com as seis etiquetas do picker (`DisplayBrightnessScreen.tsx:214-227`) copiadas byte-a-byte;
- substituiu a constante fixa por `const autoLockDelay = resolveAutoLockDelay(settings.autoLock);` em `App.tsx:61`;
- guarda o `setTimeout` com `if (autoLockDelay !== null)` em `App.tsx:104-109`, cobrindo o caso `'Never'`;
- adicionou `autoLockDelay` às deps do `useEffect` (`App.tsx:127`) para o listener reagir a mudanças de definição;
- não tocou em `suppressAutoLock()` (`src/utils/permissions.ts`), que continua a ser verificado antes de agendar o timer (`App.tsx:102`).

Confirmei que não houve revert (`git log --oneline --all | grep -i revert` sem resultados) e que os 7 testes unitários de `src/utils/__tests__/autoLockUtils.test.ts` cobrem o mapeamento completo, o `'Never'` → `null`, e o fallback 5000ms para valores desconhecidos/legados.

**O que faltava**: nenhum teste exercitava a wiring real em `App.tsx` — apenas a função pura `resolveAutoLockDelay`. O próprio issue pede explicitamente esse teste de integração ("ir para background e avançar os timers falsos... não mostra o LockScreen"), e ele não existia. Esse era o único gap real, e é o que este trabalho fecha.

## O que mudou

Adicionei `__tests__/App.autolock.test.tsx` (novo ficheiro, 3 testes) que monta o `App` real (todos os providers reais, sem stubs de `AppContent`), desbloqueia através do fluxo real de passcode do `LockScreen` (sem PIN definido, qualquer 4 dígitos desbloqueia — mesmo padrão de `LockScreen.test.tsx`), dispara transições reais de `AppState` via um handler capturado, e avança temporizadores falsos para provar o atraso efetivamente agendado.

Os mocks locais ao ficheiro (não tocam `jest.setup.js` partilhado) resolvem três lacunas de infraestrutura de teste que só se tornam visíveis ao renderizar `App.tsx` diretamente (nenhum outro teste o fazia):
- `@react-navigation/native`: o mock global não exporta `useNavigationContainerRef` nem os métodos (`getCurrentRoute`, `addListener`, `navigate`) que `AssistiveTouch`/`HomeIndicator` chamam sobre a ref.
- `../modules/launcher-module/src`: `jest.setup.js` regista um `jest.mock('./modules/launcher-module/src', …)` (caminho relativo à raiz) sem `addNotificationListener`/`onBridgeError` — só `App.tsx` importa o módulo por esse caminho exato; todos os outros ficheiros usam caminhos relativos diferentes que passam pelo `moduleNameMapper` (que aponta para `src/__mocks__/launcherModule.js`, esse sim completo).
- `expo-notifications`: `TabNavigator` importa estaticamente `ClockScreen`, que importa `expo-notifications` — módulo nativo indisponível sob Jest.

## Porque assim

Decidi **não tocar em `App.tsx`, `autoLockUtils.ts` nem `DisplayBrightnessScreen.tsx`** porque já implementam corretamente o que o issue pede — mexer neles seria um diff vazio disfarçado ou um refactor não pedido. A alternativa a este trabalho seria devolver o issue como "já resolvido" sem adicionar nada, mas isso deixaria por cumprir o critério de aceitação explícito do issue (teste vermelho de integração `App.tsx`), que é uma lacuna real e verificável.

Escolhi mockar `@react-navigation/native` e o launcher-module **localmente no novo ficheiro de teste**, não em `jest.setup.js` — evita alterar um ficheiro de configuração partilhado por toda a suite (56 outras suites) para resolver uma necessidade de um único ficheiro novo; o registo de mock do Jest é isolado por ficheiro de teste, por isso não há risco de regressão nos restantes testes (confirmado pela corrida completa da suite, ver abaixo).

Descobri e usei um comportamento já existente e não documentado: em ambiente Jest, `expo-local-authentication` não está mockado, por isso `LockScreen.triggerBiometric()` falha sempre e cai automaticamente no numpad de passcode — não é preciso simular o toque em "Use Passcode" primeiro.

## Critérios de aceitação

- [x] Teste vermelho primeiro: com `autoLock = 'Never'`, ir para background e avançar os timers falsos muito além de 5s não mostra o LockScreen; com `'30 Seconds'`, mostra a 30s e não a 5s. — `__tests__/App.autolock.test.tsx`, casos `'Never'` e `'30 Seconds'`.
- [x] O teste falha antes da alteração de produção e passa depois. — ver secção Testes abaixo (código de produção temporariamente revertido para a versão pré-`9a4b5c8`, output real colado).
- [x] Um valor de `autoLock` desconhecido/legado cai nos 5000ms sem lançar exceção. — já coberto por `src/utils/__tests__/autoLockUtils.test.ts` ("returns 5000 fallback for unknown/legacy values"), que corre e passa.
- [x] A supressão de auto-lock durante diálogos de permissões (#211) continua a funcionar. — novo teste `'auto-lock suppression (#211) still wins over a configured delay'`: com `withAutoLockSuppressed` ainda em curso, ir para background e avançar 60s (o dobro do delay configurado de 30s) **não** mostra o LockScreen.
- [x] `npm test` sem falhas novas em relação ao baseline. — 8 falhas, mesmas 4 suites da baseline (`FoldersStore`, `SettingsScreen`, `LockScreen`, `WeatherScreen`), nenhuma nova; os 3 testes novos passam sempre.

## Testes

### Passo vermelho

Código de produção temporariamente revertido para o estado pré-`9a4b5c8` (`AUTO_LOCK_GRACE_MS = 5000` fixo, sem guarda para `'Never'`), teste novo mantido, depois restaurado (`git status --porcelain App.tsx` confirma zero diff após restaurar):

```
● App auto-lock delay (issue #354) › 'Never' — backgrounding and advancing timers far past 5s never re-locks

    expect(received).toBeNull()

    Received: {"_fiber": {...}}   // <LockScreen> ainda montado — reapareceu ao fim de 5s apesar de 'Never'

      200 |     });
      201 |
    > 202 |     expect(api.queryByLabelText('Swipe up to unlock')).toBeNull();
          |                                                        ^
      203 |     api.unmount();
      204 |   });

      at Object.toBeNull (__tests__/App.autolock.test.tsx:202:56)

● App auto-lock delay (issue #354) › '30 Seconds' — does not lock at the old 5s, locks at 30s

    thrown: "Exceeded timeout of 5000 ms for a test."

● App auto-lock delay (issue #354) › auto-lock suppression (#211) still wins over a configured delay

    Can't access .root on unmounted test renderer

Test Suites: 1 failed, 1 total
Tests:       3 failed, 3 total
```

Os 3 testes falham (o primeiro pela razão certa — o LockScreen reaparece aos 5s mesmo com `'Never'` configurado; os outros dois falham em cascata porque o timer fixo de 5s da app antiga já disparou e deixou a árvore num estado que a suite não espera, o que é consistente com o comportamento antigo estar genuinamente quebrado).

Depois de restaurar `App.tsx` (fix intacto):

```
PASS Android __tests__/App.autolock.test.tsx
  App auto-lock delay (issue #354)
    ✓ 'Never' — backgrounding and advancing timers far past 5s never re-locks (153 ms)
    ✓ '30 Seconds' — does not lock at the old 5s, locks at 30s (25 ms)
    ✓ auto-lock suppression (#211) still wins over a configured delay (25 ms)

Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
```

### Casos cobertos

- **`'Never'`**: fronteira do próprio bug — o valor que a app antiga literalmente não conseguia respeitar; avança 10 minutos (muito além de qualquer opção temporizada) para garantir que não é só "ainda não bateu o timer".
- **`'30 Seconds'`**: verifica os dois lados do limiar — não bloqueia aos 5s (o valor fixo antigo) e bloqueia ao ultrapassar os 30s configurados, provando que o atraso vem de `settings.autoLock` e não de uma constante.
- **Inverso do fix / regressão (#211)**: com `withAutoLockSuppressed` ainda em curso, o app não bloqueia mesmo 2x além do delay configurado — prova que a supressão continua a ganhar à configuração, não só à constante antiga.
- **Fallback defensivo**: já coberto pelos 7 testes existentes de `autoLockUtils.test.ts` (não duplicado aqui para não testar a mesma unidade duas vezes).

### Sanity-check

Confirmado acima na secção "Passo vermelho": código de produção revertido → suite nova falha (3/3) → restaurado → `git status --porcelain App.tsx` sem diff → suite volta a passar (3/3).

### Resultado das verificações obrigatórias

- `npm run lint`: 0 erros, 1 aviso pré-existente e não relacionado (`ClockScreen.tsx:258`, `tzTick` não usado) — igual à baseline.
- `npx tsc --noEmit`: limpo, sem output.
- `npm test`: 407 passaram, 8 falharam, 415 no total, 57 suites (4 falharam: `FoldersStore`, `SettingsScreen`, `LockScreen`, `WeatherScreen` — as mesmas 4 da baseline registada em `state/baseline.json`, nenhuma falha nova). Os 3 testes novos (`__tests__/App.autolock.test.tsx`) passam sempre, incluindo isolados.

## Testes

407 passaram, 8 falharam (mesmas 4 suites pré-existentes na baseline, nenhuma nova), 415 no total, 57 suites (os 3 testes novos passam sempre)

## Linked Issue

Fixes #354