### PR TITLE
fix: remover overrides de fontSize nos 5 primitivos Cupertino (#375)

### DIFF
--- a/src/components/CupertinoActionSheet.tsx
+++ b/src/components/CupertinoActionSheet.tsx
@@ -138,7 +138,6 @@ export function CupertinoActionSheet({
                       color: option.destructive
                         ? colors.systemRed
                         : colors.systemBlue,
-                      fontSize: 20,
                     },
                   ]}
                 >
@@ -164,7 +163,7 @@ export function CupertinoActionSheet({
             <Text
               style={[
                 typography.body,
-                { color: colors.systemBlue, fontWeight: '600', fontSize: 20 },
+                { color: colors.systemBlue, fontWeight: '600' },
               ]}
             >
               {cancelLabel}

--- a/src/components/CupertinoAlertDialog.tsx
+++ b/src/components/CupertinoAlertDialog.tsx
@@ -143,7 +143,6 @@ export function CupertinoAlertDialog({
                 <Text
                   style={[
                     typography.body,
-                    { fontSize: 17 },
                     getActionTextStyle(action),
                   ]}
                 >

--- a/src/components/CupertinoPicker.tsx
+++ b/src/components/CupertinoPicker.tsx
@@ -66,7 +66,6 @@ export function CupertinoPicker({
                 typography.body,
                 {
                   color: isSelected ? colors.label : colors.tertiaryLabel,
-                  fontSize: isSelected ? 21 : 19,
                   fontWeight: isSelected ? '500' : '400',
                 },
               ]}

--- a/src/components/CupertinoShareSheet.tsx
+++ b/src/components/CupertinoShareSheet.tsx
@@ -138,7 +138,7 @@ export function CupertinoShareSheet({ visible, onClose, title, url, text }: Cupe
                 <View style={[styles.optionIconWrap, { backgroundColor: option.iconBg }]}>
                   <Ionicons name={option.icon} size={24} color="#fff" />
                 </View>
-                <Text style={[styles.optionLabel, { color: colors.label }]}>{option.label}</Text>
+                <Text style={[typography.caption2, styles.optionLabel, { color: colors.label }]}>{option.label}</Text>
               </Pressable>
             ))}
           </ScrollView>
@@ -206,7 +206,6 @@ const styles = StyleSheet.create({
     marginBottom: 6,
   },
   optionLabel: {
-    fontSize: 11,
     fontWeight: '400',
     textAlign: 'center',
   },

--- a/src/components/CupertinoSwipeableRow.tsx
+++ b/src/components/CupertinoSwipeableRow.tsx
@@ -9,6 +9,7 @@ import Animated, {
 } from 'react-native-reanimated';
 import * as Haptics from 'expo-haptics';
 import { hapticImpact } from '../utils/haptics';
+import { useTheme } from '../theme/ThemeContext';
 
 export interface SwipeAction {
   label: string;
@@ -35,6 +36,7 @@ export function CupertinoSwipeableRow({
   isOpen,
   onOpen,
 }: CupertinoSwipeableRowProps) {
+  const { typography } = useTheme();
   const translateX = useSharedValue(0);
   const contextX = useSharedValue(0);
 
@@ -117,7 +119,7 @@ export function CupertinoSwipeableRow({
               style={[styles.action, { backgroundColor: action.color, width: ACTION_WIDTH }]}
               onPress={() => handleActionPress(action)}
             >
-              <Text style={styles.actionText}>{action.label}</Text>
+              <Text style={[typography.footnote, styles.actionText]}>{action.label}</Text>
             </Pressable>
           ))}
         </View>
@@ -132,7 +134,7 @@ export function CupertinoSwipeableRow({
               style={[styles.action, { backgroundColor: action.color, width: ACTION_WIDTH }]}
               onPress={() => handleActionPress(action)}
             >
-              <Text style={styles.actionText}>{action.label}</Text>
+              <Text style={[typography.footnote, styles.actionText]}>{action.label}</Text>
             </Pressable>
           ))}
         </View>
@@ -171,7 +173,6 @@ const styles = StyleSheet.create({
   },
   actionText: {
     color: '#FFFFFF',
-    fontSize: 14,
     fontWeight: '600',
   },
   content: {

--- a/src/components/__tests__/CupertinoActionSheet.test.tsx
+++ b/src/components/__tests__/CupertinoActionSheet.test.tsx
@@ -6,6 +6,27 @@ import * as Haptics from 'expo-haptics';
 import { setHapticsEnabled } from '../../utils/haptics';
 import { useSettings } from '../../store/SettingsStore';
 
+/** Returns the effective (last-wins) fontSize from a React Native style array. */
+function getEffectiveFontSize(element: { props: { style: unknown } }): number {
+  const styles = Array.isArray(element.props.style) ? element.props.style : [element.props.style];
+  let fontSize = 0;
+  for (const s of styles) {
+    if (s && typeof s === 'object' && 'fontSize' in (s as object)) {
+      fontSize = (s as { fontSize: number }).fontSize;
+    }
+  }
+  return fontSize;
+}
+
+function SetTextSize({ index }: { index: number }) {
+  const { update } = useSettings();
+  return (
+    <Pressable testID="set-text-size" onPress={() => update('textSizeIndex', index)}>
+      <Text>resize</Text>
+    </Pressable>
+  );
+}
+
 /** Turns the real `vibration` setting off; SettingsStore feeds the haptics cache. */
 function DisableVibration() {
   const { update } = useSettings();
@@ -32,6 +53,29 @@ async function collectUnhandledRejections(fn: () => void): Promise<unknown[]> {
   }
   return captured;
 }
+
+describe('CupertinoActionSheet Dynamic Type', () => {
+  it('option label fontSize scales with textSizeIndex', () => {
+    const { getByText, getByTestId } = render(
+      <>
+        <SetTextSize index={3} />
+        <CupertinoActionSheet
+          visible
+          onClose={jest.fn()}
+          options={[{ label: 'Option', onPress: jest.fn() }]}
+        />
+      </>,
+    );
+
+    const defaultFontSize = getEffectiveFontSize(getByText('Option'));
+
+    // Push textSizeIndex to maximum (3, scale 1.3×)
+    fireEvent.press(getByTestId('set-text-size'));
+
+    const scaledFontSize = getEffectiveFontSize(getByText('Option'));
+    expect(scaledFontSize).toBeGreaterThan(defaultFontSize);
+  });
+});
 
 describe('CupertinoActionSheet haptics (H5)', () => {
   beforeEach(() => {


### PR DESCRIPTION
## Issue
Closes #375 — 5 primitivos Cupertino fixavam `fontSize` por cima do token de tipografia escalável, impedindo Dynamic Type de funcionar nesses componentes.

## Root cause
Os componentes usavam `[typography.body, { fontSize: <literal> }]`, onde o literal (vindo depois) ganhava sobre o token. Como o token é escalado em `ThemeContext` com `textSizeIndex`, mas o literal é fixo, a escala era anulada.

`CupertinoSwipeableRow` agravava o problema por nem sequer chamar `useTheme()`.

## Fix

| Componente | Override removido | Token efectivo |
|---|---|---|
| CupertinoActionSheet | `fontSize: 20` (×2) | `typography.body` |
| CupertinoAlertDialog | `fontSize: 17` | `typography.body` |
| CupertinoPicker | `fontSize: isSelected ? 21 : 19` | `typography.body` |
| CupertinoShareSheet | `fontSize: 11` (StyleSheet) | `typography.caption2` (na JSX) |
| CupertinoSwipeableRow | `fontSize: 14` (StyleSheet) | `typography.footnote` (+ importa `useTheme`) |

## Verificação da aceitação
```
grep -n "fontSize: [0-9]" src/components/CupertinoActionSheet.tsx \
  src/components/CupertinoAlertDialog.tsx src/components/CupertinoPicker.tsx \
  src/components/CupertinoShareSheet.tsx src/components/CupertinoSwipeableRow.tsx
# → zero resultados
```

## Teste vermelho/verde

**Red** (com `fontSize: 20` hardcoded em `CupertinoActionSheet`):
```
FAIL src/components/__tests__/CupertinoActionSheet.test.tsx
  ● CupertinoActionSheet Dynamic Type › option label fontSize scales with textSizeIndex

    expect(received).toBeGreaterThan(expected)
    Expected: > 20
    Received:   20
```

**Green** (overrides removidos):
```
PASS src/components/__tests__/CupertinoActionSheet.test.tsx
  CupertinoActionSheet Dynamic Type
    ✓ option label fontSize scales with textSizeIndex (116 ms)
  CupertinoActionSheet haptics (H5)
    ✓ plays light impact haptics when an option is pressed
    ✓ does not touch the native module when the user disabled vibration
    ✓ plays haptics once per press when the same option is tapped twice
    ✓ renders an empty option list without playing haptics
    ✓ does not leak an unhandled rejection when the native module rejects
  Tests: 6 passed, 6 total
```

## Suite completa
- Tests: 462 passed, 8 failed (8 pre-existing baseline)
- TypeScript: clean
- Lint: 0 errors