### PR TITLE
fix/issue-372: replace react-native SafeAreaView with useSafeAreaInsets in CalculatorScreen

### DIFF
--- a/src/screens/CalculatorScreen.tsx
+++ b/src/screens/CalculatorScreen.tsx
@@ -5,10 +5,10 @@ import {
   StyleSheet,
   Pressable,
   StatusBar,
-  SafeAreaView,
   ScrollView,
   useWindowDimensions,
 } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import * as Haptics from 'expo-haptics';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useTheme } from '../theme/ThemeContext';
@@ -288,6 +288,7 @@ function CalcButton({
 
 export function CalculatorScreen() {
   useTheme();
+  const insets = useSafeAreaInsets();
   const { width, height } = useWindowDimensions();
   const isLandscape = width > height;
 
@@ -662,7 +663,7 @@ export function CalculatorScreen() {
         : 70;
 
   return (
-    <SafeAreaView style={styles.root}>
+    <View style={[styles.root, { paddingTop: insets.top }]}>
       <StatusBar barStyle="light-content" backgroundColor="#000000" />
 
       {/* History panel overlay */}
@@ -776,7 +777,7 @@ export function CalculatorScreen() {
       <View
         style={[
           styles.grid,
-          { paddingHorizontal: gap, paddingBottom: gap, gap },
+          { paddingHorizontal: gap, paddingBottom: gap + insets.bottom, gap },
           isLandscape && { flexDirection: 'row' },
         ]}
       >
@@ -821,7 +822,7 @@ export function CalculatorScreen() {
           ))}
         </View>
       </View>
-    </SafeAreaView>
+    </View>
   );
 }
 

--- a/src/screens/__tests__/CalculatorScreen.test.tsx
+++ b/src/screens/__tests__/CalculatorScreen.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Dimensions } from 'react-native';
+import { Dimensions, View } from 'react-native';
 import Decimal from 'decimal.js';
 import { render, fireEvent } from '../../test-utils';
 import { CalculatorScreen } from '../CalculatorScreen';
@@ -386,5 +386,23 @@ describe('CalculatorScreen', () => {
       expect(calledOnNegativeInput).toBe(true);
       spy.mockRestore();
     });
+  });
+
+  it('applies safe-area insets: paddingTop on root and paddingBottom on button grid', () => {
+    // Red: before fix, root was SafeAreaView (no paddingTop), grid had paddingBottom: gap only.
+    // After fix, root View carries paddingTop: 44 and grid carries paddingBottom: gap + 34.
+    // Global jest.setup mock returns { top: 44, right: 0, bottom: 34, left: 0 }.
+    const { UNSAFE_queryAllByType } = render(<CalculatorScreen />);
+    const views = UNSAFE_queryAllByType(View);
+
+    const rootStyles: unknown[] = Array.isArray(views[0].props.style) ? views[0].props.style : [views[0].props.style];
+    expect(rootStyles).toContainEqual(expect.objectContaining({ paddingTop: 44 }));
+
+    // Portrait gap = 12; insets.bottom = 34 → expected paddingBottom = 46
+    const hasBottomInset = views.some((v) => {
+      const styleArr: unknown[] = Array.isArray(v.props.style) ? v.props.style : [v.props.style];
+      return styleArr.some((s) => s && typeof s === 'object' && (s as Record<string, number>).paddingBottom === 46);
+    });
+    expect(hasBottomInset).toBe(true);
   });
 });


### PR DESCRIPTION
## What

`CalculatorScreen` was the only screen importing `SafeAreaView` from `react-native` core. That component is iOS-only; on Android (which runs in immersive mode with hidden status/nav bars) it renders as a plain `View` with zero insets.

## Fix

- Remove `SafeAreaView` from the `react-native` import
- Import `useSafeAreaInsets` from `react-native-safe-area-context` (already a dependency; same pattern as every other screen)
- `const insets = useSafeAreaInsets()` in the component body
- Root `<View style={[styles.root, { paddingTop: insets.top }]}>` — keeps camera cutout clear
- Button grid: `paddingBottom: gap + insets.bottom` — keeps bottom row out of the home-gesture zone

No changes to calculator logic, Decimal.js, or the calculation engine.

## Test

Added `applies safe-area insets: paddingTop on root and paddingBottom on button grid` to `CalculatorScreen.test.tsx`.

Global jest.setup mock returns `{ top: 44, bottom: 34 }`. Test asserts:
- Root View style array contains `{ paddingTop: 44 }`
- Some View in the tree has `paddingBottom: 46` (gap 12 + insets.bottom 34)

**Red step (without fix):**
```
expect(rootStyles).toContainEqual(expect.objectContaining({ paddingTop: 44 }))
→ FAIL: received array does not contain expected object
```

**Green (with fix):** 29/29 pass.

`npm test` — 459 pass, 8 fail (pre-existing baseline), 0 new regressions.

Closes #372