### PR TITLE
fix #360: bridge error banner — allow-list → deny-list + anti-spam

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -60,24 +60,56 @@ function AppContent() {
   const lockTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const autoLockDelay = resolveAutoLockDelay(settings.autoLock);
 
-  // Surface native bridge errors as notification banners
+  // Methods called on a tight poll or continuous listener — never banner them
+  // (getRecentMessages: every 30 s in DeviceStore setInterval)
+  const BANNER_SUPPRESSED = useRef(new Set(['getRecentMessages'])).current;
+  const SILENCE_MS = 30_000;
+  const lastErrorTime = useRef<Record<string, number>>({});
+
+  const ERROR_LABELS: Record<string, string> = {
+    getWifiInfo: 'Não foi possível ler o estado do Wi-Fi',
+    getWifiNetworks: 'Não foi possível listar redes Wi-Fi',
+    forgetWifiNetwork: 'Não foi possível esquecer a rede Wi-Fi',
+    setWifiEnabled: 'Não foi possível alterar o estado do Wi-Fi',
+    getBluetoothInfo: 'Não foi possível ler o estado do Bluetooth',
+    setBluetoothEnabled: 'Não foi possível alterar o estado do Bluetooth',
+    getStorageInfo: 'Não foi possível ler o armazenamento',
+    getVolume: 'Não foi possível ler o volume',
+    setVolume: 'Não foi possível alterar o volume',
+    getCallLog: 'Não foi possível ler o registo de chamadas',
+    makeCall: 'Não foi possível efectuar a chamada',
+    sendSms: 'Não foi possível enviar a mensagem',
+    requestAllPermissions: 'Não foi possível pedir permissões',
+    checkPermissions: 'Não foi possível verificar permissões',
+    getCalendarEvents: 'Não foi possível ler o calendário',
+    getNotifications: 'Não foi possível ler as notificações',
+    getInstalledApps: 'Não foi possível ler as aplicações instaladas',
+    launchApp: 'Não foi possível abrir a aplicação',
+    getNetworkInfo: 'Não foi possível ler o estado da rede',
+    getNowPlaying: 'Não foi possível ler a música atual',
+  };
+
+  // Surface native bridge errors as notification banners (deny-list + anti-spam)
   useEffect(() => {
     const unsub = onBridgeError((method, error) => {
+      if (BANNER_SUPPRESSED.has(method)) return;
+
+      const now = Date.now();
+      if (now - (lastErrorTime.current[method] ?? 0) < SILENCE_MS) return;
+      lastErrorTime.current[method] = now;
+
       const msg = error instanceof Error ? error.message : String(error);
-      // Only show banners for user-facing operations
-      if (['makeCall', 'sendSms', 'requestAllPermissions'].includes(method)) {
-        setBanner({
-          id: `error-${Date.now()}`,
-          appName: 'System',
-          iconName: 'warning-outline',
-          iconColor: '#FF9500',
-          title: `${method} failed`,
-          body: msg || 'An error occurred. Please try again.',
-        });
-      }
+      setBanner({
+        id: `error-${now}`,
+        appName: 'System',
+        iconName: 'warning-outline',
+        iconColor: '#FF9500',
+        title: ERROR_LABELS[method] ?? `${method} falhou`,
+        body: msg || 'Ocorreu um erro. Tente novamente.',
+      });
     });
     return unsub;
-  }, []);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Immersive mode — hide system bars globally so all screens benefit
   useEffect(() => {

--- a/src/__tests__/App.bridgeError.test.tsx
+++ b/src/__tests__/App.bridgeError.test.tsx
@@ -1,0 +1,230 @@
+/**
+ * Tests for the bridge error → notification banner gate in App.tsx.
+ *
+ * Red step (before fix):
+ *   - onBridgeError('getWifiInfo', ...) does nothing — allow-list only covers 3 methods
+ * Green step (after fix):
+ *   - deny-list: all methods show a banner except BANNER_SUPPRESSED_METHODS
+ *   - anti-spam: same method fired twice within 30s → only 1 banner
+ *   - makeCall / sendSms / requestAllPermissions still show banners (no regression)
+ */
+import React from 'react';
+import { act, render, screen, waitFor } from '@testing-library/react-native';
+
+// ── Module-level var (NOT let/const) so the factory closure can write to it ──
+// jest.mock factories are hoisted by babel-jest above imports; `var` is
+// hoisted+initialized (undefined) before any code, so the assignment inside the
+// factory works even before the variable's source-position is reached.
+// eslint-disable-next-line no-var
+var capturedBridgeErrorCb: ((method: string, error: unknown) => void) | null = null;
+
+// Re-mock the launcher module so named exports (onBridgeError, addNotificationListener)
+// are present. jest.setup.js's factory only exposes `default`, overriding it here for
+// this file (test-file jest.mock > setupFiles).
+jest.mock('../../modules/launcher-module/src', () => ({
+  __esModule: true,
+  addNotificationListener: jest.fn(() => jest.fn()),
+  onBridgeError: jest.fn((cb: (method: string, error: unknown) => void) => {
+    capturedBridgeErrorCb = cb; // captured into module-level var
+    return jest.fn(); // unsubscribe
+  }),
+  default: {
+    getInstalledApps: jest.fn(() => Promise.resolve([])),
+    launchApp: jest.fn(() => Promise.resolve(true)),
+    getAppIcon: jest.fn(() => Promise.resolve('')),
+    isDefaultLauncher: jest.fn(() => Promise.resolve(false)),
+    openLauncherSettings: jest.fn(() => Promise.resolve(true)),
+    getWifiInfo: jest.fn(() => Promise.resolve({ enabled: true, ssid: 'TestWiFi', rssi: -50, ip: '192.168.1.100' })),
+    setWifiEnabled: jest.fn(() => Promise.resolve(true)),
+    getWifiNetworks: jest.fn(() => Promise.resolve([])),
+    getBluetoothInfo: jest.fn(() => Promise.resolve({ enabled: false, name: '', address: '', pairedDevices: [] })),
+    setBluetoothEnabled: jest.fn(() => Promise.resolve(true)),
+    getStorageInfo: jest.fn(() => Promise.resolve({ totalGB: '128.0', usedGB: '64.0', freeGB: '64.0', usedPercentage: 50 })),
+    getRecentMessages: jest.fn(() => Promise.resolve([])),
+    getVolume: jest.fn(() => Promise.resolve(0.5)),
+    setVolume: jest.fn(() => Promise.resolve(true)),
+    openSystemSettings: jest.fn(() => Promise.resolve(true)),
+    getNetworkInfo: jest.fn(() => Promise.resolve({ isConnected: true, isWifi: true, isCellular: false, isVpn: false })),
+    setFlashlight: jest.fn(() => Promise.resolve(true)),
+    isFlashlightOn: jest.fn(() => Promise.resolve(false)),
+    getCallLog: jest.fn(() => Promise.resolve([])),
+    makeCall: jest.fn(() => Promise.resolve(true)),
+    getNotifications: jest.fn(() => Promise.resolve([])),
+    clearNotification: jest.fn(() => Promise.resolve(true)),
+    clearAllNotifications: jest.fn(() => Promise.resolve(true)),
+    isNotificationAccessGranted: jest.fn(() => Promise.resolve(false)),
+    openNotificationAccessSettings: jest.fn(() => Promise.resolve(true)),
+    sendSms: jest.fn(() => Promise.resolve(true)),
+    requestAllPermissions: jest.fn(() => Promise.resolve(true)),
+    checkPermissions: jest.fn(() => Promise.resolve({})),
+    getCalendarEvents: jest.fn(() => Promise.resolve([])),
+    getNowPlaying: jest.fn(() => Promise.resolve({ title: '', artist: '', album: '', isPlaying: false, packageName: '' })),
+    uninstallApp: jest.fn(() => Promise.resolve(true)),
+  },
+}));
+
+// AsyncStorage: onboarding already done → skip OnboardingScreen
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn((key: string) =>
+      key === '@iostoandroid/onboarding_done'
+        ? Promise.resolve('true')
+        : Promise.resolve(null),
+    ),
+    setItem: jest.fn(() => Promise.resolve()),
+    removeItem: jest.fn(() => Promise.resolve()),
+  },
+}));
+
+// Auto-unlock LockScreen so NotificationBanner is in the rendered tree
+jest.mock('../screens/LockScreen', () => {
+  const R = jest.requireActual<typeof import('react')>('react');
+  return {
+    LockScreen: ({ onUnlock }: { onUnlock: () => void }) => {
+      R.useEffect(() => { onUnlock(); }, [onUnlock]);
+      return null;
+    },
+  };
+});
+
+// @react-navigation/native: add useNavigationContainerRef (missing from jest.setup.js)
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: jest.fn(), goBack: jest.fn(), canGoBack: jest.fn(() => false), getParent: () => ({ navigate: jest.fn() }) }),
+  useRoute: () => ({ params: {} }),
+  NavigationContainer: ({ children }: { children: React.ReactNode }) => children as React.ReactElement,
+  useNavigationContainerRef: () => ({ current: null, navigate: jest.fn(), isReady: () => true }),
+}));
+
+// TabNavigator: stub to avoid the full navigation stack in these tests
+jest.mock('../navigation/TabNavigator', () => ({
+  TabNavigator: () => null,
+}));
+
+// Complex layout components — stub so they don't pull in gesture/animation deps
+jest.mock('../components/GestureHost', () => ({
+  GestureHost: ({ children }: { children: React.ReactNode }) => children as React.ReactElement,
+}));
+jest.mock('../components/HomeIndicator', () => ({
+  HomeIndicator: () => null,
+}));
+jest.mock('../components/QuickSwitchHomeBar', () => ({
+  QuickSwitchHomeBar: () => null,
+}));
+jest.mock('../store/AssistiveTouchStore', () => ({
+  AssistiveTouchProvider: ({ children }: { children: React.ReactNode }) => children as React.ReactElement,
+  useAssistiveTouch: () => ({ reachabilityActive: false, setReachabilityActive: jest.fn() }),
+}));
+jest.mock('../components/AssistiveTouch', () => ({
+  AssistiveTouch: () => null,
+}));
+
+// ── Import App after all jest.mock calls ──
+import App from '../../App';
+
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('App — bridge error banner gate', () => {
+  beforeEach(() => {
+    capturedBridgeErrorCb = null;
+    jest.clearAllMocks();
+  });
+
+  /** Render App and wait until AppContent's onBridgeError useEffect has run. */
+  async function mountApp() {
+    render(<App />);
+    await waitFor(() => expect(capturedBridgeErrorCb).not.toBeNull(), { timeout: 4000 });
+  }
+
+  // ── RED STEP ──────────────────────────────────────────────────────────────
+  // Before fix: getWifiInfo is not in the 3-method allow-list → no banner.
+  // After fix:  deny-list → banner IS shown.
+  it('shows a banner for a non-suppressed method (getWifiInfo)', async () => {
+    await mountApp();
+
+    act(() => { capturedBridgeErrorCb!('getWifiInfo', new Error('timeout')); });
+
+    // After fix, title contains "Wi-Fi" (human-readable label)
+    await screen.findByText(/Wi-Fi/i);
+  });
+
+  // HIGH-FREQUENCY deny-list: getRecentMessages is polled every 30 s → no banner
+  it('suppresses banner for high-frequency method (getRecentMessages)', async () => {
+    await mountApp();
+
+    act(() => { capturedBridgeErrorCb!('getRecentMessages', new Error('timeout')); });
+
+    // Give one render cycle for any banner to appear
+    await act(async () => {});
+    expect(screen.queryByText('System')).toBeNull();
+  });
+
+  // Anti-spam: same method twice inside the 30 s silence window → only 1 banner
+  it('deduplicates same method errors within the 30 s silence window', async () => {
+    let fakeNow = 1_000_000;
+    jest.spyOn(Date, 'now').mockImplementation(() => fakeNow);
+
+    try {
+      await mountApp();
+
+      act(() => { capturedBridgeErrorCb!('getWifiInfo', new Error('first')); });
+      await screen.findByText('first');
+
+      // 10 s later — still within the 30 s window
+      fakeNow += 10_000;
+      act(() => { capturedBridgeErrorCb!('getWifiInfo', new Error('second')); });
+
+      // Body of the second error must NOT appear
+      expect(screen.queryByText('second')).toBeNull();
+    } finally {
+      jest.spyOn(Date, 'now').mockRestore();
+    }
+  });
+
+  // Anti-spam: same method after silence window → new banner IS shown
+  it('shows a new banner after the silence window expires', async () => {
+    let fakeNow = 1_000_000;
+    jest.spyOn(Date, 'now').mockImplementation(() => fakeNow);
+
+    try {
+      await mountApp();
+
+      act(() => { capturedBridgeErrorCb!('getWifiInfo', new Error('first')); });
+      await screen.findByText('first');
+
+      // Advance past the 30 s window
+      fakeNow += 31_000;
+      act(() => { capturedBridgeErrorCb!('getWifiInfo', new Error('after-window')); });
+      await screen.findByText('after-window');
+    } finally {
+      jest.spyOn(Date, 'now').mockRestore();
+    }
+  });
+
+  // Regression: makeCall must still show banner
+  it('still shows banner for makeCall (no regression)', async () => {
+    await mountApp();
+
+    act(() => { capturedBridgeErrorCb!('makeCall', new Error('call blocked')); });
+
+    await screen.findByText(/chamada/i);
+  });
+
+  // Regression: sendSms must still show banner
+  it('still shows banner for sendSms (no regression)', async () => {
+    await mountApp();
+
+    act(() => { capturedBridgeErrorCb!('sendSms', new Error('sms failed')); });
+
+    await screen.findByText(/mensagem/i);
+  });
+
+  // Regression: requestAllPermissions must still show banner
+  it('still shows banner for requestAllPermissions (no regression)', async () => {
+    await mountApp();
+
+    act(() => { capturedBridgeErrorCb!('requestAllPermissions', new Error('perm denied')); });
+
+    await screen.findByText(/permiss/i);
+  });
+});


