### PR TITLE
fix: StorageScreen marks estimated categories with (est.) and reduces precision (#366)

### DIFF
--- a/src/screens/settings/StorageScreen.tsx
+++ b/src/screens/settings/StorageScreen.tsx
@@ -49,6 +49,15 @@ function formatBytes(bytes: number): string {
   return `${(bytes / 1073741824).toFixed(2)} GB`;
 }
 
+// Lower precision for derived/estimated values so the formatting itself signals uncertainty.
+function formatBytesRough(bytes: number): string {
+  if (bytes === 0) return '0 B';
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1048576) return `${Math.round(bytes / 1024)} KB`;
+  if (bytes < 1073741824) return `${Math.round(bytes / 1048576)} MB`;
+  return `${(bytes / 1073741824).toFixed(1)} GB`;
+}
+
 export function StorageScreen({ navigation }: { navigation: AppNavigationProp }) {
   const { theme, typography, spacing } = useTheme();
   const { colors } = theme;
@@ -84,11 +93,11 @@ export function StorageScreen({ navigation }: { navigation: AppNavigationProp })
   const totalBytes = parseFloat(storage.totalGB) * 1073741824 || 1;
 
   const categories = [
-    { label: 'Apps', color: CATEGORY_COLORS.apps, bytes: totalAppBytes, fraction: totalAppBytes / totalBytes },
-    { label: 'Photos & Media', color: CATEGORY_COLORS.photos, bytes: estimatedPhotosBytes, fraction: estimatedPhotosBytes / totalBytes },
-    { label: 'Messages', color: CATEGORY_COLORS.messages, bytes: estimatedMessagesBytes, fraction: estimatedMessagesBytes / totalBytes },
-    { label: 'System', color: CATEGORY_COLORS.system, bytes: estimatedSystemBytes, fraction: estimatedSystemBytes / totalBytes },
-    { label: 'Other', color: CATEGORY_COLORS.other, bytes: estimatedOtherBytes, fraction: estimatedOtherBytes / totalBytes },
+    { label: 'Apps', color: CATEGORY_COLORS.apps, bytes: totalAppBytes, fraction: totalAppBytes / totalBytes, estimated: false },
+    { label: 'Photos & Media', color: CATEGORY_COLORS.photos, bytes: estimatedPhotosBytes, fraction: estimatedPhotosBytes / totalBytes, estimated: true },
+    { label: 'Messages', color: CATEGORY_COLORS.messages, bytes: estimatedMessagesBytes, fraction: estimatedMessagesBytes / totalBytes, estimated: true },
+    { label: 'System', color: CATEGORY_COLORS.system, bytes: estimatedSystemBytes, fraction: estimatedSystemBytes / totalBytes, estimated: true },
+    { label: 'Other', color: CATEGORY_COLORS.other, bytes: estimatedOtherBytes, fraction: estimatedOtherBytes / totalBytes, estimated: false },
   ];
 
   const freeFraction = Math.max(0, 1 - categories.reduce((sum, c) => sum + c.fraction, 0));
@@ -142,7 +151,10 @@ export function StorageScreen({ navigation }: { navigation: AppNavigationProp })
 
         {/* Category breakdown */}
         <View style={{ paddingHorizontal: spacing.md, marginTop: spacing.md }}>
-          <CupertinoListSection header="Categories">
+          <CupertinoListSection
+            header="Categories"
+            footer="Photos, Messages & System values are estimates based on typical usage patterns."
+          >
             {categories.map((cat) => (
               <CupertinoListTile
                 key={cat.label}
@@ -151,7 +163,9 @@ export function StorageScreen({ navigation }: { navigation: AppNavigationProp })
                   <View style={styles.trailingRow}>
                     <View style={[styles.dot, { backgroundColor: cat.color }]} />
                     <Text style={[typography.body, { color: colors.secondaryLabel }]}>
-                      {formatBytes(cat.bytes)}
+                      {cat.estimated
+                        ? `${formatBytesRough(cat.bytes)} (est.)`
+                        : formatBytes(cat.bytes)}
                     </Text>
                   </View>
                 }

--- a/src/screens/settings/__tests__/StorageScreen.test.tsx
+++ b/src/screens/settings/__tests__/StorageScreen.test.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { render } from '../../../test-utils';
+import { StorageScreen } from '../StorageScreen';
+
+jest.mock('@react-navigation/native', () => ({
+  ...jest.requireActual('@react-navigation/native'),
+  useNavigation: () => ({ navigate: jest.fn(), goBack: jest.fn(), canGoBack: jest.fn(() => false) }),
+  useRoute: () => ({ params: {} }),
+}));
+
+jest.mock('expo-haptics', () => ({
+  ImpactFeedbackStyle: { Light: 'Light' },
+  impactAsync: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock('../../../utils/haptics', () => ({
+  hapticImpact: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(() => Promise.resolve(null)),
+    setItem: jest.fn(() => Promise.resolve()),
+    removeItem: jest.fn(() => Promise.resolve()),
+    removeMany: jest.fn(() => Promise.resolve()),
+    multiGet: jest.fn(() => Promise.resolve([])),
+    getAllKeys: jest.fn(() => Promise.resolve([])),
+    getMany: jest.fn(() => Promise.resolve({})),
+  },
+}));
+
+jest.mock('../../../store/SettingsStore', () => ({
+  useSettings: jest.fn(() => ({ settings: { automaticUpdates: true, updateAvailable: false }, update: jest.fn() })),
+  SettingsProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const mockStorage = {
+  usedGB: '10',
+  totalGB: '64',
+  freeGB: '54',
+  usedPercentage: 15.6,
+};
+
+jest.mock('../../../store/DeviceStore', () => ({
+  useDevice: () => ({
+    openSystemPanel: jest.fn(),
+    storage: mockStorage,
+    settings: {},
+  }),
+  DeviceProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  DeviceContext: null,
+}));
+
+const mockNavigation = { navigate: jest.fn(), goBack: jest.fn() };
+
+describe('StorageScreen', () => {
+  it('renders without crashing', () => {
+    const { toJSON } = render(<StorageScreen navigation={mockNavigation as never} />);
+    expect(toJSON()).toBeTruthy();
+  });
+
+  // RED: before fix, estimated categories had no disclosure. After fix, they show "(est.)".
+  it('shows (est.) marker on Photos & Media, Messages, and System', () => {
+    const { getAllByText } = render(<StorageScreen navigation={mockNavigation as never} />);
+    // Each estimated category value ends with " (est.)"
+    const estMarkers = getAllByText(/\(est\.\)/);
+    expect(estMarkers.length).toBeGreaterThanOrEqual(3); // Photos, Messages, System
+  });
+
+  it('does NOT show (est.) marker on Apps category', () => {
+    const { queryAllByText, getByText } = render(<StorageScreen navigation={mockNavigation as never} />);
+    // Apps tile must exist
+    expect(getByText('Apps')).toBeTruthy();
+    // The Apps value row should not contain "(est.)"
+    const estItems = queryAllByText(/\(est\.\)/);
+    // Verify count is exactly 3 (Photos, Messages, System) — not 4 or 5
+    expect(estItems).toHaveLength(3);
+  });
+
+  it('shows footnote about estimated values', () => {
+    const { getByText } = render(<StorageScreen navigation={mockNavigation as never} />);
+    expect(getByText(/Photos.*Messages.*System.*estimates/i)).toBeTruthy();
+  });
+
+  it('estimated values use at most 1 decimal place for GB', () => {
+    const { getAllByText } = render(<StorageScreen navigation={mockNavigation as never} />);
+    const estItems = getAllByText(/\(est\.\)/);
+    estItems.forEach((item) => {
+      const text = item.props.children;
+      if (typeof text === 'string' && text.includes('GB')) {
+        // Should be "X.X GB (est.)" — at most 1 decimal, not 2
+        expect(text).toMatch(/^\d+(\.\d)? GB \(est\.\)$/);
+      }
+    });
+  });
+});


### PR DESCRIPTION
Fixes #366.

- Add `formatBytesRough()` that caps GB at 1 decimal (vs 2 for measured values)
- Add `estimated: boolean` flag to each category — Photos & Media, Messages, System are true; Apps and Other are false
- Render estimated values as 'X.X GB (est.)' instead of 'X.XX GB'
- Add footnote to Categories section: 'Photos, Messages & System values are estimates based on typical usage patterns.'
- Apps (measured via getAppStorageStats) and Available (measured by OS) remain unchanged
- 5 tests; 4 fail before fix (no est. marker), 5 pass after
- No regressions (same 4 pre-existing baseline failures)