### PR TITLE
fix: harden bridge loading and add keyboards/ringtone methods (#388)

### DIFF
--- a/app.json
+++ b/app.json
@@ -37,6 +37,7 @@
         "android.permission.ACCESS_COARSE_LOCATION",
         "android.permission.ACCESS_WIFI_STATE",
         "android.permission.CHANGE_WIFI_STATE",
+        "android.permission.NEARBY_WIFI_DEVICES",
         "android.permission.INTERNET",
         "android.permission.ACCESS_NETWORK_STATE",
         "android.permission.BLUETOOTH",

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -300,6 +300,11 @@ jest.mock('./modules/launcher-module/src', () => ({
     getCalendarEvents: jest.fn(() => Promise.resolve([])),
     getNowPlaying: jest.fn(() => Promise.resolve({ title: '', artist: '', album: '', isPlaying: false, packageName: '' })),
     uninstallApp: jest.fn(() => Promise.resolve(true)),
+    getInstalledKeyboards: jest.fn(() => Promise.resolve([])),
+    getRingtone: jest.fn(() => Promise.resolve('')),
+    canWriteSystemSettings: jest.fn(() => Promise.resolve(false)),
+    openWriteSettingsAccess: jest.fn(() => Promise.resolve(true)),
+    setRingtone: jest.fn(() => Promise.resolve(false)),
   },
 }));
 

--- a/modules/launcher-module/android/src/main/java/com/iostoandroid/launcher/LauncherModule.kt
+++ b/modules/launcher-module/android/src/main/java/com/iostoandroid/launcher/LauncherModule.kt
@@ -977,6 +977,59 @@ class LauncherModule : Module() {
             perms
         }
 
