### PR TITLE
fix(#368): add dismissible demo banner to MapsScreen

### DIFF
--- a/src/screens/MapsScreen.tsx
+++ b/src/screens/MapsScreen.tsx
@@ -39,6 +39,7 @@ interface RecentLocation {
 // ─── Constants ──────────────────────────────────────────────────────────────
 
 const STORAGE_KEY = '@iostoandroid/maps_recents';
+const DEMO_BANNER_KEY = '@iostoandroid/maps_demo_dismissed';
 const MAPS_ACCENT = '#007AFF';
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
@@ -194,6 +195,7 @@ export function MapsScreen({ navigation }: { navigation: AppNavigationProp }) {
   const [selectedLocation, setSelectedLocation] = useState<RecentLocation | null>(null);
   const [showShareSheet, setShowShareSheet] = useState(false);
   const [showFavoritesOnly, setShowFavoritesOnly] = useState(false);
+  const [demoBannerDismissed, setDemoBannerDismissed] = useState(true);
 
   // ── Persistence ─────────────────────────────────────────────
 
@@ -207,7 +209,10 @@ export function MapsScreen({ navigation }: { navigation: AppNavigationProp }) {
 
   useEffect(() => {
     let cancelled = false;
-    AsyncStorage.getItem(STORAGE_KEY).then((raw) => {
+    Promise.all([
+      AsyncStorage.getItem(STORAGE_KEY),
+      AsyncStorage.getItem(DEMO_BANNER_KEY),
+    ]).then(([raw, bannerRaw]) => {
       if (cancelled) return;
       if (raw) {
         try {
@@ -215,9 +220,15 @@ export function MapsScreen({ navigation }: { navigation: AppNavigationProp }) {
           setRecents(parsed.sort((a, b) => b.timestamp - a.timestamp));
         } catch { /* ignore */ }
       }
+      if (bannerRaw !== 'true') setDemoBannerDismissed(false);
       setLoaded(true);
     }).catch(() => { if (!cancelled) setLoaded(true); });
     return () => { cancelled = true; };
+  }, []);
+
+  const dismissDemoBanner = useCallback(() => {
+    setDemoBannerDismissed(true);
+    AsyncStorage.setItem(DEMO_BANNER_KEY, 'true');
   }, []);
 
   // ── Location ────────────────────────────────────────────────
@@ -333,6 +344,19 @@ export function MapsScreen({ navigation }: { navigation: AppNavigationProp }) {
 
   const renderListHeader = () => (
     <View>
+      {/* Demo banner */}
+      {!demoBannerDismissed && (
+        <View style={styles.demoBanner}>
+          <Ionicons name="information-circle-outline" size={20} color="#92400e" style={{ marginRight: 8 }} />
+          <Text style={styles.demoBannerText}>
+            Demo Mode — The map is illustrative only. No geolocation, route calculation, or GPS data is used. Recent searches are stored locally.
+          </Text>
+          <Pressable onPress={dismissDemoBanner} hitSlop={8} style={{ marginLeft: 8 }} accessibilityLabel="Dismiss demo banner">
+            <Ionicons name="close" size={18} color="#92400e" />
+          </Pressable>
+        </View>
+      )}
+
       {/* Search bar */}
       <View style={[styles.searchContainer, { paddingHorizontal: spacing.md }]}>
         <CupertinoSearchBar
@@ -550,6 +574,23 @@ export function MapsScreen({ navigation }: { navigation: AppNavigationProp }) {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
+  },
+  demoBanner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#fef3c7',
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    margin: 12,
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: '#fcd34d',
+  },
+  demoBannerText: {
+    flex: 1,
+    fontSize: 13,
+    color: '#92400e',
+    lineHeight: 18,
   },
   searchContainer: {
     paddingVertical: 8,

--- a/src/screens/__tests__/MapsScreen.test.tsx
+++ b/src/screens/__tests__/MapsScreen.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '../../test-utils';
+import { MapsScreen } from '../MapsScreen';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const navigation = { navigate: jest.fn(), goBack: jest.fn() } as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+
+describe('MapsScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (AsyncStorage.getItem as jest.Mock).mockImplementation(() => Promise.resolve(null));
+  });
+
+  it('renders without crashing', async () => {
+    const { toJSON } = render(<MapsScreen navigation={navigation} />);
+    expect(toJSON()).toBeTruthy();
+  });
+
+  it('shows demo banner when not dismissed', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockImplementation((key: string) =>
+      key === '@iostoandroid/maps_demo_dismissed' ? Promise.resolve(null) : Promise.resolve(null)
+    );
+    const { findByText } = render(<MapsScreen navigation={navigation} />);
+    await findByText(/Demo Mode/i, {}, { timeout: 5000 });
+  });
+
+  it('hides demo banner when already dismissed', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockImplementation((key: string) =>
+      key === '@iostoandroid/maps_demo_dismissed' ? Promise.resolve('true') : Promise.resolve(null)
+    );
+    const { queryByText } = render(<MapsScreen navigation={navigation} />);
+    await waitFor(() => {}, { timeout: 500 });
+    expect(queryByText(/Demo Mode/i)).toBeNull();
+  });
+
+  it('dismisses banner on close press', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockImplementation((key: string) =>
+      key === '@iostoandroid/maps_demo_dismissed' ? Promise.resolve(null) : Promise.resolve(null)
+    );
+    const { findByLabelText, queryByText } = render(<MapsScreen navigation={navigation} />);
+    const closeBtn = await findByLabelText('Dismiss demo banner', {}, { timeout: 5000 });
+    fireEvent.press(closeBtn);
+    await waitFor(() => {
+      expect(queryByText(/Demo Mode/i)).toBeNull();
+    });
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith('@iostoandroid/maps_demo_dismissed', 'true');
+  });
+});


### PR DESCRIPTION
## What

MapsScreen showed a fake map (LinearGradient with grid lines), non-functional quick actions (Directions/Search Nearby show alerts), and a recents list that stores user-typed searches — none of which was disclosed. Added a dismissible demo banner matching the MailScreen pattern.

## Changes

- `src/screens/MapsScreen.tsx`:
  - Added `DEMO_BANNER_KEY = '@iostoandroid/maps_demo_dismissed'` constant
  - Added `demoBannerDismissed` state (initialised `true` to avoid flash before AsyncStorage loads)
  - Extended existing `useEffect` to load banner state via `Promise.all`
  - Added `dismissDemoBanner` callback (sets state + persists `'true'` to AsyncStorage)
  - Inserted banner at top of `renderListHeader()` with text naming: fake map, no geolocation, no route calculation, recents = local search history
  - Added `demoBanner` + `demoBannerText` styles (identical to MailScreen)
- `src/screens/__tests__/MapsScreen.test.tsx` (new):
  - 4 tests: renders without crashing, banner shown when key absent, banner hidden when key='true', dismiss closes banner and writes key

## Illustrative elements named by banner

The map is illustrative only. No geolocation, route calculation, or GPS data is used. Recent searches are stored locally.

Note: a real map integration (react-native-maps + expo-location + API keys) is a separate issue.

## Red → Green

Before fix: `shows demo banner when not dismissed` and `dismisses banner on close press` fail (element not found).  
After fix: 4/4 pass. No new failures vs baseline (same 4 pre-existing suites).

Closes #368