### PR TITLE
fix: OnboardingScreen vertical scroll em cada página (#374)

### DIFF
--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -33,7 +33,7 @@ const getLauncher = async () => {
   }
 };
 
-const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get('window');
+const { width: SCREEN_WIDTH } = Dimensions.get('window');
 
 interface OnboardingScreenProps {
   onDone: () => void;
@@ -153,101 +153,109 @@ export function OnboardingScreen({ onDone }: OnboardingScreenProps) {
         }}
       >
         {/* ── Page 1: Welcome ──────────────────────────────────────────── */}
-        <View style={[styles.page, { paddingTop: insets.top + 60, paddingBottom: insets.bottom + 32 }]}>
-          <View style={styles.iconWrap}>
-            <BlurView intensity={20} tint="light" experimentalBlurMethod="dimezisBlurView" style={styles.iconBlur}>
-              <Ionicons name="phone-portrait" size={72} color="#FFFFFF" />
-            </BlurView>
-          </View>
-          <Text style={styles.pageTitle}>Welcome to{'\n'}iOS Launcher</Text>
-          <Text style={styles.pageSubtitle}>Transform your Android into iOS</Text>
-          <Pressable style={styles.primaryButton} onPress={() => goToPage(1)}>
-            <Text style={styles.primaryButtonText}>Get Started</Text>
-          </Pressable>
+        <View style={styles.page}>
+          <ScrollView showsVerticalScrollIndicator={false} contentContainerStyle={[styles.pageContent, { paddingTop: insets.top + 60, paddingBottom: insets.bottom + 32 }]}>
+            <View style={styles.iconWrap}>
+              <BlurView intensity={20} tint="light" experimentalBlurMethod="dimezisBlurView" style={styles.iconBlur}>
+                <Ionicons name="phone-portrait" size={72} color="#FFFFFF" />
+              </BlurView>
+            </View>
+            <Text style={styles.pageTitle}>Welcome to{'\n'}iOS Launcher</Text>
+            <Text style={styles.pageSubtitle}>Transform your Android into iOS</Text>
+            <Pressable style={styles.primaryButton} onPress={() => goToPage(1)}>
+              <Text style={styles.primaryButtonText}>Get Started</Text>
+            </Pressable>
+          </ScrollView>
         </View>
 
         {/* ── Page 2: Permissions ───────────────────────────────────────── */}
