### PR TITLE
fix/issue-370: show location-disabled message in Wi-Fi scan

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -275,6 +275,7 @@ jest.mock('./modules/launcher-module/src', () => ({
     openLauncherSettings: jest.fn(() => Promise.resolve(true)),
     getWifiInfo: jest.fn(() => Promise.resolve({ enabled: true, ssid: 'TestWiFi', rssi: -50, ip: '192.168.1.100' })),
     setWifiEnabled: jest.fn(() => Promise.resolve(true)),
+    isLocationEnabled: jest.fn(() => Promise.resolve(true)),
     getWifiNetworks: jest.fn(() => Promise.resolve([{ ssid: 'TestWiFi', level: -50, isSecure: true }])),
     getBluetoothInfo: jest.fn(() => Promise.resolve({ enabled: true, name: 'TestDevice', address: '', pairedDevices: [] })),
     setBluetoothEnabled: jest.fn(() => Promise.resolve(true)),

--- a/modules/launcher-module/android/src/main/java/com/iostoandroid/launcher/LauncherModule.kt
+++ b/modules/launcher-module/android/src/main/java/com/iostoandroid/launcher/LauncherModule.kt
@@ -252,6 +252,17 @@ class LauncherModule : Module() {
             } catch (e: Exception) { false }
         }
 
+        AsyncFunction("isLocationEnabled") {
+            val lm = context.getSystemService(Context.LOCATION_SERVICE) as android.location.LocationManager
+            @Suppress("DEPRECATION")
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P) {
+                lm.isLocationEnabled
+            } else {
+                lm.isProviderEnabled(android.location.LocationManager.GPS_PROVIDER) ||
+                        lm.isProviderEnabled(android.location.LocationManager.NETWORK_PROVIDER)
+            }
+        }
+
         AsyncFunction("getWifiNetworks") {
             val wifiManager = context.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
             val results = wifiManager.scanResults ?: emptyList()

--- a/modules/launcher-module/src/index.ts
+++ b/modules/launcher-module/src/index.ts
@@ -149,6 +149,7 @@ interface LauncherModuleType {
   // Wi-Fi
   getWifiInfo(): Promise<WifiInfo>;
   setWifiEnabled(enabled: boolean): Promise<boolean>;
+  isLocationEnabled(): Promise<boolean>;
   getWifiNetworks(): Promise<WifiNetwork[]>;
   joinWifiNetwork(ssid: string, password: string, security: string): Promise<boolean>;
   forgetWifiNetwork(ssid: string): Promise<boolean>;
@@ -220,6 +221,7 @@ const stub: LauncherModuleType = {
   uninstallApp: async () => false,
   getWifiInfo: async () => ({ enabled: false, ssid: '', rssi: 0, linkSpeed: 0, ip: '' }),
   setWifiEnabled: async () => false,
+  isLocationEnabled: async () => true,
   getWifiNetworks: async () => [],
   joinWifiNetwork: async () => false,
   forgetWifiNetwork: async () => false,
@@ -307,6 +309,10 @@ function createBridgedModule(): LauncherModuleType {
     setWifiEnabled: async (enabled: boolean) => {
       try { return await nativeModule.setWifiEnabled(enabled); }
       catch (e) { console.error('LauncherModule.setWifiEnabled failed:', e); reportBridgeError('setWifiEnabled', e); return false; }
+    },
+    isLocationEnabled: async () => {
+      try { return await nativeModule.isLocationEnabled(); }
+      catch (e) { console.error('LauncherModule.isLocationEnabled failed:', e); reportBridgeError('isLocationEnabled', e); return true; }
     },
     getWifiNetworks: async () => {
       try { return await nativeModule.getWifiNetworks(); }

--- a/src/__mocks__/launcherModule.js
+++ b/src/__mocks__/launcherModule.js
@@ -11,6 +11,7 @@ module.exports = {
     openLauncherSettings: jest.fn(() => Promise.resolve(true)),
     getWifiInfo: jest.fn(() => Promise.resolve({ enabled: true, ssid: 'TestWiFi', rssi: -50, ip: '192.168.1.100' })),
     setWifiEnabled: jest.fn(() => Promise.resolve(true)),
+    isLocationEnabled: jest.fn(() => Promise.resolve(true)),
     getWifiNetworks: jest.fn(() => Promise.resolve([{ ssid: 'TestWiFi', level: -50, isSecure: true }])),
     getBluetoothInfo: jest.fn(() => Promise.resolve({ enabled: true, name: 'TestDevice', address: '', pairedDevices: [] })),
     setBluetoothEnabled: jest.fn(() => Promise.resolve(true)),

--- a/src/screens/settings/WifiScreen.tsx
+++ b/src/screens/settings/WifiScreen.tsx
@@ -14,6 +14,7 @@ import {
   useAlert,
 } from '../../components';
 import type { AppNavigationProp } from '../../navigation/types';
+import launcherModule from '../../../modules/launcher-module/src';
 
 interface ScannedNetwork {
   ssid: string;
@@ -23,14 +24,7 @@ interface ScannedNetwork {
   isSecure: boolean;
 }
 
-const getLauncher = async () => {
-  if (Platform.OS !== 'android') return null;
-  try {
-    return (await import('../../../modules/launcher-module/src')).default;
-  } catch {
-    return null;
-  }
-};
+const getLauncher = () => (Platform.OS === 'android' ? launcherModule : null);
 
 function getSignalBars(level: number): number {
   if (level > -50) return 3;
@@ -63,6 +57,7 @@ export function WifiScreen({ navigation }: { navigation: AppNavigationProp }) {
   const [scannedNetworks, setScannedNetworks] = useState<ScannedNetwork[]>([]);
   const [scanning, setScanning] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
+  const [locationEnabled, setLocationEnabled] = useState(true);
   const [joinSsid, setJoinSsid] = useState('');
   const [joinPassword, setJoinPassword] = useState('');
   const [joinSecurity, setJoinSecurity] = useState<'WPA2' | 'WPA3' | 'Open'>('WPA2');
@@ -71,10 +66,17 @@ export function WifiScreen({ navigation }: { navigation: AppNavigationProp }) {
   const [pendingNetwork, setPendingNetwork] = useState<ScannedNetwork | null>(null);
 
   const scanNetworks = useCallback(async () => {
+    // eslint-disable-next-line no-console
     setScanning(true);
     try {
-      const mod = await getLauncher();
+      const mod = getLauncher();
       if (!mod) return;
+      const locEnabled = await mod.isLocationEnabled().catch(() => true);
+      setLocationEnabled(locEnabled);
+      if (!locEnabled) {
+        setScannedNetworks([]);
+        return;
+      }
       const networks = await mod.getWifiNetworks().catch(() => []);
       // Deduplicate by SSID and keep the strongest signal for each
       const seen = new Map<string, ScannedNetwork>();
@@ -128,7 +130,7 @@ export function WifiScreen({ navigation }: { navigation: AppNavigationProp }) {
       (async () => {
         setConnecting(true);
         try {
-          const mod = await getLauncher();
+          const mod = getLauncher();
           if (!mod) return;
           const ok = await mod.joinWifiNetwork(network.ssid, '', 'Open');
           if (ok) {
@@ -151,7 +153,7 @@ export function WifiScreen({ navigation }: { navigation: AppNavigationProp }) {
     }
     setConnecting(true);
     try {
-      const mod = await getLauncher();
+      const mod = getLauncher();
       if (!mod) return;
       const ok = await mod.joinWifiNetwork(pendingNetwork.ssid, joinPassword, joinSecurity);
       if (ok) {
@@ -300,6 +302,12 @@ export function WifiScreen({ navigation }: { navigation: AppNavigationProp }) {
                     Scanning for networks...
                   </Text>
                 </View>
+              ) : !locationEnabled ? (
+                <CupertinoListTile
+                  title="Turn on Location to scan for networks"
+                  subtitle="Wi-Fi scanning requires Location Services to be enabled in Android Settings."
+                  showChevron={false}
+                />
               ) : scannedNetworks.length === 0 ? (
                 <CupertinoListTile
                   title="No networks found"

--- a/src/screens/settings/WifiScreen.tsx
+++ b/src/screens/settings/WifiScreen.tsx
@@ -66,7 +66,6 @@ export function WifiScreen({ navigation }: { navigation: AppNavigationProp }) {
   const [pendingNetwork, setPendingNetwork] = useState<ScannedNetwork | null>(null);
 
   const scanNetworks = useCallback(async () => {
-    // eslint-disable-next-line no-console
     setScanning(true);
     try {
       const mod = getLauncher();

--- a/src/screens/settings/__tests__/WifiScreen.test.tsx
+++ b/src/screens/settings/__tests__/WifiScreen.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { render, waitFor } from '../../../test-utils';
+import { WifiScreen } from '../WifiScreen';
+
+const mockNavigation = { navigate: jest.fn(), goBack: jest.fn() } as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+
+// Static import in WifiScreen (post-refactor from dynamic import) allows Jest's mock
+// registry to intercept it normally. Path from this __tests__/ dir needs 4 levels up
+// to reach project root (one deeper than the component's location).
+jest.mock('../../../../modules/launcher-module/src', () => ({
+  __esModule: true,
+  default: {
+    isLocationEnabled: jest.fn(() => Promise.resolve(true)),
+    getWifiNetworks: jest.fn(() => Promise.resolve([])),
+    getWifiInfo: jest.fn(() => Promise.resolve({ enabled: true, ssid: '', rssi: 0, ip: '' })),
+    setWifiEnabled: jest.fn(() => Promise.resolve(true)),
+    openSystemSettings: jest.fn(() => Promise.resolve(true)),
+    getNetworkInfo: jest.fn(() => Promise.resolve({ isConnected: true })),
+    joinWifiNetwork: jest.fn(() => Promise.resolve(false)),
+  },
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const launcherMock = (jest.requireMock('../../../../modules/launcher-module/src') as { default: Record<string, jest.Mock> }).default;
+
+jest.mock('../../../store/DeviceStore', () => ({
+  useDevice: () => ({
+    wifi: { enabled: true, ssid: '', rssi: 0, linkSpeed: 0, ip: '' },
+    toggleWifi: jest.fn(),
+    openSystemPanel: jest.fn(),
+  }),
+  DeviceProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  DeviceContext: null,
+}));
+
+describe('WifiScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    launcherMock.isLocationEnabled.mockResolvedValue(true);
+    launcherMock.getWifiNetworks.mockResolvedValue([]);
+  });
+
+  it('renders without crashing', () => {
+    const { toJSON } = render(<WifiScreen navigation={mockNavigation} />);
+    expect(toJSON()).toBeTruthy();
+  });
+
+  it('shows location-disabled message when location is off and networks empty', async () => {
+    launcherMock.isLocationEnabled.mockResolvedValue(false);
+    const { findByText } = render(<WifiScreen navigation={mockNavigation} />);
+    await findByText(/Turn on Location/i, {}, { timeout: 5000 });
+  });
+
+  it('does not show location message when location is on and networks empty', async () => {
+    launcherMock.isLocationEnabled.mockResolvedValue(true);
+    const { queryByText } = render(<WifiScreen navigation={mockNavigation} />);
+    await waitFor(() => {
+      expect(queryByText(/Turn on Location/i)).toBeNull();
+    }, { timeout: 3000 });
+  });
+});


### PR DESCRIPTION
## What

Fixes #370. When Android Location Services are off, `getWifiNetworks()` returns an empty list without explanation. The screen now shows a clear informational tile instead.

## Changes

**Kotlin — `LauncherModule.kt`**
- Added `AsyncFunction("isLocationEnabled")` — returns `true`/`false` via `LocationManager.isLocationEnabled` (API 28+) or GPS/Network provider check for older devices.

**TypeScript — `modules/launcher-module/src/index.ts`**
- Added `isLocationEnabled(): Promise<boolean>` to the interface
- Added stub (`async () => true`, non-blocking default)
- Added wrapper in `createBridgedModule()` with error catch + reportBridgeError

**WifiScreen.tsx**
- Converted `getLauncher` from a dynamic `import()` (which fails silently in Jest due to `--experimental-vm-modules` not being enabled) to a static import with a Platform guard — same runtime behaviour, testable in Jest
- Added `locationEnabled` state (default `true`)
- In `scanNetworks`: call `isLocationEnabled()` before `getWifiNetworks()`; if false, set state and return early
- Added conditional render: when `!locationEnabled`, show `CupertinoListTile` with title "Turn on Location to scan for networks"

**Mocks**
- `jest.setup.js` and `src/__mocks__/launcherModule.js`: added `isLocationEnabled: jest.fn(() => Promise.resolve(true))`

**Tests — `WifiScreen.test.tsx` (new)**
- `renders without crashing`
- `shows location-disabled message when location is off and networks empty` (red → green)
- `does not show location message when location is on and networks empty`

## Test run

```
✓ renders without crashing (1420 ms)
✓ shows location-disabled message when location is off and networks empty (132 ms)
✓ does not show location message when location is on and networks empty (136 ms)

Test Suites: 63 passed (4 pre-existing failures, unchanged)
Tests:       451 passed, 8 failed (same baseline)
```

## Red step

Without the `locationEnabled` state and conditional render, the test `shows location-disabled message when location is off and networks empty` fails with a 5s timeout — `Turn on Location` never appears. After the fix, it resolves in 132ms.