### PR TITLE
fix/issue-373: CupertinoNavigationBar large title height derived from typography

### DIFF
--- a/src/components/CupertinoNavigationBar.tsx
+++ b/src/components/CupertinoNavigationBar.tsx
@@ -20,9 +20,6 @@ interface CupertinoNavigationBarProps {
   contentContainerStyle?: ViewStyle;
 }
 
-const LARGE_TITLE_HEIGHT = 52;
-const COLLAPSE_THRESHOLD = LARGE_TITLE_HEIGHT;
-
 export function CupertinoNavigationBar({
   title,
   largeTitle = true,
@@ -34,6 +31,9 @@ export function CupertinoNavigationBar({
   const { theme, typography } = useTheme();
   const { colors } = theme;
   const insets = useSafeAreaInsets();
+  // Derived from typography so it scales with Dynamic Type. paddingTop(4) + paddingBottom(8) from styles.largeTitleContainer.
+  const largeTitleHeight = typography.largeTitle.lineHeight + 12;
+  const collapseThreshold = largeTitleHeight;
   const scrollY = useSharedValue(0);
 
   const scrollHandler = useAnimatedScrollHandler({
@@ -47,13 +47,13 @@ export function CupertinoNavigationBar({
     if (!largeTitle) return {};
     const opacity = interpolate(
       scrollY.value,
-      [0, COLLAPSE_THRESHOLD * 0.6, COLLAPSE_THRESHOLD],
+      [0, collapseThreshold * 0.6, collapseThreshold],
       [1, 0.5, 0],
       Extrapolation.CLAMP,
     );
     const translateY = interpolate(
       scrollY.value,
-      [0, COLLAPSE_THRESHOLD],
+      [0, collapseThreshold],
       [0, -10],
       Extrapolation.CLAMP,
     );
@@ -65,7 +65,7 @@ export function CupertinoNavigationBar({
     if (!largeTitle) return { opacity: 1 };
     const opacity = interpolate(
       scrollY.value,
-      [COLLAPSE_THRESHOLD * 0.7, COLLAPSE_THRESHOLD],
+      [collapseThreshold * 0.7, collapseThreshold],
       [0, 1],
       Extrapolation.CLAMP,
     );
@@ -77,8 +77,8 @@ export function CupertinoNavigationBar({
     if (!largeTitle) return { height: 0 };
     const height = interpolate(
       scrollY.value,
-      [0, COLLAPSE_THRESHOLD],
-      [LARGE_TITLE_HEIGHT, 0],
+      [0, collapseThreshold],
+      [largeTitleHeight, 0],
       Extrapolation.CLAMP,
     );
     return { height, overflow: 'hidden' as const };
@@ -116,7 +116,7 @@ export function CupertinoNavigationBar({
         </BlurView>
         {largeTitle && (
           <View style={[styles.largeTitleContainer, { backgroundColor: colors.systemGroupedBackground }]}>
-            <Text style={[typography.largeTitle, { color: colors.label }]}>{title}</Text>
+            <Text style={[typography.largeTitle, { color: colors.label }]} numberOfLines={1} adjustsFontSizeToFit minimumFontScale={0.7}>{title}</Text>
           </View>
         )}
       </View>
@@ -135,7 +135,7 @@ export function CupertinoNavigationBar({
         contentContainerStyle={contentContainerStyle}
       >
         {/* Spacer for the nav bar + large title */}
-        <View style={{ height: insets.top + 44 + (largeTitle ? LARGE_TITLE_HEIGHT : 0) }} />
+        <View style={{ height: insets.top + 44 + (largeTitle ? largeTitleHeight : 0) }} />
         {children}
       </Animated.ScrollView>
 
@@ -175,7 +175,7 @@ export function CupertinoNavigationBar({
               largeTitleContainerStyle,
             ]}
           >
-            <Animated.Text style={[typography.largeTitle, { color: colors.label }, largeTitleStyle]}>
+            <Animated.Text style={[typography.largeTitle, { color: colors.label }, largeTitleStyle]} numberOfLines={1} adjustsFontSizeToFit minimumFontScale={0.7}>
               {title}
             </Animated.Text>
           </Animated.View>

--- a/src/components/__tests__/CupertinoNavigationBar.test.tsx
+++ b/src/components/__tests__/CupertinoNavigationBar.test.tsx
@@ -53,6 +53,17 @@ describe('CupertinoNavigationBar', () => {
     expect(getByText('Large Title')).toBeTruthy();
   });
 
+  it('large title Text has numberOfLines={1} to prevent overflow clipping', () => {
+    // Red: before fix, large title had no numberOfLines prop.
+    // After fix, numberOfLines={1} prevents the text from wrapping into the overflow:hidden container.
+    const { getAllByText } = render(
+      <CupertinoNavigationBar title="Very Long Title That Would Wrap" largeTitle />,
+    );
+    // Static variant (no children) + largeTitle=true: only one Text element renders the title
+    const largeTitleElement = getAllByText('Very Long Title That Would Wrap')[0];
+    expect(largeTitleElement.props.numberOfLines).toBe(1);
+  });
+
   it('does not render large title when largeTitle={false}', () => {
     const { queryByText } = render(
       <CupertinoNavigationBar title="Test" largeTitle={false} />,


### PR DESCRIPTION
## What

`LARGE_TITLE_HEIGHT = 52` was a module-level literal that didn't scale with Dynamic Type. At textSizeIndex max (scale 1.3), `typography.largeTitle.lineHeight` grows to `Math.round(41 × 1.3) = 53px` — already 1px above the 52px container before any wrapping. The large title container also applies `overflow: hidden`, so the second line of a wrapped title is silently cut.

## Fix

- Remove module-level `LARGE_TITLE_HEIGHT = 52` and `COLLAPSE_THRESHOLD`
- Inside the component (after `useTheme()`), compute:
  ```ts
  const largeTitleHeight = typography.largeTitle.lineHeight + 12; // paddingTop(4) + paddingBottom(8)
  const collapseThreshold = largeTitleHeight;
  ```
- Both the collapsing animation (`largeTitleContainerStyle`, line 81) and the scroll spacer (line 138) derive from `largeTitleHeight` — same expression, no divergence
- Add `numberOfLines={1} adjustsFontSizeToFit minimumFontScale={0.7}` to both large title Text elements (static variant line 119, animated variant line 178)

`grep -n "LARGE_TITLE_HEIGHT = 52" src/components/CupertinoNavigationBar.tsx` → **0 results**

## Test

Added `large title Text has numberOfLines={1} to prevent overflow clipping` to `CupertinoNavigationBar.test.tsx`.

**Red step (without `numberOfLines` prop):**
```
expect(largeTitleElement.props.numberOfLines).toBe(1)
→ FAIL: received undefined, expected 1
```

**Green (with fix):** 7/7 pass including existing `decelerationRate` test from #214.

`npm test` — 460 pass, 8 fail (pre-existing baseline), 0 new regressions.

## Scale verification

At base (textSizeIndex=0): `largeTitleHeight = 41 + 12 = 53` (was 52 — 1px gain, now fits)
At max (textSizeIndex=4, scale 1.3): `largeTitleHeight = 53 + 12 = 65` — container grows to accommodate

Closes #373