### PR TITLE
fix(#369): clear Bluetooth discovered map on each new discovery

### DIFF
--- a/modules/launcher-module/android/src/main/java/com/iostoandroid/launcher/LauncherModule.kt
+++ b/modules/launcher-module/android/src/main/java/com/iostoandroid/launcher/LauncherModule.kt
@@ -314,6 +314,7 @@ class LauncherModule : Module() {
                 val btManager = context.getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager
                 val adapter = btManager?.adapter
                 if (adapter == null || !adapter.isEnabled) return@AsyncFunction false
+                BluetoothDiscoveryReceiver.clear()
                 BluetoothDiscoveryReceiver.register(context)
                 if (adapter.isDiscovering) {
                     adapter.cancelDiscovery()


### PR DESCRIPTION
## What

`BluetoothDiscoveryReceiver.clear()` was defined (BluetoothDiscoveryReceiver.kt:70) but never called. Every `startBluetoothDiscovery` call accumulated stale devices from prior scans — devices that may now be powered off or out of range — into the `ConcurrentHashMap` for the lifetime of the process.

## Fix

Added a single call to `BluetoothDiscoveryReceiver.clear()` in `startBluetoothDiscovery` (LauncherModule.kt) **before** `register()`:

```kotlin
// before
BluetoothDiscoveryReceiver.register(context)

// after
BluetoothDiscoveryReceiver.clear()
BluetoothDiscoveryReceiver.register(context)
```

`clear()` is placed before `register()` (not after) to eliminate the race window between registration and clearing: an `ACTION_FOUND` broadcast arriving after `register()` but before `clear()` would be immediately wiped.

## Verification

`grep -n "clear()" modules/launcher-module/android/` before fix: definition only (BluetoothDiscoveryReceiver.kt:70-71), no caller.  
After fix: LauncherModule.kt:317 is the caller.

Device test (cannot be run in headless CI): start scan, stop, power off a discovered device, start again — that device should not appear in the second list. Acceptance criterion requires manual device verification.

## Tests

Kotlin change; no automated Jest test exists for this path. JS test suite: 4 pre-existing suites failing (LockScreen/FoldersStore/SettingsScreen/WeatherScreen), 8 tests — unchanged from baseline.

Closes #369