### PR DESCRIPTION
Closes #360

## What changed

**`App.tsx`** — `onBridgeError` useEffect rewritten:

| Before | After |
|--------|-------|
| Allow-list of 3 methods | Deny-list: all methods banner by default |
| No dedup | 30 s per-method silence window (`lastErrorTime` ref) |
| Raw `"${method} failed"` title | `ERROR_LABELS` map with PT-PT strings, fallback to `"${method} falhou"` |

High-frequency polled methods in `BANNER_SUPPRESSED` (const ref):
- `getRecentMessages` — called every 30 s by `DeviceStore` setInterval (lines 321-326)

**`src/__tests__/App.bridgeError.test.tsx`** — 7 new tests:

1. `shows a banner for a non-suppressed method (getWifiInfo)` — **red step**: before fix, getWifiInfo was blocked by the allow-list (no banner); after fix, banner shows "Wi-Fi"
2. `suppresses banner for high-frequency method (getRecentMessages)` — deny-list entry works
3. `deduplicates same method errors within the 30 s silence window` — second identical error within window doesn't update the banner body
4. `shows a new banner after the silence window expires` — error after 31 s produces a new banner
5. `still shows banner for makeCall` — no regression, now shows `/chamada/i`
6. `still shows banner for sendSms` — no regression, now shows `/mensagem/i`
7. `still shows banner for requestAllPermissions` — no regression, shows `/permiss/i`

## Red step output (before fix)

```
● App — bridge error banner gate › shows a banner for a non-suppressed method (getWifiInfo)
  Unable to find an element with text: /Wi-Fi/i
```

## Green step output (after fix)

```
PASS Android src/__tests__/App.bridgeError.test.tsx
  ✓ shows a banner for a non-suppressed method (getWifiInfo) (157 ms)
  ✓ suppresses banner for high-frequency method (getRecentMessages) (53 ms)
  ✓ deduplicates same method errors within the 30 s silence window (70 ms)
  ✓ shows a new banner after the silence window expires (91 ms)
  ✓ still shows banner for makeCall (no regression) (56 ms)
  ✓ still shows banner for sendSms (no regression) (54 ms)
  ✓ still shows banner for requestAllPermissions (no regression) (57 ms)
Tests: 7 passed
```

## Test results vs baseline

Baseline (before PR): 5 suites failed, 13 tests failed
After PR: 4 suites failed, 8 tests failed (pre-existing failures unrelated to this change)
No new failures introduced.