### PR TITLE
fix: CallScreen — disable Mute/Speaker and disclose system call management (#379)

### DIFF
--- a/src/screens/CallScreen.tsx
+++ b/src/screens/CallScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useEffect, useCallback } from 'react';
 import {
   View,
   Text,
@@ -53,19 +53,22 @@ interface ControlButtonProps {
   label: string;
   onPress: () => void;
   active?: boolean;
+  disabled?: boolean;
 }
 
-function ControlButton({ icon, label, onPress, active }: ControlButtonProps) {
+function ControlButton({ icon, label, onPress, active, disabled }: ControlButtonProps) {
   const { typography } = useTheme();
   return (
     <Pressable
-      style={[styles.controlBtn, active && styles.controlBtnActive]}
-      onPress={onPress}
-      android_ripple={{ color: 'rgba(255,255,255,0.15)', radius: 35 }}
+      style={[styles.controlBtn, active && styles.controlBtnActive, disabled && styles.controlBtnDisabled]}
+      onPress={disabled ? undefined : onPress}
+      disabled={disabled}
+      android_ripple={disabled ? null : { color: 'rgba(255,255,255,0.15)', radius: 35 }}
       accessibilityRole="button"
       accessibilityLabel={label}
+      accessibilityState={{ disabled }}
     >
-      <Ionicons name={icon} size={28} color="#ffffff" />
+      <Ionicons name={icon} size={28} color={disabled ? 'rgba(255,255,255,0.35)' : '#ffffff'} />
       <Text style={[typography.tabLabel, styles.controlLabel]}>{label}</Text>
     </Pressable>
   );
@@ -85,9 +88,6 @@ export function CallScreen({ navigation, route }: CallScreenProps) {
   const insets = useSafeAreaInsets();
   const { number, name } = route.params;
   const displayName = name || number || 'Unknown';
-
-  const [isMuted, setIsMuted] = useState(false);
-  const [isSpeaker, setIsSpeaker] = useState(false);
 
   // Pulsing animation while the call is being placed
   const pulseScale = useSharedValue(1);
@@ -156,19 +156,6 @@ export function CallScreen({ navigation, route }: CallScreenProps) {
     navigation.goBack();
   }, [navigation]);
 
-  const toggleMute = useCallback(async () => {
-    hapticImpact(Haptics.ImpactFeedbackStyle.Light).catch(() => {});
-    setIsMuted((v) => !v);
-    // Note: mute/speaker toggle the visual state only.
-    // The native Android dialer handles actual call audio routing.
-  }, []);
-
-  const toggleSpeaker = useCallback(async () => {
-    hapticImpact(Haptics.ImpactFeedbackStyle.Light).catch(() => {});
-    setIsSpeaker((v) => !v);
-  }, []);
-
-
   return (
     <LinearGradient
       colors={['#1a1a2e', '#16213e']}
@@ -192,6 +179,11 @@ export function CallScreen({ navigation, route }: CallScreenProps) {
 
         {/* Status — honest label: native dialer handles the actual call */}
         <Text style={[styles.callStatus, { fontSize: 14 * textScale }]}>Call Initiated</Text>
+
+        {/* Disclosure — call and audio controls are managed by the system */}
+        <Text style={[typography.caption2, styles.systemDisclosure]}>
+          Call managed by system phone — audio controls unavailable
+        </Text>
       </View>
 
       {/* ------------------------------------------------------------------ */}
@@ -200,16 +192,16 @@ export function CallScreen({ navigation, route }: CallScreenProps) {
       <View style={styles.controlsGrid}>
         <View style={styles.controlsRow}>
           <ControlButton
-            icon={isMuted ? 'mic-off' : 'mic'}
+            icon="mic"
             label="Mute"
-            onPress={toggleMute}
-            active={isMuted}
+            onPress={() => {}}
+            disabled
           />
           <ControlButton
-            icon={isSpeaker ? 'volume-high' : 'volume-medium'}
+            icon="volume-medium"
             label="Speaker"
-            onPress={toggleSpeaker}
-            active={isSpeaker}
+            onPress={() => {}}
+            disabled
           />
         </View>
         <Text style={[typography.caption2, styles.audioHint]}>Audio controlled by system dialer</Text>
@@ -277,6 +269,12 @@ const styles = StyleSheet.create({
     color: 'rgba(255,255,255,0.55)',
     fontWeight: '400',
   },
+  systemDisclosure: {
+    color: 'rgba(255,255,255,0.4)',
+    textAlign: 'center',
+    marginTop: 12,
+    paddingHorizontal: 16,
+  },
 
   // Controls grid
   controlsGrid: {
@@ -299,6 +297,9 @@ const styles = StyleSheet.create({
   },
   controlBtnActive: {
     backgroundColor: 'rgba(255,255,255,0.28)',
+  },
+  controlBtnDisabled: {
+    opacity: 0.38,
   },
   controlLabel: {
     color: 'rgba(255,255,255,0.7)',

--- a/src/screens/__tests__/CallScreen.test.tsx
+++ b/src/screens/__tests__/CallScreen.test.tsx
@@ -80,90 +80,42 @@ describe('CallScreen', () => {
     });
   });
 
-  describe('mute toggle', () => {
-    it('pressing Mute switches the icon from mic to mic-off', () => {
-      const { getByLabelText, UNSAFE_getByProps, UNSAFE_queryByProps } = renderCall({
-        number: '+15551234567',
-        name: 'Jane Doe',
-      });
-
-      expect(UNSAFE_getByProps({ name: 'mic' })).toBeTruthy();
-      expect(UNSAFE_queryByProps({ name: 'mic-off' })).toBeNull();
-
-      fireEvent.press(getByLabelText('Mute'));
-
-      expect(UNSAFE_getByProps({ name: 'mic-off' })).toBeTruthy();
-      expect(UNSAFE_queryByProps({ name: 'mic' })).toBeNull();
-    });
-
-    it('pressing Mute twice returns to the unmuted icon', () => {
-      const { getByLabelText, UNSAFE_getByProps, UNSAFE_queryByProps } = renderCall({
-        number: '+15551234567',
-        name: 'Jane Doe',
-      });
-
-      const mute = getByLabelText('Mute');
-      fireEvent.press(mute);
-      fireEvent.press(mute);
-
-      expect(UNSAFE_getByProps({ name: 'mic' })).toBeTruthy();
-      expect(UNSAFE_queryByProps({ name: 'mic-off' })).toBeNull();
-    });
-
-    it('toggling Mute does not affect the Speaker icon', () => {
-      const { getByLabelText, UNSAFE_getByProps } = renderCall({
+  describe('mute and speaker controls are inert (disabled)', () => {
+    it('pressing Mute does not switch the mic icon', () => {
+      // Red step: broken code (with isMuted state + toggleMute) renders mic-off after press.
+      // Fixed code (disabled button, no state) keeps the icon as mic.
+      const { getByLabelText, UNSAFE_queryByProps } = renderCall({
         number: '+15551234567',
         name: 'Jane Doe',
       });
 
       fireEvent.press(getByLabelText('Mute'));
 
-      expect(UNSAFE_getByProps({ name: 'volume-medium' })).toBeTruthy();
+      expect(UNSAFE_queryByProps({ name: 'mic-off' })).toBeNull();
+    });
+
+    it('pressing Speaker does not switch the speaker icon', () => {
+      // Red step mirror: broken code renders volume-high after press; fixed code does not.
+      const { getByLabelText, UNSAFE_queryByProps } = renderCall({
+        number: '+15551234567',
+        name: 'Jane Doe',
+      });
+
+      fireEvent.press(getByLabelText('Speaker'));
+
+      expect(UNSAFE_queryByProps({ name: 'volume-high' })).toBeNull();
+    });
+
+    it('Mute and Speaker buttons report disabled accessibility state', () => {
+      const { getByLabelText } = renderCall({ number: '+15551234567', name: 'Jane Doe' });
+      expect(getByLabelText('Mute').props.accessibilityState?.disabled).toBe(true);
+      expect(getByLabelText('Speaker').props.accessibilityState?.disabled).toBe(true);
     });
   });
 
-  describe('speaker toggle', () => {
-    it('pressing Speaker switches the icon from volume-medium to volume-high', () => {
-      const { getByLabelText, UNSAFE_getByProps, UNSAFE_queryByProps } = renderCall({
-        number: '+15551234567',
-        name: 'Jane Doe',
-      });
-
-      expect(UNSAFE_getByProps({ name: 'volume-medium' })).toBeTruthy();
-      expect(UNSAFE_queryByProps({ name: 'volume-high' })).toBeNull();
-
-      fireEvent.press(getByLabelText('Speaker'));
-
-      expect(UNSAFE_getByProps({ name: 'volume-high' })).toBeTruthy();
-      expect(UNSAFE_queryByProps({ name: 'volume-medium' })).toBeNull();
-    });
-
-    it('pressing Speaker twice returns to the non-speaker icon', () => {
-      const { getByLabelText, UNSAFE_getByProps, UNSAFE_queryByProps } = renderCall({
-        number: '+15551234567',
-        name: 'Jane Doe',
-      });
-
-      const speaker = getByLabelText('Speaker');
-      fireEvent.press(speaker);
-      fireEvent.press(speaker);
-
-      expect(UNSAFE_getByProps({ name: 'volume-medium' })).toBeTruthy();
-      expect(UNSAFE_queryByProps({ name: 'volume-high' })).toBeNull();
-    });
-
-    it('pressing Mute and Speaker both flips both icons independently', () => {
-      const { getByLabelText, UNSAFE_getByProps } = renderCall({
-        number: '+15551234567',
-        name: 'Jane Doe',
-      });
-
-      fireEvent.press(getByLabelText('Mute'));
-      fireEvent.press(getByLabelText('Speaker'));
-
-      expect(UNSAFE_getByProps({ name: 'mic-off' })).toBeTruthy();
-      expect(UNSAFE_getByProps({ name: 'volume-high' })).toBeTruthy();
-    });
+  it('shows disclosure text that audio controls are managed by the system phone', () => {
+    const { getByText } = renderCall({ number: '+15551234567', name: 'Jane Doe' });
+    expect(getByText(/audio controls unavailable/i)).toBeTruthy();
   });
 
   describe('end call', () => {


### PR DESCRIPTION
Closes #379. Part of #378.

## What changed

`src/screens/CallScreen.tsx` — one file, two changes:

1. **`ControlButton` gets a `disabled` prop**: when true, applies 0.38 opacity, sets `onPress={undefined}`, `disabled={true}` on `<Pressable>`, and reports `accessibilityState={{ disabled: true }}`. The ripple is suppressed on Android.

2. **Mute and Speaker are permanently disabled**: `isMuted`/`isSpeaker` state and their toggle callbacks removed; buttons always render resting icons (`mic`, `volume-medium`).

3. **Disclosure text under caller name** using `typography.caption2` (no literal `fontSize`): _"Call managed by system phone — audio controls unavailable"_.

`src/screens/__tests__/CallScreen.test.tsx` — tests updated:

- Replaced the 6 icon-toggle tests (which described broken behaviour) with 3 inert-control tests + 1 disclosure test.
- All 5 caller-identity tests, 2 end-call tests, and the Dynamic Type test continue to pass unchanged.

## Red step

**Before fix** (with `isMuted` state + `toggleMute` restored):
```
● mute and speaker controls are inert › pressing Mute does not switch the mic icon
  expect(received).toBeNull()
  Received: ReactTestInstance { _fiber.memoizedProps.name: 'mic-off' … }
  at CallScreen.test.tsx:94
```

**After fix**: test passes — `mic-off` is not found.

## Verification

| Check | Result |
|---|---|
| `npm run lint` | 0 errors |
| `npx tsc --noEmit` | 0 errors |
| `npm test` | 8 failures (all pre-existing baseline) — 0 new regressions |
| Hold button | Not present in the current codebase — nothing to check |
| Literal `fontSize` introduced | None |