### PR TITLE
fix/issue-383: replace hardcoded inset offsets with useSafeAreaInsets in immersive mode

### DIFF
--- a/src/components/ControlCenterOverlay.tsx
+++ b/src/components/ControlCenterOverlay.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react';
 import { View, Text, StyleSheet, Dimensions } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import Animated, {
   useSharedValue,
   useAnimatedStyle,
@@ -26,6 +27,7 @@ interface Props {
 }
 
 export function ControlCenterOverlay({ zone, onCommit }: Props) {
+  const insets = useSafeAreaInsets();
   const reduceMotion = useGestureReduceMotion();
   const reduceMotionShared = useSharedValue(reduceMotion);
   useEffect(() => {
@@ -116,7 +118,7 @@ export function ControlCenterOverlay({ zone, onCommit }: Props) {
 
       {/* Sliding preview sheet — visual only, hidden from screen readers */}
       <Animated.View
-        style={[styles.sheet, sheetStyle]}
+        style={[styles.sheet, { paddingTop: insets.top + 12 }, sheetStyle]}
         pointerEvents="none"
         accessible={false}
         importantForAccessibility="no-hide-descendants"
@@ -168,7 +170,6 @@ const styles = StyleSheet.create({
     borderBottomLeftRadius: 20,
     borderBottomRightRadius: 20,
     alignItems: 'center',
-    paddingTop: 12,
   },
   handle: {
     width: 36,

--- a/src/components/NotificationCenterOverlay.tsx
+++ b/src/components/NotificationCenterOverlay.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react';
 import { View, Text, StyleSheet, Dimensions } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import Animated, {
   useSharedValue,
   useAnimatedStyle,
@@ -26,6 +27,7 @@ interface Props {
 }
 
 export function NotificationCenterOverlay({ zone, onCommit }: Props) {
+  const insets = useSafeAreaInsets();
   const reduceMotion = useGestureReduceMotion();
   const reduceMotionShared = useSharedValue(reduceMotion);
   useEffect(() => {
@@ -115,7 +117,7 @@ export function NotificationCenterOverlay({ zone, onCommit }: Props) {
 
       {/* Sliding preview sheet — visual only, hidden from screen readers */}
       <Animated.View
-        style={[styles.sheet, sheetStyle]}
+        style={[styles.sheet, { paddingTop: insets.top + 12 }, sheetStyle]}
         pointerEvents="none"
         accessible={false}
         importantForAccessibility="no-hide-descendants"
@@ -166,7 +168,6 @@ const styles = StyleSheet.create({
     borderBottomLeftRadius: 20,
     borderBottomRightRadius: 20,
     alignItems: 'center',
-    paddingTop: 12,
   },
   handle: {
     width: 36,

--- a/src/components/SpotlightReveal.tsx
+++ b/src/components/SpotlightReveal.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import Animated, {
   SharedValue,
   useAnimatedStyle,
@@ -13,6 +14,7 @@ interface SpotlightRevealProps {
 }
 
 export function SpotlightReveal({ progress }: SpotlightRevealProps) {
+  const insets = useSafeAreaInsets();
   // Animated affordance: search field that slides in from above
   const fieldStyle = useAnimatedStyle(() => {
     'worklet';
@@ -46,7 +48,7 @@ export function SpotlightReveal({ progress }: SpotlightRevealProps) {
       {/* Search field affordance — preview only, real field is on SpotlightSearchScreen */}
       <Animated.View
         pointerEvents="none"
-        style={[styles.fieldHolder, fieldStyle]}
+        style={[styles.fieldHolder, { top: insets.top + 24 }, fieldStyle]}
         accessibilityLabel="Spotlight Search"
         importantForAccessibility="no-hide-descendants"
       >
@@ -67,7 +69,6 @@ const styles = StyleSheet.create({
     position: 'absolute',
     left: '10%',
     right: '10%',
-    top: 80,
     zIndex: 21,
     alignItems: 'center',
   },

--- a/src/screens/AppLibraryScreen.tsx
+++ b/src/screens/AppLibraryScreen.tsx
@@ -265,12 +265,13 @@ const SearchResults = React.memo(function SearchResults({
 }) {
   const { theme, typography } = useTheme();
   const { colors } = theme;
+  const insets = useSafeAreaInsets();
 
   return (
     <FlatList
       data={apps}
       keyExtractor={(item) => item.packageName}
-      contentContainerStyle={{ paddingHorizontal: 16, paddingBottom: 32 }}
+      contentContainerStyle={{ paddingHorizontal: 16, paddingBottom: insets.bottom + 32 }}
       ItemSeparatorComponent={() => (
         <View style={{ height: 1, backgroundColor: colors.separator, marginLeft: 66 }} />
       )}

--- a/src/screens/ClockScreen.tsx
+++ b/src/screens/ClockScreen.tsx
@@ -310,7 +310,7 @@ function WorldClockTab() {
 
   return (
     <View style={styles.tabContent}>
-      <ScrollView contentContainerStyle={{ paddingBottom: 80 }}>
+      <ScrollView contentContainerStyle={{ paddingBottom: insets.bottom + 80 }}>
         {cities.map((wc) => (
           <CupertinoSwipeableRow
             key={wc.timezone}
@@ -637,7 +637,7 @@ function AlarmTab() {
 
   return (
     <View style={styles.tabContent}>
-      <ScrollView contentContainerStyle={{ paddingBottom: 80 }}>
+      <ScrollView contentContainerStyle={{ paddingBottom: insets.bottom + 80 }}>
         {alarms.length === 0 && (
           <View style={styles.emptyState}>
             <Ionicons name="alarm-outline" size={48} color={colors.tertiaryLabel} />

--- a/src/screens/LauncherSettingsScreen.tsx
+++ b/src/screens/LauncherSettingsScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useCallback } from 'react';
 import { View, Text, StyleSheet, TextInput, Modal, Pressable } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as SecureStore from 'expo-secure-store';
 import { useNavigation } from '@react-navigation/native';
@@ -46,6 +47,7 @@ export function LauncherSettingsScreen() {
   const themeCtx = useTheme();
   const { theme, typography, isDark, toggleTheme, textScale } = themeCtx;
   const { colors } = theme;
+  const insets = useSafeAreaInsets();
   const { settings, update, reset: resetSettings } = useSettings();
   const { dockApps } = useApps();
   const { folders, deleteFolder } = useFolders();
@@ -224,7 +226,7 @@ export function LauncherSettingsScreen() {
       title="Launcher Settings"
       largeTitle
       rightButton={doneButton}
-      contentContainerStyle={{ paddingBottom: 40 }}
+      contentContainerStyle={{ paddingBottom: insets.bottom + 40 }}
     >
       {/* ── Appearance ─────────────────────────────────────────── */}
       <CupertinoListSection header="Appearance">

--- a/src/screens/MessagesScreen.tsx
+++ b/src/screens/MessagesScreen.tsx
@@ -644,7 +644,7 @@ export function MessagesScreen() {
           contentContainerStyle={
             filtered.length === 0
               ? styles.emptyList
-              : { paddingBottom: editMode ? insets.bottom + 60 : 20 }
+              : { paddingBottom: editMode ? insets.bottom + 60 : insets.bottom + 20 }
           }
         />
       )}

--- a/src/screens/NotificationCenterScreen.tsx
+++ b/src/screens/NotificationCenterScreen.tsx
@@ -263,7 +263,7 @@ export function NotificationCenterScreen() {
           >
           <ScrollView
             style={styles.scroll}
-            contentContainerStyle={styles.scrollContent}
+            contentContainerStyle={[styles.scrollContent, { paddingBottom: insets.bottom + 40 }]}
             showsVerticalScrollIndicator={false}
             decelerationRate={0.998}
           >
@@ -481,7 +481,6 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   scrollContent: {
-    paddingBottom: 40,
     gap: 20,
   },
   group: {

--- a/src/screens/PhoneScreen.tsx
+++ b/src/screens/PhoneScreen.tsx
@@ -152,6 +152,7 @@ const CallLogItem = React.memo(function CallLogItem({ call, isLast, colors, typo
 function FavoritesTab({ onCall }: { onCall: (phone: string, name?: string) => void }) {
   const { theme, typography } = useTheme();
   const { colors } = theme;
+  const insets = useSafeAreaInsets();
   const { favorites, toggleFavorite, deviceFavoriteIds } = useContacts();
   const { contacts: deviceContacts } = useDevice();
 
@@ -199,7 +200,7 @@ function FavoritesTab({ onCall }: { onCall: (phone: string, name?: string) => vo
       data={allFavorites}
       keyExtractor={(item) => item.id}
       decelerationRate={0.998}
-      contentContainerStyle={{ paddingBottom: 20 }}
+      contentContainerStyle={{ paddingBottom: insets.bottom + 20 }}
       ItemSeparatorComponent={() => (
         <View style={[styles.separator, { backgroundColor: colors.separator, marginLeft: 72 }]} />
       )}
@@ -243,6 +244,7 @@ function FavoritesTab({ onCall }: { onCall: (phone: string, name?: string) => vo
 function RecentsTab({ onCall }: { onCall: (phone: string, name?: string) => void }) {
   const { theme, typography } = useTheme();
   const { colors } = theme;
+  const insets = useSafeAreaInsets();
   const [callLog, setCallLog] = useState<CallLogEntry[]>([]);
   const [permissionDenied, setPermissionDenied] = useState(false);
   const [callLogLoading, setCallLogLoading] = useState(true);
@@ -314,7 +316,7 @@ function RecentsTab({ onCall }: { onCall: (phone: string, name?: string) => void
   }
 
   return (
-    <ScrollView contentContainerStyle={{ paddingBottom: 20 }} decelerationRate={0.998}>
+    <ScrollView contentContainerStyle={{ paddingBottom: insets.bottom + 20 }} decelerationRate={0.998}>
       <View style={{ backgroundColor: colors.secondarySystemGroupedBackground }}>
         {callLog.map((call, idx) => (
           <CallLogItem
@@ -336,6 +338,7 @@ function RecentsTab({ onCall }: { onCall: (phone: string, name?: string) => void
 function ContactsTab({ contacts, onCall, isLoading }: { contacts: DeviceContact[]; onCall: (phone: string, name?: string) => void; isLoading?: boolean }) {
   const { theme, typography } = useTheme();
   const { colors } = theme;
+  const insets = useSafeAreaInsets();
 
   const sorted = useMemo(
     () =>
@@ -374,10 +377,11 @@ function ContactsTab({ contacts, onCall, isLoading }: { contacts: DeviceContact[
 
   return (
     <FlatList
+      testID="contacts-list"
       data={sorted}
       keyExtractor={(item) => item.id}
       decelerationRate={0.998}
-      contentContainerStyle={{ paddingBottom: 20 }}
+      contentContainerStyle={{ paddingBottom: insets.bottom + 20 }}
       ItemSeparatorComponent={() => (
         <View style={[styles.separator, { backgroundColor: colors.separator, marginLeft: 72 }]} />
       )}

--- a/src/screens/__tests__/PhoneScreen.test.tsx
+++ b/src/screens/__tests__/PhoneScreen.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, fireEvent } from '../../test-utils';
 import { PhoneScreen } from '../PhoneScreen';
+import * as DeviceStore from '../../store/DeviceStore';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const mockNav = { goBack: jest.fn() } as any;
@@ -38,6 +39,19 @@ describe('PhoneScreen', () => {
     expect(getByText('0')).toBeTruthy();
     expect(getByText('*')).toBeTruthy();
     expect(getByText('#')).toBeTruthy();
+  });
+
+  it('contacts tab list uses insets.bottom (34) + 20 = 54 for paddingBottom', () => {
+    // jest.setup.js mocks useSafeAreaInsets → bottom: 34
+    // Provide one contact so ContactsTab renders the FlatList instead of the empty state
+    jest.spyOn(DeviceStore, 'useDevice').mockReturnValue({
+      contacts: [{ id: '1', firstName: 'Ana', lastName: 'Silva', phone: '+351910000001' }],
+    } as ReturnType<typeof DeviceStore.useDevice>);
+
+    const { getByText, getByTestId } = render(<PhoneScreen navigation={mockNav} />);
+    fireEvent.press(getByText('Contacts'));
+    const list = getByTestId('contacts-list');
+    expect(list.props.contentContainerStyle.paddingBottom).toBe(54);
   });
 
   it('keypad shows typed number', () => {


### PR DESCRIPTION
Closes #383
Part of #352

## What

Replaces static padding/top offsets with `useSafeAreaInsets()` across 9 files. The app runs in immersive mode with no system chrome, so hardcoded values are device-specific bets.

### Primary fixes (lists cut off by home gesture zone)
- **MessagesScreen.tsx:646**: non-edit branch `paddingBottom: 20` → `insets.bottom + 20`
- **PhoneScreen.tsx**: FavoritesTab (l.202), RecentsTab (l.317), ContactsTab (l.380) — `paddingBottom: 20` → `insets.bottom + 20`

### Overlay cosmetic fixes
- **SpotlightReveal.tsx**: `top: 80` → `insets.top + 24` (dynamic)
- **ControlCenterOverlay.tsx**: `paddingTop: 12` → `insets.top + 12` (dynamic)
- **NotificationCenterOverlay.tsx**: `paddingTop: 12` → `insets.top + 12` (dynamic)

### Secondary paddings
- **ClockScreen.tsx**: WorldClockTab + AlarmTab `paddingBottom: 80` → `insets.bottom + 80`
- **LauncherSettingsScreen.tsx**: `paddingBottom: 40` → `insets.bottom + 40`
- **AppLibraryScreen.tsx** (SearchResults): `paddingBottom: 32` → `insets.bottom + 32`
- **NotificationCenterScreen.tsx**: `paddingBottom: 40` → `insets.bottom + 40` (insets already in scope)

### Dimensions deferral (AC item 4)
app.json has orientation: portrait — orientation is locked. The module-level Dimensions.get('window') in ControlCenterOverlay, NotificationCenterOverlay, QuickSwitchHomeBar, AssistiveTouch, and BackEdgeSwipe is therefore stable across the app's lifecycle. Moving to useWindowDimensions() is preventive robustness, not a fix for an active bug. Deferred to a dedicated issue.

## Red-step proof

Reverted insets.bottom + 20 → 20 in ContactsTab FlatList: Expected 54, Received 20. Restored: PASS.

## AC verification

- grep -n 'paddingBottom: 20' src/screens/MessagesScreen.tsx src/screens/PhoneScreen.tsx → 0 results
- SpotlightReveal, ControlCenterOverlay, NotificationCenterOverlay all import useSafeAreaInsets
- app.json orientation locked to portrait — Dimensions deferral explicitly noted
- npm test → 487 tests, 8 failures (all pre-existing baseline)