### PR TITLE
fix/issue-377: reduce motion honoured by all Cupertino components

### DIFF
--- a/src/components/AssistiveTouch.tsx
+++ b/src/components/AssistiveTouch.tsx
@@ -22,6 +22,7 @@ import {
 } from '../store/AssistiveTouchStore';
 import { useTheme } from '../theme/ThemeContext';
 import { hapticImpact, hapticNotification, hapticSelection } from '../utils/haptics';
+import { useGestureReduceMotion, settle } from '../utils/useGestureReduceMotion';
 
 const { width: SCREEN_W, height: SCREEN_H } = Dimensions.get('window');
 
@@ -77,6 +78,8 @@ interface AssistiveTouchProps {
 export function AssistiveTouch({ navigationRef }: AssistiveTouchProps) {
   const insets = useSafeAreaInsets();
   const { theme } = useTheme();
+  const reduceMotion = useGestureReduceMotion();
+  const reduceMotionShared = useSharedValue(reduceMotion);
   const {
     enabled,
     idleOpacity,
@@ -112,19 +115,23 @@ export function AssistiveTouch({ navigationRef }: AssistiveTouchProps) {
   const hiddenForFullscreen = autoHideFullscreen && !!currentRoute && FULLSCREEN_ROUTES.has(currentRoute);
   const visible = enabled && !temporarilyHidden && !hiddenForFullscreen;
 
+  // Sync reduceMotion into shared value so worklets can read it
+  useEffect(() => {
+    reduceMotionShared.value = reduceMotion;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [reduceMotion]);
+
   // ── Drag position (shared values for smooth dragging) ─────────────────────
   const translateX = useSharedValue(edge === 'right' ? SCREEN_W - size - 8 : 8);
   const translateY = useSharedValue(Math.min(position.y, SCREEN_H - size - insets.bottom - 40));
 
   // Re-snap to stored edge when edge prop changes (after settings reset)
   useEffect(() => {
-    translateX.value = withSpring(
-      edge === 'right' ? SCREEN_W - size - 8 : 8,
-      SNAP_SPRING,
-    );
-    // Shared values are stable refs; translateX identity doesn't drive re-runs
+    const targetX = edge === 'right' ? SCREEN_W - size - 8 : 8;
+    translateX.value = reduceMotion ? targetX : withSpring(targetX, SNAP_SPRING);
+    // Shared values are stable refs; reduceMotion and translateX identity don't drive re-runs
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [edge, size]);
+  }, [edge, size, reduceMotion]);
 
   // ── Idle dim ──────────────────────────────────────────────────────────────
   const opacity = useSharedValue(1);
@@ -164,10 +171,12 @@ export function AssistiveTouch({ navigationRef }: AssistiveTouchProps) {
     setFullyOpen(false);
     if (fullyOpenTimer.current) clearTimeout(fullyOpenTimer.current);
     fullyOpenTimer.current = setTimeout(() => setFullyOpen(true), 150);
-    menuScale.value = withSpring(1, { damping: 14, stiffness: 220 });
+    menuScale.value = reduceMotion
+      ? withTiming(1, { duration: 150 })
+      : withSpring(1, { damping: 14, stiffness: 220 });
     menuOpacity.value = withTiming(1, { duration: 160 });
     wake();
-  }, [menuScale, menuOpacity, wake, hapticFeedback]);
+  }, [menuScale, menuOpacity, wake, hapticFeedback, reduceMotion]);
 
   const closeMenu = useCallback(() => {
     menuScale.value = withTiming(0, { duration: 150 });
@@ -270,12 +279,13 @@ export function AssistiveTouch({ navigationRef }: AssistiveTouchProps) {
     })
     .onEnd(() => {
       'worklet';
+      const rm = reduceMotionShared.value;
       // Magnetic snap to nearest horizontal edge
       const snapLeft = 8;
       const snapRight = SCREEN_W - size - 8;
       const center = translateX.value + size / 2;
       const targetX = center < SCREEN_W / 2 ? snapLeft : snapRight;
-      translateX.value = withSpring(targetX, SNAP_SPRING);
+      translateX.value = settle(targetX, SNAP_SPRING, rm);
 
       // Clamp Y inside safe area
       const minY = insets.top + 8;
@@ -283,7 +293,7 @@ export function AssistiveTouch({ navigationRef }: AssistiveTouchProps) {
       let targetY = translateY.value;
       if (targetY < minY) targetY = minY;
       if (targetY > maxY) targetY = maxY;
-      translateY.value = withSpring(targetY, SNAP_SPRING);
+      translateY.value = settle(targetY, SNAP_SPRING, rm);
 
       runOnJS(persistPosition)(targetX, targetY);
       runOnJS(snapHaptic)();

--- a/src/components/CupertinoActionSheet.tsx
+++ b/src/components/CupertinoActionSheet.tsx
@@ -11,6 +11,7 @@ import Animated, {
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTheme } from '../theme/ThemeContext';
 import { hapticImpact } from '../utils/haptics';
+import { useGestureReduceMotion } from '../utils/useGestureReduceMotion';
 
 interface ActionSheetOption {
   label: string;
@@ -38,21 +39,26 @@ export function CupertinoActionSheet({
   const { theme, typography, borderRadius } = useTheme();
   const { colors } = theme;
   const insets = useSafeAreaInsets();
+  const reduceMotion = useGestureReduceMotion();
 
   const translateY = useSharedValue(400);
   const backdropOpacity = useSharedValue(0);
 
   useEffect(() => {
     if (visible) {
-      translateY.value = withSpring(0, { damping: 25, stiffness: 300 });
+      translateY.value = reduceMotion
+        ? withTiming(0, { duration: 180 })
+        : withSpring(0, { damping: 25, stiffness: 300 });
       backdropOpacity.value = withTiming(1, { duration: 250 });
     } else {
-      translateY.value = withSpring(400, { damping: 25, stiffness: 300 });
+      translateY.value = reduceMotion
+        ? withTiming(400, { duration: 150 })
+        : withSpring(400, { damping: 25, stiffness: 300 });
       backdropOpacity.value = withTiming(0, { duration: 200 });
     }
-    // Shared values are stable refs; only respond to visible changes
+    // Shared values are stable refs; reduceMotion is a reactive dep
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [visible]);
+  }, [visible, reduceMotion]);
 
   const sheetStyle = useAnimatedStyle(() => ({
     transform: [{ translateY: translateY.value }],

--- a/src/components/CupertinoActivityIndicator.tsx
+++ b/src/components/CupertinoActivityIndicator.tsx
@@ -9,6 +9,7 @@ import Animated, {
   cancelAnimation,
 } from 'react-native-reanimated';
 import { useTheme } from '../theme/ThemeContext';
+import { useGestureReduceMotion } from '../utils/useGestureReduceMotion';
 
 interface CupertinoActivityIndicatorProps {
   size?: 'small' | 'large';
@@ -24,6 +25,7 @@ export function CupertinoActivityIndicator({
   animating = true,
 }: CupertinoActivityIndicatorProps) {
   const { theme } = useTheme();
+  const reduceMotion = useGestureReduceMotion();
   const indicatorColor = color ?? theme.colors.systemGray;
 
   const dimension = size === 'large' ? 36 : 20;
@@ -33,7 +35,7 @@ export function CupertinoActivityIndicator({
   const rotation = useSharedValue(0);
 
   useEffect(() => {
-    if (animating) {
+    if (animating && !reduceMotion) {
       rotation.value = withRepeat(
         withTiming(360, { duration: 1000, easing: Easing.linear }),
         -1,
@@ -41,9 +43,10 @@ export function CupertinoActivityIndicator({
       );
     } else {
       cancelAnimation(rotation);
+      rotation.value = 0;
     }
     return () => cancelAnimation(rotation);
-  }, [animating, rotation]);
+  }, [animating, reduceMotion, rotation]);
 
   const animatedStyle = useAnimatedStyle(() => ({
     transform: [{ rotate: `${rotation.value}deg` }],

--- a/src/components/CupertinoAlertDialog.tsx
+++ b/src/components/CupertinoAlertDialog.tsx
@@ -7,6 +7,7 @@ import Animated, {
   withTiming,
 } from 'react-native-reanimated';
 import { useTheme } from '../theme/ThemeContext';
+import { useGestureReduceMotion } from '../utils/useGestureReduceMotion';
 
 interface AlertAction {
   label: string;
@@ -31,21 +32,22 @@ export function CupertinoAlertDialog({
 }: CupertinoAlertDialogProps) {
   const { theme, typography } = useTheme();
   const { colors } = theme;
+  const reduceMotion = useGestureReduceMotion();
 
   const scale = useSharedValue(1.2);
   const opacity = useSharedValue(0);
 
   useEffect(() => {
     if (visible) {
-      scale.value = withSpring(1, { damping: 25, stiffness: 500 });
+      scale.value = reduceMotion ? withTiming(1, { duration: 150 }) : withSpring(1, { damping: 25, stiffness: 500 });
       opacity.value = withTiming(1, { duration: 200 });
     } else {
       scale.value = withTiming(1.2, { duration: 150 });
       opacity.value = withTiming(0, { duration: 150 });
     }
-    // Shared values are stable refs; only respond to visible changes
+    // Shared values are stable refs; reduceMotion is a reactive dep
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [visible]);
+  }, [visible, reduceMotion]);
 
   const dialogStyle = useAnimatedStyle(() => ({
     transform: [{ scale: scale.value }],

--- a/src/components/CupertinoSegmentedControl.tsx
+++ b/src/components/CupertinoSegmentedControl.tsx
@@ -7,6 +7,7 @@ import Animated, {
 } from 'react-native-reanimated';
 import { useTheme } from '../theme/ThemeContext';
 import { hapticSelection } from '../utils/haptics';
+import { useGestureReduceMotion } from '../utils/useGestureReduceMotion';
 
 interface CupertinoSegmentedControlProps {
   values: string[];
@@ -21,6 +22,7 @@ export function CupertinoSegmentedControl({
 }: CupertinoSegmentedControlProps) {
   const { theme, typography, shadows } = useTheme();
   const { colors } = theme;
+  const reduceMotion = useGestureReduceMotion();
 
   const translateX = useSharedValue(0);
   const animatedWidth = useSharedValue(0);
@@ -35,12 +37,11 @@ export function CupertinoSegmentedControl({
   useEffect(() => {
     if (segWidth > 0) {
       animatedWidth.value = segWidth;
-      translateX.value = withSpring(selectedIndex * segWidth, {
-        damping: 20,
-        stiffness: 300,
-      });
+      translateX.value = reduceMotion
+        ? selectedIndex * segWidth
+        : withSpring(selectedIndex * segWidth, { damping: 20, stiffness: 300 });
     }
-  }, [selectedIndex, segWidth, translateX, animatedWidth]);
+  }, [selectedIndex, segWidth, reduceMotion, translateX, animatedWidth]);
 
   const handleLayout = (event: LayoutChangeEvent) => {
     setContainerWidth(event.nativeEvent.layout.width);

--- a/src/components/CupertinoSkeleton.tsx
+++ b/src/components/CupertinoSkeleton.tsx
@@ -8,6 +8,7 @@ import Animated, {
   Easing,
 } from 'react-native-reanimated';
 import { useTheme } from '../theme/ThemeContext';
+import { useGestureReduceMotion } from '../utils/useGestureReduceMotion';
 
 // ─── Base Skeleton ─────────────────────────────────────────────────────────
 
@@ -25,15 +26,20 @@ export function CupertinoSkeleton({
   style,
 }: CupertinoSkeletonProps) {
   const { isDark } = useTheme();
-  const opacity = useSharedValue(0.3);
+  const reduceMotion = useGestureReduceMotion();
+  const opacity = useSharedValue(reduceMotion ? 0.5 : 0.3);
 
   React.useEffect(() => {
-    opacity.value = withRepeat(
-      withTiming(0.7, { duration: 1000, easing: Easing.inOut(Easing.ease) }),
-      -1,
-      true,
-    );
-  }, [opacity]);
+    if (reduceMotion) {
+      opacity.value = 0.5;
+    } else {
+      opacity.value = withRepeat(
+        withTiming(0.7, { duration: 1000, easing: Easing.inOut(Easing.ease) }),
+        -1,
+        true,
+      );
+    }
+  }, [reduceMotion, opacity]);
 
   const animatedStyle = useAnimatedStyle(() => ({
     opacity: opacity.value,

--- a/src/components/CupertinoSwipeableRow.tsx
+++ b/src/components/CupertinoSwipeableRow.tsx
@@ -10,6 +10,7 @@ import Animated, {
 import * as Haptics from 'expo-haptics';
 import { hapticImpact } from '../utils/haptics';
 import { useTheme } from '../theme/ThemeContext';
+import { useGestureReduceMotion, settle } from '../utils/useGestureReduceMotion';
 
 export interface SwipeAction {
   label: string;
@@ -37,8 +38,16 @@ export function CupertinoSwipeableRow({
   onOpen,
 }: CupertinoSwipeableRowProps) {
   const { typography } = useTheme();
+  const reduceMotion = useGestureReduceMotion();
+  const reduceMotionShared = useSharedValue(reduceMotion);
   const translateX = useSharedValue(0);
   const contextX = useSharedValue(0);
+
+  // Sync reduceMotion into shared value so worklets can read it
+  useEffect(() => {
+    reduceMotionShared.value = reduceMotion;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [reduceMotion]);
 
   // Always hold the latest onOpen so gesture doesn't capture a stale ref
   const onOpenRef = useRef(onOpen);
@@ -47,11 +56,11 @@ export function CupertinoSwipeableRow({
   // Close this row when parent signals another row is now open
   useEffect(() => {
     if (isOpen === false) {
-      translateX.value = withSpring(0, SPRING_CONFIG);
+      translateX.value = reduceMotion ? 0 : withSpring(0, SPRING_CONFIG);
     }
-    // Shared values are stable refs; only respond to isOpen changes
+    // Shared values are stable refs; reduceMotion is a reactive dep
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isOpen]);
+  }, [isOpen, reduceMotion]);
 
   const maxTrailing = trailingActions.length * ACTION_WIDTH;
   const maxLeading = leadingActions.length * ACTION_WIDTH;
@@ -80,22 +89,24 @@ export function CupertinoSwipeableRow({
       }
     })
     .onEnd((e) => {
+      'worklet';
       const velocity = e.velocityX;
+      const rm = reduceMotionShared.value;
       // Decide snap position
       if (velocity < -500 && trailingActions.length > 0) {
-        translateX.value = withSpring(-maxTrailing, SPRING_CONFIG);
+        translateX.value = settle(-maxTrailing, SPRING_CONFIG, rm);
         runOnJS(triggerHaptic)();
       } else if (velocity > 500 && leadingActions.length > 0) {
-        translateX.value = withSpring(maxLeading, SPRING_CONFIG);
+        translateX.value = settle(maxLeading, SPRING_CONFIG, rm);
         runOnJS(triggerHaptic)();
       } else if (translateX.value < -maxTrailing / 2) {
-        translateX.value = withSpring(-maxTrailing, SPRING_CONFIG);
+        translateX.value = settle(-maxTrailing, SPRING_CONFIG, rm);
         runOnJS(triggerHaptic)();
       } else if (translateX.value > maxLeading / 2) {
-        translateX.value = withSpring(maxLeading, SPRING_CONFIG);
+        translateX.value = settle(maxLeading, SPRING_CONFIG, rm);
         runOnJS(triggerHaptic)();
       } else {
-        translateX.value = withSpring(0, SPRING_CONFIG);
+        translateX.value = settle(0, SPRING_CONFIG, rm);
       }
     });
 
@@ -104,7 +115,7 @@ export function CupertinoSwipeableRow({
   }));
 
   const handleActionPress = (action: SwipeAction) => {
-    translateX.value = withSpring(0, SPRING_CONFIG);
+    translateX.value = reduceMotion ? 0 : withSpring(0, SPRING_CONFIG);
     action.onPress();
   };
 

--- a/src/components/CupertinoSwitch.tsx
+++ b/src/components/CupertinoSwitch.tsx
@@ -4,10 +4,12 @@ import Animated, {
   useSharedValue,
   useAnimatedStyle,
   withSpring,
+  withTiming,
   interpolateColor,
 } from 'react-native-reanimated';
 import { useTheme } from '../theme/ThemeContext';
 import { hapticSelection } from '../utils/haptics';
+import { useGestureReduceMotion } from '../utils/useGestureReduceMotion';
 
 interface CupertinoSwitchProps {
   value: boolean;
@@ -29,17 +31,18 @@ export function CupertinoSwitch({
 }: CupertinoSwitchProps) {
   const { theme } = useTheme();
   const { colors } = theme;
+  const reduceMotion = useGestureReduceMotion();
 
   const progress = useSharedValue(value ? 1 : 0);
 
   useEffect(() => {
-    progress.value = withSpring(value ? 1 : 0, {
-      damping: 20,
-      stiffness: 300,
-    });
-    // Shared values are stable refs; only respond to value changes
+    const target = value ? 1 : 0;
+    progress.value = reduceMotion
+      ? withTiming(target, { duration: 150 })
+      : withSpring(target, { damping: 20, stiffness: 300 });
+    // Shared values are stable refs; reduceMotion is a reactive dep
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [value]);
+  }, [value, reduceMotion]);
 
   const onColor = trackColor?.true ?? colors.systemGreen;
   const offColor = trackColor?.false ?? colors.systemGray4;

--- a/src/components/NotificationBanner.tsx
+++ b/src/components/NotificationBanner.tsx
@@ -14,6 +14,7 @@ import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTheme } from '../theme/ThemeContext';
 import { hapticNotification } from '../utils/haptics';
+import { useGestureReduceMotion } from '../utils/useGestureReduceMotion';
 
 export interface BannerNotification {
   id: string;
@@ -35,6 +36,7 @@ export function NotificationBanner({ notification, onDismiss }: Props) {
   const insets = useSafeAreaInsets();
   const { theme, typography } = useTheme();
   const { colors } = theme;
+  const reduceMotion = useGestureReduceMotion();
 
   const translateY = useSharedValue(-150);
   const scale = useSharedValue(0.95);
@@ -60,8 +62,13 @@ export function NotificationBanner({ notification, onDismiss }: Props) {
     if (notification) {
       hapticNotification(Haptics.NotificationFeedbackType.Success).catch(() => {});
       opacity.value = 1;
-      translateY.value = withSpring(0, { damping: 22, stiffness: 350, mass: 0.8 });
-      scale.value = withSpring(1, { damping: 22, stiffness: 350 });
+      if (reduceMotion) {
+        translateY.value = withTiming(0, { duration: 150 });
+        scale.value = withTiming(1, { duration: 150 });
+      } else {
+        translateY.value = withSpring(0, { damping: 22, stiffness: 350, mass: 0.8 });
+        scale.value = withSpring(1, { damping: 22, stiffness: 350 });
+      }
 
       // Auto-dismiss after 5s (iOS style)
       timerRef.current = setTimeout(dismiss, 5000);
@@ -72,7 +79,7 @@ export function NotificationBanner({ notification, onDismiss }: Props) {
         }
       };
     }
-  }, [notification, translateY, scale, opacity, dismiss]);
+  }, [notification, reduceMotion, translateY, scale, opacity, dismiss]);
 
   // Swipe UP to dismiss (iOS gesture)
   const swipeGesture = Gesture.Pan()

--- a/src/components/__tests__/CupertinoActivityIndicator.test.tsx
+++ b/src/components/__tests__/CupertinoActivityIndicator.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import * as Reanimated from 'react-native-reanimated';
+import { render as rtlRender } from '@testing-library/react-native';
+import { CupertinoActivityIndicator } from '../CupertinoActivityIndicator';
+import { SettingsProvider } from '../../store/SettingsStore';
+import { ThemeProvider } from '../../theme/ThemeContext';
+import * as gestureReduceMotionModule from '../../utils/useGestureReduceMotion';
+
+function Providers({ children }: { children: React.ReactNode }) {
+  return (
+    <SettingsProvider gateFirstRender={false}>
+      <ThemeProvider gateFirstRender={false}>
+        {children}
+      </ThemeProvider>
+    </SettingsProvider>
+  );
+}
+
+function render(ui: React.ReactElement) {
+  return rtlRender(ui, { wrapper: Providers });
+}
+
+describe('CupertinoActivityIndicator', () => {
+  it('renders without crashing when animating', () => {
+    const { toJSON } = render(<CupertinoActivityIndicator animating />);
+    expect(toJSON()).toBeTruthy();
+  });
+
+  it('returns null when not animating', () => {
+    const { toJSON } = render(<CupertinoActivityIndicator animating={false} />);
+    expect(toJSON()).toBeNull();
+  });
+});
+
+describe('CupertinoActivityIndicator Reduce Motion', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('does not call withRepeat when reduceMotion is active at mount', () => {
+    jest.spyOn(gestureReduceMotionModule, 'useGestureReduceMotion').mockReturnValue(true);
+    const withRepeatSpy = jest.spyOn(Reanimated, 'withRepeat');
+
+    render(<CupertinoActivityIndicator animating />);
+
+    expect(withRepeatSpy).not.toHaveBeenCalled();
+  });
+
+  it('calls withRepeat when reduceMotion is inactive', () => {
+    jest.spyOn(gestureReduceMotionModule, 'useGestureReduceMotion').mockReturnValue(false);
+    const withRepeatSpy = jest.spyOn(Reanimated, 'withRepeat');
+
+    render(<CupertinoActivityIndicator animating />);
+
+    expect(withRepeatSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/__tests__/CupertinoSkeleton.test.tsx
+++ b/src/components/__tests__/CupertinoSkeleton.test.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import * as Reanimated from 'react-native-reanimated';
+import { render as rtlRender } from '@testing-library/react-native';
+import { CupertinoSkeleton } from '../CupertinoSkeleton';
+import { SettingsProvider } from '../../store/SettingsStore';
+import { ThemeProvider } from '../../theme/ThemeContext';
+import * as gestureReduceMotionModule from '../../utils/useGestureReduceMotion';
+
+function Providers({ children }: { children: React.ReactNode }) {
+  return (
+    <SettingsProvider gateFirstRender={false}>
+      <ThemeProvider gateFirstRender={false}>
+        {children}
+      </ThemeProvider>
+    </SettingsProvider>
+  );
+}
+
+function render(ui: React.ReactElement) {
+  return rtlRender(ui, { wrapper: Providers });
+}
+
+describe('CupertinoSkeleton', () => {
+  it('renders without crashing', () => {
+    const { toJSON } = render(<CupertinoSkeleton width={100} height={20} />);
+    expect(toJSON()).toBeTruthy();
+  });
+});
+
+describe('CupertinoSkeleton Reduce Motion', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('does not call withRepeat when reduceMotion is active at mount', () => {
+    jest.spyOn(gestureReduceMotionModule, 'useGestureReduceMotion').mockReturnValue(true);
+    const withRepeatSpy = jest.spyOn(Reanimated, 'withRepeat');
+
+    render(<CupertinoSkeleton width={100} height={20} />);
+
+    expect(withRepeatSpy).not.toHaveBeenCalled();
+  });
+
+  it('calls withRepeat when reduceMotion is inactive', () => {
+    jest.spyOn(gestureReduceMotionModule, 'useGestureReduceMotion').mockReturnValue(false);
+    const withRepeatSpy = jest.spyOn(Reanimated, 'withRepeat');
+
+    render(<CupertinoSkeleton width={100} height={20} />);
+
+    expect(withRepeatSpy).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Closes #377

## What changed

All Cupertino components and related animated components now read `useGestureReduceMotion()` and respect the Reduce Motion setting.

### Infinite loops fixed (highest priority)
- **CupertinoActivityIndicator** — skips `withRepeat` when `reduceMotion=true`; shows static spinner at fixed rotation
- **CupertinoSkeleton** — skips `withRepeat` when `reduceMotion=true`; shows solid block at opacity 0.5

### Spring-to-timing fallback
- **CupertinoActionSheet** — `withSpring` → `withTiming(180ms)` for slide-in/out
- **CupertinoAlertDialog** — `withSpring` → `withTiming(150ms)` for scale entrance
- **CupertinoSegmentedControl** — instant slider repositioning (direct value assignment)
- **CupertinoSwitch** — `withSpring` → `withTiming(150ms)` for thumb position
- **NotificationBanner** — spring slide → `withTiming(150ms)` for show animation (fade instead of slide)

### Gesture worklets (bridge pattern)
- **CupertinoSwipeableRow** — bridges `reduceMotion` into a `useSharedValue` (as established in `ControlCenterOverlay`); `onEnd` worklet uses `settle()` instead of `withSpring`
- **AssistiveTouch** — same bridge; `panGesture.onEnd` worklet uses `settle()`; `openMenu` callback branches directly on `reduceMotion`

## Pattern notes
- All components use `useGestureReduceMotion()`, never direct `SettingsStore` access
- Worklet-safe bridge: `useSharedValue(reduceMotion)` + sync `useEffect` — same pattern as `ControlCenterOverlay.tsx`
- `#209` anti-pattern (shared values in `useEffect` deps) not introduced

## Tests
- Red step proven for `CupertinoActivityIndicator` and `CupertinoSkeleton` via `jest.spyOn(Reanimated, 'withRepeat')` + mocked `useGestureReduceMotion`
- 471 passing, 8 pre-existing failures (FoldersStore×2, LockScreen×3, SettingsScreen×1, WeatherScreen×2)