### PR TITLE
fix: app icons never render in App Library, Spotlight, Lock Screen and Notification Center

### DIFF
--- a/modules/launcher-module/src/index.ts
+++ b/modules/launcher-module/src/index.ts
@@ -4,6 +4,13 @@ import { Platform } from 'react-native';
 export interface InstalledApp {
   name: string;
   packageName: string;
+  /**
+   * A COMPLETE data URI — `data:image/png;base64,<payload>` — already prefixed by
+   * `LauncherModule.drawableToBase64` on the Kotlin side. Pass it straight to
+   * `<Image source={{ uri: app.icon }} />`; prefixing it again yields a
+   * double-prefixed URI that silently renders nothing.
+   * Empty string when the icon could not be loaded.
+   */
   icon: string;
   isSystem: boolean;
 }

--- a/src/screens/AppLibraryScreen.tsx
+++ b/src/screens/AppLibraryScreen.tsx
@@ -75,7 +75,7 @@ const AppIcon = React.memo(function AppIcon({ app, size = ICON_SIZE }: { app: In
   if (app.icon) {
     return (
       <Image
-        source={{ uri: `data:image/png;base64,${app.icon}` }}
+        source={{ uri: app.icon }}
         style={{ width: size, height: size, borderRadius: radius }}
         resizeMode="cover"
       />

--- a/src/screens/LockScreen.tsx
+++ b/src/screens/LockScreen.tsx
@@ -181,7 +181,7 @@ function NotificationGroupCard({
       <Pressable onPress={count > 1 ? onToggle : undefined} style={styles.groupHeader} accessibilityLabel="Toggle notification group" accessibilityRole="button">
         {group.appIcon ? (
           <Image
-            source={{ uri: `data:image/png;base64,${group.appIcon}` }}
+            source={{ uri: group.appIcon }}
             style={styles.groupAppIcon}
           />
         ) : (

--- a/src/screens/NotificationCenterScreen.tsx
+++ b/src/screens/NotificationCenterScreen.tsx
@@ -286,7 +286,7 @@ export function NotificationCenterScreen() {
                     {/* App name header */}
                     <View style={styles.groupHeader}>
                       {group.appIcon ? (
-                        <Image source={{ uri: `data:image/png;base64,${group.appIcon}` }} style={styles.appIcon} />
+                        <Image source={{ uri: group.appIcon }} style={styles.appIcon} />
                       ) : (
                         <View style={styles.appIconFallback}>
                           <Ionicons name="apps" size={14} color="#FFFFFF" />

--- a/src/screens/SpotlightSearchScreen.tsx
+++ b/src/screens/SpotlightSearchScreen.tsx
@@ -164,7 +164,7 @@ function AppIcon({ app, size = ICON_SIZE }: { app: InstalledApp; size?: number }
   if (app.icon) {
     return (
       <Image
-        source={{ uri: `data:image/png;base64,${app.icon}` }}
+        source={{ uri: app.icon }}
         style={{ width: size, height: size, borderRadius: radius }}
         resizeMode="cover"
       />

--- a/src/screens/__tests__/appIconDataUri.test.ts
+++ b/src/screens/__tests__/appIconDataUri.test.ts
@@ -1,0 +1,53 @@
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * Regression guard for the double-prefixed data URI bug.
+ *
+ * `LauncherModule.drawableToBase64` (Kotlin) returns a COMPLETE data URI —
+ * `"data:image/png;base64," + Base64.encodeToString(...)`. Four call sites
+ * prepended the prefix a second time, producing
+ * `data:image/png;base64,data:image/png;base64,iVBOR...`, which React Native's
+ * <Image> silently fails to decode: no icons in App Library, Spotlight search,
+ * the Lock Screen notification stack, or Notification Center — with no error.
+ *
+ * Icons flowing from the native bridge must be passed through untouched.
+ */
+
+const SRC = path.join(__dirname, '..', '..');
+
+function walk(dir: string): string[] {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      return entry.name === '__tests__' || entry.name === 'node_modules' ? [] : walk(full);
+    }
+    return /\.tsx?$/.test(entry.name) ? [full] : [];
+  });
+}
+
+describe('app icons from the native bridge', () => {
+  it('are never re-prefixed with a data: URI scheme', () => {
+    const offenders = walk(SRC)
+      .map((file) => ({ file, source: fs.readFileSync(file, 'utf8') }))
+      .flatMap(({ file, source }) =>
+        source
+          .split('\n')
+          .map((line, i) => ({ line, lineNo: i + 1 }))
+          // Template literal that hardcodes the prefix and then interpolates.
+          .filter(({ line }) => /data:image\/\w+;base64,\$\{/.test(line))
+          .map(({ lineNo }) => `${path.relative(SRC, file)}:${lineNo}`)
+      );
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('documents the full-data-URI contract on InstalledApp.icon', () => {
+    const bridge = fs.readFileSync(
+      path.join(SRC, '..', 'modules', 'launcher-module', 'src', 'index.ts'),
+      'utf8'
+    );
+    // The comment is the only thing standing between the next reader and this bug.
+    expect(bridge).toMatch(/COMPLETE data URI/);
+  });
+});


### PR DESCRIPTION
## Root cause

`LauncherModule.drawableToBase64` (Kotlin, `LauncherModule.kt:1034`) returns a **complete** data URI:

```kotlin
return "data:image/png;base64," + Base64.encodeToString(bytes, Base64.NO_WRAP)
```

Four TypeScript call sites prepended the prefix a second time, producing `data:image/png;base64,data:image/png;base64,iVBOR...`. React Native's `<Image>` silently fails to decode that — no icon, no error, no console warning.

## Symptoms this explains

Reported from the device, all four now fixed:

| Symptom | Site |
|---|---|
| App Library shows no app icons | `AppLibraryScreen.tsx:78` |
| Spotlight search shows no icons | `SpotlightSearchScreen.tsx:167` |
| Lock Screen notification stack | `LockScreen.tsx:184` |
| Notification Center groups | `NotificationCenterScreen.tsx:289` |

## Blast radius — all consumers enumerated

Every consumer of `InstalledApp.icon` / `appIcon` was checked:

**Already correct, untouched** (pass `app.icon` straight through):
- `LauncherHomeScreen.tsx:233` — home grid
- `LauncherHomeScreen.tsx:344` — folder mini icons
- `MultitaskScreen.tsx:132,158`
- `QuickSwitchHomeBar.tsx:154,170,186`

That asymmetry is what pinned the diagnosis: the sites that always worked are exactly the ones without the second prefix. No consumer was left in an inconsistent state — after this change all nine treat `icon` identically.

## Why it happened, and the actual fix

`InstalledApp.icon` was typed as a bare `string` with nothing recording which half of the URI it carries. Half the readers guessed raw base64, half guessed data URI. The type is now documented at `modules/launcher-module/src/index.ts`, and a regression guard (`src/screens/__tests__/appIconDataUri.test.ts`) greps `src/` for the re-prefix pattern and asserts the doc comment survives.

## Verification

- **Red step proven:** reverting `AppLibraryScreen` alone fails the guard, pointing at `screens/AppLibraryScreen.tsx:78`. Restored → passes.
- `npm run lint` — 0 errors (1 pre-existing warning in `ClockScreen.tsx:258`, untouched)
- `npx tsc --noEmit` — clean
- `npm test` — **505 pass / 8 fail**; baseline is 503/8. Two new passing tests, zero new failures.

## Note on how this was found

This class of defect — visually broken but silent at runtime — was invisible to the static audit that produced #352 and its 38 sub-issues. That audit searched for "state persisted but never consumed" and found it 38 times, but nothing in it could see an icon that fails to decode. Found here by tracing the bridge contract end to end.