### PR TITLE
fix: photo viewer cannot swipe to the next photo

### DIFF
--- a/src/screens/PhotosScreen.tsx
+++ b/src/screens/PhotosScreen.tsx
@@ -91,7 +91,14 @@ export function PhotosScreen({ navigation }: { navigation: AppNavigationProp }) 
   const [loadingLibrary, setLoadingLibrary] = useState(false);
 
   // ---- Full-screen viewer state ----
-  const [selectedAsset, setSelectedAsset] = useState<MediaLibrary.Asset | null>(null);
+  // The viewer carries the list it was opened from, so it can page sideways
+  // through that list. Holding only the asset (as it did) left no way to reach
+  // the neighbours without backing out to the grid.
+  const [viewer, setViewer] = useState<{ assets: MediaLibrary.Asset[]; index: number } | null>(null);
+  const openViewer = useCallback(
+    (assets: MediaLibrary.Asset[], index: number) => setViewer({ assets, index }),
+    []
+  );
 
   // ---- For You tab state ----
   const [forYouAssets, setForYouAssets] = useState<MediaLibrary.Asset[]>([]);
@@ -387,18 +394,54 @@ export function PhotosScreen({ navigation }: { navigation: AppNavigationProp }) 
   // ==================================================================
   // Full-screen photo viewer
   // ==================================================================
