### PR TITLE
fix/issue-386: Remove false language/restart claims from LanguageRegionScreen

### DIFF
--- a/src/screens/settings/LanguageRegionScreen.tsx
+++ b/src/screens/settings/LanguageRegionScreen.tsx
@@ -12,18 +12,6 @@ import {
 } from '../../components';
 import type { AppNavigationProp } from '../../navigation/types';
 
-const LANGUAGES: { code: string; name: string; native: string }[] = [
-  { code: 'en-US', name: 'English (US)', native: 'English (US)' },
-  { code: 'es', name: 'Spanish', native: 'Español' },
-  { code: 'fr', name: 'French', native: 'Français' },
-  { code: 'de', name: 'German', native: 'Deutsch' },
-  { code: 'pt', name: 'Portuguese', native: 'Português' },
-  { code: 'zh-Hans', name: 'Chinese (Simplified)', native: '中文(简体)' },
-  { code: 'ja', name: 'Japanese', native: '日本語' },
-  { code: 'ko', name: 'Korean', native: '한국어' },
-  { code: 'ar', name: 'Arabic', native: 'العربية' },
-];
-
 const REGIONS: { code: string; name: string }[] = [
   { code: 'US', name: 'United States' },
   { code: 'GB', name: 'United Kingdom' },
@@ -37,7 +25,6 @@ const REGIONS: { code: string; name: string }[] = [
 
 const CALENDAR_TYPES = ['Gregorian', 'Japanese', 'Buddhist', 'Hebrew', 'Islamic'];
 
-const LANG_STORAGE_KEY = '@iostoandroid/language';
 const REGION_STORAGE_KEY = '@iostoandroid/region';
 
 export function LanguageRegionScreen({ navigation }: { navigation: AppNavigationProp }) {
@@ -45,30 +32,17 @@ export function LanguageRegionScreen({ navigation }: { navigation: AppNavigation
   const { colors } = theme;
   const insets = useSafeAreaInsets();
   const { update } = useSettings();
-  const [showLangPicker, setShowLangPicker] = useState(false);
   const [showRegionPicker, setShowRegionPicker] = useState(false);
   const [showCalendarPicker, setShowCalendarPicker] = useState(false);
   const [calendarType, setCalendarType] = useState('Gregorian');
-  const [selectedLang, setSelectedLang] = useState<string>('en-US');
   const [selectedRegion, setSelectedRegion] = useState<string>('US');
 
-  // Load persisted language/region preferences
+  // Load persisted region preference
   useEffect(() => {
-    Promise.all([
-      AsyncStorage.getItem(LANG_STORAGE_KEY),
-      AsyncStorage.getItem(REGION_STORAGE_KEY),
-    ]).then(([lang, region]) => {
-      if (lang) setSelectedLang(lang);
+    AsyncStorage.getItem(REGION_STORAGE_KEY).then((region) => {
       if (region) setSelectedRegion(region);
     }).catch(() => {});
   }, []);
-
-  const handleSelectLanguage = useCallback((code: string, displayName: string) => {
-    setSelectedLang(code);
-    update('language', displayName);
-    AsyncStorage.setItem(LANG_STORAGE_KEY, code).catch(() => {});
-    setShowLangPicker(false);
-  }, [update]);
 
   const handleSelectRegion = useCallback((code: string, regionName: string) => {
     setSelectedRegion(code);
@@ -77,7 +51,6 @@ export function LanguageRegionScreen({ navigation }: { navigation: AppNavigation
     setShowRegionPicker(false);
   }, [update]);
 
-  const currentLang = LANGUAGES.find((l) => l.code === selectedLang) ?? LANGUAGES[0];
   const currentRegion = REGIONS.find((r) => r.code === selectedRegion) ?? REGIONS[0];
 
   const trailing = (text: string) => (
@@ -116,31 +89,8 @@ export function LanguageRegionScreen({ navigation }: { navigation: AppNavigation
         contentContainerStyle={{ paddingBottom: insets.bottom + 90 }}
         showsVerticalScrollIndicator={false}
       >
-        {/* Language section */}
-        <View style={{ paddingHorizontal: spacing.md, marginTop: spacing.md }}>
-          <CupertinoListSection
-            header="Language"
-            footer="Language preference affects app text display. Restart the app to apply changes."
-          >
-            {LANGUAGES.map((lang) => (
-              <CupertinoListTile
-                key={lang.code}
-                title={lang.name}
-                subtitle={lang.native !== lang.name ? lang.native : undefined}
-                trailing={
-                  selectedLang === lang.code ? (
-                    <Text style={[typography.body, { color: colors.systemBlue, fontWeight: '600' }]}>✓</Text>
-                  ) : undefined
-                }
-                showChevron={false}
-                onPress={() => handleSelectLanguage(lang.code, lang.name)}
-              />
-            ))}
-          </CupertinoListSection>
-        </View>
-
         {/* Region section */}
-        <View style={{ paddingHorizontal: spacing.md }}>
+        <View style={{ paddingHorizontal: spacing.md, marginTop: spacing.md }}>
           <CupertinoListSection
             header="Region"
             footer="Region affects number, date, and currency formats."
@@ -167,11 +117,6 @@ export function LanguageRegionScreen({ navigation }: { navigation: AppNavigation
             header="Format Preview"
             footer="These preferences control formatting within the app."
           >
-            <CupertinoListTile
-              title="Preferred Language"
-              trailing={trailing(`${currentLang.name} (${currentLang.native})`)}
-              onPress={() => setShowLangPicker(true)}
-            />
             <CupertinoListTile
               title="Region"
               trailing={trailing(currentRegion.name)}
@@ -201,16 +146,6 @@ export function LanguageRegionScreen({ navigation }: { navigation: AppNavigation
         </View>
       </ScrollView>
 
-      <CupertinoActionSheet
-        visible={showLangPicker}
-        onClose={() => setShowLangPicker(false)}
-        title="Preferred Language"
-        options={LANGUAGES.map((l) => ({
-          label: `${l.name} — ${l.native}`,
-          onPress: () => handleSelectLanguage(l.code, l.name),
-        }))}
-        cancelLabel="Cancel"
-      />
       <CupertinoActionSheet
         visible={showRegionPicker}
         onClose={() => setShowRegionPicker(false)}

--- a/src/screens/settings/__tests__/LanguageRegionScreen.test.tsx
+++ b/src/screens/settings/__tests__/LanguageRegionScreen.test.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react-native';
+import { render } from '../../../test-utils';
+import { LanguageRegionScreen } from '../LanguageRegionScreen';
+
+const mockNavigation = { navigate: jest.fn(), goBack: jest.fn() } as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+
+describe('LanguageRegionScreen', () => {
+  it('renders without crashing', () => {
+    const { toJSON } = render(<LanguageRegionScreen navigation={mockNavigation} />);
+    expect(toJSON()).toBeTruthy();
+  });
+
+  it('shows °F and US measurement when region is United States (default)', () => {
+    const { getByText } = render(<LanguageRegionScreen navigation={mockNavigation} />);
+    expect(getByText('°F')).toBeTruthy();
+    expect(getByText('US')).toBeTruthy();
+  });
+
+  it('switches to °C and Metric when a metric region is selected', () => {
+    const { getByText } = render(<LanguageRegionScreen navigation={mockNavigation} />);
+    fireEvent.press(getByText('France'));
+    expect(getByText('°C')).toBeTruthy();
+    expect(getByText('Metric')).toBeTruthy();
+  });
+
+  it('footer does not mention language text display or restart', () => {
+    const { queryByText } = render(<LanguageRegionScreen navigation={mockNavigation} />);
+    expect(queryByText(/app text display/i)).toBeNull();
+    expect(queryByText(/restart/i)).toBeNull();
+  });
+
+  it('does not render a Language section', () => {
+    const { queryByText } = render(<LanguageRegionScreen navigation={mockNavigation} />);
+    expect(queryByText(/^English \(US\)$/)).toBeNull();
+    expect(queryByText(/^Spanish$/)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #386.

Removed the "Language" list section from `LanguageRegionScreen` entirely. The project has no i18n — `grep -rn "i18n\|useTranslation" src` returns zero results. The persisted language preference was only shown as trailing text in `GeneralScreen`; nothing ever consumed it to change the app's display language. Keeping it with a misleading footer invited users to restart and conclude the app was broken when nothing changed.

**What was removed:**
- `LANGUAGES` array constant and `LANG_STORAGE_KEY`
- `selectedLang`, `showLangPicker` state
- `handleSelectLanguage` callback
- `currentLang` computed
- Language section JSX (header + list of languages)
- "Preferred Language" row from the Format Preview section
- Language `CupertinoActionSheet`
- Old footer: "Language preference affects app text display. Restart the app to apply changes."

**What remains and works:**
- Region selection → persisted, drives `localeInfo` (temperature unit, measurement system, number format)
- Calendar type selection
- Format Preview section showing derived values from the selected region

The `update('language', ...)` call was removed; `settings.language` in `GeneralScreen` will now show the SettingsStore default ("English"), which is accurate.

## Verification

- `npx tsc --noEmit` → clean ✓
- `npm run lint` → 0 errors, 1 pre-existing warning ✓
- `npm test` → same 8 pre-existing failures (FoldersStore, SettingsScreen, LockScreen, WeatherScreen); 0 new failures ✓

## Red step

Temporarily restored the old footer text. The test `footer does not mention language text display or restart` failed with the text found in the render output. Restored fix — 5 tests pass:

```
✓ renders without crashing
✓ shows °F and US measurement when region is United States (default)
✓ switches to °C and Metric when a metric region is selected
✓ footer does not mention language text display or restart
✓ does not render a Language section
```
