### PR TITLE
Normaliza o parallax do wallpaper pelo range real de scroll, ligado à mesma constante do overhang, para nunca exceder a margem oversized (#433)

### DIFF
--- a/src/screens/LauncherHomeScreen.tsx
+++ b/src/screens/LauncherHomeScreen.tsx
@@ -74,6 +74,26 @@ const GRID_HORIZONTAL_PADDING = 16;
 const CELL_WIDTH = (SCREEN_WIDTH - GRID_HORIZONTAL_PADDING * 2) / COLS;
 const DOCK_CELL_WIDTH = (SCREEN_WIDTH - 32) / 4; // dock has 16px padding each side
 
+// How far past the screen edge the wallpaper layer is oversized (see the
+// `{ left: -PARALLAX_OVERHANG, right: -PARALLAX_OVERHANG }` layer style below).
+// This is the entire travel budget for the parallax shift, so the shift must be
+// derived from it — not from a separate, independently-chosen multiplier — or
+// the layer can translate further than it was oversized and expose bare
+// background at the screen edge.
+export const PARALLAX_OVERHANG = 20;
+
+// Maps raw scroll progress (0 = first page, 1 = last page) to a horizontal
+// shift bounded by `overhang` in both directions, so the oversized layer never
+// reveals its own edge regardless of how many pages there are.
+export function computeWallpaperTranslateX(
+  scrollX: number,
+  maxScrollX: number,
+  overhang: number = PARALLAX_OVERHANG,
+): number {
+  const progress = Math.min(1, Math.max(0, scrollX / Math.max(1, maxScrollX)));
+  return overhang * (1 - 2 * progress);
+}
+
 // Built-in app routing: packageName → navigation screen name
 const BUILT_IN_APPS: Record<string, keyof RootStackParamList> = {
   'com.iostoandroid.phone': 'Phone',
@@ -705,8 +725,9 @@ export function LauncherHomeScreen() {
 
   // Parallax wallpaper
   const scrollX = useSharedValue(0);
+  const maxScrollX = useSharedValue(1);
   const wallpaperAnimStyle = useAnimatedStyle(() => ({
-    transform: [{ translateX: -(scrollX.value * 0.3) }],
+    transform: [{ translateX: computeWallpaperTranslateX(scrollX.value, maxScrollX.value) }],
   }));
 
   // Custom wallpaper URI (loaded from AsyncStorage when wallpaperIndex === 6)
@@ -827,6 +848,7 @@ export function LauncherHomeScreen() {
   const handleScroll = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
     const offsetX = event.nativeEvent.contentOffset.x;
     scrollX.value = offsetX;
+    maxScrollX.value = event.nativeEvent.contentSize.width - event.nativeEvent.layoutMeasurement.width;
     const page = Math.round(offsetX / SCREEN_WIDTH);
     if (page !== currentPage && page >= 0 && page < totalPages) {
       setCurrentPage(page);
@@ -836,6 +858,7 @@ export function LauncherHomeScreen() {
 
   const handlePageScroll = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
     scrollX.value = event.nativeEvent.contentOffset.x;
+    maxScrollX.value = event.nativeEvent.contentSize.width - event.nativeEvent.layoutMeasurement.width;
   };
 
   // Build "Move to Folder" sub-options for action sheet
@@ -987,9 +1010,10 @@ export function LauncherHomeScreen() {
       <Animated.View style={[styles.root, { overflow: 'hidden' }]}>
         {/* Parallax wallpaper — absolute layer, slightly oversized to allow horizontal shift */}
         <Animated.View
+          testID="wallpaper-layer"
           style={[
             StyleSheet.absoluteFillObject,
-            { left: -20, right: -20 },
+            { left: -PARALLAX_OVERHANG, right: -PARALLAX_OVERHANG },
             wallpaperAnimStyle,
           ]}
         >

--- a/src/screens/__tests__/LauncherHomeScreen.test.tsx
+++ b/src/screens/__tests__/LauncherHomeScreen.test.tsx
@@ -1,7 +1,13 @@
 import React from 'react';
 import { render } from '../../test-utils';
-import { LauncherHomeScreen, NonAndroidFallback } from '../LauncherHomeScreen';
+import { LauncherHomeScreen, NonAndroidFallback, computeWallpaperTranslateX, PARALLAX_OVERHANG } from '../LauncherHomeScreen';
 import * as DeviceStore from '../../store/DeviceStore';
+import * as AppsStore from '../../store/AppsStore';
+
+function flattenStyle(style: unknown): Record<string, unknown>[] {
+  if (Array.isArray(style)) return style.flat(Infinity).filter(Boolean) as Record<string, unknown>[];
+  return style ? [style as Record<string, unknown>] : [];
+}
 
 describe('LauncherHomeScreen', () => {
   it('renders without crashing', () => {
@@ -87,6 +93,106 @@ describe('LauncherHomeScreen clock interval cleanup (H7)', () => {
 
     setIntervalSpy.mockRestore();
     clearIntervalSpy.mockRestore();
+  });
+});
+
+// #433: the wallpaper parallax layer translated by a raw fraction of the
+// scroll offset (`scrollX.value * 0.3`) while the layer itself was only
+// oversized by a fixed 20px overhang, and the two numbers were never derived
+// from each other. With 3 pages the scroll range is 2 * SCREEN_WIDTH, so the
+// translation (~648px) vastly exceeded the overhang (20px) and the layer slid
+// off, exposing bare background on later pages.
+//
+// `computeWallpaperTranslateX` is the exact function `wallpaperAnimStyle`
+// calls inside its worklet (LauncherHomeScreen.tsx) — these tests call it
+// directly rather than mounting the screen and driving a real scroll, because
+// the Reanimated jest mock (jest.setup.js) hands back a brand-new plain object
+// from every `useSharedValue()` call instead of a ref-persisted one, so a
+// mutate-then-rerender against the mounted component can never observe its own
+// mutation (see `reanimated-jest-animation-target-testing` skill). Testing the
+// real exported unit sidesteps that mock limitation without reimplementing it.
+describe('LauncherHomeScreen wallpaper parallax (#433)', () => {
+  it('sits at +overhang on the first page (progress 0)', () => {
+    expect(computeWallpaperTranslateX(0, 1000, 20)).toBe(20);
+  });
+
+  it('sits at -overhang on the last page (progress 1)', () => {
+    expect(computeWallpaperTranslateX(1000, 1000, 20)).toBe(-20);
+  });
+
+  it('sits at 0 at the exact midpoint', () => {
+    expect(computeWallpaperTranslateX(500, 1000, 20)).toBe(0);
+  });
+
+  it('never exceeds the overhang, for any page count or scroll position', () => {
+    // Regression check for the reported bug: with the old formula
+    // `-(scrollX * 0.3)`, 3 pages at SCREEN_WIDTH=1080 produced ~-648, a 32x
+    // overshoot against a 20px overhang. This sweeps page counts and
+    // fractions the same way a user's swipe would drive scrollX.
+    for (const totalPages of [2, 3, 5, 8, 20]) {
+      const maxScrollX = (totalPages - 1) * 1080;
+      for (let fraction = 0; fraction <= 1; fraction += 0.1) {
+        const translateX = computeWallpaperTranslateX(maxScrollX * fraction, maxScrollX, PARALLAX_OVERHANG);
+        expect(Math.abs(translateX)).toBeLessThanOrEqual(PARALLAX_OVERHANG);
+      }
+    }
+  });
+
+  it('still clamps to the overhang during overscroll/bounce (scrollX outside [0, maxScrollX])', () => {
+    expect(Math.abs(computeWallpaperTranslateX(-50, 1000, 20))).toBeLessThanOrEqual(20);
+    expect(Math.abs(computeWallpaperTranslateX(1500, 1000, 20))).toBeLessThanOrEqual(20);
+  });
+
+  it('does not divide by zero when there is no scrollable range (a single page)', () => {
+    const translateX = computeWallpaperTranslateX(0, 0, 20);
+    expect(Number.isFinite(translateX)).toBe(true);
+    expect(Math.abs(translateX)).toBeLessThanOrEqual(20);
+  });
+
+  it('still shifts noticeably between the first and last page (parallax is not flattened to zero)', () => {
+    const atStart = computeWallpaperTranslateX(0, 2160, PARALLAX_OVERHANG);
+    const atEnd = computeWallpaperTranslateX(2160, 2160, PARALLAX_OVERHANG);
+    expect(Math.abs(atEnd - atStart)).toBeGreaterThan(1);
+  });
+
+  // Guards against the root cause named in the issue: the overhang used to
+  // oversize the layer and the overhang used to bound the translation must be
+  // the SAME constant, or they can drift apart again exactly like before.
+  it('oversizes the wallpaper layer by exactly PARALLAX_OVERHANG on both sides', () => {
+    jest.spyOn(AppsStore, 'useApps').mockReturnValue({
+      apps: [],
+      homeApps: [],
+      dockApps: [],
+      nonDockApps: [],
+      recentPackages: [],
+      recentApps: [],
+      isLoading: false,
+      refreshApps: jest.fn(() => Promise.resolve()),
+      launchApp: jest.fn(() => Promise.resolve()),
+      addToHome: jest.fn(),
+      removeFromHome: jest.fn(),
+      addToDock: jest.fn(),
+      removeFromDock: jest.fn(),
+      removeFromRecents: jest.fn(),
+      clearRecents: jest.fn(),
+      isDefaultLauncher: true,
+      openLauncherSettings: jest.fn(() => Promise.resolve()),
+    } as ReturnType<typeof AppsStore.useApps>);
+
+    const { getByTestId } = render(<LauncherHomeScreen />);
+    const layer = getByTestId('wallpaper-layer');
+    const flat = flattenStyle(layer.props.style);
+    // StyleSheet.absoluteFillObject also sets `left`/`right` (to 0) earlier in
+    // the same style array, so skip that one and take the overhang override.
+    const overhangStyle = flat.find((s) => 'left' in s && (s as { left: number }).left !== 0) as {
+      left: number;
+      right: number;
+    };
+
+    expect(overhangStyle.left).toBe(-PARALLAX_OVERHANG);
+    expect(overhangStyle.right).toBe(-PARALLAX_OVERHANG);
+
+    jest.restoreAllMocks();
   });
 });
 


### PR DESCRIPTION
## Resumo

Normaliza o parallax do wallpaper pelo range real de scroll, ligado à mesma constante do overhang, para nunca exceder a margem oversized

## Causa raiz

`src/screens/LauncherHomeScreen.tsx:707-710` (antes do fix) traduzia a camada do wallpaper por uma fracção crua do scroll em bruto (`-(scrollX.value * 0.3)`), enquanto a camada só estava sobredimensionada em 20px fixos (`{ left: -20, right: -20 }`, linha ~992). Os dois números — o multiplicador `0.3` e a margem `20` — nunca foram derivados um do outro. Com N páginas a `SCREEN_WIDTH` cada, `scrollX` varia até `(N-1) * SCREEN_WIDTH`; a 0.3 isso ultrapassa a margem de 20px em qualquer ecrã com mais de ~1 página (num ecrã de 1080px e 3 páginas, a deslocação chega a ~648px contra um orçamento de 20px — confirmado empiricamente pelo teste, ver "Passo vermelho"). O código bate com a descrição do issue.

## O que mudou

Em `src/screens/LauncherHomeScreen.tsx`:

- Nova constante exportada `PARALLAX_OVERHANG = 20`, única fonte de verdade para a margem de sobredimensionamento.
- Nova função pura exportada `computeWallpaperTranslateX(scrollX, maxScrollX, overhang = PARALLAX_OVERHANG)`: normaliza o progresso do scroll para `[0, 1]` (com `Math.min`/`Math.max`, protegendo contra overscroll/bounce) e mapeia para `overhang * (1 - 2 * progress)` — sempre dentro de `[-overhang, +overhang]`, qualquer que seja `maxScrollX`.
- `wallpaperAnimStyle` passa a chamar `computeWallpaperTranslateX(scrollX.value, maxScrollX.value)` em vez da fórmula antiga.
- Novo shared value `maxScrollX`, alimentado em `handleScroll` e `handlePageScroll` a partir de `event.nativeEvent.contentSize.width - event.nativeEvent.layoutMeasurement.width` — como o issue notou, isto evita depender de `totalPages` (que só existe depois de `wallpaperAnimStyle` ser definido e não pode ser capturado pelo worklet).
- A camada do wallpaper usa agora `{ left: -PARALLAX_OVERHANG, right: -PARALLAX_OVERHANG }` em vez do `-20`/`20` hardcoded — o mesmo número que limita a translação.
- Adicionado `testID="wallpaper-layer"` à camada, só para permitir a inspecção do estilo nos testes (não muda comportamento).

## Porque assim

A normalização pelo range real de scroll (em vez de um multiplicador fixo) garante que a deslocação cabe sempre no orçamento disponível, seja qual for o número de páginas — cumpre directamente o critério de aceitação "funciona com qualquer número de páginas". Usar a mesma constante `PARALLAX_OVERHANG` nos dois sítios (estilo da camada e função de cálculo) impede que os dois números voltem a divergir, que foi exactamente a causa raiz original.

Alternativa descartada: manter o multiplicador fixo e apenas aumentar a margem de 20px para, digamos, 700px. Isso resolveria o sintoma mas manteria o acoplamento implícito entre dois números escolhidos independentemente — com páginas suficientes (ou um ecrã maior) o defeito reaparece. A normalização elimina a classe de bug, não só a instância.

Extraí a matemática para uma função pura exportada (`computeWallpaperTranslateX`) em vez de a deixar inline no worklet, para poder testá-la directamente chamando o código real de produção — ver nota nos testes sobre a limitação do mock do Reanimated em jest.

## Critérios de aceitação

- [x] Em todas as páginas, o wallpaper cobre 100% da largura do ecrã — `computeWallpaperTranslateX` está matematicamente limitada a `[-overhang, +overhang]` (clamp de `progress` a `[0,1]`), e a camada está sobredimensionada exactamente por `overhang` de cada lado, logo nunca expõe a própria aresta. Verificado com testes de fronteira (progress 0, 0.5, 1) e um sweep sobre 2/3/5/8/20 páginas × 11 fracções de scroll.
- [x] O deslocamento continua perceptível entre a primeira e a última página — teste `still shifts noticeably...` confirma um salto de `2 * PARALLAX_OVERHANG` (40px) entre extremos, não achatado a zero.
- [x] Funciona com qualquer número de páginas — `maxScrollX` vem da geometria real do `ScrollView` (`contentSize.width - layoutMeasurement.width`), não de `totalPages`; testado para 2, 3, 5, 8 e 20 páginas.
- [x] O que NÃO devia mudar: a paginação (`handleScroll`'s `Math.round(offsetX / SCREEN_WIDTH)` e `setCurrentPage`) fica intacta — só acrescentei a atribuição a `maxScrollX.value`, não toquei na lógica de página. Confirmado por diff mínimo (ver abaixo) e pelos testes pré-existentes do ecrã continuarem a passar.

## Testes

**Passo vermelho** (produzido revertendo `computeWallpaperTranslateX` para a fórmula original do bug, `-(scrollX * 0.3)`, mantendo os testes e o `testID` intactos — via `git stash push -- src/screens/LauncherHomeScreen.tsx` seguido de `npx jest`):

```
● LauncherHomeScreen wallpaper parallax (#433) › sits at +overhang on the first page (progress 0)
  expect(received).toBe(expected)
  Expected: 20
  Received: -0
    > 116 |     expect(computeWallpaperTranslateX(0, 1000, 20)).toBe(20);

● LauncherHomeScreen wallpaper parallax (#433) › sits at -overhang on the last page (progress 1)
  expect(received).toBe(expected)
  Expected: -20
  Received: -300
    > 120 |     expect(computeWallpaperTranslateX(1000, 1000, 20)).toBe(-20);

● LauncherHomeScreen wallpaper parallax (#433) › never exceeds the overhang, for any page count or scroll position
  expect(received).toBeLessThanOrEqual(expected)
  Expected: <= 20
  Received:    32.4
    > 136 |         expect(Math.abs(translateX)).toBeLessThanOrEqual(PARALLAX_OVERHANG);

● LauncherHomeScreen wallpaper parallax (#433) › still clamps to the overhang during overscroll/bounce (scrollX outside [0, maxScrollX])
  expect(received).toBeLessThanOrEqual(expected)
  Expected: <= 20
  Received:    450
    > 143 |     expect(Math.abs(computeWallpaperTranslateX(1500, 1000, 20))).toBeLessThanOrEqual(20);

Tests:       5 failed, 3 passed, 8 total (subconjunto dos 8 testes novos; os outros 3 falham por razões diferentes só quando o export inteiro falta — ver nota abaixo)
```

A falha `Received: 32.4` confirma empiricamente o excesso de escala que o issue descreveu (o valor real de overshoot varia com `maxScrollX`, mas a ordem de grandeza — dezenas de vezes o overhang — bate certo).

**Sanity-check adicional** pedido no protocolo: revertendo o ficheiro de produção por completo (`git stash push -- src/screens/LauncherHomeScreen.tsx` sem reaplicar nenhuma versão da função), os 8 testes novos falham todos — 6 por `computeWallpaperTranslateX`/`PARALLAX_OVERHANG` não existirem (import undefined) e por `getByTestId('wallpaper-layer')` não encontrar o elemento — e os 6 testes pré-existentes do ficheiro continuam a passar. Com o fix restaurado (`git stash pop`), os 14 testes do ficheiro passam.

**Casos cobertos** (além do caminho feliz progress=0/0.5/1):
- **Fronteiras**: progress exactamente 0, 0.5 (midpoint) e 1.
- **Qualquer número de páginas**: sweep sobre totalPages ∈ {2,3,5,8,20} × 11 fracções de scroll (0.0 a 1.0 em passos de 0.1) — cobre directamente o 3º critério de aceitação.
- **Hostil / fora do intervalo**: overscroll/bounce com `scrollX` negativo (-50) e acima de `maxScrollX` (1500 contra max 1000) — confirma o clamp `Math.min(1, Math.max(0, ...))`.
- **Vazio/degenerado**: `maxScrollX = 0` (uma só página, sem range de scroll) — confirma que não há `NaN`/`Infinity` (guarda `Math.max(1, maxScrollX)`).
- **Inverso do fix**: teste dedicado a provar que o deslocamento NÃO foi achatado a zero (regressão oposta — um fix ingénuo que apenas fixasse `translateX = 0` também passaria os testes de limite, mas não este).
- **Consistência estilo↔lógica**: teste que renderiza o ecrã (com `AppsStore.useApps` mockado para bypassar um bug de ordem de hooks pré-existente e não relacionado — ver comentário no teste) e confirma que o `left`/`right` da camada é exactamente `-PARALLAX_OVERHANG`, prevenindo que os dois números voltem a divergir.

Nota técnica sobre a escolha de testar via função pura exportada em vez de montar o ScrollView e disparar `onScroll` directamente: o mock do Reanimated em `jest.setup.js` devolve um objecto novo a cada chamada de `useSharedValue()` (não persistido por `ref`), pelo que mutar `scrollX.value` e depois forçar um `rerender` no componente montado nunca observa a própria mutação — o `wallpaperAnimStyle` do novo render lê um `scrollX` acabado de recriar a 0. Confirmei isto empiricamente (a minha primeira tentativa, com `UNSAFE_getByType(ScrollView)` + `rerender`, dava sempre `translateX: 0`) antes de mudar de abordagem — ver a skill `reanimated-jest-animation-target-testing` do repositório, que documenta exactamente esta limitação. Testar `computeWallpaperTranslateX` directamente exercita o código real de produção (é a função exacta chamada dentro do worklet) sem lutar contra essa limitação do mock nem reimplementar a fórmula no teste.

**Bug pré-existente encontrado, não corrigido (fora de âmbito)**: ao tentar montar `LauncherHomeScreen` e esperar (`waitFor`) que `isLoading` do `AppsStore` resolvesse para `false`, o componente crasha com "Rendered more hooks than during previous render" — o `useMemo` de `gridItems` (linha ~782) está declarado *depois* do `if (isLoading) return (...)` early-return, pelo que só é invocado quando `isLoading` é `false`, violando as Rules of Hooks assim que a transição acontece. Isto é real e parece capaz de crashar a app em produção sempre que `getInstalledApps()` resolve depois do primeiro render (o caso normal). Não toquei nisto porque é completamente alheio ao parallax do #433 — contornei-o nos meus testes mockando `useApps()` para devolver `isLoading: false` desde o primeiro render, evitando a transição. Vale a pena abrir um issue novo para isto.

**Resultado das verificações obrigatórias:**

`npm run lint`: 0 erros, 1 warning pré-existente (`ClockScreen.tsx:258` `tzTick` não usado — não relacionado, presente também em `main`).

`npx tsc --noEmit`: limpo, sem output.

`npm test`: 516 passaram, 8 falharam, 79 suites (75 passaram, 4 falharam). As 8 falhas são um subconjunto exacto das 9 falhas documentadas na linha de base (`FoldersStore` × 2, `SettingsScreen` × 1, `LockScreen` × 3, `WeatherScreen` × 2) — `CalculatorScreen` já não falha porque main avançou desde o commit `470a816` da baseline. Nenhuma falha nova, nenhuma falha em `LauncherHomeScreen.test.tsx` nem em qualquer ficheiro tocado por este PR.

## Testes

516 passaram, 8 falharam (pré-existentes, subconjunto da baseline), 79 suites (75 passaram, 4 falharam)

## Linked Issue

Fixes #433