-        <View style={[styles.page, { paddingTop: insets.top + 60, paddingBottom: insets.bottom + 32 }]}>
-          <Text style={styles.pageTitle}>Permissions</Text>
-          <Text style={styles.pageSubtitle}>We need a few permissions to give you the full experience</Text>
-          <View style={styles.permList}>
-            {PERMISSIONS.map(perm => (
-              <View key={perm.label} style={styles.permRow}>
-                <View style={styles.permIconWrap}>
-                  <Ionicons name={perm.icon} size={22} color="#FFFFFF" />
-                </View>
-                <View style={styles.permText}>
-                  <Text style={styles.permLabel}>{perm.label}</Text>
-                  <Text style={styles.permDesc}>{perm.description}</Text>
-                </View>
-              </View>
-            ))}
-          </View>
-          {permissionError && (
-            <View style={styles.errorContainer}>
-              <Ionicons name="warning-outline" size={18} color="#FF453A" />
-              <Text style={styles.errorText}>{permissionError}</Text>
-            </View>
-          )}
-          <Pressable style={styles.primaryButton} onPress={handleGrantPermissions}>
-            <Text style={styles.primaryButtonText}>
-              {permissionError ? 'Try Again' : 'Grant Permissions'}
-            </Text>
-          </Pressable>
-        </View>
-
-        {/* ── Page 3: Default Launcher ─────────────────────────────────── */}
-        <View style={[styles.page, { paddingTop: insets.top + 60, paddingBottom: insets.bottom + 32 }]}>
-          <View style={styles.iconWrap}>
-            <BlurView intensity={20} tint="light" experimentalBlurMethod="dimezisBlurView" style={styles.iconBlur}>
-              <Ionicons name="phone-portrait-outline" size={64} color="#FFFFFF" />
-              <Ionicons
-                name="square"
-                size={22}
-                color="#FFFFFF"
-                style={styles.homeButtonIcon}
-              />
-            </BlurView>
-          </View>
-          <Text style={styles.pageTitle}>Set as Default{'\n'}Launcher</Text>
-          <Text style={styles.pageSubtitle}>
-            To get the full experience, set this app as your home launcher
-          </Text>
-          <Pressable style={styles.primaryButton} onPress={handleSetLauncher}>
-            <Text style={styles.primaryButtonText}>Set Now</Text>
-          </Pressable>
-          <Pressable onPress={() => goToPage(3)} hitSlop={12} style={{ marginTop: 16 }}>
-            <Text style={styles.skipText}>Skip</Text>
-          </Pressable>
-        </View>
-
-        {/* ── Page 4: Ready ─────────────────────────────────────────────── */}
-        <View style={[styles.page, { paddingTop: insets.top + 60, paddingBottom: insets.bottom + 32 }]}>
-          <View style={styles.checkCircle}>
-            <Ionicons name="checkmark" size={72} color="#FFFFFF" />
-          </View>
-          <Text style={styles.pageTitle}>{"You're All Set!"}</Text>
-          <Text style={styles.pageSubtitle}>Your iOS experience starts now</Text>
-
-          {/* Permission status summary */}
-          {Object.keys(permissionResults).length > 0 && (
-            <View style={styles.permSummary}>
-              {Object.entries(permissionResults).map(([key, granted]) => (
-                <View key={key} style={styles.permStatusRow}>
-                  <Ionicons
-                    name={granted ? 'checkmark-circle' : 'close-circle'}
-                    size={18}
-                    color={granted ? '#30D158' : '#FF453A'}
-                  />
-                  <Text style={styles.permStatusLabel}>{key}</Text>
+        <View style={styles.page}>
+          <ScrollView showsVerticalScrollIndicator={false} contentContainerStyle={[styles.pageContent, { paddingTop: insets.top + 60, paddingBottom: insets.bottom + 32 }]}>
+            <Text style={styles.pageTitle}>Permissions</Text>
+            <Text style={styles.pageSubtitle}>We need a few permissions to give you the full experience</Text>
+            <View style={styles.permList}>
+              {PERMISSIONS.map(perm => (
+                <View key={perm.label} style={styles.permRow}>
+                  <View style={styles.permIconWrap}>
+                    <Ionicons name={perm.icon} size={22} color="#FFFFFF" />
+                  </View>
+                  <View style={styles.permText}>
+                    <Text style={styles.permLabel}>{perm.label}</Text>
+                    <Text style={styles.permDesc}>{perm.description}</Text>
+                  </View>
                 </View>
               ))}
             </View>
-          )}
+            {permissionError && (
+              <View style={styles.errorContainer}>
+                <Ionicons name="warning-outline" size={18} color="#FF453A" />
+                <Text style={styles.errorText}>{permissionError}</Text>
+              </View>
+            )}
+            <Pressable style={styles.primaryButton} onPress={handleGrantPermissions}>
+              <Text style={styles.primaryButtonText}>
+                {permissionError ? 'Try Again' : 'Grant Permissions'}
+              </Text>
+            </Pressable>
+          </ScrollView>
+        </View>
 
-          <Pressable style={styles.primaryButton} onPress={handleDone}>
-            <Text style={styles.primaryButtonText}>Start</Text>
-          </Pressable>
+        {/* ── Page 3: Default Launcher ─────────────────────────────────── */}
+        <View style={styles.page}>
+          <ScrollView showsVerticalScrollIndicator={false} contentContainerStyle={[styles.pageContent, { paddingTop: insets.top + 60, paddingBottom: insets.bottom + 32 }]}>
+            <View style={styles.iconWrap}>
+              <BlurView intensity={20} tint="light" experimentalBlurMethod="dimezisBlurView" style={styles.iconBlur}>
+                <Ionicons name="phone-portrait-outline" size={64} color="#FFFFFF" />
+                <Ionicons
+                  name="square"
+                  size={22}
+                  color="#FFFFFF"
+                  style={styles.homeButtonIcon}
+                />
+              </BlurView>
+            </View>
+            <Text style={styles.pageTitle}>Set as Default{'\n'}Launcher</Text>
+            <Text style={styles.pageSubtitle}>
+              To get the full experience, set this app as your home launcher
+            </Text>
+            <Pressable style={styles.primaryButton} onPress={handleSetLauncher}>
+              <Text style={styles.primaryButtonText}>Set Now</Text>
+            </Pressable>
+            <Pressable onPress={() => goToPage(3)} hitSlop={12} style={{ marginTop: 16 }}>
+              <Text style={styles.skipText}>Skip</Text>
+            </Pressable>
+          </ScrollView>
+        </View>
+
+        {/* ── Page 4: Ready ─────────────────────────────────────────────── */}
+        <View style={styles.page}>
+          <ScrollView showsVerticalScrollIndicator={false} contentContainerStyle={[styles.pageContent, { paddingTop: insets.top + 60, paddingBottom: insets.bottom + 32 }]}>
+            <View style={styles.checkCircle}>
+              <Ionicons name="checkmark" size={72} color="#FFFFFF" />
+            </View>
+            <Text style={styles.pageTitle}>{"You're All Set!"}</Text>
+            <Text style={styles.pageSubtitle}>Your iOS experience starts now</Text>
+
+            {/* Permission status summary */}
+            {Object.keys(permissionResults).length > 0 && (
+              <View style={styles.permSummary}>
+                {Object.entries(permissionResults).map(([key, granted]) => (
+                  <View key={key} style={styles.permStatusRow}>
+                    <Ionicons
+                      name={granted ? 'checkmark-circle' : 'close-circle'}
+                      size={18}
+                      color={granted ? '#30D158' : '#FF453A'}
+                    />
+                    <Text style={styles.permStatusLabel}>{key}</Text>
+                  </View>
+                ))}
+              </View>
+            )}
+
+            <Pressable style={styles.primaryButton} onPress={handleDone}>
+              <Text style={styles.primaryButtonText}>Start</Text>
+            </Pressable>
+          </ScrollView>
         </View>
       </ScrollView>
     </LinearGradient>
@@ -281,11 +289,13 @@ const styles = StyleSheet.create({
   page: {
     width: SCREEN_WIDTH,
     flex: 1,
-    alignItems: 'center',
+  },
+  pageContent: {
+    flexGrow: 1,
     justifyContent: 'center',
+    alignItems: 'center',
     paddingHorizontal: 32,
     gap: 16,
-    minHeight: SCREEN_HEIGHT,
   },
   iconWrap: {
     marginBottom: 8,

--- a/src/screens/__tests__/OnboardingScreen.test.tsx
+++ b/src/screens/__tests__/OnboardingScreen.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { ScrollView } from 'react-native';
 import { render, fireEvent, act } from '../../test-utils';
 import { OnboardingScreen } from '../OnboardingScreen';
 
@@ -24,6 +25,14 @@ describe('OnboardingScreen', () => {
       fireEvent.press(getByText('Get Started'));
     });
     expect(getByText('Permissions')).toBeTruthy();
+  });
+
+  it('each page contains a vertical ScrollView for overflow scroll', () => {
+    const { UNSAFE_queryAllByType } = render(<OnboardingScreen onDone={jest.fn()} />);
+    const allScrollViews = UNSAFE_queryAllByType(ScrollView);
+    // Outer horizontal paging ScrollView + 4 inner vertical ScrollViews per page = 5 total
+    const verticalScrollViews = allScrollViews.filter((sv) => !sv.props.horizontal);
+    expect(verticalScrollViews).toHaveLength(4);
   });
 
   it('calls onDone when Start is pressed', async () => {


### PR DESCRIPTION
## Issue
Closes #374 — com texto grande o botão de permissões sai do ecrã porque as páginas de onboarding não fazem scroll vertical.

## Root cause
Cada página era um `View` estático com `minHeight: SCREEN_HEIGHT`. Com Dynamic Type ou texto longo, o conteúdo ultrapassava o ecrã sem possibilidade de scroll.

## Fix
- Cada página passa a conter um `<ScrollView vertical>` envolvendo todo o conteúdo.
- `contentContainerStyle` usa `flexGrow: 1` + `justifyContent: 'center'` — centraliza quando cabe, faz scroll quando transborda.
- `styles.page` simplificado para `{ width: SCREEN_WIDTH, flex: 1 }`.
- Novo `styles.pageContent`: `{ flexGrow: 1, justifyContent: 'center', alignItems: 'center', paddingHorizontal: 32, gap: 16 }`.
- `minHeight: SCREEN_HEIGHT` e `SCREEN_HEIGHT` removidos completamente.
- ScrollView exterior (paginação horizontal) mantém `scrollEnabled={false}` — sem conflito.

## Ficheiros alterados
- `src/screens/OnboardingScreen.tsx`
- `src/screens/__tests__/OnboardingScreen.test.tsx`

## Teste vermelho/verde

**Red** (pages com View em vez de ScrollView):
```
FAIL src/screens/__tests__/OnboardingScreen.test.tsx
  ● each page contains a vertical ScrollView for overflow scroll
    Expected length: 4
    Received length: 0
```

**Green** (com fix):
```
PASS src/screens/__tests__/OnboardingScreen.test.tsx
  ✓ renders without crashing
  ✓ renders welcome title on first page
  ✓ renders Get Started button on first page
  ✓ Get Started reveals the Permissions page
  ✓ each page contains a vertical ScrollView for overflow scroll
  ✓ calls onDone when Start is pressed
  Tests: 6 passed, 6 total
```

## Suite completa
- Tests: 461 passed, 8 failed (8 pre-existing baseline)
- TypeScript: clean
- Lint: 0 errors