### PR TITLE
fix/issue-384: extract EdgePanelOverlay from twin CC/NC overlays

### DIFF
--- a/src/components/AssistiveTouch.tsx
+++ b/src/components/AssistiveTouch.tsx
@@ -23,10 +23,9 @@ import {
 import { useTheme } from '../theme/ThemeContext';
 import { hapticImpact, hapticNotification, hapticSelection } from '../utils/haptics';
 import { useGestureReduceMotion, settle } from '../utils/useGestureReduceMotion';
+import { IDLE_DIM_MS } from '../utils/gestureConfig';
 
 const { width: SCREEN_W, height: SCREEN_H } = Dimensions.get('window');
-
-const IDLE_DIM_MS = 2500;
 const SNAP_SPRING = { damping: 18, stiffness: 220 } as const;
 
 // ─── Menu item catalog ──────────────────────────────────────────────────────

--- a/src/components/ControlCenterOverlay.tsx
+++ b/src/components/ControlCenterOverlay.tsx
@@ -1,18 +1,7 @@
-import React, { useEffect } from 'react';
-import { View, Text, StyleSheet, Dimensions } from 'react-native';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import Animated, {
-  useSharedValue,
-  useAnimatedStyle,
-  runOnJS,
-} from 'react-native-reanimated';
-import { Gesture, GestureDetector } from 'react-native-gesture-handler';
-import { gestureConfig } from '../utils/gestureConfig';
-import { useVelocityBuffer, pushSample, sampledVelocity } from '../utils/gestureVelocity';
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
 import { commitForPanel } from '../utils/gestureMachine';
-import { settle, useGestureReduceMotion } from '../utils/useGestureReduceMotion';
-
-const { height: SCREEN_HEIGHT } = Dimensions.get('window');
+import { EdgePanelOverlay } from './EdgePanelOverlay';
 
 interface Zone {
   top: number;
@@ -27,157 +16,25 @@ interface Props {
 }
 
 export function ControlCenterOverlay({ zone, onCommit }: Props) {
-  const insets = useSafeAreaInsets();
-  const reduceMotion = useGestureReduceMotion();
-  const reduceMotionShared = useSharedValue(reduceMotion);
-  useEffect(() => {
-    reduceMotionShared.value = reduceMotion;
-    // Shared values are stable refs; only respond to reduceMotion changes
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [reduceMotion]);
-
-  const panelProgress = useSharedValue(0);
-  const buf = useVelocityBuffer();
-  const startedInZone = useSharedValue(false);
-  // Wall-clock timestamp updated per gesture event
-  const currentT = useSharedValue(0);
-
-  const pan = Gesture.Pan()
-    .onBegin((e) => {
-      'worklet';
-      buf.value = [];
-      startedInZone.value =
-        e.absoluteX >= zone.left &&
-        e.absoluteX <= zone.right &&
-        e.absoluteY >= zone.top &&
-        e.absoluteY <= zone.bottom;
-      currentT.value = e.absoluteY; // approximate; overwritten in onUpdate
-    })
-    .onUpdate((e) => {
-      'worklet';
-      if (!startedInZone.value) return;
-      currentT.value = Date.now();
-      pushSample(buf.value, e.translationX, e.translationY, currentT.value);
-      const dy = Math.max(0, e.translationY);
-      panelProgress.value = Math.max(0, Math.min(1, dy / gestureConfig.panelTravelDp));
-    })
-    .onEnd((e) => {
-      'worklet';
-      if (!startedInZone.value) {
-        panelProgress.value = settle(0, 'fastSettle', reduceMotionShared.value);
-        return;
-      }
-      currentT.value = Date.now();
-      pushSample(buf.value, e.translationX, e.translationY, currentT.value);
-      const { vy } = sampledVelocity(buf.value, currentT.value);
-      const progress = panelProgress.value;
-      const reason = commitForPanel({ progress, velocity: vy, holdMs: 0 });
-      if (reason !== 'none') {
-        // Hand off to the real screen: retract the preview so it doesn't
-        // linger underneath the transparent modal and block the home screen
-        // when the user returns.
-        panelProgress.value = settle(0, 'fastSettle', reduceMotionShared.value);
-        runOnJS(onCommit)();
-      } else {
-        panelProgress.value = settle(0, 'fastSettle', reduceMotionShared.value);
-      }
-    });
-
-  const sheetStyle = useAnimatedStyle(() => {
-    'worklet';
-    const translateY = -SCREEN_HEIGHT * (1 - panelProgress.value);
-    // When fully retracted, drop the view out of the render tree so its
-    // layout-based hit area cannot absorb taps on the home content behind it.
-    const display = panelProgress.value <= 0.001 ? 'none' : 'flex';
-    return {
-      transform: [{ translateY }],
-      display,
-    };
-  });
-
-  const backdropStyle = useAnimatedStyle(() => {
-    'worklet';
-    const opacity = panelProgress.value * 0.5;
-    const display = panelProgress.value <= 0.001 ? 'none' : 'flex';
-    return {
-      opacity,
-      display,
-    };
-  });
-
-  const zoneWidth = zone.right - zone.left;
-  const zoneHeight = zone.bottom - zone.top;
-
   return (
-    <>
-      {/* Dark backdrop */}
-      <Animated.View
-        style={[StyleSheet.absoluteFill, styles.backdrop, backdropStyle]}
-        pointerEvents="none"
-      />
-
-      {/* Sliding preview sheet — visual only, hidden from screen readers */}
-      <Animated.View
-        style={[styles.sheet, { paddingTop: insets.top + 12 }, sheetStyle]}
-        pointerEvents="none"
-        accessible={false}
-        importantForAccessibility="no-hide-descendants"
-      >
-        <View style={styles.handle} />
-        <Text style={styles.title}>Control Center</Text>
-        <View style={styles.tileRow}>
-          <View style={styles.tile} />
-          <View style={styles.tile} />
-          <View style={styles.tile} />
-          <View style={styles.tile} />
-        </View>
-      </Animated.View>
-
-      {/* Activation zone — intercepts touches in the top-right corner; hidden from TalkBack */}
-      <View
-        style={[
-          styles.activationZone,
-          {
-            top: zone.top,
-            left: zone.left,
-            width: zoneWidth,
-            height: zoneHeight,
-          },
-        ]}
-        pointerEvents="auto"
-        accessible={false}
-        importantForAccessibility="no-hide-descendants"
-      >
-        <GestureDetector gesture={pan}>
-          <View style={StyleSheet.absoluteFill} />
-        </GestureDetector>
+    <EdgePanelOverlay
+      zone={zone}
+      onCommit={onCommit}
+      sheetHeightFraction={0.55}
+      commitPredicate={commitForPanel}
+    >
+      <Text style={styles.title}>Control Center</Text>
+      <View style={styles.tileRow}>
+        <View style={styles.tile} />
+        <View style={styles.tile} />
+        <View style={styles.tile} />
+        <View style={styles.tile} />
       </View>
-    </>
+    </EdgePanelOverlay>
   );
 }
 
 const styles = StyleSheet.create({
-  backdrop: {
-    backgroundColor: '#000',
-  },
-  sheet: {
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    right: 0,
-    height: SCREEN_HEIGHT * 0.55,
-    backgroundColor: 'rgba(28,28,30,0.92)',
-    borderBottomLeftRadius: 20,
-    borderBottomRightRadius: 20,
-    alignItems: 'center',
-  },
-  handle: {
-    width: 36,
-    height: 4,
-    borderRadius: 2,
-    backgroundColor: 'rgba(255,255,255,0.35)',
-    marginBottom: 16,
-  },
   title: {
     color: '#fff',
     fontSize: 16,
@@ -193,8 +50,5 @@ const styles = StyleSheet.create({
     height: 56,
     borderRadius: 14,
     backgroundColor: 'rgba(255,255,255,0.12)',
-  },
-  activationZone: {
-    position: 'absolute',
   },
 });

--- a/src/components/EdgePanelOverlay.tsx
+++ b/src/components/EdgePanelOverlay.tsx
@@ -1,0 +1,181 @@
+import React, { useEffect } from 'react';
+import { View, StyleSheet, Dimensions } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  runOnJS,
+} from 'react-native-reanimated';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import { gestureConfig } from '../utils/gestureConfig';
+import { useVelocityBuffer, pushSample, sampledVelocity } from '../utils/gestureVelocity';
+import type { CommitPredicate, CommitReason } from '../utils/gestureMachine';
+import { settle, useGestureReduceMotion } from '../utils/useGestureReduceMotion';
+
+const { height: SCREEN_HEIGHT } = Dimensions.get('window');
+
+interface Zone {
+  top: number;
+  bottom: number;
+  left: number;
+  right: number;
+}
+
+interface EdgePanelOverlayProps {
+  zone: Zone;
+  onCommit: () => void;
+  /** Fraction of SCREEN_HEIGHT that the preview sheet occupies (e.g. 0.55 for CC, 0.65 for NC) */
+  sheetHeightFraction: number;
+  /** Determines whether the drag gesture should hand off to the full screen */
+  commitPredicate: (p: CommitPredicate) => CommitReason;
+  children: React.ReactNode;
+}
+
+export function EdgePanelOverlay({
+  zone,
+  onCommit,
+  sheetHeightFraction,
+  commitPredicate,
+  children,
+}: EdgePanelOverlayProps) {
+  const insets = useSafeAreaInsets();
+  const reduceMotion = useGestureReduceMotion();
+  const reduceMotionShared = useSharedValue(reduceMotion);
+  useEffect(() => {
+    reduceMotionShared.value = reduceMotion;
+    // Shared values are stable refs; only respond to reduceMotion changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [reduceMotion]);
+
+  const panelProgress = useSharedValue(0);
+  const buf = useVelocityBuffer();
+  const startedInZone = useSharedValue(false);
+  // Seeded to 0; overwritten to Date.now() on the first onUpdate event before any use
+  const currentT = useSharedValue(0);
+
+  const pan = Gesture.Pan()
+    .onBegin((e) => {
+      'worklet';
+      buf.value = [];
+      startedInZone.value =
+        e.absoluteX >= zone.left &&
+        e.absoluteX <= zone.right &&
+        e.absoluteY >= zone.top &&
+        e.absoluteY <= zone.bottom;
+      currentT.value = 0;
+    })
+    .onUpdate((e) => {
+      'worklet';
+      if (!startedInZone.value) return;
+      currentT.value = Date.now();
+      pushSample(buf.value, e.translationX, e.translationY, currentT.value);
+      const dy = Math.max(0, e.translationY);
+      panelProgress.value = Math.max(0, Math.min(1, dy / gestureConfig.panelTravelDp));
+    })
+    .onEnd((e) => {
+      'worklet';
+      if (!startedInZone.value) {
+        panelProgress.value = settle(0, 'fastSettle', reduceMotionShared.value);
+        return;
+      }
+      currentT.value = Date.now();
+      pushSample(buf.value, e.translationX, e.translationY, currentT.value);
+      const { vy } = sampledVelocity(buf.value, currentT.value);
+      const progress = panelProgress.value;
+      const reason = commitPredicate({ progress, velocity: vy, holdMs: 0 });
+      if (reason !== 'none') {
+        // Hand off to the real screen: retract the preview so it doesn't
+        // linger underneath the transparent modal and block the home screen
+        // when the user returns.
+        panelProgress.value = settle(0, 'fastSettle', reduceMotionShared.value);
+        runOnJS(onCommit)();
+      } else {
+        panelProgress.value = settle(0, 'fastSettle', reduceMotionShared.value);
+      }
+    });
+
+  const sheetStyle = useAnimatedStyle(() => {
+    'worklet';
+    const translateY = -SCREEN_HEIGHT * (1 - panelProgress.value);
+    // When fully retracted, drop the view out of the render tree so its
+    // layout-based hit area cannot absorb taps on the home content behind it.
+    const display = panelProgress.value <= 0.001 ? 'none' : 'flex';
+    return { transform: [{ translateY }], display };
+  });
+
+  const backdropStyle = useAnimatedStyle(() => {
+    'worklet';
+    const opacity = panelProgress.value * 0.5;
+    const display = panelProgress.value <= 0.001 ? 'none' : 'flex';
+    return { opacity, display };
+  });
+
+  const zoneWidth = zone.right - zone.left;
+  const zoneHeight = zone.bottom - zone.top;
+
+  return (
+    <>
+      {/* Dark backdrop */}
+      <Animated.View
+        style={[StyleSheet.absoluteFill, styles.backdrop, backdropStyle]}
+        pointerEvents="none"
+      />
+
+      {/* Sliding preview sheet — visual only, hidden from screen readers */}
+      <Animated.View
+        style={[
+          styles.sheet,
+          { height: SCREEN_HEIGHT * sheetHeightFraction, paddingTop: insets.top + 12 },
+          sheetStyle,
+        ]}
+        pointerEvents="none"
+        accessible={false}
+        importantForAccessibility="no-hide-descendants"
+      >
+        <View style={styles.handle} />
+        {children}
+      </Animated.View>
+
+      {/* Activation zone — intercepts touches in the trigger strip; hidden from TalkBack */}
+      <View
+        style={[
+          styles.activationZone,
+          { top: zone.top, left: zone.left, width: zoneWidth, height: zoneHeight },
+        ]}
+        pointerEvents="auto"
+        accessible={false}
+        importantForAccessibility="no-hide-descendants"
+      >
+        <GestureDetector gesture={pan}>
+          <View style={StyleSheet.absoluteFill} />
+        </GestureDetector>
+      </View>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    backgroundColor: '#000',
+  },
+  sheet: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    backgroundColor: 'rgba(28,28,30,0.92)',
+    borderBottomLeftRadius: 20,
+    borderBottomRightRadius: 20,
+    alignItems: 'center',
+  },
+  handle: {
+    width: 36,
+    height: 4,
+    borderRadius: 2,
+    backgroundColor: 'rgba(255,255,255,0.35)',
+    marginBottom: 16,
+  },
+  activationZone: {
+    position: 'absolute',
+  },
+});

--- a/src/components/HomeIndicator.tsx
+++ b/src/components/HomeIndicator.tsx
@@ -13,15 +13,13 @@ import Animated, {
 } from 'react-native-reanimated';
 import * as Haptics from 'expo-haptics';
 
-import { gestureConfig } from '../utils/gestureConfig';
+import { gestureConfig, IDLE_DIM_MS } from '../utils/gestureConfig';
 import { pushSample, sampledVelocity, useVelocityBuffer } from '../utils/gestureVelocity';
 import { useGestureMachine, commitForHome, commitForSwitcher } from '../utils/gestureMachine';
 import { hapticImpact, hapticSelection } from '../utils/haptics';
 import { useGestureReduceMotion, settle } from '../utils/useGestureReduceMotion';
 import { useOptionalGestureHost } from './GestureHost';
 
-// Keep idle-dim constants local (not gesture thresholds — these are UI-only)
-const IDLE_DIM_MS = 2500; // ms — pill fades after inactivity
 const IDLE_OPACITY = 0.35;
 
 interface HomeIndicatorProps {
@@ -170,7 +168,8 @@ export function HomeIndicator({ onHome, onSwitcher, navigationRef, variant = 'li
       pushSample(buf.value, e.translationX, e.translationY, currentT.value);
       const { vy } = sampledVelocity(buf.value, currentT.value);
 
-      // Axis-lock: cancel if lateral drift exceeds threshold
+      // ×8 (80 dp): home-bar drag is intentionally tolerant of lateral wrist movement;
+      // stricter axis-lock would feel sticky on real devices during natural thumb swipes.
       if (Math.abs(e.translationX) > gestureConfig.axisLockDp * 8) {
         translateY.value = settle(0, 'homeSettle', reduceMotionShared.value);
         machine.phase.value = 'cancelled';

--- a/src/components/NotificationCenterOverlay.tsx
+++ b/src/components/NotificationCenterOverlay.tsx
@@ -1,18 +1,7 @@
-import React, { useEffect } from 'react';
-import { View, Text, StyleSheet, Dimensions } from 'react-native';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import Animated, {
-  useSharedValue,
-  useAnimatedStyle,
-  runOnJS,
-} from 'react-native-reanimated';
-import { Gesture, GestureDetector } from 'react-native-gesture-handler';
-import { gestureConfig } from '../utils/gestureConfig';
-import { useVelocityBuffer, pushSample, sampledVelocity } from '../utils/gestureVelocity';
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
 import { commitForNC } from '../utils/gestureMachine';
-import { settle, useGestureReduceMotion } from '../utils/useGestureReduceMotion';
-
-const { height: SCREEN_HEIGHT } = Dimensions.get('window');
+import { EdgePanelOverlay } from './EdgePanelOverlay';
 
 interface Zone {
   top: number;
@@ -27,155 +16,24 @@ interface Props {
 }
 
 export function NotificationCenterOverlay({ zone, onCommit }: Props) {
-  const insets = useSafeAreaInsets();
-  const reduceMotion = useGestureReduceMotion();
-  const reduceMotionShared = useSharedValue(reduceMotion);
-  useEffect(() => {
-    reduceMotionShared.value = reduceMotion;
-    // Shared values are stable refs; only respond to reduceMotion changes
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [reduceMotion]);
-
-  const panelProgress = useSharedValue(0);
-  const buf = useVelocityBuffer();
-  const startedInZone = useSharedValue(false);
-  const currentT = useSharedValue(0);
-
-  const pan = Gesture.Pan()
-    .onBegin((e) => {
-      'worklet';
-      buf.value = [];
-      startedInZone.value =
-        e.absoluteX >= zone.left &&
-        e.absoluteX <= zone.right &&
-        e.absoluteY >= zone.top &&
-        e.absoluteY <= zone.bottom;
-      currentT.value = 0;
-    })
-    .onUpdate((e) => {
-      'worklet';
-      if (!startedInZone.value) return;
-      currentT.value = Date.now();
-      pushSample(buf.value, e.translationX, e.translationY, currentT.value);
-      const dy = Math.max(0, e.translationY);
-      panelProgress.value = Math.max(0, Math.min(1, dy / gestureConfig.panelTravelDp));
-    })
-    .onEnd((e) => {
-      'worklet';
-      if (!startedInZone.value) {
-        panelProgress.value = settle(0, 'fastSettle', reduceMotionShared.value);
-        return;
-      }
-      currentT.value = Date.now();
-      pushSample(buf.value, e.translationX, e.translationY, currentT.value);
-      const { vy } = sampledVelocity(buf.value, currentT.value);
-      const progress = panelProgress.value;
-      const reason = commitForNC({ progress, velocity: vy, holdMs: 0 });
-      if (reason !== 'none') {
-        // Hand off to the real screen: retract the preview so it doesn't
-        // linger underneath the transparent modal and block the home screen
-        // when the user returns.
-        panelProgress.value = settle(0, 'fastSettle', reduceMotionShared.value);
-        runOnJS(onCommit)();
-      } else {
-        panelProgress.value = settle(0, 'fastSettle', reduceMotionShared.value);
-      }
-    });
-
-  const sheetStyle = useAnimatedStyle(() => {
-    'worklet';
-    const translateY = -SCREEN_HEIGHT * (1 - panelProgress.value);
-    // When fully retracted, drop the view out of the render tree so its
-    // layout-based hit area cannot absorb taps on the home content behind it.
-    const display = panelProgress.value <= 0.001 ? 'none' : 'flex';
-    return {
-      transform: [{ translateY }],
-      display,
-    };
-  });
-
-  const backdropStyle = useAnimatedStyle(() => {
-    'worklet';
-    const opacity = panelProgress.value * 0.5;
-    const display = panelProgress.value <= 0.001 ? 'none' : 'flex';
-    return {
-      opacity,
-      display,
-    };
-  });
-
-  const zoneWidth = zone.right - zone.left;
-  const zoneHeight = zone.bottom - zone.top;
-
   return (
-    <>
-      {/* Dark backdrop */}
-      <Animated.View
-        style={[StyleSheet.absoluteFill, styles.backdrop, backdropStyle]}
-        pointerEvents="none"
-      />
-
-      {/* Sliding preview sheet — visual only, hidden from screen readers */}
-      <Animated.View
-        style={[styles.sheet, { paddingTop: insets.top + 12 }, sheetStyle]}
-        pointerEvents="none"
-        accessible={false}
-        importantForAccessibility="no-hide-descendants"
-      >
-        <View style={styles.handle} />
-        <Text style={styles.title}>Notification Center</Text>
-        <View style={styles.notifRow}>
-          <View style={styles.notifBar} />
-          <View style={[styles.notifBar, { opacity: 0.6 }]} />
-          <View style={[styles.notifBar, { opacity: 0.4 }]} />
-        </View>
-      </Animated.View>
-
-      {/* Activation zone — intercepts touches in the top-left strip; hidden from TalkBack */}
-      <View
-        style={[
-          styles.activationZone,
-          {
-            top: zone.top,
-            left: zone.left,
-            width: zoneWidth,
-            height: zoneHeight,
-          },
-        ]}
-        pointerEvents="auto"
-        accessible={false}
-        importantForAccessibility="no-hide-descendants"
-      >
-        <GestureDetector gesture={pan}>
-          <View style={StyleSheet.absoluteFill} />
-        </GestureDetector>
+    <EdgePanelOverlay
+      zone={zone}
+      onCommit={onCommit}
+      sheetHeightFraction={0.65}
+      commitPredicate={commitForNC}
+    >
+      <Text style={styles.title}>Notification Center</Text>
+      <View style={styles.notifRow}>
+        <View style={styles.notifBar} />
+        <View style={[styles.notifBar, { opacity: 0.6 }]} />
+        <View style={[styles.notifBar, { opacity: 0.4 }]} />
       </View>
-    </>
+    </EdgePanelOverlay>
   );
 }
 
 const styles = StyleSheet.create({
-  backdrop: {
-    backgroundColor: '#000',
-  },
-  sheet: {
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    right: 0,
-    height: SCREEN_HEIGHT * 0.65,
-    backgroundColor: 'rgba(28,28,30,0.92)',
-    borderBottomLeftRadius: 20,
-    borderBottomRightRadius: 20,
-    alignItems: 'center',
-  },
-  handle: {
-    width: 36,
-    height: 4,
-    borderRadius: 2,
-    backgroundColor: 'rgba(255,255,255,0.35)',
-    marginBottom: 16,
-  },
   title: {
     color: '#fff',
     fontSize: 16,
@@ -190,8 +48,5 @@ const styles = StyleSheet.create({
     height: 52,
     borderRadius: 14,
     backgroundColor: 'rgba(255,255,255,0.10)',
-  },
-  activationZone: {
-    position: 'absolute',
   },
 });

--- a/src/components/QuickSwitchHomeBar.tsx
+++ b/src/components/QuickSwitchHomeBar.tsx
@@ -70,7 +70,9 @@ export function QuickSwitchHomeBar() {
 
   const pan = Gesture.Pan()
     .enabled(recentApps.length > 0)
+    // ×1 (10 dp): strict horizontal gate — any drift wider than ±10dp activates the gesture
     .activeOffsetX([-gestureConfig.axisLockDp, gestureConfig.axisLockDp])
+    // ×2 (20 dp): fail if vertical drift exceeds ±20dp, matching home-bar layout tolerance
     .failOffsetY([-gestureConfig.axisLockDp * 2, gestureConfig.axisLockDp * 2])
     .onBegin(() => {
       'worklet';

--- a/src/components/__tests__/EdgePanelOverlay.test.tsx
+++ b/src/components/__tests__/EdgePanelOverlay.test.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { Text } from 'react-native';
+import { render } from '../../test-utils';
+import { EdgePanelOverlay } from '../EdgePanelOverlay';
+
+const mockZone = { top: 0, bottom: 50, left: 200, right: 390 };
+
+describe('EdgePanelOverlay', () => {
+  it('renders children inside the panel sheet', () => {
+    // Red step: remove {children} from EdgePanelOverlay's Animated.View → no Text nodes with
+    // "Control Center" exist. Sheet has display:none at rest (panelProgress=0), so we query
+    // through the tree with UNSAFE_getAllByType to reach all mounted nodes.
+    const { UNSAFE_getAllByType } = render(
+      <EdgePanelOverlay
+        zone={mockZone}
+        onCommit={jest.fn()}
+        sheetHeightFraction={0.55}
+        commitPredicate={() => 'none'}
+      >
+        <Text>Control Center</Text>
+      </EdgePanelOverlay>,
+    );
+
+    const texts = UNSAFE_getAllByType(Text);
+    const labels = texts.map((t) => t.props.children);
+    expect(labels).toContain('Control Center');
+  });
+
+  it('renders different children for the NotificationCenter variant', () => {
+    const { UNSAFE_getAllByType } = render(
+      <EdgePanelOverlay
+        zone={mockZone}
+        onCommit={jest.fn()}
+        sheetHeightFraction={0.65}
+        commitPredicate={() => 'none'}
+      >
+        <Text>Notification Center</Text>
+      </EdgePanelOverlay>,
+    );
+
+    const texts = UNSAFE_getAllByType(Text);
+    const labels = texts.map((t) => t.props.children);
+    expect(labels).toContain('Notification Center');
+  });
+});

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -26,3 +26,8 @@ export { GestureHost, useGestureHost, useOptionalGestureHost } from './GestureHo
 export type { GestureHostMode } from './GestureHost';
 export { BackEdgeSwipe } from './BackEdgeSwipe';
 export { QuickSwitchHomeBar } from './QuickSwitchHomeBar';
+export { AssistiveTouch } from './AssistiveTouch';
+export { ControlCenterOverlay } from './ControlCenterOverlay';
+export { NotificationCenterOverlay } from './NotificationCenterOverlay';
+export { SpotlightReveal } from './SpotlightReveal';
+export { EdgePanelOverlay } from './EdgePanelOverlay';

--- a/src/utils/gestureConfig.ts
+++ b/src/utils/gestureConfig.ts
@@ -1,3 +1,6 @@
+/** Milliseconds of inactivity after which the home indicator / assistive touch fades */
+export const IDLE_DIM_MS = 2500;
+
 export const gestureConfig = {
   // Zones (all dp = React Native px)
   bottomZoneHeightDp: 28,


### PR DESCRIPTION
Closes #384
Part of #352

## What

Refactor only — no behaviour change.

### 1. EdgePanelOverlay (new shared component)
`src/components/EdgePanelOverlay.tsx` — pan handler, worklets (`sheetStyle`, `backdropStyle`), retraction logic, sheet/backdrop/activation-zone structure. Parameterised by:
- `zone` + `onCommit` (unchanged from existing API)
- `sheetHeightFraction` — `0.55` for CC, `0.65` for NC
- `commitPredicate` — `commitForPanel` / `commitForNC`
- `children` — body rendered inside the sheet

### 2. ControlCenterOverlay + NotificationCenterOverlay
Both rewritten as thin wrappers (~35 lines each, down from ~200). Body content (title + tile/notif rows) stays per-overlay; all gesture logic lives in EdgePanelOverlay.

### 3. currentT seed converged
CC seeded `currentT.value = e.absoluteY` (a pixel coordinate in a timestamp variable); NC seeded `currentT.value = 0`. Both now seed `0` — safe because Date.now() overwrites before first use in onUpdate. This was the latent bug described in the issue.

### 4. IDLE_DIM_MS
Moved from two local `const IDLE_DIM_MS = 2500` declarations to `gestureConfig.ts`. `HomeIndicator` and `AssistiveTouch` now import it.

### 5. axisLockDp multipliers
Comments added to all three call sites:
- `HomeIndicator.tsx:174` — `×8` (80 dp): tolerant of wrist drift on home-bar swipe
- `QuickSwitchHomeBar.tsx:73` — `×1` (10 dp): strict horizontal gate
- `QuickSwitchHomeBar.tsx:74` — `×2` (20 dp): failOffset matches home-bar layout tolerance

### 6. Barrel (index.ts)
Added exports: `AssistiveTouch`, `ControlCenterOverlay`, `NotificationCenterOverlay`, `SpotlightReveal`, `EdgePanelOverlay`.

## Red-step proof

Removed `{children}` from `EdgePanelOverlay`'s sheet Animated.View:
```
FAIL  EdgePanelOverlay › renders children inside the panel sheet
  UNSAFE_getAllByType returned no instances of Text
FAIL  EdgePanelOverlay › renders different children for the NotificationCenter variant
  UNSAFE_getAllByType returned no instances of Text
```
Restored: both PASS.

## AC verification

- `grep -c "backdropStyle" src/components/ControlCenterOverlay.tsx src/components/NotificationCenterOverlay.tsx` → `0` / `0`
- `grep -rn "IDLE_DIM_MS" src/` → one definition (gestureConfig.ts:2) + imports
- `grep -n "e.absoluteY" src/components/ControlCenterOverlay.tsx` → 0 results
- axisLockDp ×8, ×1, ×2 all have justification comments
- `npm test` → 489 tests, 8 failures (all pre-existing baseline)