### PR TITLE
fix(issue-381): wire design-system tokens; fix ErrorBoundary + RemindersScreen dark mode

### DIFF
--- a/src/components/CupertinoAlertDialog.tsx
+++ b/src/components/CupertinoAlertDialog.tsx
@@ -7,6 +7,7 @@ import Animated, {
   withTiming,
 } from 'react-native-reanimated';
 import { useTheme } from '../theme/ThemeContext';
+import { BorderRadius } from '../theme/CupertinoTheme';
 import { useGestureReduceMotion } from '../utils/useGestureReduceMotion';
 
 interface AlertAction {
@@ -81,7 +82,7 @@ export function CupertinoAlertDialog({
             styles.dialog,
             {
               backgroundColor: dialogBg,
-              borderRadius: 14,
+              borderRadius: BorderRadius.card14,
             },
             dialogStyle,
           ]}

--- a/src/components/CupertinoListSection.tsx
+++ b/src/components/CupertinoListSection.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { View, Text, Pressable, StyleSheet, ViewStyle } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useTheme } from '../theme/ThemeContext';
+import { BorderRadius } from '../theme/CupertinoTheme';
 
 // ─── ListTile ────────────────────────────────────────────────
 
@@ -179,7 +180,7 @@ const styles = StyleSheet.create({
   iconContainer: {
     width: 29,
     height: 29,
-    borderRadius: 7,
+    borderRadius: BorderRadius.tag,
     alignItems: 'center',
     justifyContent: 'center',
     marginRight: 12,

--- a/src/components/CupertinoSearchBar.tsx
+++ b/src/components/CupertinoSearchBar.tsx
@@ -7,6 +7,7 @@ import Animated, {
   withTiming,
 } from 'react-native-reanimated';
 import { useTheme } from '../theme/ThemeContext';
+import { BorderRadius } from '../theme/CupertinoTheme';
 
 interface CupertinoSearchBarProps extends Omit<TextInputProps, 'style'> {
   value: string;
@@ -128,7 +129,7 @@ const styles = StyleSheet.create({
     flex: 1,
     flexDirection: 'row',
     alignItems: 'center',
-    borderRadius: 10,
+    borderRadius: BorderRadius.input,
     height: 36,
     paddingHorizontal: 8,
   },

--- a/src/components/CupertinoSegmentedControl.tsx
+++ b/src/components/CupertinoSegmentedControl.tsx
@@ -6,6 +6,7 @@ import Animated, {
   withSpring,
 } from 'react-native-reanimated';
 import { useTheme } from '../theme/ThemeContext';
+import { AnimationConfig, BorderRadius } from '../theme/CupertinoTheme';
 import { hapticSelection } from '../utils/haptics';
 import { useGestureReduceMotion } from '../utils/useGestureReduceMotion';
 
@@ -39,7 +40,7 @@ export function CupertinoSegmentedControl({
       animatedWidth.value = segWidth;
       translateX.value = reduceMotion
         ? selectedIndex * segWidth
-        : withSpring(selectedIndex * segWidth, { damping: 20, stiffness: 300 });
+        : withSpring(selectedIndex * segWidth, AnimationConfig.defaultSpring);
     }
   }, [selectedIndex, segWidth, reduceMotion, translateX, animatedWidth]);
 
@@ -113,7 +114,7 @@ const styles = StyleSheet.create({
     position: 'absolute',
     top: 2,
     bottom: 2,
-    borderRadius: 7,
+    borderRadius: BorderRadius.tag,
   },
   segment: {
     flex: 1,

--- a/src/components/CupertinoShareSheet.tsx
+++ b/src/components/CupertinoShareSheet.tsx
@@ -14,6 +14,7 @@ import { Ionicons } from '@expo/vector-icons';
 import * as Clipboard from 'expo-clipboard';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTheme } from '../theme/ThemeContext';
+import { BorderRadius } from '../theme/CupertinoTheme';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -185,7 +186,7 @@ const styles = StyleSheet.create({
   previewCard: {
     marginHorizontal: 16,
     marginBottom: 16,
-    borderRadius: 12,
+    borderRadius: BorderRadius.medium,
     padding: 12,
   },
   optionsScroll: {
@@ -200,7 +201,7 @@ const styles = StyleSheet.create({
   optionIconWrap: {
     width: 52,
     height: 52,
-    borderRadius: 14,
+    borderRadius: BorderRadius.card14,
     alignItems: 'center',
     justifyContent: 'center',
     marginBottom: 6,

--- a/src/components/CupertinoSkeleton.tsx
+++ b/src/components/CupertinoSkeleton.tsx
@@ -25,7 +25,8 @@ export function CupertinoSkeleton({
   borderRadius = 4,
   style,
 }: CupertinoSkeletonProps) {
-  const { isDark } = useTheme();
+  const { theme } = useTheme();
+  const { colors } = theme;
   const reduceMotion = useGestureReduceMotion();
   const opacity = useSharedValue(reduceMotion ? 0.5 : 0.3);
 
@@ -45,7 +46,7 @@ export function CupertinoSkeleton({
     opacity: opacity.value,
   }));
 
-  const bgColor = isDark ? '#3A3A3C' : '#D1D1D6';
+  const bgColor = colors.systemGray4;
 
   return (
     <Animated.View

--- a/src/components/CupertinoSlider.tsx
+++ b/src/components/CupertinoSlider.tsx
@@ -7,6 +7,7 @@ import Animated, {
 } from 'react-native-reanimated';
 import * as Haptics from 'expo-haptics';
 import { useTheme } from '../theme/ThemeContext';
+import { Shadows } from '../theme/CupertinoTheme';
 import { hapticImpact } from '../utils/haptics';
 
 interface CupertinoSliderProps {
@@ -139,10 +140,6 @@ const styles = StyleSheet.create({
     height: THUMB_SIZE,
     borderRadius: THUMB_SIZE / 2,
     backgroundColor: '#FFFFFF',
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.2,
-    shadowRadius: 4,
-    elevation: 4,
+    ...Shadows.thumb,
   },
 });

--- a/src/components/CupertinoSwitch.tsx
+++ b/src/components/CupertinoSwitch.tsx
@@ -8,6 +8,7 @@ import Animated, {
   interpolateColor,
 } from 'react-native-reanimated';
 import { useTheme } from '../theme/ThemeContext';
+import { AnimationConfig, Shadows } from '../theme/CupertinoTheme';
 import { hapticSelection } from '../utils/haptics';
 import { useGestureReduceMotion } from '../utils/useGestureReduceMotion';
 
@@ -39,7 +40,7 @@ export function CupertinoSwitch({
     const target = value ? 1 : 0;
     progress.value = reduceMotion
       ? withTiming(target, { duration: 150 })
-      : withSpring(target, { damping: 20, stiffness: 300 });
+      : withSpring(target, AnimationConfig.defaultSpring);
     // Shared values are stable refs; reduceMotion is a reactive dep
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [value, reduceMotion]);
@@ -105,10 +106,6 @@ const styles = StyleSheet.create({
     height: THUMB_SIZE,
     borderRadius: THUMB_SIZE / 2,
     backgroundColor: '#FFFFFF',
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.2,
-    shadowRadius: 4,
-    elevation: 4,
+    ...Shadows.thumb,
   },
 });

--- a/src/components/CupertinoTextField.tsx
+++ b/src/components/CupertinoTextField.tsx
@@ -9,6 +9,7 @@ import {
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useTheme } from '../theme/ThemeContext';
+import { BorderRadius } from '../theme/CupertinoTheme';
 
 interface CupertinoTextFieldProps extends TextInputProps {
   clearButton?: boolean;
@@ -77,7 +78,7 @@ const styles = StyleSheet.create({
   container: {
     flexDirection: 'row',
     alignItems: 'center',
-    borderRadius: 10,
+    borderRadius: BorderRadius.input,
     paddingHorizontal: 12,
     minHeight: 44,
   },

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -64,7 +64,7 @@ export class ErrorBoundary extends Component<Props, State> {
         <View style={[styles.container, { backgroundColor: bg }]}>
           {this.state.recovering ? (
             <>
-              <ActivityIndicator size="large" color={SystemColors.light.accent} style={styles.spinner} />
+              <ActivityIndicator size="large" color={SystemColors[isDark ? 'dark' : 'light'].accent} style={styles.spinner} />
               <Text style={[styles.title, { color: textColor }]}>Recovering...</Text>
               <Text style={[styles.message, { color: secondaryColor }]}>
                 The launcher encountered an error and is restarting automatically.
@@ -82,7 +82,7 @@ export class ErrorBoundary extends Component<Props, State> {
             {this.state.error?.message || 'An unexpected error occurred'}
           </Text>
           {!exhausted && (
-            <Pressable style={styles.button} onPress={this.handleReset}>
+            <Pressable style={[styles.button, { backgroundColor: SystemColors[isDark ? 'dark' : 'light'].accent }]} onPress={this.handleReset}>
               <Text style={styles.buttonText}>Try Again</Text>
             </Pressable>
           )}
@@ -122,7 +122,6 @@ const styles = StyleSheet.create({
     lineHeight: 18,
   },
   button: {
-    backgroundColor: SystemColors.light.accent,
     paddingVertical: 12,
     paddingHorizontal: 32,
     borderRadius: 9999,

--- a/src/components/__tests__/ErrorBoundary.test.tsx
+++ b/src/components/__tests__/ErrorBoundary.test.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { Appearance } from 'react-native';
+import { render } from '../../test-utils';
+import { ErrorBoundary } from '../ErrorBoundary';
+import { SystemColors } from '../../theme/CupertinoTheme';
+
+// Suppress console.error noise from intentional throws
+beforeEach(() => { jest.spyOn(console, 'error').mockImplementation(() => {}); });
+afterEach(() => { jest.restoreAllMocks(); });
+
+function Bomb(): React.ReactElement {
+  throw new Error('test error');
+}
+
+describe('ErrorBoundary', () => {
+  it('renders children when no error', () => {
+    const { getByText } = render(
+      <ErrorBoundary>
+        <React.Fragment><React.Fragment /></React.Fragment>
+      </ErrorBoundary>,
+    );
+    // No error UI should appear
+    expect(() => getByText('Try Again')).toThrow();
+  });
+
+  it('shows recovery UI after a crash', () => {
+    const { getByText } = render(
+      <ErrorBoundary>
+        <Bomb />
+      </ErrorBoundary>,
+    );
+    expect(getByText('Recovering...')).toBeTruthy();
+  });
+});
+
+describe('ErrorBoundary dark mode accent', () => {
+  it('uses dark accent color for ActivityIndicator in dark mode', () => {
+    // Red step: broken code used SystemColors.light.accent (#007AFF) unconditionally.
+    // Fixed code uses SystemColors.dark.accent (#0A84FF) when dark mode is active.
+    jest.spyOn(Appearance, 'getColorScheme').mockReturnValue('dark');
+
+    const { UNSAFE_getByType } = render(
+      <ErrorBoundary>
+        <Bomb />
+      </ErrorBoundary>,
+    );
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { ActivityIndicator } = require('react-native');
+    const spinner = UNSAFE_getByType(ActivityIndicator);
+
+    expect(spinner.props.color).toBe(SystemColors['dark'].accent);
+    expect(spinner.props.color).not.toBe(SystemColors['light'].accent);
+  });
+
+  it('uses light accent color for ActivityIndicator in light mode', () => {
+    jest.spyOn(Appearance, 'getColorScheme').mockReturnValue('light');
+
+    const { UNSAFE_getByType } = render(
+      <ErrorBoundary>
+        <Bomb />
+      </ErrorBoundary>,
+    );
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { ActivityIndicator } = require('react-native');
+    const spinner = UNSAFE_getByType(ActivityIndicator);
+
+    expect(spinner.props.color).toBe(SystemColors['light'].accent);
+    expect(spinner.props.color).not.toBe(SystemColors['dark'].accent);
+  });
+});

--- a/src/screens/RemindersScreen.tsx
+++ b/src/screens/RemindersScreen.tsx
@@ -195,12 +195,14 @@ interface CheckboxProps {
 }
 
 function Checkbox({ checked, color, onToggle }: CheckboxProps) {
+  const { theme } = useTheme();
+  const { colors } = theme;
   return (
     <Pressable onPress={onToggle} hitSlop={8} style={styles.checkbox}>
       <View
         style={[
           styles.checkboxOuter,
-          { borderColor: checked ? color : '#C7C7CC' },
+          { borderColor: checked ? color : colors.systemGray3 },
           checked && { backgroundColor: color, borderColor: color },
         ]}
       >
@@ -974,7 +976,7 @@ export function RemindersScreen({ navigation }: { navigation: AppNavigationProp 
       {/* Create List Modal */}
       <Modal visible={showCreateListModal} animationType="slide" presentationStyle="pageSheet">
         <View style={[styles.modalContainer, { backgroundColor: colors.systemBackground }]}>
-          <View style={styles.modalHeader}>
+          <View style={[styles.modalHeader, { borderBottomColor: colors.separator }]}>
             <Pressable onPress={() => { setShowCreateListModal(false); setNewListName(''); }}>
               <Text style={[typography.body, { color: REMINDERS_ACCENT }]}>Cancel</Text>
             </Pressable>
@@ -1015,7 +1017,7 @@ export function RemindersScreen({ navigation }: { navigation: AppNavigationProp 
       {/* Edit Reminder Modal */}
       <Modal visible={editingReminder !== null} animationType="slide" presentationStyle="pageSheet">
         <View style={[styles.modalContainer, { backgroundColor: colors.systemBackground }]}>
-          <View style={styles.modalHeader}>
+          <View style={[styles.modalHeader, { borderBottomColor: colors.separator }]}>
             <Pressable onPress={() => setEditingReminder(null)}>
               <Text style={[typography.body, { color: REMINDERS_ACCENT }]}>Cancel</Text>
             </Pressable>
@@ -1302,7 +1304,6 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingVertical: 14,
     borderBottomWidth: StyleSheet.hairlineWidth,
-    borderBottomColor: '#C6C6C8',
   },
   modalInput: {
     borderBottomWidth: StyleSheet.hairlineWidth,

--- a/src/theme/CupertinoTheme.ts
+++ b/src/theme/CupertinoTheme.ts
@@ -255,6 +255,10 @@ export const BorderRadius = {
   large: 16,
   extraLarge: 20,
   pill: 9999,
+  // Named tokens for recurrent values that don't fit the standard scale
+  tag: 7,       // small list section corners, chip sub-elements
+  input: 10,    // search bars, text fields
+  card14: 14,   // dialog containers, sheet list items
 } as const;
 
 // iOS-style Shadows (soft, not Material elevation)
@@ -286,6 +290,14 @@ export const Shadows = StyleSheet.create({
     shadowOpacity: 0.16,
     shadowRadius: 20,
     elevation: 8,
+  },
+  // Stronger drop shadow for interactive thumbs (sliders, switches)
+  thumb: {
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.2,
+    shadowRadius: 4,
+    elevation: 4,
   },
 });
 


### PR DESCRIPTION
## Issue
Closes #381 — design system tokens defined but unused; ErrorBoundary uses light-mode accent in dark mode.

## Changes

### Visible dark mode bug fixes
1. **ErrorBoundary** (`src/components/ErrorBoundary.tsx`): `ActivityIndicator` and retry `Pressable` now use `SystemColors[isDark?'dark':'light'].accent` — eliminates unconditional `SystemColors.light.accent` (#007AFF) in dark mode (should be #0A84FF). `grep -rn "SystemColors.light.accent" src/components/ErrorBoundary.tsx` → 0 results.
2. **RemindersScreen** (`src/screens/RemindersScreen.tsx`): `Checkbox` unchecked border → `colors.systemGray3`; modal header `borderBottomColor` → `colors.separator` (inline override on both `styles.modalHeader` usages; removed static literal).

### Token wiring
3. **CupertinoSkeleton**: `bgColor` → `colors.systemGray4` (was `isDark ? '#3A3A3C' : '#D1D1D6'` — same values, now token-driven)
4. **CupertinoSegmentedControl + CupertinoSwitch**: `withSpring({damping:20,stiffness:300})` → `AnimationConfig.defaultSpring` (exact match). `grep -n "AnimationConfig\." src/components/*.tsx` → 2 results.
5. **CupertinoSlider + CupertinoSwitch**: thumb shadow → `...Shadows.thumb` (new token added)
6. **BorderRadius updates**: `7→BorderRadius.tag`, `10→BorderRadius.input`, `12→BorderRadius.medium`, `14→BorderRadius.card14` across CupertinoListSection, CupertinoSegmentedControl, CupertinoTextField, CupertinoSearchBar, CupertinoAlertDialog, CupertinoShareSheet. `3` (handle bar) left as literal — unique value, no recurrence.

### Theme additions (`src/theme/CupertinoTheme.ts`)
- `Shadows.thumb` — interactive thumb shadow (opacity 0.2, radius 4, elevation 4)
- `BorderRadius.tag = 7`, `BorderRadius.input = 10`, `BorderRadius.card14 = 14`

## Tests
- 4 new tests in `ErrorBoundary.test.tsx` — dark mode renders correct accent (`#0A84FF`), light mode renders correct accent (`#007AFF`)
- Red step proven: reverting to `SystemColors.light.accent` causes `toBe(SystemColors['dark'].accent)` to fail
- Full suite: 477 pass / 8 fail (same baseline — FoldersStore, SettingsScreen, LockScreen, WeatherScreen)

## Before/After (BorderRadius changes — no visual delta)
| File | Before | After |
|------|--------|-------|
| CupertinoListSection icon container | `7` | `BorderRadius.tag` (7) |
| CupertinoSegmentedControl slider | `7` | `BorderRadius.tag` (7) |
| CupertinoTextField container | `10` | `BorderRadius.input` (10) |
| CupertinoSearchBar inputContainer | `10` | `BorderRadius.input` (10) |
| CupertinoAlertDialog dialog | `14` (inline) | `BorderRadius.card14` (14) |
| CupertinoShareSheet previewCard | `12` | `BorderRadius.medium` (12) |
| CupertinoShareSheet optionIconWrap | `14` | `BorderRadius.card14` (14) |
| CupertinoShareSheet handle | `3` | `3` (unique, no token) |