### PR TITLE
fix(#367): remove duplicate Screen Rec tile from ControlCenterScreen

### DIFF
--- a/src/screens/ControlCenterScreen.tsx
+++ b/src/screens/ControlCenterScreen.tsx
@@ -537,21 +537,6 @@ export function ControlCenterScreen({ navigation }: { navigation: AppNavigationP
                 accessibilityLabel={flashlightOn ? 'Turn off torch' : 'Turn on torch'}
               />
               <ShortcutButton
-                iconName="radio-button-on"
-                label="Screen Rec"
-                textScale={textScale}
-                onPress={async () => {
-                  hapticImpact(Haptics.ImpactFeedbackStyle.Light).catch(() => {});
-                  const mod = await getLauncher();
-                  if (mod) {
-                    await mod.openSystemSettings('cast');
-                  } else {
-                    alert('Screen Recording', 'Could not open screen recorder settings.');
-                  }
-                }}
-                accessibilityLabel="Open Screen Recording"
-              />
-              <ShortcutButton
                 iconName="calculator-outline"
                 label="Calculator"
                 textScale={textScale}

--- a/src/screens/__tests__/ControlCenterScreen.test.tsx
+++ b/src/screens/__tests__/ControlCenterScreen.test.tsx
@@ -51,4 +51,19 @@ describe('ControlCenterScreen', () => {
     // Should not throw — state toggling works
     expect(wifi).toBeTruthy();
   });
+
+  it('does not render a Screen Rec tile', () => {
+    const { queryByText, queryByLabelText } = render(
+      <ControlCenterScreen navigation={navigation} />,
+    );
+    expect(queryByText('Screen Rec')).toBeNull();
+    expect(queryByLabelText('Open Screen Recording')).toBeNull();
+  });
+
+  it('renders Screen Mirroring tile', () => {
+    const { getByLabelText } = render(
+      <ControlCenterScreen navigation={navigation} />,
+    );
+    expect(getByLabelText('Screen Mirroring')).toBeTruthy();
+  });
 });


### PR DESCRIPTION
## What

Removes the "Screen Rec" `ShortcutButton` from `ControlCenterScreen`. That tile called `openSystemSettings('cast')` — identical to the "Screen Mirroring" tile already present in the same screen. Having two tiles with the same action is confusing and redundant.

## Changes

- `src/screens/ControlCenterScreen.tsx`: removed the `ShortcutButton` block with `iconName="radio-button-on"`, `label="Screen Rec"`, `accessibilityLabel="Open Screen Recording"` (~lines 539–553).
- `src/screens/__tests__/ControlCenterScreen.test.tsx`: added two tests:
  - `does not render a Screen Rec tile` — asserts `queryByText('Screen Rec')` and `queryByLabelText('Open Screen Recording')` return null.
  - `renders Screen Mirroring tile` — asserts Screen Mirroring tile is still present.

## Red → Green

Before fix: `does not render a Screen Rec tile` fails (tile exists).  
After fix: 8/8 pass. No new failures in the full suite (same 4 pre-existing failures as main).

Closes #367