-  if (selectedAsset) {
+  if (viewer) {
+    const current = viewer.assets[viewer.index];
     return (
       <View style={[styles.fullView, { paddingTop: insets.top, paddingBottom: insets.bottom }]}>
         <View style={styles.fullTopBar}>
-          <Pressable onPress={() => setSelectedAsset(null)} accessibilityLabel="Back" accessibilityRole="button">
+          <Pressable onPress={() => setViewer(null)} accessibilityLabel="Back" accessibilityRole="button">
             <Ionicons name="chevron-back" size={28} color="#fff" />
           </Pressable>
-          <Pressable onPress={() => handleShare(selectedAsset)} accessibilityLabel="Share photo" accessibilityRole="button">
+          {viewer.assets.length > 1 ? (
+            <Text style={styles.fullCounter}>
+              {viewer.index + 1} of {viewer.assets.length}
+            </Text>
+          ) : null}
+          <Pressable
+            onPress={() => current && handleShare(current)}
+            accessibilityLabel="Share photo"
+            accessibilityRole="button"
+          >
             <Ionicons name="share-outline" size={24} color="#fff" />
           </Pressable>
         </View>
-        <Image source={{ uri: selectedAsset.uri }} style={styles.fullImage} resizeMode="contain" />
+        <FlatList
+          data={viewer.assets}
+          keyExtractor={(item) => item.id}
+          horizontal
+          pagingEnabled
+          showsHorizontalScrollIndicator={false}
+          initialScrollIndex={viewer.index}
+          // Every page is exactly one screen wide, so the offset is arithmetic —
+          // without this, initialScrollIndex cannot resolve and the viewer opens
+          // on the first photo instead of the tapped one.
+          getItemLayout={(_, i) => ({
+            length: SCREEN_WIDTH,
+            offset: SCREEN_WIDTH * i,
+            index: i,
+          })}
+          onMomentumScrollEnd={(e) => {
+            const next = Math.round(e.nativeEvent.contentOffset.x / SCREEN_WIDTH);
+            if (next !== viewer.index) setViewer({ ...viewer, index: next });
+          }}
+          renderItem={({ item }) => (
+            <Image
+              source={{ uri: item.uri }}
+              style={{ width: SCREEN_WIDTH, height: '100%' }}
+              resizeMode="contain"
+            />
+          )}
+        />
       </View>
     );
   }
@@ -443,8 +486,8 @@ export function PhotosScreen({ navigation }: { navigation: AppNavigationProp }) 
             numColumns={COLS}
             columnWrapperStyle={{ gap: GRID_GAP }}
             contentContainerStyle={{ gap: GRID_GAP, padding: GRID_GAP, paddingBottom: insets.bottom + 90 }}
-            renderItem={({ item }) => (
-              <Pressable onPress={() => setSelectedAsset(item)} accessibilityLabel="Photo" accessibilityRole="button">
+            renderItem={({ item, index }) => (
+              <Pressable onPress={() => openViewer(albumAssets, index)} accessibilityLabel="Photo" accessibilityRole="button">
                 <Image source={{ uri: item.uri }} style={styles.thumb} />
               </Pressable>
             )}
@@ -574,8 +617,8 @@ export function PhotosScreen({ navigation }: { navigation: AppNavigationProp }) 
                 typography={typography}
               />
             }
-            renderItem={({ item }) => (
-              <Pressable onPress={() => setSelectedAsset(item)} accessibilityLabel="Photo" accessibilityRole="button">
+            renderItem={({ item, index }) => (
+              <Pressable onPress={() => openViewer(libraryAssets, index)} accessibilityLabel="Photo" accessibilityRole="button">
                 <Image source={{ uri: item.uri }} style={styles.thumb} />
               </Pressable>
             )}
@@ -596,7 +639,7 @@ export function PhotosScreen({ navigation }: { navigation: AppNavigationProp }) 
           colors={colors}
           typography={typography}
           insets={insets}
-          onSelectAsset={setSelectedAsset}
+          onSelectAsset={openViewer}
         />
       ) : (
         // ============================================================
@@ -690,7 +733,7 @@ interface ForYouTabProps {
   colors: CupertinoColors;
   typography: typeof Typography;
   insets: { bottom: number };
-  onSelectAsset: (asset: MediaLibrary.Asset) => void;
+  onSelectAsset: (assets: MediaLibrary.Asset[], index: number) => void;
 }
 
 function ForYouTab({ assets, loading, colors, typography, insets, onSelectAsset }: ForYouTabProps) {
@@ -728,8 +771,8 @@ function ForYouTab({ assets, loading, colors, typography, insets, onSelectAsset 
             Featured Photos
           </Text>
           <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={{ paddingHorizontal: 16 }}>
-            {featured.map((asset) => (
-              <Pressable key={asset.id} onPress={() => onSelectAsset(asset)} style={styles.featuredCard} accessibilityLabel={`Featured photo from ${new Date(asset.creationTime).toLocaleDateString()}`} accessibilityRole="button">
+            {featured.map((asset, index) => (
+              <Pressable key={asset.id} onPress={() => onSelectAsset(featured, index)} style={styles.featuredCard} accessibilityLabel={`Featured photo from ${new Date(asset.creationTime).toLocaleDateString()}`} accessibilityRole="button">
                 <Image source={{ uri: asset.uri }} style={styles.featuredImage} />
                 <Text style={[typography.caption1, styles.featuredLabel]} numberOfLines={1}>
                   {new Date(asset.creationTime).toLocaleDateString()}
@@ -774,7 +817,7 @@ interface MemorySectionProps {
   assets: MediaLibrary.Asset[];
   colors: CupertinoColors;
   typography: typeof Typography;
-  onSelectAsset: (asset: MediaLibrary.Asset) => void;
+  onSelectAsset: (assets: MediaLibrary.Asset[], index: number) => void;
 }
 
 function MemorySection({ title, assets, colors, typography, onSelectAsset }: MemorySectionProps) {
@@ -786,8 +829,10 @@ function MemorySection({ title, assets, colors, typography, onSelectAsset }: Mem
         {title}
       </Text>
       <View style={[styles.grid, { paddingHorizontal: GRID_GAP }]}>
-        {assets.slice(0, 9).map((asset) => (
-          <Pressable key={asset.id} onPress={() => onSelectAsset(asset)} accessibilityLabel="Photo" accessibilityRole="button">
+        {/* Only nine thumbs are shown, but the viewer pages through the whole
+            section — swiping past the ninth continues instead of dead-ending. */}
+        {assets.slice(0, 9).map((asset, index) => (
+          <Pressable key={asset.id} onPress={() => onSelectAsset(assets, index)} accessibilityLabel="Photo" accessibilityRole="button">
             <Image source={{ uri: asset.uri }} style={styles.thumb} />
           </Pressable>
         ))}
@@ -982,6 +1027,7 @@ const styles = StyleSheet.create({
   fullView: { flex: 1, backgroundColor: '#000' },
   fullTopBar: { flexDirection: 'row', justifyContent: 'space-between', paddingHorizontal: 16, paddingVertical: 12 },
   fullImage: { flex: 1 },
+  fullCounter: { color: '#fff', fontSize: 15, fontWeight: '600' },
 
   // For You tab
   sectionContainer: { marginTop: 20 },

--- a/src/screens/__tests__/PhotosScreen.test.tsx
+++ b/src/screens/__tests__/PhotosScreen.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { FlatList } from 'react-native';
-import { render, act } from '../../test-utils';
+import { render, act, fireEvent } from '../../test-utils';
 import { PhotosScreen } from '../PhotosScreen';
 import { CupertinoSkeleton } from '../../components';
 import type { AppNavigationProp } from '../../navigation/types';
@@ -236,6 +236,65 @@ describe('PhotosScreen', () => {
 
     expect(queryByTestId('library-skeleton-loading')).toBeNull();
     expect(UNSAFE_getByType(FlatList).props.data).toHaveLength(3);
+  });
+
+  // ------------------------------------------------------------------
+  // Full-screen viewer paging
+  //
+  // The viewer used to hold a single asset, so the only way to reach the
+  // next photo was to back out to the grid and tap again. It now carries the
+  // list it was opened from and pages sideways through it.
+  // ------------------------------------------------------------------
+
+  async function openLibraryAt(index: number) {
+    mediaLibMock.getAssetsAsync.mockResolvedValue({
+      assets: [asset('1'), asset('2'), asset('3')],
+      endCursor: 'cursor-1',
+      hasNextPage: false,
+    });
+    const utils = render(<PhotosScreen navigation={mockNavigation} />);
+    await flush();
+    await act(async () => {
+      fireEvent.press(utils.getAllByLabelText('Photo')[index]);
+    });
+    await flush();
+    return utils;
+  }
+
+  it('opens the viewer on the photo that was tapped, not the first one', async () => {
+    const { UNSAFE_getByType, getByText } = await openLibraryAt(2);
+
+    // The whole list travels with the viewer, so the neighbours are reachable.
+    expect(UNSAFE_getByType(FlatList).props.data).toHaveLength(3);
+    // Third thumbnail tapped => opens at index 2, and says so.
+    expect(UNSAFE_getByType(FlatList).props.initialScrollIndex).toBe(2);
+    expect(getByText('3 of 3')).toBeTruthy();
+  });
+
+  it('renders the viewer as a horizontal pager so photos can be swiped', async () => {
+    const { UNSAFE_getByType } = await openLibraryAt(0);
+
+    const pager = UNSAFE_getByType(FlatList);
+    expect(pager.props.horizontal).toBe(true);
+    expect(pager.props.pagingEnabled).toBe(true);
+    // Without getItemLayout, initialScrollIndex cannot resolve and the viewer
+    // silently opens on the first photo regardless of what was tapped.
+    expect(typeof pager.props.getItemLayout).toBe('function');
+  });
+
+  it('advances the counter when the pager scrolls to the next photo', async () => {
+    const { UNSAFE_getByType, getByText } = await openLibraryAt(0);
+    expect(getByText('1 of 3')).toBeTruthy();
+
+    const pager = UNSAFE_getByType(FlatList);
+    const pageWidth = pager.props.getItemLayout(null, 1).offset;
+
+    await act(async () => {
+      pager.props.onMomentumScrollEnd({ nativeEvent: { contentOffset: { x: pageWidth } } });
+    });
+    await flush();
+
+    expect(getByText('2 of 3')).toBeTruthy();
   });
 
   it('does not update state when the asset fetch resolves after unmount', async () => {


### PR DESCRIPTION
## Problem

Reported from the device: *"na galeria não dá para andar para o lado para ver a foto seguinte sem sair da foto."*

The full-screen viewer held a single asset and rendered one `<Image>` with **no gesture handling of any kind**:

```tsx
if (selectedAsset) {
  return (
    <View style={styles.fullView}>
      <View style={styles.fullTopBar}>…</View>
      <Image source={{ uri: selectedAsset.uri }} style={styles.fullImage} resizeMode="contain" />
    </View>
  );
}
```

To reach the next photo you had to press Back, find the next thumbnail, and tap it. Every time.

## Fix

The viewer now carries the list it was opened from plus an index, and renders a horizontal paged `FlatList` over that list.

All five entry points pass their own list, so the swipe stays inside the context you opened from:

| Entry point | Pages through |
|---|---|
| Library grid | `libraryAssets` |
| Album grid | `albumAssets` |
| For You — featured strip | the featured strip |
| Memory sections (×3) | that section's assets |

Memory sections show nine thumbs but hand the viewer the **whole** section, so swiping past the ninth continues rather than dead-ending.

### `getItemLayout` is load-bearing

Without it `initialScrollIndex` cannot resolve and the viewer opens on the first photo regardless of which was tapped — a silent wrong-photo bug. That exact failure is what the first new test asserts.

### Also

- A `3 of 12` counter in the top bar tracks the visible page.
- Share now acts on the photo **actually on screen**, not the one originally tapped. Previously, had swiping existed, Share would have shared the wrong photo.

## Blast radius

`selectedAsset` is fully removed — `grep` confirms no stale references. The `onSelectAsset` prop signature changed from `(asset)` to `(assets, index)`; both consumers (`ForYouTab`, `MemorySection`) were updated, and `tsc --noEmit` is clean, which would have caught any missed call site.

## Verification

- **Red step proven:** forcing `initialScrollIndex` to `0` fails `opens the viewer on the photo that was tapped, not the first one`. Restored → passes.
- `npm run lint` — 0 errors (1 pre-existing warning in `ClockScreen.tsx:258`, untouched)
- `npx tsc --noEmit` — clean
- `npm test` — **506 pass / 8 fail**; baseline 503/8. Three new tests, zero new failures.

The three tests cover: opening at the tapped index (not 0), the pager being horizontal + paged + layout-resolvable, and the counter advancing on scroll.