### PR TITLE
fix: VpnScreen — ler isVpn do bridge; remover botão duplicado (#363)

### DIFF
--- a/src/screens/settings/VpnScreen.tsx
+++ b/src/screens/settings/VpnScreen.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
-import { View, Text, ScrollView, StyleSheet } from 'react-native';
+import React, { useState, useCallback } from 'react';
+import { Platform, View, Text, ScrollView, StyleSheet } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
+import { useFocusEffect } from '@react-navigation/native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import * as Haptics from 'expo-haptics';
 import { useTheme } from '../../theme/ThemeContext';
@@ -12,12 +13,31 @@ import {
 } from '../../components';
 import type { AppNavigationProp } from '../../navigation/types';
 import { hapticImpact } from '../../utils/haptics';
+import LauncherModule from '../../../modules/launcher-module/src';
 
 export function VpnScreen({ navigation }: { navigation: AppNavigationProp }) {
   const { theme, typography, spacing } = useTheme();
   const { colors } = theme;
   const insets = useSafeAreaInsets();
   const { openSystemPanel } = useDevice();
+
+  const [isVpn, setIsVpn] = useState<boolean | null>(null);
+
+  const loadVpnStatus = useCallback(async () => {
+    if (Platform.OS !== 'android') return;
+    try {
+      const info = await LauncherModule.getNetworkInfo();
+      setIsVpn(info.isVpn);
+    } catch { /* ignore — module unavailable */ }
+  }, []);
+
+  useFocusEffect(useCallback(() => { loadVpnStatus(); }, [loadVpnStatus]));
+
+  const statusLabel = isVpn === null
+    ? 'Checking...'
+    : isVpn
+      ? 'Connected'
+      : 'Not Connected';
 
   return (
     <View style={[styles.container, { backgroundColor: colors.systemGroupedBackground }]}>
@@ -54,7 +74,7 @@ export function VpnScreen({ navigation }: { navigation: AppNavigationProp }) {
               title="Status"
               trailing={
                 <Text style={[typography.body, { color: colors.secondaryLabel }]}>
-                  Not Configured
+                  {statusLabel}
                 </Text>
               }
               showChevron={false}
@@ -68,17 +88,6 @@ export function VpnScreen({ navigation }: { navigation: AppNavigationProp }) {
             <CupertinoListTile
               title="Add VPN Configuration..."
               leading={{ name: 'add-circle-outline', color: '#FFFFFF', backgroundColor: colors.systemBlue }}
-              onPress={() => { hapticImpact(Haptics.ImpactFeedbackStyle.Light).catch(() => {}); openSystemPanel('vpn'); }}
-            />
-          </CupertinoListSection>
-        </View>
-
-        {/* Open System Settings */}
-        <View style={{ paddingHorizontal: spacing.md }}>
-          <CupertinoListSection>
-            <CupertinoListTile
-              title="Open VPN Settings"
-              leading={{ name: 'open-outline', color: '#FFF', backgroundColor: colors.systemBlue }}
               onPress={() => { hapticImpact(Haptics.ImpactFeedbackStyle.Light).catch(() => {}); openSystemPanel('vpn'); }}
             />
           </CupertinoListSection>

--- a/src/screens/settings/__tests__/VpnScreen.test.tsx
+++ b/src/screens/settings/__tests__/VpnScreen.test.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { render, waitFor } from '../../../test-utils';
+import { VpnScreen } from '../VpnScreen';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(() => Promise.resolve(null)),
+    setItem: jest.fn(() => Promise.resolve()),
+    removeItem: jest.fn(() => Promise.resolve()),
+    getMany: jest.fn(() => Promise.resolve({})),
+  },
+}));
+
+const mockOpenSystemPanel = jest.fn();
+
+jest.mock('../../../store/DeviceStore', () => ({
+  useDevice: () => ({
+    openSystemPanel: mockOpenSystemPanel,
+    settings: {},
+  }),
+  DeviceProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  DeviceContext: null,
+}));
+
+// useFocusEffect not in global setup — call callback on mount for tests
+jest.mock('@react-navigation/native', () => ({
+  ...jest.requireActual('@react-navigation/native'),
+  useFocusEffect: (cb: () => void) => { cb(); },
+  useNavigation: () => ({ navigate: jest.fn(), goBack: jest.fn(), canGoBack: jest.fn(() => false) }),
+  useRoute: () => ({ params: {} }),
+  NavigationContainer: ({ children }: { children: React.ReactNode }) => children as React.ReactElement,
+}));
+
+// The global moduleNameMapper stubs launcher-module; get a reference to spy on getNetworkInfo
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const launcherStub = require('../../../__mocks__/launcherModule');
+
+const mockNavigation = { navigate: jest.fn(), goBack: jest.fn(), push: jest.fn() };
+
+describe('VpnScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders without crashing when getNetworkInfo rejects', async () => {
+    launcherStub.default.getNetworkInfo.mockRejectedValue(new Error('unavailable'));
+    const { toJSON } = render(<VpnScreen navigation={mockNavigation as never} />);
+    await waitFor(() => {}); // flush async
+    expect(toJSON()).toBeTruthy();
+  });
+
+  // RED: before fix, status is hardcoded 'Not Configured' regardless of isVpn
+  it('shows "Connected" when isVpn is true', async () => {
+    launcherStub.default.getNetworkInfo.mockResolvedValue({
+      isConnected: true, isWifi: false, isCellular: false, isVpn: true,
+    });
+
+    const { findByText, queryByText } = render(<VpnScreen navigation={mockNavigation as never} />);
+
+    await findByText('Connected');
+    expect(queryByText('Not Configured')).toBeNull();
+    expect(queryByText('Not Connected')).toBeNull();
+  });
+
+  // RED: before fix, 'Not Configured' appears; after fix, 'Not Connected' when isVpn=false
+  it('shows "Not Connected" when isVpn is false', async () => {
+    launcherStub.default.getNetworkInfo.mockResolvedValue({
+      isConnected: true, isWifi: true, isCellular: false, isVpn: false,
+    });
+
+    const { findByText, queryByText } = render(<VpnScreen navigation={mockNavigation as never} />);
+
+    await findByText('Not Connected');
+    expect(queryByText('Not Configured')).toBeNull();
+  });
+
+  // Only one VPN settings button should exist (duplicate "Open VPN Settings" was removed)
+  it('renders exactly one "Add VPN Configuration" button and no duplicate', () => {
+    launcherStub.default.getNetworkInfo.mockResolvedValue({
+      isConnected: false, isWifi: false, isCellular: false, isVpn: false,
+    });
+
+    const { getAllByText, queryByText } = render(<VpnScreen navigation={mockNavigation as never} />);
+    expect(getAllByText('Add VPN Configuration...')).toHaveLength(1);
+    expect(queryByText('Open VPN Settings')).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #363. isVpn lido via LauncherModule.getNetworkInfo() com useFocusEffect; status dinâmico 'Connected'/'Not Connected'; botão duplicado 'Open VPN Settings' removido; 4 testes novos.