### PR TITLE
fix/issue-385: Consolidate avatar colour + AppLibrary nav bar + empty state

### DIFF
--- a/src/screens/AppLibraryScreen.tsx
+++ b/src/screens/AppLibraryScreen.tsx
@@ -18,6 +18,7 @@ import * as Haptics from 'expo-haptics';
 import { useApps, InstalledApp } from '../store/AppsStore';
 import { useTheme } from '../theme/ThemeContext';
 import { CupertinoSearchBar } from '../components/CupertinoSearchBar';
+import { CupertinoNavigationBar, CupertinoEmptyState } from '../components';
 import type { AppNavigationProp } from '../navigation/types';
 import type { CupertinoColors } from '../theme/CupertinoTheme';
 import { hapticImpact } from '../utils/haptics';
@@ -275,6 +276,13 @@ const SearchResults = React.memo(function SearchResults({
       ItemSeparatorComponent={() => (
         <View style={{ height: 1, backgroundColor: colors.separator, marginLeft: 66 }} />
       )}
+      ListEmptyComponent={
+        <CupertinoEmptyState
+          icon="search-outline"
+          title="No Results"
+          message="No apps match your search."
+        />
+      }
       renderItem={({ item }) => (
         <Pressable
           onPress={() => onLaunch(item.packageName)}
@@ -381,18 +389,20 @@ export function AppLibraryScreen({ navigation }: { navigation: AppNavigationProp
       <StatusBar barStyle={isDark ? 'light-content' : 'dark-content'} />
 
       {/* Navigation bar */}
-      <View style={[styles.navBar, { paddingTop: insets.top + 8, borderBottomColor: colors.separator }]}>
-        <Pressable
-          onPress={() => navigation.goBack()}
-          style={styles.backBtn}
-          accessibilityLabel="Back"
-        >
-          <Ionicons name="chevron-back" size={22} color={colors.systemBlue} />
-          <Text style={[typography.body, styles.backLabel, { color: colors.systemBlue }]}>Back</Text>
-        </Pressable>
-        <Text style={[typography.body, styles.navTitle, { color: colors.label }]}>App Library</Text>
-        <View style={styles.backBtn} />
-      </View>
+      <CupertinoNavigationBar
+        title="App Library"
+        largeTitle={false}
+        leftButton={
+          <Pressable
+            onPress={() => navigation.goBack()}
+            style={styles.backBtn}
+            accessibilityLabel="Back"
+          >
+            <Ionicons name="chevron-back" size={22} color={colors.systemBlue} />
+            <Text style={[typography.body, styles.backLabel, { color: colors.systemBlue }]}>Back</Text>
+          </Pressable>
+        }
+      />
 
       {/* Search bar */}
       <View style={styles.searchBarWrap}>
@@ -470,14 +480,6 @@ const styles = StyleSheet.create({
   root: {
     flex: 1,
   },
-  navBar: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    paddingHorizontal: 8,
-    paddingBottom: 10,
-    borderBottomWidth: StyleSheet.hairlineWidth,
-  },
   backBtn: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -486,10 +488,6 @@ const styles = StyleSheet.create({
   },
   backLabel: {
     fontWeight: '400',
-  },
-  navTitle: {
-    fontWeight: '600',
-    letterSpacing: -0.3,
   },
   searchBarWrap: {
     paddingHorizontal: 12,

--- a/src/screens/MailScreen.tsx
+++ b/src/screens/MailScreen.tsx
@@ -24,6 +24,7 @@ import {
 } from '../components';
 import type { AppNavigationProp } from '../navigation/types';
 import { hapticImpact, hapticNotification } from '../utils/haptics';
+import { avatarColorForName } from '../utils/avatarColor';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -63,12 +64,6 @@ function getInitials(name: string): string {
   return parts.map(p => p[0] || '').join('').toUpperCase().slice(0, 2);
 }
 
-const AVATAR_COLORS = ['#007AFF', '#5856D6', '#FF9500', '#34C759', '#FF3B30', '#AF52DE', '#5AC8FA', '#FF2D55'];
-function avatarColor(name: string): string {
-  let hash = 0;
-  for (let i = 0; i < name.length; i++) hash = name.charCodeAt(i) + ((hash << 5) - hash);
-  return AVATAR_COLORS[Math.abs(hash) % AVATAR_COLORS.length];
-}
 
 export function MailScreen({ navigation, route }: { navigation: AppNavigationProp; route?: { params?: { composeTo?: string; composeSubject?: string; composeBody?: string } } }) {
   const { theme, typography } = useTheme();
@@ -217,7 +212,7 @@ export function MailScreen({ navigation, route }: { navigation: AppNavigationPro
         <ScrollView contentContainerStyle={{ padding: 16, paddingBottom: insets.bottom + 80 }}>
           <Text style={[typography.title2, { color: colors.label, marginBottom: 12 }]}>{selectedEmail.subject}</Text>
           <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 16 }}>
-            <View style={[styles.avatar, { backgroundColor: avatarColor(selectedEmail.from) }]}>
+            <View style={[styles.avatar, { backgroundColor: avatarColorForName(selectedEmail.from) }]}>
               <Text style={[typography.callout, styles.avatarText]}>{getInitials(selectedEmail.from)}</Text>
             </View>
             <View style={{ marginLeft: 12, flex: 1 }}>
@@ -322,7 +317,7 @@ export function MailScreen({ navigation, route }: { navigation: AppNavigationPro
               onPress={() => handleOpenEmail(item)}
             >
               {!item.isRead && <View style={[styles.unreadDot, { backgroundColor: colors.systemBlue }]} />}
-              <View style={[styles.avatar, { backgroundColor: avatarColor(item.from) }]}>
+              <View style={[styles.avatar, { backgroundColor: avatarColorForName(item.from) }]}>
                 <Text style={[typography.callout, styles.avatarText]}>{getInitials(item.from)}</Text>
               </View>
               <View style={styles.emailContent}>

--- a/src/screens/MessagesScreen.tsx
+++ b/src/screens/MessagesScreen.tsx
@@ -25,6 +25,7 @@ import { CupertinoButton, CupertinoSwipeableRow, useAlert, SkeletonListRow } fro
 import { findContactByPhone } from '../utils/contacts';
 import { logger } from '../utils/logger';
 import { hapticImpact } from '../utils/haptics';
+import { avatarColorForName } from '../utils/avatarColor';
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -70,16 +71,6 @@ function getInitials(contact: DeviceContact): string {
 }
 
 const AVATAR_SIZE = 48;
-const AVATAR_COLORS = [
-  '#FF3B30', '#FF9500', '#FFCC00', '#34C759',
-  '#5AC8FA', '#007AFF', '#5856D6', '#AF52DE', '#FF2D55',
-];
-
-function avatarColor(address: string): string {
-  let hash = 0;
-  for (let i = 0; i < address.length; i++) hash = address.charCodeAt(i) + ((hash << 5) - hash);
-  return AVATAR_COLORS[Math.abs(hash) % AVATAR_COLORS.length];
-}
 
 // ─── Conversation Row ────────────────────────────────────────────────────────
 
@@ -121,7 +112,7 @@ const ConversationRow = React.memo(function ConversationRow({
   const displayName = contact
     ? `${contact.firstName} ${contact.lastName}`.trim()
     : conversation.address;
-  const bgColor = contact ? avatarColor(contact.id) : avatarColor(conversation.address);
+  const bgColor = avatarColorForName(displayName);
 
   const trailingActions = editMode ? [] : [
     { label: 'Delete', color: '#FF3B30', onPress: onDelete },

--- a/src/screens/MessagesScreen.tsx
+++ b/src/screens/MessagesScreen.tsx
@@ -21,7 +21,7 @@ import type { AppNavigationProp } from '../navigation/types';
 import * as Haptics from 'expo-haptics';
 import { useDevice, DeviceSms, DeviceContact } from '../store/DeviceStore';
 import { migrateAsyncStorageKey, draftStorageKey, draftLegacyStorageKey } from '../store/storage';
-import { CupertinoButton, CupertinoSwipeableRow, useAlert, SkeletonListRow } from '../components';
+import { CupertinoButton, CupertinoSwipeableRow, useAlert, SkeletonListRow, CupertinoNavigationBar } from '../components';
 import { findContactByPhone } from '../utils/contacts';
 import { logger } from '../utils/logger';
 import { hapticImpact } from '../utils/haptics';
@@ -540,10 +540,12 @@ export function MessagesScreen() {
     <View style={[styles.container, { backgroundColor: colors.systemBackground }]}>
       <StatusBar style={theme.dark ? 'light' : 'dark'} />
 
-      {/* Header */}
-      <View style={[styles.header, { paddingTop: insets.top }]}>
-        <View style={styles.headerTopRow}>
-          {editMode ? (
+      {/* Navigation bar */}
+      <CupertinoNavigationBar
+        title="Messages"
+        largeTitle={true}
+        leftButton={
+          editMode ? (
             <Pressable
               onPress={toggleEditMode}
               hitSlop={8}
@@ -562,40 +564,36 @@ export function MessagesScreen() {
             >
               <Ionicons name="chevron-back" size={28} color={colors.systemBlue} />
             </Pressable>
-          )}
+          )
+        }
+        rightButton={
+          !editMode ? (
+            <View style={styles.headerRight}>
+              <Pressable
+                onPress={toggleEditMode}
+                hitSlop={8}
+                style={{ marginRight: 16 }}
+                accessibilityRole="button"
+                accessibilityLabel="Edit conversations"
+              >
+                <Text style={[typography.body, { color: colors.systemBlue }]}>Edit</Text>
+              </Pressable>
+              <Pressable
+                onPress={handleComposePress}
+                hitSlop={8}
+                accessibilityRole="button"
+                accessibilityLabel="Compose new message"
+              >
+                <Ionicons name="create-outline" size={24} color={colors.systemBlue} />
+              </Pressable>
+            </View>
+          ) : undefined
+        }
+      />
 
-          <View style={styles.headerRight}>
-            {!editMode && (
-              <>
-                <Pressable
-                  onPress={toggleEditMode}
-                  hitSlop={8}
-                  style={{ marginRight: 16 }}
-                  accessibilityRole="button"
-                  accessibilityLabel="Edit conversations"
-                >
-                  <Text style={[typography.body, { color: colors.systemBlue }]}>Edit</Text>
-                </Pressable>
-                <Pressable
-                  onPress={handleComposePress}
-                  hitSlop={8}
-                  accessibilityRole="button"
-                  accessibilityLabel="Compose new message"
-                >
-                  <Ionicons name="create-outline" size={24} color={colors.systemBlue} />
-                </Pressable>
-              </>
-            )}
-          </View>
-        </View>
-
-        {/* Large title */}
-        <Text style={[typography.largeTitle, styles.largeTitle, { color: colors.label }]}>
-          Messages
-        </Text>
-
-        {/* Search bar */}
-        {!editMode && (
+      {/* Search bar */}
+      {!editMode && (
+        <View style={styles.searchBarWrap}>
           <View style={[styles.searchBar, { backgroundColor: colors.systemGray5 }]}>
             <Ionicons name="search" size={16} color={colors.systemGray} style={{ marginRight: 6 }} />
             <TextInput
@@ -614,8 +612,8 @@ export function MessagesScreen() {
               </Pressable>
             )}
           </View>
-        )}
-      </View>
+        </View>
+      )}
 
       {/* List or loading */}
       {!device.isReady ? (
@@ -676,16 +674,6 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
   },
-  header: {
-    paddingHorizontal: 16,
-    paddingBottom: 10,
-  },
-  headerTopRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    height: 44,
-  },
   headerRight: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -695,10 +683,9 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     marginLeft: -8,
   },
-  largeTitle: {
-    fontWeight: '700',
-    letterSpacing: 0.41,
-    marginBottom: 8,
+  searchBarWrap: {
+    paddingHorizontal: 16,
+    paddingBottom: 10,
   },
   searchBar: {
     flexDirection: 'row',

--- a/src/screens/PhoneScreen.tsx
+++ b/src/screens/PhoneScreen.tsx
@@ -23,6 +23,7 @@ import type { AppNavigationProp } from '../navigation/types';
 import type { CupertinoColors } from '../theme/CupertinoTheme';
 import { Typography } from '../theme/CupertinoTheme';
 import { hapticImpact, hapticNotification } from '../utils/haptics';
+import { avatarColorForName } from '../utils/avatarColor';
 
 const getLauncher = async () => {
   try {
@@ -44,16 +45,6 @@ function getFullName(contact: DeviceContact): string {
   return [contact.firstName, contact.lastName].filter(Boolean).join(' ') || contact.phone;
 }
 
-const AVATAR_COLORS = [
-  '#007AFF', '#34C759', '#FF9500', '#FF2D55',
-  '#AF52DE', '#5AC8FA', '#5856D6', '#FF3B30',
-  '#30B0C7', '#32ADE6',
-];
-
-function avatarColor(contact: DeviceContact): string {
-  const seed = contact.id.split('').reduce((acc, c) => acc + c.charCodeAt(0), 0);
-  return AVATAR_COLORS[seed % AVATAR_COLORS.length];
-}
 
 
 const KEYPAD_ROWS = [
@@ -67,7 +58,7 @@ const KEYPAD_ROWS = [
 
 function ContactAvatar({ contact, size = 40 }: { contact: DeviceContact; size?: number }) {
   const initials = getInitials(contact);
-  const bg = avatarColor(contact);
+  const bg = avatarColorForName(getFullName(contact));
   return (
     <View
       style={[

--- a/src/utils/__tests__/avatarColor.test.ts
+++ b/src/utils/__tests__/avatarColor.test.ts
@@ -1,0 +1,25 @@
+import { avatarColorForName } from '../avatarColor';
+
+describe('avatarColorForName', () => {
+  it('returns a hex color string', () => {
+    expect(avatarColorForName('Ana Silva')).toMatch(/^#[0-9A-F]{6}$/i);
+  });
+
+  it('is idempotent — same name always returns the same color', () => {
+    const name = 'João Santos';
+    expect(avatarColorForName(name)).toBe(avatarColorForName(name));
+  });
+
+  it('returns a color for an empty string without throwing', () => {
+    expect(() => avatarColorForName('')).not.toThrow();
+    expect(avatarColorForName('')).toMatch(/^#[0-9A-F]{6}$/i);
+  });
+
+  it('returns different colors for different names (distribution check)', () => {
+    const names = ['Alice', 'Bob', 'Carol', 'Dave', 'Eve', 'Frank', 'Grace', 'Heidi', 'Ivan'];
+    const colors = names.map(avatarColorForName);
+    const unique = new Set(colors);
+    // With 9 palette colors and 9 distinct names, expect at least 3 distinct colors
+    expect(unique.size).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/src/utils/avatarColor.ts
+++ b/src/utils/avatarColor.ts
@@ -1,0 +1,11 @@
+// djb2 hash for stable colour assignment across screens
+const AVATAR_COLORS = [
+  '#FF3B30', '#FF9500', '#FFCC00', '#34C759',
+  '#5AC8FA', '#007AFF', '#5856D6', '#AF52DE', '#FF2D55',
+];
+
+export function avatarColorForName(name: string): string {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) hash = name.charCodeAt(i) + ((hash << 5) - hash);
+  return AVATAR_COLORS[Math.abs(hash) % AVATAR_COLORS.length];
+}


### PR DESCRIPTION
## Summary

Closes #385.

### Avatar colour consolidation

Extracted `avatarColorForName(name: string): string` to `src/utils/avatarColor.ts`.

Algorithm: djb2 (`hash = charCode + ((hash << 5) - hash)`). Palette: MessagesScreen's 9-colour superset of MailScreen's 8 (`#FFCC00` added for more variety). Same name → same colour on every screen.

Screens updated:
- `MailScreen.tsx` — removed local `AVATAR_COLORS` + `avatarColor`, imports `avatarColorForName`
- `MessagesScreen.tsx` — same; uses `displayName` (full name when contact found, address otherwise) — was seeding from `contact.id`, which differed from PhoneScreen's seeding
- `PhoneScreen.tsx` — same; uses `getFullName(contact)` so colours match MessagesScreen for the same person

Left alone (different semantics): `LockScreen.tsx` `appIconColor` and `AppLibraryScreen.tsx` hsl fallback — both colour app icons, not people.

### MessagesScreen nav bar

Migrated to `CupertinoNavigationBar title="Messages" largeTitle={true}`. Dynamic `leftButton` (back arrow or "Cancel" in edit mode) and `rightButton` (Edit + compose or nothing). Search bar moved to a sibling `View` below the bar, still conditional on `!editMode`. Dead styles `header`, `headerTopRow`, `largeTitle` removed.

### AppLibraryScreen nav bar

Replaced the bespoke `<View style={styles.navBar}>` header with `CupertinoNavigationBar title="App Library" largeTitle={false}`. Dead `styles.navBar` and `styles.navTitle` removed.

### AppLibraryScreen empty state

Added `ListEmptyComponent={<CupertinoEmptyState icon="search-outline" title="No Results" message="No apps match your search." />}` to the `SearchResults` `FlatList`.

### What's left for PhoneScreen and ConversationScreen

`PhoneScreen` has a `CupertinoSegmentedControl` (Favorites / Recents / Contacts) that lives inside the nav bar area. `CupertinoNavigationBar` has no slot for a segmented control — it would need a new `bottomContent?: React.ReactNode` prop below the large title. Not in scope for this issue.

`ConversationScreen` has a contact name + avatar as the title and a phone/FaceTime action row. Both require a custom layout that doesn't map to the current `title: string` + `leftButton`/`rightButton` API. Would need a `customTitle?: React.ReactNode` escape hatch or a dedicated variant.

## Verification

- `grep -rn "function avatarColor" src/screens` → 0 results ✓
- `npx tsc --noEmit` → clean ✓
- `npm run lint` → 0 errors, 1 pre-existing warning (ClockScreen `tzTick`) ✓
- `npm test` → 8 pre-existing failures (same 4 suites as on `main`); 0 new failures ✓

## Red step

Stubbed `avatarColorForName` to always return `#FF0000`. Distribution test failed (`Expected: >= 3, Received: 1`). Restored — 4 tests pass.