+        // ── Keyboards ────────────────────────────────────────────────────
+
+        AsyncFunction("getInstalledKeyboards") {
+            val imm = context.getSystemService(Context.INPUT_METHOD_SERVICE) as android.view.inputmethod.InputMethodManager
+            val enabled = imm.enabledInputMethodList.map { it.id }.toSet()
+            imm.inputMethodList.map { imi ->
+                mapOf("id" to imi.id, "label" to imi.loadLabel(context.packageManager).toString(), "enabled" to enabled.contains(imi.id))
+            }
+        }
+
+        // ── Ringtone ─────────────────────────────────────────────────────
+
+        AsyncFunction("getRingtone") {
+            val uri = android.media.RingtoneManager.getActualDefaultRingtoneUri(
+                context, android.media.RingtoneManager.TYPE_RINGTONE
+            )
+            uri?.toString() ?: ""
+        }
+
+        AsyncFunction("canWriteSystemSettings") {
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
+                android.provider.Settings.System.canWrite(context)
+            } else {
+                true
+            }
+        }
+
+        AsyncFunction("openWriteSettingsAccess") {
+            val intent = android.content.Intent(
+                android.provider.Settings.ACTION_MANAGE_WRITE_SETTINGS,
+                android.net.Uri.parse("package:${context.packageName}")
+            )
+            intent.addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK)
+            context.startActivity(intent)
+            true
+        }
+
+        AsyncFunction("setRingtone") { uri: String ->
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M &&
+                !android.provider.Settings.System.canWrite(context)
+            ) {
+                return@AsyncFunction false
+            }
+            try {
+                android.media.RingtoneManager.setActualDefaultRingtoneUri(
+                    context,
+                    android.media.RingtoneManager.TYPE_RINGTONE,
+                    android.net.Uri.parse(uri)
+                )
+                true
+            } catch (e: Exception) { false }
+        }
+
         // ── Lifecycle ────────────────────────────────────────────────────
 
         OnDestroy {

--- a/modules/launcher-module/src/__tests__/index.test.ts
+++ b/modules/launcher-module/src/__tests__/index.test.ts
@@ -49,6 +49,31 @@ function loadBridge() {
   return mod!;
 }
 
+describe('requireNativeModule try/catch hardening', () => {
+  beforeAll(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+  afterAll(() => {
+    (console.error as jest.Mock).mockRestore();
+  });
+
+  it('exports the stub (not undefined) when requireNativeModule throws on Android', async () => {
+    const { requireNativeModule } = jest.requireMock('expo') as { requireNativeModule: jest.Mock };
+    requireNativeModule.mockImplementationOnce(() => { throw new Error('module not found'); });
+
+    let mod: typeof import('../index');
+    jest.isolateModules(() => { mod = jest.requireActual('../index'); });
+
+    // The module must export a callable default (the stub), never crash at import time.
+    expect(mod!.default).toBeDefined();
+    // Stub methods resolve to their default values without throwing.
+    await expect(mod!.default.getInstalledApps()).resolves.toEqual([]);
+    await expect(mod!.default.getInstalledKeyboards()).resolves.toEqual([]);
+    await expect(mod!.default.getRingtone()).resolves.toBe('');
+    await expect(mod!.default.canWriteSystemSettings()).resolves.toBe(false);
+  });
+});
+
 describe('LauncherModule bridge error reporting', () => {
   let mod: typeof import('../index');
   let listener: jest.Mock;

--- a/modules/launcher-module/src/index.ts
+++ b/modules/launcher-module/src/index.ts
@@ -137,6 +137,12 @@ export interface DailyScreenTime {
   topApps: ScreenTimeApp[];
 }
 
+export interface InstalledKeyboard {
+  id: string;
+  label: string;
+  enabled: boolean;
+}
+
 interface LauncherModuleType {
   // Apps
   getInstalledApps(): Promise<InstalledApp[]>;
@@ -205,11 +211,23 @@ interface LauncherModuleType {
   // Permissions
   requestAllPermissions(): Promise<boolean>;
   checkPermissions(): Promise<Record<string, boolean>>;
+  // Keyboards
+  getInstalledKeyboards(): Promise<InstalledKeyboard[]>;
+  // Ringtone
+  getRingtone(): Promise<string>;
+  canWriteSystemSettings(): Promise<boolean>;
+  openWriteSettingsAccess(): Promise<boolean>;
+  setRingtone(uri: string): Promise<boolean>;
 }
 
 const isAndroid = Platform.OS === 'android';
 
-const nativeModule = isAndroid ? requireNativeModule('LauncherModule') : null;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- requireNativeModule returns an opaque native object; typing it as any is required for property access
+let nativeModule: any = null;
+if (isAndroid) {
+  try { nativeModule = requireNativeModule('LauncherModule'); }
+  catch (e) { console.error('LauncherModule unavailable, using stub', e); }
+}
 
 const stub: LauncherModuleType = {
   getInstalledApps: async () => [],
@@ -252,6 +270,11 @@ const stub: LauncherModuleType = {
   sendSms: async () => false,
   requestAllPermissions: async () => false,
   checkPermissions: async () => ({}),
+  getInstalledKeyboards: async () => [],
+  getRingtone: async () => '',
+  canWriteSystemSettings: async () => false,
+  openWriteSettingsAccess: async () => false,
+  setRingtone: async () => false,
   getCalendarEvents: async () => [],
   getNowPlaying: async () => ({ title: '', artist: '', album: '', isPlaying: false, packageName: '' }),
   mediaPrev: async () => false,
@@ -469,6 +492,26 @@ function createBridgedModule(): LauncherModuleType {
     getTodayScreenTime: async () => {
       try { return await nativeModule.getTodayScreenTime(); }
       catch (e) { console.error('LauncherModule.getTodayScreenTime failed:', e); reportBridgeError('getTodayScreenTime', e); return { totalMinutes: 0, topApps: [] }; }
+    },
+    getInstalledKeyboards: async () => {
+      try { return await nativeModule.getInstalledKeyboards(); }
+      catch (e) { console.error('LauncherModule.getInstalledKeyboards failed:', e); reportBridgeError('getInstalledKeyboards', e); return []; }
+    },
+    getRingtone: async () => {
+      try { return await nativeModule.getRingtone(); }
+      catch (e) { console.error('LauncherModule.getRingtone failed:', e); reportBridgeError('getRingtone', e); return ''; }
+    },
+    canWriteSystemSettings: async () => {
+      try { return await nativeModule.canWriteSystemSettings(); }
+      catch (e) { console.error('LauncherModule.canWriteSystemSettings failed:', e); reportBridgeError('canWriteSystemSettings', e); return false; }
+    },
+    openWriteSettingsAccess: async () => {
+      try { return await nativeModule.openWriteSettingsAccess(); }
+      catch (e) { console.error('LauncherModule.openWriteSettingsAccess failed:', e); reportBridgeError('openWriteSettingsAccess', e); return false; }
+    },
+    setRingtone: async (uri: string) => {
+      try { return await nativeModule.setRingtone(uri); }
+      catch (e) { console.error('LauncherModule.setRingtone failed:', e); reportBridgeError('setRingtone', e); return false; }
     },
   };
 }


### PR DESCRIPTION
## Summary

Closes #388.

Four independent improvements to the bridge, in order of implementation:

### 1. Hardened `requireNativeModule` loading

`modules/launcher-module/src/index.ts:225` changed from:
```ts
const nativeModule = isAndroid ? requireNativeModule('LauncherModule') : null;
```
to:
```ts
let nativeModule: any = null;
if (isAndroid) {
  try { nativeModule = requireNativeModule('LauncherModule'); }
  catch (e) { console.error('LauncherModule unavailable, using stub', e); }
}
```
When `requireNativeModule` throws (e.g. Expo Go on Android), the module now falls back to the stub instead of crashing the entire bundle at evaluation time. The `ErrorBoundary` in `App.tsx` cannot catch module-level errors.

**Red step (proven):** reverted to old code, ran `requireNativeModule try/catch hardening` test → failed with:
```
at Object.<anonymous> (modules/launcher-module/src/index.ts:225:53)
at requireActual (index.test.ts:65:44)
Error: module not found
```
Restored fix → test passes. 16/16 tests in the bridge suite pass.

### 2. `getInstalledKeyboards` — new method

Added in 4 parity points:
- **Interface**: `getInstalledKeyboards(): Promise<InstalledKeyboard[]>` + new `InstalledKeyboard` export type
- **Stub**: `async () => []`
- **Wrapper**: try/catch + `reportBridgeError`
- **Kotlin**: `InputMethodManager.inputMethodList` + `enabledInputMethodList`, returns `id/label/enabled`

No special permissions required (`InputMethodManager` is always available).

### 3. Ringtone methods — new pair following notification access pattern

Four methods following the `isNotificationAccessGranted` / `openNotificationAccessSettings` pattern line-by-line:

| Method | Interface | Stub | Wrapper | Kotlin |
|--------|-----------|------|---------|--------|
| `getRingtone` | ✓ | `''` | ✓ | `RingtoneManager.getActualDefaultRingtoneUri` (no permission needed) |
| `canWriteSystemSettings` | ✓ | `false` | ✓ | `Settings.System.canWrite(context)` |
| `openWriteSettingsAccess` | ✓ | `false` | ✓ | `ACTION_MANAGE_WRITE_SETTINGS` intent |
| `setRingtone` | ✓ | `false` | ✓ | `RingtoneManager.setActualDefaultRingtoneUri` (gated on `canWrite`) |

Parity count: 4 methods × 4 parity points = 16 definitions. Both sides (TS + Kotlin): 16.

### 4. `NEARBY_WIFI_DEVICES` added to `app.json`

**Decision on `neverForLocation` flag:** NOT used. `getWifiNetworks` returns `bssid` (MAC address) and `level` (RSSI). BSSID + RSSI can be used for Wi-Fi triangulation to derive approximate location. Applying `neverForLocation` in that context would be a false declaration. `ACCESS_FINE_LOCATION` remains declared and continues to cover `getWifiNetworks` on Android 12 and below; `NEARBY_WIFI_DEVICES` extends the explicit capability declaration on API 33+.

## Verification

- `requireNativeModule` try/catch: red step proven above ✓
- `npx tsc --noEmit` → exit 0 ✓
- `npm run lint` → 0 errors, 1 pre-existing warning ✓
- `npm test --no-coverage` → 491 pass / 8 fail; all 8 are pre-existing baseline (FoldersStore ×2, LockScreen ×3, SettingsScreen ×1, WeatherScreen ×2); the +1 pass is the new try/catch test ✓
- No hidden APIs called by reflection ✓
