### PR TITLE
fix: Dynamic Type em 14 ecrãs — typography tokens + textScale (#376)

### DIFF
--- a/src/screens/AppLibraryScreen.tsx
+++ b/src/screens/AppLibraryScreen.tsx
@@ -113,7 +113,7 @@ interface CategoryCardProps {
 }
 
 const CategoryCard = React.memo(function CategoryCard({ title, apps, onPress, cardWidth }: CategoryCardProps) {
-  const { theme } = useTheme();
+  const { theme, typography } = useTheme();
   const { colors } = theme;
   const iconSize = (cardWidth - 24 - 6) / 2; // 2 columns with gap inside padding
 
@@ -143,12 +143,12 @@ const CategoryCard = React.memo(function CategoryCard({ title, apps, onPress, ca
         })}
       </View>
       <Text
-        style={[styles.categoryTitle, { color: colors.label }]}
+        style={[typography.subhead, styles.categoryTitle, { color: colors.label }]}
         numberOfLines={1}
       >
         {title}
       </Text>
-      <Text style={[styles.categoryCount, { color: colors.secondaryLabel }]}>
+      <Text style={[typography.caption1, styles.categoryCount, { color: colors.secondaryLabel }]}>
         {apps.length} app{apps.length !== 1 ? 's' : ''}
       </Text>
     </Pressable>
@@ -168,7 +168,7 @@ interface CategoryDetailProps {
 }
 
 function CategoryDetailModal({ visible, title, apps, onClose, onLaunch }: CategoryDetailProps) {
-  const { theme, isDark } = useTheme();
+  const { theme, isDark, typography, textScale } = useTheme();
   const { colors } = theme;
   const insets = useSafeAreaInsets();
   const { width } = useWindowDimensions();
@@ -187,7 +187,7 @@ function CategoryDetailModal({ visible, title, apps, onClose, onLaunch }: Catego
         <StatusBar barStyle={isDark ? 'light-content' : 'dark-content'} />
         {/* Header */}
         <View style={[styles.modalHeader, { paddingTop: insets.top + 16, borderBottomColor: colors.separator }]}>
-          <Text style={[styles.modalTitle, { color: colors.label }]}>{title}</Text>
+          <Text style={[styles.modalTitle, { color: colors.label, fontSize: 18 * textScale }]}>{title}</Text>
           <Pressable onPress={onClose} style={styles.modalCloseBtn} accessibilityLabel="Close">
             <Ionicons name="close-circle" size={28} color={colors.systemGray2} />
           </Pressable>
@@ -206,7 +206,7 @@ function CategoryDetailModal({ visible, title, apps, onClose, onLaunch }: Catego
               accessibilityRole="button"
             >
               <AppIcon app={item} size={iconSize} />
-              <Text style={[styles.modalAppLabel, { color: colors.label }]} numberOfLines={2}>
+              <Text style={[typography.caption2, styles.modalAppLabel, { color: colors.label }]} numberOfLines={2}>
                 {item.name}
               </Text>
             </Pressable>
@@ -228,7 +228,7 @@ const AppStrip = React.memo(function AppStrip({
   apps: InstalledApp[];
   onLaunch: (pkg: string) => void;
 }) {
-  const { theme } = useTheme();
+  const { theme, typography } = useTheme();
   const { colors } = theme;
   const stripIconSize = 62;
 
@@ -243,7 +243,7 @@ const AppStrip = React.memo(function AppStrip({
           accessibilityRole="button"
         >
           <AppIcon app={app} size={stripIconSize} />
-          <Text style={[styles.stripLabel, { color: colors.label }]} numberOfLines={2}>
+          <Text style={[typography.caption2, styles.stripLabel, { color: colors.label }]} numberOfLines={2}>
             {app.name}
           </Text>
         </Pressable>
@@ -263,7 +263,7 @@ const SearchResults = React.memo(function SearchResults({
   apps: InstalledApp[];
   onLaunch: (pkg: string) => void;
 }) {
-  const { theme } = useTheme();
+  const { theme, typography } = useTheme();
   const { colors } = theme;
 
   return (
@@ -282,7 +282,7 @@ const SearchResults = React.memo(function SearchResults({
           accessibilityRole="button"
         >
           <AppIcon app={item} size={46} />
-          <Text style={[styles.searchRowLabel, { color: colors.label }]}>{item.name}</Text>
+          <Text style={[typography.callout, styles.searchRowLabel, { color: colors.label }]}>{item.name}</Text>
         </Pressable>
       )}
     />
@@ -294,8 +294,9 @@ const SearchResults = React.memo(function SearchResults({
 // ---------------------------------------------------------------------------
 
 function SectionHeader({ title, colors }: { title: string; colors: CupertinoColors }) {
+  const { typography } = useTheme();
   return (
-    <Text style={[styles.sectionHeader, { color: colors.label }]}>{title}</Text>
+    <Text style={[typography.title3, styles.sectionHeader, { color: colors.label }]}>{title}</Text>
   );
 }
 
@@ -304,7 +305,7 @@ function SectionHeader({ title, colors }: { title: string; colors: CupertinoColo
 // ---------------------------------------------------------------------------
 
 export function AppLibraryScreen({ navigation }: { navigation: AppNavigationProp }) {
-  const { theme, isDark } = useTheme();
+  const { theme, isDark, typography } = useTheme();
   const { colors } = theme;
   const { apps, launchApp, recentApps } = useApps();
   const insets = useSafeAreaInsets();
@@ -386,9 +387,9 @@ export function AppLibraryScreen({ navigation }: { navigation: AppNavigationProp
           accessibilityLabel="Back"
         >
           <Ionicons name="chevron-back" size={22} color={colors.systemBlue} />
-          <Text style={[styles.backLabel, { color: colors.systemBlue }]}>Back</Text>
+          <Text style={[typography.body, styles.backLabel, { color: colors.systemBlue }]}>Back</Text>
         </Pressable>
-        <Text style={[styles.navTitle, { color: colors.label }]}>App Library</Text>
+        <Text style={[typography.body, styles.navTitle, { color: colors.label }]}>App Library</Text>
         <View style={styles.backBtn} />
       </View>
 
@@ -483,11 +484,9 @@ const styles = StyleSheet.create({
     paddingHorizontal: 4,
   },
   backLabel: {
-    fontSize: 17,
     fontWeight: '400',
   },
   navTitle: {
-    fontSize: 17,
     fontWeight: '600',
     letterSpacing: -0.3,
   },
@@ -500,7 +499,6 @@ const styles = StyleSheet.create({
     paddingTop: 4,
   },
   sectionHeader: {
-    fontSize: 20,
     fontWeight: '700',
     letterSpacing: -0.4,
     marginBottom: 10,
@@ -525,7 +523,6 @@ const styles = StyleSheet.create({
     width: 72,
   },
   stripLabel: {
-    fontSize: 11,
     fontWeight: '400',
     marginTop: 5,
     textAlign: 'center',
@@ -550,12 +547,10 @@ const styles = StyleSheet.create({
     marginBottom: 10,
   },
   categoryTitle: {
-    fontSize: 15,
     fontWeight: '600',
     letterSpacing: -0.2,
   },
   categoryCount: {
-    fontSize: 12,
     fontWeight: '400',
     marginTop: 2,
   },
@@ -568,7 +563,6 @@ const styles = StyleSheet.create({
     gap: 12,
   },
   searchRowLabel: {
-    fontSize: 16,
     fontWeight: '400',
   },
 
@@ -585,7 +579,6 @@ const styles = StyleSheet.create({
     borderBottomWidth: StyleSheet.hairlineWidth,
   },
   modalTitle: {
-    fontSize: 18,
     fontWeight: '700',
     letterSpacing: -0.3,
     flex: 1,
@@ -602,7 +595,6 @@ const styles = StyleSheet.create({
     paddingHorizontal: 4,
   },
   modalAppLabel: {
-    fontSize: 11,
     fontWeight: '400',
     textAlign: 'center',
     marginTop: 5,

--- a/src/screens/CalculatorScreen.tsx
+++ b/src/screens/CalculatorScreen.tsx
@@ -287,7 +287,7 @@ function CalcButton({
 // ---------------------------------------------------------------------------
 
 export function CalculatorScreen() {
-  useTheme();
+  const { typography, textScale } = useTheme();
   const insets = useSafeAreaInsets();
   const { width, height } = useWindowDimensions();
   const isLandscape = width > height;
@@ -671,18 +671,18 @@ export function CalculatorScreen() {
         <View style={styles.historyOverlay}>
           <View style={styles.historyPanel}>
             <View style={styles.historyHeader}>
-              <Text style={styles.historyTitle}>History</Text>
+              <Text style={[typography.title3, styles.historyTitle]}>History</Text>
               <Pressable
                 onPress={() => setShowHistory(false)}
                 accessibilityLabel="Close history"
                 accessibilityRole="button"
               >
-                <Text style={styles.historyClose}>✕</Text>
+                <Text style={[typography.title3, styles.historyClose]}>✕</Text>
               </Pressable>
             </View>
             <ScrollView style={styles.historyScroll}>
               {history.length === 0 ? (
-                <Text style={styles.historyEmpty}>No calculations yet</Text>
+                <Text style={[typography.callout, styles.historyEmpty]}>No calculations yet</Text>
               ) : (
                 history.map((entry, idx) => (
                   <Pressable
@@ -695,10 +695,10 @@ export function CalculatorScreen() {
                       pressed && { backgroundColor: '#2C2C2E' },
                     ]}
                   >
-                    <Text style={styles.historyExpression}>
+                    <Text style={[styles.historyExpression, { fontSize: 14 * textScale }]}>
                       {entry.expression}
                     </Text>
-                    <Text style={styles.historyResult}>= {entry.result}</Text>
+                    <Text style={[styles.historyResult, { fontSize: 18 * textScale }]}>= {entry.result}</Text>
                   </Pressable>
                 ))
               )}
@@ -710,7 +710,7 @@ export function CalculatorScreen() {
                 accessibilityLabel="Clear all history"
                 accessibilityRole="button"
               >
-                <Text style={styles.clearHistoryText}>Clear History</Text>
+                <Text style={[typography.callout, styles.clearHistoryText]}>Clear History</Text>
               </Pressable>
             )}
           </View>
@@ -720,7 +720,7 @@ export function CalculatorScreen() {
       {/* Top bar with memory indicator and history toggle */}
       <View style={styles.topBar}>
         <View style={styles.topBarLeft}>
-          {hasMemory && <Text style={styles.memoryIndicator}>M</Text>}
+          {hasMemory && <Text style={[styles.memoryIndicator, { fontSize: 14 * textScale }]}>M</Text>}
           {isLandscape && (
             <Pressable
               onPress={() => setIsDeg(!isDeg)}
@@ -728,7 +728,7 @@ export function CalculatorScreen() {
               accessibilityLabel={isDeg ? 'Switch to radians' : 'Switch to degrees'}
               accessibilityRole="button"
             >
-              <Text style={styles.degRadText}>{isDeg ? 'DEG' : 'RAD'}</Text>
+              <Text style={[typography.footnote, styles.degRadText]}>{isDeg ? 'DEG' : 'RAD'}</Text>
             </Pressable>
           )}
         </View>
@@ -738,14 +738,14 @@ export function CalculatorScreen() {
           accessibilityRole="button"
           style={styles.historyToggle}
         >
-          <Text style={styles.historyIcon}>🕐</Text>
+          <Text style={[typography.title3, styles.historyIcon]}>🕐</Text>
         </Pressable>
       </View>
 
       {/* Display */}
       <View style={[styles.displayArea, isLandscape && { paddingBottom: 8 }]}>
         {parenDepth > 0 && (
-          <Text style={styles.parenIndicator}>
+          <Text style={[styles.parenIndicator, { fontSize: 18 * textScale }]}>
             {'('.repeat(parenDepth)}
           </Text>
         )}
@@ -853,7 +853,6 @@ const styles = StyleSheet.create({
 
   memoryIndicator: {
     color: '#FFFFFF',
-    fontSize: 14,
     fontWeight: '600',
     opacity: 0.7,
   },
@@ -867,7 +866,6 @@ const styles = StyleSheet.create({
 
   degRadText: {
     color: '#FF9F0A',
-    fontSize: 13,
     fontWeight: '600',
   },
 
@@ -876,7 +874,6 @@ const styles = StyleSheet.create({
   },
 
   historyIcon: {
-    fontSize: 20,
   },
 
   displayArea: {
@@ -893,7 +890,6 @@ const styles = StyleSheet.create({
 
   parenIndicator: {
     color: '#FF9F0A',
-    fontSize: 18,
     fontWeight: '400',
     alignSelf: 'flex-end',
     marginBottom: 2,
@@ -946,13 +942,11 @@ const styles = StyleSheet.create({
 
   historyTitle: {
     color: '#FFFFFF',
-    fontSize: 20,
     fontWeight: '600',
   },
 
   historyClose: {
     color: '#A5A5A5',
-    fontSize: 20,
     padding: 4,
   },
 
@@ -962,7 +956,6 @@ const styles = StyleSheet.create({
 
   historyEmpty: {
     color: '#A5A5A5',
-    fontSize: 16,
     textAlign: 'center',
     paddingVertical: 24,
   },
@@ -976,12 +969,10 @@ const styles = StyleSheet.create({
 
   historyExpression: {
     color: '#A5A5A5',
-    fontSize: 14,
   },
 
   historyResult: {
     color: '#FFFFFF',
-    fontSize: 18,
     fontWeight: '500',
     marginTop: 2,
   },
@@ -996,7 +987,6 @@ const styles = StyleSheet.create({
 
   clearHistoryText: {
     color: '#FF453A',
-    fontSize: 16,
     fontWeight: '500',
   },
 });

--- a/src/screens/CallScreen.tsx
+++ b/src/screens/CallScreen.tsx
@@ -22,6 +22,7 @@ import Animated, {
 import type { AppNavigationProp, AppRouteProp } from '../navigation/types';
 import { logger } from '../utils/logger';
 import { hapticImpact } from '../utils/haptics';
+import { useTheme } from '../theme/ThemeContext';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -55,6 +56,7 @@ interface ControlButtonProps {
 }
 
 function ControlButton({ icon, label, onPress, active }: ControlButtonProps) {
+  const { typography } = useTheme();
   return (
     <Pressable
       style={[styles.controlBtn, active && styles.controlBtnActive]}
@@ -64,7 +66,7 @@ function ControlButton({ icon, label, onPress, active }: ControlButtonProps) {
       accessibilityLabel={label}
     >
       <Ionicons name={icon} size={28} color="#ffffff" />
-      <Text style={styles.controlLabel}>{label}</Text>
+      <Text style={[typography.tabLabel, styles.controlLabel]}>{label}</Text>
     </Pressable>
   );
 }
@@ -79,6 +81,7 @@ interface CallScreenProps {
 }
 
 export function CallScreen({ navigation, route }: CallScreenProps) {
+  const { typography, textScale } = useTheme();
   const insets = useSafeAreaInsets();
   const { number, name } = route.params;
   const displayName = name || number || 'Unknown';
@@ -179,16 +182,16 @@ export function CallScreen({ navigation, route }: CallScreenProps) {
       <View style={styles.contactSection}>
         {/* Avatar — pulses when in calling/incoming state */}
         <Animated.View style={[styles.avatarCircle, pulseAnimStyle]}>
-          <Text style={styles.avatarInitials}>{getInitials(displayName)}</Text>
+          <Text style={[styles.avatarInitials, { fontSize: 36 * textScale }]}>{getInitials(displayName)}</Text>
         </Animated.View>
 
         {/* Name */}
-        <Text style={styles.callerName} numberOfLines={1} adjustsFontSizeToFit>
+        <Text style={[typography.title1, styles.callerName]} numberOfLines={1} adjustsFontSizeToFit>
           {displayName}
         </Text>
 
         {/* Status — honest label: native dialer handles the actual call */}
-        <Text style={styles.callStatus}>Call Initiated</Text>
+        <Text style={[styles.callStatus, { fontSize: 14 * textScale }]}>Call Initiated</Text>
       </View>
 
       {/* ------------------------------------------------------------------ */}
@@ -209,7 +212,7 @@ export function CallScreen({ navigation, route }: CallScreenProps) {
             active={isSpeaker}
           />
         </View>
-        <Text style={styles.audioHint}>Audio controlled by system dialer</Text>
+        <Text style={[typography.caption2, styles.audioHint]}>Audio controlled by system dialer</Text>
       </View>
 
       {/* ------------------------------------------------------------------ */}
@@ -260,13 +263,11 @@ const styles = StyleSheet.create({
   },
   avatarInitials: {
     color: '#ffffff',
-    fontSize: 36,
     fontWeight: '300',
     letterSpacing: 1,
   },
   callerName: {
     color: '#ffffff',
-    fontSize: 28,
     fontWeight: '300',
     letterSpacing: 0.5,
     marginBottom: 8,
@@ -274,7 +275,6 @@ const styles = StyleSheet.create({
   },
   callStatus: {
     color: 'rgba(255,255,255,0.55)',
-    fontSize: 14,
     fontWeight: '400',
   },
 
@@ -302,13 +302,11 @@ const styles = StyleSheet.create({
   },
   controlLabel: {
     color: 'rgba(255,255,255,0.7)',
-    fontSize: 10,
     fontWeight: '500',
     marginTop: 2,
   },
   audioHint: {
     color: 'rgba(255,255,255,0.35)',
-    fontSize: 11,
     textAlign: 'center',
     marginTop: 12,
   },

--- a/src/screens/LauncherSettingsScreen.tsx
+++ b/src/screens/LauncherSettingsScreen.tsx
@@ -44,7 +44,7 @@ const DOCK_LABELS: Record<string, string> = {
 export function LauncherSettingsScreen() {
   const navigation = useNavigation<AppNavigationProp>();
   const themeCtx = useTheme();
-  const { theme, typography, isDark, toggleTheme } = themeCtx;
+  const { theme, typography, isDark, toggleTheme, textScale } = themeCtx;
   const { colors } = theme;
   const { settings, update, reset: resetSettings } = useSettings();
   const { dockApps } = useApps();
@@ -377,7 +377,7 @@ export function LauncherSettingsScreen() {
               {pinStep === 'current' ? 'Default passcode is 1234' : 'Must be exactly 4 digits'}
             </Text>
             <TextInput
-              style={[styles.pinInput, { color: colors.label, borderColor: colors.separator, backgroundColor: colors.systemBackground }]}
+              style={[styles.pinInput, { color: colors.label, borderColor: colors.separator, backgroundColor: colors.systemBackground, fontSize: 18 * textScale }]}
               value={pinInput}
               onChangeText={setPinInput}
               keyboardType="number-pad"
@@ -450,7 +450,6 @@ const styles = StyleSheet.create({
     borderRadius: 8,
     paddingHorizontal: 12,
     paddingVertical: 10,
-    fontSize: 18,
     textAlign: 'center',
     marginBottom: 20,
     letterSpacing: 8,

--- a/src/screens/MailScreen.tsx
+++ b/src/screens/MailScreen.tsx
@@ -218,7 +218,7 @@ export function MailScreen({ navigation, route }: { navigation: AppNavigationPro
           <Text style={[typography.title2, { color: colors.label, marginBottom: 12 }]}>{selectedEmail.subject}</Text>
           <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 16 }}>
             <View style={[styles.avatar, { backgroundColor: avatarColor(selectedEmail.from) }]}>
-              <Text style={styles.avatarText}>{getInitials(selectedEmail.from)}</Text>
+              <Text style={[typography.callout, styles.avatarText]}>{getInitials(selectedEmail.from)}</Text>
             </View>
             <View style={{ marginLeft: 12, flex: 1 }}>
               <Text style={[typography.headline, { color: colors.label }]}>{selectedEmail.from}</Text>
@@ -292,7 +292,7 @@ export function MailScreen({ navigation, route }: { navigation: AppNavigationPro
           !demoBannerDismissed ? (
             <View style={[styles.demoBanner]}>
               <Ionicons name="information-circle-outline" size={20} color="#92400e" style={{ marginRight: 8 }} />
-              <Text style={styles.demoBannerText}>
+              <Text style={[typography.footnote, styles.demoBannerText]}>
                 Demo Mode — These are sample emails. This app does not send or receive real mail.
               </Text>
               <Pressable onPress={dismissDemoBanner} hitSlop={8} style={{ marginLeft: 8 }}>
@@ -323,7 +323,7 @@ export function MailScreen({ navigation, route }: { navigation: AppNavigationPro
             >
               {!item.isRead && <View style={[styles.unreadDot, { backgroundColor: colors.systemBlue }]} />}
               <View style={[styles.avatar, { backgroundColor: avatarColor(item.from) }]}>
-                <Text style={styles.avatarText}>{getInitials(item.from)}</Text>
+                <Text style={[typography.callout, styles.avatarText]}>{getInitials(item.from)}</Text>
               </View>
               <View style={styles.emailContent}>
                 <View style={styles.emailHeader}>
@@ -359,7 +359,7 @@ export function MailScreen({ navigation, route }: { navigation: AppNavigationPro
           </View>
           <ScrollView contentContainerStyle={{ padding: 16 }}>
             <TextInput
-              style={[styles.composeField, { color: colors.label, borderBottomColor: colors.separator }]}
+              style={[typography.callout, styles.composeField, { color: colors.label, borderBottomColor: colors.separator }]}
               placeholder="To:"
               placeholderTextColor={colors.secondaryLabel}
               value={composeTo}
@@ -368,14 +368,14 @@ export function MailScreen({ navigation, route }: { navigation: AppNavigationPro
               autoCapitalize="none"
             />
             <TextInput
-              style={[styles.composeField, { color: colors.label, borderBottomColor: colors.separator }]}
+              style={[typography.callout, styles.composeField, { color: colors.label, borderBottomColor: colors.separator }]}
               placeholder="Subject:"
               placeholderTextColor={colors.secondaryLabel}
               value={composeSubject}
               onChangeText={setComposeSubject}
             />
             <TextInput
-              style={[styles.composeBody, { color: colors.label }]}
+              style={[typography.callout, styles.composeBody, { color: colors.label }]}
               placeholder="Write your email..."
               placeholderTextColor={colors.secondaryLabel}
               value={composeBody}
@@ -405,20 +405,19 @@ const styles = StyleSheet.create({
   },
   demoBannerText: {
     flex: 1,
-    fontSize: 13,
     color: '#92400e',
     lineHeight: 18,
   },
   emailRow: { flexDirection: 'row', alignItems: 'center', paddingVertical: 10, paddingHorizontal: 16 },
   unreadDot: { width: 8, height: 8, borderRadius: 4, position: 'absolute', left: 4, top: '50%' },
   avatar: { width: 44, height: 44, borderRadius: 22, alignItems: 'center', justifyContent: 'center' },
-  avatarText: { color: '#fff', fontSize: 16, fontWeight: '600' },
+  avatarText: { color: '#fff', fontWeight: '600' },
   emailContent: { flex: 1, marginLeft: 12 },
   emailHeader: { flexDirection: 'row', alignItems: 'center', marginBottom: 2 },
   separator: { height: StyleSheet.hairlineWidth },
   emptyState: { flex: 1, alignItems: 'center', justifyContent: 'center', paddingTop: 120 },
   actionBtn: { flexDirection: 'row', alignItems: 'center', paddingVertical: 10, paddingHorizontal: 20, borderRadius: 10 },
   composeHeader: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', paddingHorizontal: 16, paddingVertical: 12, borderBottomWidth: StyleSheet.hairlineWidth },
-  composeField: { fontSize: 16, paddingVertical: 12, borderBottomWidth: StyleSheet.hairlineWidth },
-  composeBody: { fontSize: 16, minHeight: 200, paddingTop: 12 },
+  composeField: { paddingVertical: 12, borderBottomWidth: StyleSheet.hairlineWidth },
+  composeBody: { minHeight: 200, paddingTop: 12 },
 });

--- a/src/screens/MessagesScreen.tsx
+++ b/src/screens/MessagesScreen.tsx
@@ -169,7 +169,7 @@ const ConversationRow = React.memo(function ConversationRow({
       {/* Avatar */}
       <View style={[styles.avatar, { backgroundColor: bgColor }]}>
         {contact ? (
-          <Text style={styles.avatarInitials}>{getInitials(contact)}</Text>
+          <Text style={[styles.avatarInitials, { fontSize: 19 * textScale }]}>{getInitials(contact)}</Text>
         ) : (
           <Ionicons name="person-outline" size={22} color="#FFFFFF" />
         )}
@@ -195,7 +195,7 @@ const ConversationRow = React.memo(function ConversationRow({
           </Text>
           {!editMode && (
             <View style={styles.dateChevronRow}>
-              <Text style={[typography.subhead, { color: colors.secondaryLabel, fontSize: 15 }]}>
+              <Text style={[typography.subhead, { color: colors.secondaryLabel }]}>
                 {conversation.lastMessage.dateFormatted}
               </Text>
               <Ionicons
@@ -248,7 +248,7 @@ const ConversationRow = React.memo(function ConversationRow({
 // ─── Main Screen ─────────────────────────────────────────────────────────────
 
 export function MessagesScreen() {
-  const { theme, typography, spacing } = useTheme();
+  const { theme, typography, spacing, textScale } = useTheme();
   const { colors } = theme;
   const insets = useSafeAreaInsets();
   const navigation = useNavigation<AppNavigationProp>();
@@ -598,7 +598,7 @@ export function MessagesScreen() {
         </View>
 
         {/* Large title */}
-        <Text style={[styles.largeTitle, { color: colors.label }]}>
+        <Text style={[typography.largeTitle, styles.largeTitle, { color: colors.label }]}>
           Messages
         </Text>
 
@@ -607,7 +607,7 @@ export function MessagesScreen() {
           <View style={[styles.searchBar, { backgroundColor: colors.systemGray5 }]}>
             <Ionicons name="search" size={16} color={colors.systemGray} style={{ marginRight: 6 }} />
             <TextInput
-              style={[styles.searchInput, { color: colors.label }]}
+              style={[typography.body, styles.searchInput, { color: colors.label }]}
               placeholder="Search"
               placeholderTextColor={colors.systemGray}
               value={searchQuery}
@@ -704,7 +704,6 @@ const styles = StyleSheet.create({
     marginLeft: -8,
   },
   largeTitle: {
-    fontSize: 34,
     fontWeight: '700',
     letterSpacing: 0.41,
     marginBottom: 8,
@@ -718,7 +717,6 @@ const styles = StyleSheet.create({
   },
   searchInput: {
     flex: 1,
-    fontSize: 17,
     paddingVertical: 0,
   },
 
@@ -762,7 +760,6 @@ const styles = StyleSheet.create({
     flexShrink: 0,
   },
   avatarInitials: {
-    fontSize: 19,
     fontWeight: '600',
     color: '#FFFFFF',
   },

--- a/src/screens/MessagesScreen.tsx
+++ b/src/screens/MessagesScreen.tsx
@@ -116,6 +116,7 @@ const ConversationRow = React.memo(function ConversationRow({
   onSelect,
   hasUnread,
 }: ConversationRowProps) {
+  const { textScale } = useTheme();
   const contact = findContactByPhone(conversation.address, contacts);
   const displayName = contact
     ? `${contact.firstName} ${contact.lastName}`.trim()
@@ -248,7 +249,7 @@ const ConversationRow = React.memo(function ConversationRow({
 // ─── Main Screen ─────────────────────────────────────────────────────────────
 
 export function MessagesScreen() {
-  const { theme, typography, spacing, textScale } = useTheme();
+  const { theme, typography, spacing } = useTheme();
   const { colors } = theme;
   const insets = useSafeAreaInsets();
   const navigation = useNavigation<AppNavigationProp>();

--- a/src/screens/MultitaskScreen.tsx
+++ b/src/screens/MultitaskScreen.tsx
@@ -24,6 +24,7 @@ import * as Haptics from 'expo-haptics';
 import { useApps, InstalledApp, RecentApp } from '../store/AppsStore';
 import type { AppNavigationProp } from '../navigation/types';
 import { hapticImpact } from '../utils/haptics';
+import { useTheme } from '../theme/ThemeContext';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -79,6 +80,7 @@ interface RecentAppCardProps {
 }
 
 function RecentAppCard({ app, launchedAt, onSwipeUp, onTap }: RecentAppCardProps) {
+  const { typography, textScale } = useTheme();
   const translateY = useSharedValue(0);
   const opacity = useSharedValue(1);
 
@@ -139,7 +141,7 @@ function RecentAppCard({ app, launchedAt, onSwipeUp, onTap }: RecentAppCardProps
             </View>
 
             {/* App name on card */}
-            <Text style={styles.cardAppName} numberOfLines={1}>
+            <Text style={[typography.subhead, styles.cardAppName]} numberOfLines={1}>
               {app.name}
             </Text>
           </View>
@@ -160,10 +162,10 @@ function RecentAppCard({ app, launchedAt, onSwipeUp, onTap }: RecentAppCardProps
             </View>
           )}
           <View style={styles.appInfoText}>
-            <Text style={styles.appInfoName} numberOfLines={1}>
+            <Text style={[typography.footnote, styles.appInfoName]} numberOfLines={1}>
               {app.name}
             </Text>
-            <Text style={styles.appInfoTime} numberOfLines={1}>
+            <Text style={[typography.caption2, styles.appInfoTime]} numberOfLines={1}>
               {timeSince(launchedAt)}
             </Text>
           </View>
@@ -183,6 +185,7 @@ interface RecentEntry {
 }
 
 export function MultitaskScreen({ navigation }: { navigation: AppNavigationProp }) {
+  const { typography, textScale } = useTheme();
   const insets = useSafeAreaInsets();
   const { apps, recentApps, removeFromRecents, clearRecents } = useApps();
 
@@ -233,15 +236,15 @@ export function MultitaskScreen({ navigation }: { navigation: AppNavigationProp 
 
       {/* Header */}
       <View style={[styles.header, { marginTop: insets.top + 12 }]}>
-        <Text style={styles.headerTitle}>Recents</Text>
+        <Text style={[typography.body, styles.headerTitle]}>Recents</Text>
         {(entries.length > 0 || showClearedNotice) && (
           <Pressable onPress={handleClearAll} style={styles.clearAllButton} accessibilityLabel="Clear all recent apps" accessibilityRole="button">
-            <Text style={styles.clearAllText}>Clear All</Text>
+            <Text style={[styles.clearAllText, { fontSize: 14 * textScale }]}>Clear All</Text>
           </Pressable>
         )}
       </View>
       {showClearedNotice && (
-        <Text style={styles.clearedNotice}>
+        <Text style={[typography.caption1, styles.clearedNotice]}>
           Recent apps cleared from this view. Background processes are managed by Android.
         </Text>
       )}
@@ -249,8 +252,8 @@ export function MultitaskScreen({ navigation }: { navigation: AppNavigationProp 
       {entries.length === 0 ? (
         <View style={styles.empty}>
           <Ionicons name="apps-outline" size={56} color="rgba(255,255,255,0.3)" />
-          <Text style={styles.emptyTitle}>No Recent Apps</Text>
-          <Text style={styles.emptySubtitle}>Apps you use will appear here</Text>
+          <Text style={[styles.emptyTitle, { fontSize: 18 * textScale }]}>No Recent Apps</Text>
+          <Text style={[styles.emptySubtitle, { fontSize: 14 * textScale }]}>Apps you use will appear here</Text>
         </View>
       ) : (
         <ScrollView
@@ -299,7 +302,6 @@ const styles = StyleSheet.create({
   },
   headerTitle: {
     color: '#ffffff',
-    fontSize: 17,
     fontWeight: '600',
     letterSpacing: -0.3,
   },
@@ -311,12 +313,10 @@ const styles = StyleSheet.create({
   },
   clearAllText: {
     color: 'rgba(255,255,255,0.7)',
-    fontSize: 14,
     fontWeight: '500',
   },
   clearedNotice: {
     color: 'rgba(255,255,255,0.5)',
-    fontSize: 12,
     fontWeight: '400',
     textAlign: 'center',
     paddingHorizontal: 32,
@@ -392,7 +392,6 @@ const styles = StyleSheet.create({
 
   cardAppName: {
     color: 'rgba(255,255,255,0.6)',
-    fontSize: 15,
     fontWeight: '400',
     letterSpacing: -0.3,
   },
@@ -437,12 +436,10 @@ const styles = StyleSheet.create({
   },
   appInfoName: {
     color: 'rgba(255,255,255,0.85)',
-    fontSize: 13,
     fontWeight: '500',
   },
   appInfoTime: {
     color: 'rgba(255,255,255,0.4)',
-    fontSize: 11,
     fontWeight: '400',
     marginTop: 1,
   },
@@ -455,13 +452,11 @@ const styles = StyleSheet.create({
   },
   emptyTitle: {
     color: 'rgba(255,255,255,0.5)',
-    fontSize: 18,
     fontWeight: '500',
     marginTop: 4,
   },
   emptySubtitle: {
     color: 'rgba(255,255,255,0.3)',
-    fontSize: 14,
     fontWeight: '400',
   },
 });

--- a/src/screens/MultitaskScreen.tsx
+++ b/src/screens/MultitaskScreen.tsx
@@ -80,7 +80,7 @@ interface RecentAppCardProps {
 }
 
 function RecentAppCard({ app, launchedAt, onSwipeUp, onTap }: RecentAppCardProps) {
-  const { typography, textScale } = useTheme();
+  const { typography } = useTheme();
   const translateY = useSharedValue(0);
   const opacity = useSharedValue(1);
 

--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -13,6 +13,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { LinearGradient } from 'expo-linear-gradient';
 import { SystemColors } from '../theme/CupertinoTheme';
+import { useTheme } from '../theme/ThemeContext';
 import { withAutoLockSuppressed } from '../utils/permissions';
 import type { LauncherModuleType } from '../../modules/launcher-module/src';
 
@@ -73,6 +74,7 @@ const PERMISSIONS = [
 ];
 
 export function OnboardingScreen({ onDone }: OnboardingScreenProps) {
+  const { typography, textScale } = useTheme();
   const insets = useSafeAreaInsets();
   const scrollRef = useRef<ScrollView>(null);
   const [currentPage, setCurrentPage] = useState(0);
@@ -160,10 +162,10 @@ export function OnboardingScreen({ onDone }: OnboardingScreenProps) {
                 <Ionicons name="phone-portrait" size={72} color="#FFFFFF" />
               </BlurView>
             </View>
-            <Text style={styles.pageTitle}>Welcome to{'\n'}iOS Launcher</Text>
-            <Text style={styles.pageSubtitle}>Transform your Android into iOS</Text>
+            <Text style={[typography.largeTitle, styles.pageTitle]}>Welcome to{'\n'}iOS Launcher</Text>
+            <Text style={[typography.body, styles.pageSubtitle]}>Transform your Android into iOS</Text>
             <Pressable style={styles.primaryButton} onPress={() => goToPage(1)}>
-              <Text style={styles.primaryButtonText}>Get Started</Text>
+              <Text style={[typography.body, styles.primaryButtonText]}>Get Started</Text>
             </Pressable>
           </ScrollView>
         </View>
@@ -171,8 +173,8 @@ export function OnboardingScreen({ onDone }: OnboardingScreenProps) {
         {/* ── Page 2: Permissions ───────────────────────────────────────── */}
         <View style={styles.page}>
           <ScrollView showsVerticalScrollIndicator={false} contentContainerStyle={[styles.pageContent, { paddingTop: insets.top + 60, paddingBottom: insets.bottom + 32 }]}>
-            <Text style={styles.pageTitle}>Permissions</Text>
-            <Text style={styles.pageSubtitle}>We need a few permissions to give you the full experience</Text>
+            <Text style={[typography.largeTitle, styles.pageTitle]}>Permissions</Text>
+            <Text style={[typography.body, styles.pageSubtitle]}>We need a few permissions to give you the full experience</Text>
             <View style={styles.permList}>
               {PERMISSIONS.map(perm => (
                 <View key={perm.label} style={styles.permRow}>
@@ -180,8 +182,8 @@ export function OnboardingScreen({ onDone }: OnboardingScreenProps) {
                     <Ionicons name={perm.icon} size={22} color="#FFFFFF" />
                   </View>
                   <View style={styles.permText}>
-                    <Text style={styles.permLabel}>{perm.label}</Text>
-                    <Text style={styles.permDesc}>{perm.description}</Text>
+                    <Text style={[typography.subhead, styles.permLabel]}>{perm.label}</Text>
+                    <Text style={[typography.footnote, styles.permDesc]}>{perm.description}</Text>
                   </View>
                 </View>
               ))}
@@ -189,11 +191,11 @@ export function OnboardingScreen({ onDone }: OnboardingScreenProps) {
             {permissionError && (
               <View style={styles.errorContainer}>
                 <Ionicons name="warning-outline" size={18} color="#FF453A" />
-                <Text style={styles.errorText}>{permissionError}</Text>
+                <Text style={[typography.footnote, styles.errorText]}>{permissionError}</Text>
               </View>
             )}
             <Pressable style={styles.primaryButton} onPress={handleGrantPermissions}>
-              <Text style={styles.primaryButtonText}>
+              <Text style={[typography.body, styles.primaryButtonText]}>
                 {permissionError ? 'Try Again' : 'Grant Permissions'}
               </Text>
             </Pressable>
@@ -214,15 +216,15 @@ export function OnboardingScreen({ onDone }: OnboardingScreenProps) {
                 />
               </BlurView>
             </View>
-            <Text style={styles.pageTitle}>Set as Default{'\n'}Launcher</Text>
-            <Text style={styles.pageSubtitle}>
+            <Text style={[typography.largeTitle, styles.pageTitle]}>Set as Default{'\n'}Launcher</Text>
+            <Text style={[typography.body, styles.pageSubtitle]}>
               To get the full experience, set this app as your home launcher
             </Text>
             <Pressable style={styles.primaryButton} onPress={handleSetLauncher}>
-              <Text style={styles.primaryButtonText}>Set Now</Text>
+              <Text style={[typography.body, styles.primaryButtonText]}>Set Now</Text>
             </Pressable>
             <Pressable onPress={() => goToPage(3)} hitSlop={12} style={{ marginTop: 16 }}>
-              <Text style={styles.skipText}>Skip</Text>
+              <Text style={[typography.subhead, styles.skipText]}>Skip</Text>
             </Pressable>
           </ScrollView>
         </View>
@@ -233,8 +235,8 @@ export function OnboardingScreen({ onDone }: OnboardingScreenProps) {
             <View style={styles.checkCircle}>
               <Ionicons name="checkmark" size={72} color="#FFFFFF" />
             </View>
-            <Text style={styles.pageTitle}>{"You're All Set!"}</Text>
-            <Text style={styles.pageSubtitle}>Your iOS experience starts now</Text>
+            <Text style={[typography.largeTitle, styles.pageTitle]}>{"You're All Set!"}</Text>
+            <Text style={[typography.body, styles.pageSubtitle]}>Your iOS experience starts now</Text>
 
             {/* Permission status summary */}
             {Object.keys(permissionResults).length > 0 && (
@@ -246,14 +248,14 @@ export function OnboardingScreen({ onDone }: OnboardingScreenProps) {
                       size={18}
                       color={granted ? '#30D158' : '#FF453A'}
                     />
-                    <Text style={styles.permStatusLabel}>{key}</Text>
+                    <Text style={[styles.permStatusLabel, { fontSize: 14 * textScale }]}>{key}</Text>
                   </View>
                 ))}
               </View>
             )}
 
             <Pressable style={styles.primaryButton} onPress={handleDone}>
-              <Text style={styles.primaryButtonText}>Start</Text>
+              <Text style={[typography.body, styles.primaryButtonText]}>Start</Text>
             </Pressable>
           </ScrollView>
         </View>
@@ -326,7 +328,6 @@ const styles = StyleSheet.create({
     marginBottom: 8,
   },
   pageTitle: {
-    fontSize: 34,
     fontWeight: '700',
     color: '#FFFFFF',
     textAlign: 'center',
@@ -334,7 +335,6 @@ const styles = StyleSheet.create({
     letterSpacing: 0.3,
   },
   pageSubtitle: {
-    fontSize: 17,
     color: 'rgba(255,255,255,0.7)',
     textAlign: 'center',
     lineHeight: 24,
@@ -351,12 +351,10 @@ const styles = StyleSheet.create({
   },
   primaryButtonText: {
     color: '#FFFFFF',
-    fontSize: 17,
     fontWeight: '600',
   },
   skipText: {
     color: 'rgba(255,255,255,0.55)',
-    fontSize: 15,
     fontWeight: '500',
   },
   permList: {
@@ -385,13 +383,11 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   permLabel: {
-    fontSize: 15,
     fontWeight: '600',
     color: '#FFFFFF',
     marginBottom: 2,
   },
   permDesc: {
-    fontSize: 13,
     color: 'rgba(255,255,255,0.6)',
   },
   errorContainer: {
@@ -405,7 +401,6 @@ const styles = StyleSheet.create({
   },
   errorText: {
     flex: 1,
-    fontSize: 13,
     color: '#FF453A',
   },
   permSummary: {
@@ -423,7 +418,6 @@ const styles = StyleSheet.create({
     gap: 8,
   },
   permStatusLabel: {
-    fontSize: 14,
     color: 'rgba(255,255,255,0.8)',
     textTransform: 'capitalize',
   },

--- a/src/screens/SpotlightSearchScreen.tsx
+++ b/src/screens/SpotlightSearchScreen.tsx
@@ -195,7 +195,7 @@ function AppIcon({ app, size = ICON_SIZE }: { app: InstalledApp; size?: number }
 // ---------------------------------------------------------------------------
 
 export function SpotlightSearchScreen({ navigation }: { navigation: AppNavigationProp }) {
-  const { theme, isDark } = useTheme();
+  const { theme, isDark, typography } = useTheme();
   const { colors } = theme;
   const insets = useSafeAreaInsets();
   const { apps, launchApp } = useApps();
@@ -406,7 +406,7 @@ export function SpotlightSearchScreen({ navigation }: { navigation: AppNavigatio
               <Ionicons name="globe-outline" size={24} color="#fff" />
             </View>
             <View style={styles.resultTextWrap}>
-              <Text style={[styles.resultTitle, { color: colors.label }]}>
+              <Text style={[typography.callout, styles.resultTitle, { color: colors.label }]}>
                 Search Web for &ldquo;{item.query}&rdquo;
               </Text>
             </View>
@@ -420,7 +420,7 @@ export function SpotlightSearchScreen({ navigation }: { navigation: AppNavigatio
           >
             <AppIcon app={item.app} size={40} />
             <View style={styles.resultTextWrap}>
-              <Text style={[styles.resultTitle, { color: colors.label }]}>{item.app.name}</Text>
+              <Text style={[typography.callout, styles.resultTitle, { color: colors.label }]}>{item.app.name}</Text>
             </View>
           </Pressable>
         );
@@ -434,9 +434,9 @@ export function SpotlightSearchScreen({ navigation }: { navigation: AppNavigatio
               <Ionicons name="person-circle-outline" size={36} color={colors.systemGray} />
             </View>
             <View style={styles.resultTextWrap}>
-              <Text style={[styles.resultTitle, { color: colors.label }]}>{item.name}</Text>
+              <Text style={[typography.callout, styles.resultTitle, { color: colors.label }]}>{item.name}</Text>
               {item.phone ? (
-                <Text style={[styles.resultSubtitle, { color: colors.secondaryLabel }]}>{item.phone}</Text>
+                <Text style={[typography.footnote, styles.resultSubtitle, { color: colors.secondaryLabel }]}>{item.phone}</Text>
               ) : null}
             </View>
           </Pressable>
@@ -451,8 +451,8 @@ export function SpotlightSearchScreen({ navigation }: { navigation: AppNavigatio
               <Ionicons name="document-text-outline" size={22} color="#000" />
             </View>
             <View style={styles.resultTextWrap}>
-              <Text style={[styles.resultTitle, { color: colors.label }]}>{item.title}</Text>
-              <Text style={[styles.resultSubtitle, { color: colors.secondaryLabel }]}>Notes</Text>
+              <Text style={[typography.callout, styles.resultTitle, { color: colors.label }]}>{item.title}</Text>
+              <Text style={[typography.footnote, styles.resultSubtitle, { color: colors.secondaryLabel }]}>Notes</Text>
             </View>
           </Pressable>
         );
@@ -466,8 +466,8 @@ export function SpotlightSearchScreen({ navigation }: { navigation: AppNavigatio
               <Ionicons name="mail-outline" size={22} color="#fff" />
             </View>
             <View style={styles.resultTextWrap}>
-              <Text style={[styles.resultTitle, { color: colors.label }]} numberOfLines={1}>{item.subject}</Text>
-              <Text style={[styles.resultSubtitle, { color: colors.secondaryLabel }]}>Mail · {item.sender}</Text>
+              <Text style={[typography.callout, styles.resultTitle, { color: colors.label }]} numberOfLines={1}>{item.subject}</Text>
+              <Text style={[typography.footnote, styles.resultSubtitle, { color: colors.secondaryLabel }]}>Mail · {item.sender}</Text>
             </View>
           </Pressable>
         );
@@ -481,8 +481,8 @@ export function SpotlightSearchScreen({ navigation }: { navigation: AppNavigatio
               <Ionicons name="checkmark-circle-outline" size={22} color="#fff" />
             </View>
             <View style={styles.resultTextWrap}>
-              <Text style={[styles.resultTitle, { color: colors.label }]} numberOfLines={1}>{item.title}</Text>
-              <Text style={[styles.resultSubtitle, { color: colors.secondaryLabel }]}>Reminders</Text>
+              <Text style={[typography.callout, styles.resultTitle, { color: colors.label }]} numberOfLines={1}>{item.title}</Text>
+              <Text style={[typography.footnote, styles.resultSubtitle, { color: colors.secondaryLabel }]}>Reminders</Text>
             </View>
           </Pressable>
         );
@@ -496,8 +496,8 @@ export function SpotlightSearchScreen({ navigation }: { navigation: AppNavigatio
               <Ionicons name="settings-outline" size={24} color={colors.systemGray} />
             </View>
             <View style={styles.resultTextWrap}>
-              <Text style={[styles.resultTitle, { color: colors.label }]}>{item.name}</Text>
-              <Text style={[styles.resultSubtitle, { color: colors.secondaryLabel }]}>
+              <Text style={[typography.callout, styles.resultTitle, { color: colors.label }]}>{item.name}</Text>
+              <Text style={[typography.footnote, styles.resultSubtitle, { color: colors.secondaryLabel }]}>
                 Settings &gt; {item.name}
               </Text>
             </View>
@@ -510,7 +510,7 @@ export function SpotlightSearchScreen({ navigation }: { navigation: AppNavigatio
 
   const renderSectionHeader = useCallback(({ section }: { section: { title: string } }) => (
     <View style={[styles.sectionHeader, { backgroundColor: colors.systemGroupedBackground }]}>
-      <Text style={[styles.sectionHeaderText, { color: colors.secondaryLabel }]}>
+      <Text style={[typography.footnote, styles.sectionHeaderText, { color: colors.secondaryLabel }]}>
         {section.title}
       </Text>
     </View>
@@ -528,9 +528,9 @@ export function SpotlightSearchScreen({ navigation }: { navigation: AppNavigatio
           accessibilityLabel="Back"
         >
           <Ionicons name="chevron-back" size={22} color={colors.systemBlue} />
-          <Text style={[styles.backLabel, { color: colors.systemBlue }]}>Back</Text>
+          <Text style={[typography.body, styles.backLabel, { color: colors.systemBlue }]}>Back</Text>
         </Pressable>
-        <Text style={[styles.navTitle, { color: colors.label }]}>Search</Text>
+        <Text style={[typography.body, styles.navTitle, { color: colors.label }]}>Search</Text>
         <View style={styles.backBtn} />
       </View>
 
@@ -549,9 +549,9 @@ export function SpotlightSearchScreen({ navigation }: { navigation: AppNavigatio
         /* Search history */
         <View style={styles.historyContainer}>
           <View style={styles.historyHeader}>
-            <Text style={[styles.historyTitle, { color: colors.label }]}>Recent Searches</Text>
+            <Text style={[typography.title3, styles.historyTitle, { color: colors.label }]}>Recent Searches</Text>
             <Pressable onPress={handleClearHistory}>
-              <Text style={[styles.historyClear, { color: colors.systemBlue }]}>Clear</Text>
+              <Text style={[typography.callout, styles.historyClear, { color: colors.systemBlue }]}>Clear</Text>
             </Pressable>
           </View>
           {history.map((item, index) => (
@@ -568,7 +568,7 @@ export function SpotlightSearchScreen({ navigation }: { navigation: AppNavigatio
               ]}
             >
               <Ionicons name="time-outline" size={18} color={colors.secondaryLabel} />
-              <Text style={[styles.historyText, { color: colors.label }]}>{item}</Text>
+              <Text style={[typography.callout, styles.historyText, { color: colors.label }]}>{item}</Text>
             </Pressable>
           ))}
         </View>
@@ -596,7 +596,7 @@ export function SpotlightSearchScreen({ navigation }: { navigation: AppNavigatio
           keyboardDismissMode="on-drag"
           ListEmptyComponent={
             <View style={styles.emptyContainer}>
-              <Text style={[styles.emptyText, { color: colors.secondaryLabel }]}>No Results</Text>
+              <Text style={[typography.body, styles.emptyText, { color: colors.secondaryLabel }]}>No Results</Text>
             </View>
           }
         />
@@ -628,11 +628,9 @@ const styles = StyleSheet.create({
     paddingHorizontal: 4,
   },
   backLabel: {
-    fontSize: 17,
     fontWeight: '400',
   },
   navTitle: {
-    fontSize: 17,
     fontWeight: '600',
     letterSpacing: -0.3,
   },
@@ -647,7 +645,6 @@ const styles = StyleSheet.create({
     paddingTop: 12,
   },
   sectionHeaderText: {
-    fontSize: 13,
     fontWeight: '600',
     textTransform: 'uppercase',
     letterSpacing: 0.5,
@@ -664,11 +661,9 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   resultTitle: {
-    fontSize: 16,
     fontWeight: '400',
   },
   resultSubtitle: {
-    fontSize: 13,
     fontWeight: '400',
     marginTop: 2,
   },
@@ -691,12 +686,10 @@ const styles = StyleSheet.create({
     marginBottom: 8,
   },
   historyTitle: {
-    fontSize: 20,
     fontWeight: '700',
     letterSpacing: -0.4,
   },
   historyClear: {
-    fontSize: 16,
     fontWeight: '400',
   },
   historyRow: {
@@ -706,7 +699,6 @@ const styles = StyleSheet.create({
     gap: 10,
   },
   historyText: {
-    fontSize: 16,
     fontWeight: '400',
   },
   // Empty
@@ -716,7 +708,6 @@ const styles = StyleSheet.create({
     paddingTop: 60,
   },
   emptyText: {
-    fontSize: 17,
     fontWeight: '500',
   },
 });

--- a/src/screens/SpotlightSearchScreen.tsx
+++ b/src/screens/SpotlightSearchScreen.tsx
@@ -506,7 +506,7 @@ export function SpotlightSearchScreen({ navigation }: { navigation: AppNavigatio
       default:
         return null;
     }
-  }, [colors, handleResultPress]);
+  }, [colors, handleResultPress, typography]);
 
   const renderSectionHeader = useCallback(({ section }: { section: { title: string } }) => (
     <View style={[styles.sectionHeader, { backgroundColor: colors.systemGroupedBackground }]}>
@@ -514,7 +514,7 @@ export function SpotlightSearchScreen({ navigation }: { navigation: AppNavigatio
         {section.title}
       </Text>
     </View>
-  ), [colors]);
+  ), [colors, typography]);
 
   return (
     <View style={[styles.root, { backgroundColor: colors.systemGroupedBackground }]}>

--- a/src/screens/WeatherScreen.tsx
+++ b/src/screens/WeatherScreen.tsx
@@ -6,6 +6,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 import * as Location from 'expo-location';
 import { withAutoLockSuppressed } from '../utils/permissions';
 import { useDevice } from '../store/DeviceStore';
+import { useTheme } from '../theme/ThemeContext';
 import { CupertinoNavigationBar } from '../components';
 import type { AppNavigationProp } from '../navigation/types';
 
@@ -58,6 +59,7 @@ export function WeatherScreen({ navigation }: WeatherScreenProps) {
   const insets = useSafeAreaInsets();
   const device = useDevice();
   const { weather } = device;
+  const { typography, textScale } = useTheme();
 
   const [forecast, setForecast] = useState<ForecastDay[]>([]);
   const [hourly, setHourly] = useState<HourlyEntry[]>([]);
@@ -191,11 +193,11 @@ export function WeatherScreen({ navigation }: WeatherScreenProps) {
       <ScrollView contentContainerStyle={[styles.content, { paddingBottom: insets.bottom + 90 }]} showsVerticalScrollIndicator={false}>
         {/* City & current temp */}
         <View style={styles.hero}>
-          <Text style={styles.cityName}>{currentCity || weather.city || 'My Location'}</Text>
-          <Text style={styles.bigTemp}>{currentTemp ?? weather.temp}°</Text>
-          <Text style={styles.condition}>{weather.condition}</Text>
+          <Text style={[typography.largeTitle, styles.cityName]}>{currentCity || weather.city || 'My Location'}</Text>
+          <Text style={[styles.bigTemp, { fontSize: 96 * textScale }]}>{currentTemp ?? weather.temp}°</Text>
+          <Text style={[styles.condition, { fontSize: 18 * textScale }]}>{weather.condition}</Text>
           {forecast.length > 0 && (
-            <Text style={styles.highLow}>
+            <Text style={[typography.callout, styles.highLow]}>
               H:{forecast[0].high}° L:{forecast[0].low}°
             </Text>
           )}
@@ -207,9 +209,9 @@ export function WeatherScreen({ navigation }: WeatherScreenProps) {
             <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.hourlyRow}>
               {hourly.map((h, i) => (
                 <View key={i} style={styles.hourlyItem}>
-                  <Text style={styles.hourlyTime}>{h.time}</Text>
+                  <Text style={[typography.footnote, styles.hourlyTime]}>{h.time}</Text>
                   <WeatherIcon name={h.icon} size={22} />
-                  <Text style={styles.hourlyTemp}>{h.temp}°</Text>
+                  <Text style={[typography.body, styles.hourlyTemp]}>{h.temp}°</Text>
                 </View>
               ))}
             </ScrollView>
@@ -221,15 +223,15 @@ export function WeatherScreen({ navigation }: WeatherScreenProps) {
           <View style={styles.card}>
             <View style={styles.cardHeader}>
               <Ionicons name="calendar-outline" size={14} color="rgba(255,255,255,0.6)" />
-              <Text style={styles.cardHeaderText}>5-DAY FORECAST</Text>
+              <Text style={[typography.caption2, styles.cardHeaderText]}>5-DAY FORECAST</Text>
             </View>
             {forecast.map((d, i) => (
               <View key={i} style={styles.forecastRow}>
-                <Text style={styles.forecastDay}>{i === 0 ? 'Today' : d.date}</Text>
+                <Text style={[typography.body, styles.forecastDay]}>{i === 0 ? 'Today' : d.date}</Text>
                 <WeatherIcon name={d.icon} size={20} />
-                <Text style={styles.forecastLow}>{d.low}°</Text>
+                <Text style={[typography.body, styles.forecastLow]}>{d.low}°</Text>
                 <View style={styles.tempBar} />
-                <Text style={styles.forecastHigh}>{d.high}°</Text>
+                <Text style={[typography.body, styles.forecastHigh]}>{d.high}°</Text>
               </View>
             ))}
           </View>
@@ -239,23 +241,23 @@ export function WeatherScreen({ navigation }: WeatherScreenProps) {
         <View style={styles.detailsGrid}>
           <View style={styles.detailCard}>
             <Ionicons name="water-outline" size={16} color="rgba(255,255,255,0.6)" />
-            <Text style={styles.detailLabel}>HUMIDITY</Text>
-            <Text style={styles.detailValue}>{humidity}</Text>
+            <Text style={[typography.caption2, styles.detailLabel]}>HUMIDITY</Text>
+            <Text style={[typography.title1, styles.detailValue]}>{humidity}</Text>
           </View>
           <View style={styles.detailCard}>
             <Ionicons name="speedometer-outline" size={16} color="rgba(255,255,255,0.6)" />
-            <Text style={styles.detailLabel}>WIND</Text>
-            <Text style={styles.detailValue}>{wind}</Text>
+            <Text style={[typography.caption2, styles.detailLabel]}>WIND</Text>
+            <Text style={[typography.title1, styles.detailValue]}>{wind}</Text>
           </View>
           <View style={styles.detailCard}>
             <Ionicons name="thermometer-outline" size={16} color="rgba(255,255,255,0.6)" />
-            <Text style={styles.detailLabel}>FEELS LIKE</Text>
-            <Text style={styles.detailValue}>{feelsLike}</Text>
+            <Text style={[typography.caption2, styles.detailLabel]}>FEELS LIKE</Text>
+            <Text style={[typography.title1, styles.detailValue]}>{feelsLike}</Text>
           </View>
           <View style={styles.detailCard}>
             <Ionicons name="sunny-outline" size={16} color="rgba(255,255,255,0.6)" />
-            <Text style={styles.detailLabel}>UV INDEX</Text>
-            <Text style={styles.detailValue}>{uv}</Text>
+            <Text style={[typography.caption2, styles.detailLabel]}>UV INDEX</Text>
+            <Text style={[typography.title1, styles.detailValue]}>{uv}</Text>
           </View>
         </View>
       </ScrollView>
@@ -267,10 +269,10 @@ const styles = StyleSheet.create({
   root: { flex: 1 },
   content: { paddingHorizontal: 16 },
   hero: { alignItems: 'center', marginBottom: 24 },
-  cityName: { color: '#fff', fontSize: 34, fontWeight: '300', letterSpacing: 0.5 },
-  bigTemp: { color: '#fff', fontSize: 96, fontWeight: '100', lineHeight: 110 },
-  condition: { color: 'rgba(255,255,255,0.8)', fontSize: 18, fontWeight: '400' },
-  highLow: { color: 'rgba(255,255,255,0.7)', fontSize: 16, marginTop: 4 },
+  cityName: { color: '#fff', fontWeight: '300', letterSpacing: 0.5 },
+  bigTemp: { color: '#fff', fontWeight: '100', lineHeight: 110 },
+  condition: { color: 'rgba(255,255,255,0.8)', fontWeight: '400' },
+  highLow: { color: 'rgba(255,255,255,0.7)', marginTop: 4 },
 
   card: {
     backgroundColor: 'rgba(255,255,255,0.12)',
@@ -279,21 +281,21 @@ const styles = StyleSheet.create({
     marginBottom: 12,
   },
   cardHeader: { flexDirection: 'row', alignItems: 'center', gap: 6, marginBottom: 10 },
-  cardHeaderText: { color: 'rgba(255,255,255,0.6)', fontSize: 11, fontWeight: '600', letterSpacing: 0.5 },
+  cardHeaderText: { color: 'rgba(255,255,255,0.6)', fontWeight: '600', letterSpacing: 0.5 },
 
   hourlyRow: { flexDirection: 'row', gap: 20, paddingHorizontal: 4 },
   hourlyItem: { alignItems: 'center', gap: 6 },
-  hourlyTime: { color: 'rgba(255,255,255,0.8)', fontSize: 13, fontWeight: '500' },
-  hourlyTemp: { color: '#fff', fontSize: 17, fontWeight: '500' },
+  hourlyTime: { color: 'rgba(255,255,255,0.8)', fontWeight: '500' },
+  hourlyTemp: { color: '#fff', fontWeight: '500' },
 
   forecastRow: { flexDirection: 'row', alignItems: 'center', paddingVertical: 8, borderTopWidth: StyleSheet.hairlineWidth, borderTopColor: 'rgba(255,255,255,0.15)' },
-  forecastDay: { color: '#fff', fontSize: 17, fontWeight: '500', width: 60 },
-  forecastLow: { color: 'rgba(255,255,255,0.5)', fontSize: 17, marginLeft: 12, width: 30, textAlign: 'right' },
+  forecastDay: { color: '#fff', fontWeight: '500', width: 60 },
+  forecastLow: { color: 'rgba(255,255,255,0.5)', marginLeft: 12, width: 30, textAlign: 'right' },
   tempBar: { flex: 1, height: 4, backgroundColor: 'rgba(255,255,255,0.2)', borderRadius: 2, marginHorizontal: 8 },
-  forecastHigh: { color: '#fff', fontSize: 17, width: 30 },
+  forecastHigh: { color: '#fff', width: 30 },
 
   detailsGrid: { flexDirection: 'row', flexWrap: 'wrap', gap: 12, marginTop: 4 },
   detailCard: { width: '47%', backgroundColor: 'rgba(255,255,255,0.12)', borderRadius: 16, padding: 14, gap: 4 },
-  detailLabel: { color: 'rgba(255,255,255,0.6)', fontSize: 11, fontWeight: '600', letterSpacing: 0.5 },
-  detailValue: { color: '#fff', fontSize: 28, fontWeight: '300' },
+  detailLabel: { color: 'rgba(255,255,255,0.6)', fontWeight: '600', letterSpacing: 0.5 },
+  detailValue: { color: '#fff', fontWeight: '300' },
 });

--- a/src/screens/__tests__/CallScreen.test.tsx
+++ b/src/screens/__tests__/CallScreen.test.tsx
@@ -1,6 +1,28 @@
 import React from 'react';
+import { Pressable, Text } from 'react-native';
 import { render, fireEvent } from '../../test-utils';
 import { CallScreen } from '../CallScreen';
+import { useSettings } from '../../store/SettingsStore';
+
+function getEffectiveFontSize(element: { props: { style: unknown } }): number {
+  const styles = Array.isArray(element.props.style) ? element.props.style : [element.props.style];
+  let fontSize = 0;
+  for (const s of styles) {
+    if (s && typeof s === 'object' && 'fontSize' in (s as object)) {
+      fontSize = (s as { fontSize: number }).fontSize;
+    }
+  }
+  return fontSize;
+}
+
+function SetTextSize({ index }: { index: number }) {
+  const { update } = useSettings();
+  return (
+    <Pressable testID="set-text-size" onPress={() => update('textSizeIndex', index)}>
+      <Text>resize</Text>
+    </Pressable>
+  );
+}
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const navigation = { navigate: jest.fn(), goBack: jest.fn() } as any;
@@ -171,5 +193,26 @@ describe('CallScreen', () => {
     expect(getByLabelText('Mute')).toBeTruthy();
     expect(getByLabelText('Speaker')).toBeTruthy();
     expect(getByLabelText('End Call')).toBeTruthy();
+  });
+});
+
+describe('CallScreen Dynamic Type', () => {
+  it('avatar initials fontSize scales with textSizeIndex (textScale multiplication)', () => {
+    const { getByText, getByTestId } = render(
+      <>
+        <SetTextSize index={3} />
+        <CallScreen
+          navigation={navigation}
+          route={{ params: { number: '+15551234567', name: 'Jane Doe' } } as never}
+        />
+      </>,
+    );
+
+    const defaultFontSize = getEffectiveFontSize(getByText('JD'));
+
+    fireEvent.press(getByTestId('set-text-size'));
+
+    const scaledFontSize = getEffectiveFontSize(getByText('JD'));
+    expect(scaledFontSize).toBeGreaterThan(defaultFontSize);
   });
 });

--- a/src/screens/__tests__/MessagesScreen.test.tsx
+++ b/src/screens/__tests__/MessagesScreen.test.tsx
@@ -1,6 +1,46 @@
 import React from 'react';
-import { render } from '../../test-utils';
+import { Pressable, Text } from 'react-native';
+import { render, fireEvent } from '../../test-utils';
 import { MessagesScreen } from '../MessagesScreen';
+import { useSettings } from '../../store/SettingsStore';
+
+function getEffectiveFontSize(element: { props: { style: unknown } }): number {
+  const styles = Array.isArray(element.props.style) ? element.props.style : [element.props.style];
+  let fontSize = 0;
+  for (const s of styles) {
+    if (s && typeof s === 'object' && 'fontSize' in (s as object)) {
+      fontSize = (s as { fontSize: number }).fontSize;
+    }
+  }
+  return fontSize;
+}
+
+function SetTextSize({ index }: { index: number }) {
+  const { update } = useSettings();
+  return (
+    <Pressable testID="set-text-size" onPress={() => update('textSizeIndex', index)}>
+      <Text>resize</Text>
+    </Pressable>
+  );
+}
+
+describe('MessagesScreen Dynamic Type', () => {
+  it('Messages title fontSize scales with textSizeIndex (typography.largeTitle token)', () => {
+    const { getByText, getByTestId } = render(
+      <>
+        <SetTextSize index={3} />
+        <MessagesScreen />
+      </>,
+    );
+
+    const defaultFontSize = getEffectiveFontSize(getByText('Messages'));
+
+    fireEvent.press(getByTestId('set-text-size'));
+
+    const scaledFontSize = getEffectiveFontSize(getByText('Messages'));
+    expect(scaledFontSize).toBeGreaterThan(defaultFontSize);
+  });
+});
 
 describe('MessagesScreen', () => {
   it('renders Messages title', () => {

--- a/src/screens/contacts/ContactEditScreen.tsx
+++ b/src/screens/contacts/ContactEditScreen.tsx
@@ -139,7 +139,7 @@ export function ContactEditScreen({ navigation, route }: ContactEditScreenProps)
           />
         </CupertinoListSection>
         {firstNameEmpty && lastName.length > 0 && (
-          <Text style={styles.validationError}>First name is required</Text>
+          <Text style={[typography.caption1, styles.validationError]}>First name is required</Text>
         )}
 
         {/* Phone section */}
@@ -155,7 +155,7 @@ export function ContactEditScreen({ navigation, route }: ContactEditScreenProps)
           />
         </CupertinoListSection>
         {phoneInvalid && (
-          <Text style={styles.validationError}>Enter a valid phone number (at least 7 digits)</Text>
+          <Text style={[typography.caption1, styles.validationError]}>Enter a valid phone number (at least 7 digits)</Text>
         )}
 
         {/* Email section */}
@@ -173,7 +173,7 @@ export function ContactEditScreen({ navigation, route }: ContactEditScreenProps)
           />
         </CupertinoListSection>
         {emailInvalid && (
-          <Text style={styles.validationError}>Invalid email address</Text>
+          <Text style={[typography.caption1, styles.validationError]}>Invalid email address</Text>
         )}
 
         {/* Company section */}
@@ -225,7 +225,6 @@ const styles = StyleSheet.create({
   },
   validationError: {
     color: '#FF3B30',
-    fontSize: 12,
     marginTop: 4,
     marginBottom: 4,
     marginHorizontal: 4,

--- a/src/screens/profile/EditProfileScreen.tsx
+++ b/src/screens/profile/EditProfileScreen.tsx
@@ -94,7 +94,7 @@ export function EditProfileScreen({ navigation }: { navigation: AppNavigationPro
           />
         </CupertinoListSection>
         {emailError && (
-          <Text style={styles.emailError}>Invalid email format</Text>
+          <Text style={[typography.caption1, styles.emailError]}>Invalid email format</Text>
         )}
 
         <CupertinoListSection header="Bio">
@@ -129,7 +129,6 @@ const styles = StyleSheet.create({
   },
   emailError: {
     color: '#FF3B30',
-    fontSize: 12,
     marginTop: 4,
     marginHorizontal: 20,
   },

--- a/src/screens/settings/BatteryScreen.tsx
+++ b/src/screens/settings/BatteryScreen.tsx
@@ -27,7 +27,7 @@ function getBatteryIcon(level: number, isCharging: boolean): 'battery-full-outli
 }
 
 export function BatteryScreen({ navigation }: { navigation: AppNavigationProp }) {
-  const { theme, typography, spacing } = useTheme();
+  const { theme, typography, spacing, textScale } = useTheme();
   const { colors } = theme;
   const insets = useSafeAreaInsets();
   const { settings, update } = useSettings();
@@ -57,7 +57,7 @@ export function BatteryScreen({ navigation }: { navigation: AppNavigationProp })
         {/* Battery level display */}
         <View style={[styles.batteryDisplay, { backgroundColor: colors.secondarySystemGroupedBackground }]}>
           <Ionicons name={batteryIcon} size={64} color={batteryColor} />
-          <Text style={[styles.batteryPercent, { color: batteryColor }]}>
+          <Text style={[styles.batteryPercent, { color: batteryColor, fontSize: 48 * textScale }]}>
             {batteryLevel}%
           </Text>
           <Text style={[typography.footnote, { color: colors.secondaryLabel, marginTop: 4 }]}>
@@ -112,7 +112,6 @@ const styles = StyleSheet.create({
     borderRadius: 12,
   },
   batteryPercent: {
-    fontSize: 48,
     fontWeight: '700',
     lineHeight: 56,
   },

--- a/src/screens/settings/ScreenTimeScreen.tsx
+++ b/src/screens/settings/ScreenTimeScreen.tsx
@@ -42,7 +42,7 @@ const APP_BAR_COLORS = [
 ];
 
 export function ScreenTimeScreen({ navigation }: { navigation: AppNavigationProp }) {
-  const { theme, typography, spacing } = useTheme();
+  const { theme, typography, spacing, textScale } = useTheme();
   const { colors } = theme;
   const insets = useSafeAreaInsets();
   const { settings, update } = useSettings();
@@ -194,7 +194,7 @@ export function ScreenTimeScreen({ navigation }: { navigation: AppNavigationProp
               <View style={{ paddingHorizontal: spacing.md }}>
                 <CupertinoListSection header="Today">
                   <View style={styles.dailyAverageCard}>
-                    <Text style={[styles.dailyAverageTime, { color: colors.label }]}>
+                    <Text style={[styles.dailyAverageTime, { color: colors.label, fontSize: 48 * textScale }]}>
                       {todayData ? formatMinutes(todayData.totalMinutes) : '0m'}
                     </Text>
                     <Text style={[typography.caption1, { color: colors.secondaryLabel }]}>
@@ -253,7 +253,7 @@ export function ScreenTimeScreen({ navigation }: { navigation: AppNavigationProp
               <View style={{ paddingHorizontal: spacing.md }}>
                 <CupertinoListSection header="Weekly Average">
                   <View style={styles.dailyAverageCard}>
-                    <Text style={[styles.weeklyAverageTime, { color: colors.label }]}>
+                    <Text style={[styles.weeklyAverageTime, { color: colors.label, fontSize: 36 * textScale }]}>
                       {formatMinutes(weeklyAvgMinutes)}
                     </Text>
                     <Text style={[typography.caption1, { color: colors.secondaryLabel }]}>
@@ -349,13 +349,11 @@ const styles = StyleSheet.create({
     paddingVertical: 20,
   },
   dailyAverageTime: {
-    fontSize: 48,
     fontWeight: '300',
     letterSpacing: -1,
     lineHeight: 56,
   },
   weeklyAverageTime: {
-    fontSize: 36,
     fontWeight: '300',
     letterSpacing: -0.5,
     lineHeight: 44,


### PR DESCRIPTION
## Issue

Closes #376 — Dynamic Type: ~15 ecrãs nunca consomem o typography do tema — 'Larger Text' não faz nada lá.

## O que foi feito

14 ecrãs actualizados para respeitar a preferência de tamanho de texto do sistema:

- **Valores com token no tema**: `style={[typography.TOKEN, styles.xxx]}` e `fontSize` removido do StyleSheet
- **Valores sem token (14, 18, 19, 36, 48, 96)**: `style={[styles.xxx, { fontSize: N * textScale }]}` e `fontSize` removido do StyleSheet

### Ecrãs principais (`src/screens/`)
| Ecrã | Tokens usados | textScale usado |
|---|---|---|
| WeatherScreen | largeTitle, callout, caption2, footnote, body, title1 | 96, 18 |
| OnboardingScreen | largeTitle, body, subhead, footnote | 14 |
| AppLibraryScreen | body, title3, caption2, subhead, caption1, callout, caption2 | 18 |
| CalculatorScreen | footnote, title3, callout | 14, 18 |
| MessagesScreen | largeTitle, body | 19 |
| MailScreen | footnote, callout | — |
| LauncherSettingsScreen | — | 18 |
| MultitaskScreen | body, caption1, subhead, footnote, caption2 | 14, 18 |
| SpotlightSearchScreen | body, footnote, callout, title3 | — |
| CallScreen | title1, caption2, tabLabel | 36, 14 |

### Sub-directórios (`settings/`, `contacts/`, `profile/`)
| Ecrã | Tokens usados |
|---|---|
| settings/BatteryScreen | — (textScale 48) |
| settings/ScreenTimeScreen | — (textScale 48, 36) |
| contacts/ContactEditScreen | caption1 |
| profile/EditProfileScreen | caption1 |

### Ecrãs identificados só por grep (conforme requisito do issue)
- **MultitaskScreen**: tinha `fontSize` em 8 entradas StyleSheet, sem `useTheme` → corrigido
- **SpotlightSearchScreen**: tinha `useTheme` parcial (sem `typography`), `fontSize` em 9 entradas → corrigido; `fontSize: size * 0.4` (linha ~186, já escalado) deixado intacto
- **CallScreen**: tinha `fontSize` em 5 entradas StyleSheet, sem `useTheme` → corrigido

## Verificação

```bash
# Zero literais fontSize em StyleSheet após o fix:
grep -rn "fontSize: [0-9][0-9]*," src/screens/...  # output vazio
# Apenas os N * textScale inline (correcto) permanecem
```

## Testes

Dois testes red-step que falhariam com o código antigo (fontSize hardcoded não escala):

- **`MessagesScreen.test.tsx`** — verifica `typography.largeTitle` (token): fontSize do título "Messages" cresce quando `textSizeIndex` passa de 1 para 3
- **`CallScreen.test.tsx`** — verifica `N * textScale` (multiplicação): fontSize das iniciais do avatar cresce de 36 para 46.8 no máximo

## Resultados dos testes

```
Tests: 472 passed (8 pré-existentes a falhar — baseline inalterado)
Test Suites: 68 (4 a falhar — todos baseline: FoldersStore×2, LockScreen×3, SettingsScreen×1, WeatherScreen×2)
```