### PR TITLE
fix: corrigir nomes de painéis do sistema incorrectos (#361)

### DIFF
--- a/modules/launcher-module/android/src/main/java/com/iostoandroid/launcher/LauncherModule.kt
+++ b/modules/launcher-module/android/src/main/java/com/iostoandroid/launcher/LauncherModule.kt
@@ -444,7 +444,10 @@ class LauncherModule : Module() {
                 "cellular" -> Settings.ACTION_NETWORK_OPERATOR_SETTINGS
                 "data_roaming" -> Settings.ACTION_DATA_ROAMING_SETTINGS
                 "appinfo" -> Settings.ACTION_APPLICATION_DETAILS_SETTINGS
-                else -> Settings.ACTION_SETTINGS
+                // ACTION_APN_SETTINGS opens the APN editor. On carrier-locked ROMs it may
+                // start a no-op activity; the outer try/catch already falls back gracefully.
+                "apn" -> Settings.ACTION_APN_SETTINGS
+                else -> { android.util.Log.w("LauncherModule", "openSystemSettings: unknown panel '$panel'"); Settings.ACTION_SETTINGS }
             }
             try {
                 val intent = if (panel == "appinfo") {

--- a/src/screens/ControlCenterScreen.tsx
+++ b/src/screens/ControlCenterScreen.tsx
@@ -565,30 +565,6 @@ export function ControlCenterScreen({ navigation }: { navigation: AppNavigationP
                 onPress={() => { hapticImpact(Haptics.ImpactFeedbackStyle.Light).catch(() => {}); launchCamera(); }}
                 accessibilityLabel="Open Camera"
               />
-              <ShortcutButton
-                iconName="share-social-outline"
-                label="Nearby Share"
-                textScale={textScale}
-                onPress={async () => {
-                  hapticImpact(Haptics.ImpactFeedbackStyle.Light).catch(() => {});
-                  const mod = await getLauncher();
-                  if (mod) {
-                    try {
-                      // Try to open Nearby Share system panel; fall back to general settings
-                      await mod.openSystemSettings('nearby_share');
-                    } catch {
-                      try {
-                        await mod.openSystemSettings('settings');
-                      } catch {
-                        alert('Nearby Share', 'Opening Nearby Share...');
-                      }
-                    }
-                  } else {
-                    alert('Nearby Share', 'Opening Nearby Share...');
-                  }
-                }}
-                accessibilityLabel="Open Nearby Share"
-              />
             </View>
           </View>
 

--- a/src/screens/settings/KeyboardScreen.tsx
+++ b/src/screens/settings/KeyboardScreen.tsx
@@ -145,7 +145,7 @@ export function KeyboardScreen({ navigation }: { navigation: AppNavigationProp }
                 backgroundColor: colors.systemGray,
               }}
               showChevron
-              onPress={() => openSystemPanel('input_method')}
+              onPress={() => openSystemPanel('keyboard')}
             />
           </CupertinoListSection>
         </View>

--- a/src/screens/settings/__tests__/KeyboardScreen.test.tsx
+++ b/src/screens/settings/__tests__/KeyboardScreen.test.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { fireEvent, render } from '../../../test-utils';
+import { KeyboardScreen } from '../KeyboardScreen';
+
+// getMany is not in the global mock — add it here
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(() => Promise.resolve(null)),
+    setItem: jest.fn(() => Promise.resolve()),
+    removeItem: jest.fn(() => Promise.resolve()),
+    getMany: jest.fn(() => Promise.resolve({})),
+  },
+}));
+
+const mockOpenSystemPanel = jest.fn();
+
+jest.mock('../../../store/DeviceStore', () => ({
+  useDevice: () => ({
+    openSystemPanel: mockOpenSystemPanel,
+    settings: {},
+  }),
+  DeviceProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  DeviceContext: null,
+}));
+
+const mockNavigation = { navigate: jest.fn(), goBack: jest.fn(), push: jest.fn() };
+
+describe('KeyboardScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders without crashing', () => {
+    const { toJSON } = render(<KeyboardScreen navigation={mockNavigation as never} />);
+    expect(toJSON()).toBeTruthy();
+  });
+
+  // Red step: before fix, pressing "Advanced Keyboard Settings" calls openSystemPanel
+  // with 'input_method' (wrong — not a known panel in the Kotlin when).
+  // After fix: calls with 'keyboard' (the correct case in LauncherModule.kt:435).
+  it('pressing "Advanced Keyboard Settings" calls openSystemPanel with "keyboard"', () => {
+    const { getByText } = render(<KeyboardScreen navigation={mockNavigation as never} />);
+
+    fireEvent.press(getByText('Advanced Keyboard Settings (System)'));
+
+    expect(mockOpenSystemPanel).toHaveBeenCalledWith('keyboard');
+    expect(mockOpenSystemPanel).not.toHaveBeenCalledWith('input_method');
+  });
+});


### PR DESCRIPTION
Closes #361. Fixes: KeyboardScreen 'input_method'→'keyboard', LauncherModule.kt adiciona case 'apn', remove tile Nearby Share (sem Intent estável). 2 testes novos, 0 regressões.