### PR TITLE
fix(438): esconde da grelha do ecrã inicial as apps Android que duplicam um built-in (#438)

### DIFF
--- a/src/screens/LauncherHomeScreen.tsx
+++ b/src/screens/LauncherHomeScreen.tsx
@@ -108,6 +108,37 @@ const BUILT_IN_APPS: Record<string, keyof RootStackParamList> = {
   'com.iostoandroid.calculator': 'Calculator',
 };
 
+// Known Android packages that duplicate a built-in app (issue #438).
+//
+// The home screen shows a virtual icon for every entry of BUILT_IN_APPS, which
+// opens the internal iOS-style screen. The real Android app that serves the
+// same function has a different packageName, so it used to pass through the
+// grid filter untouched and render a second icon with the SAME label that
+// launched an external app instead — one "Phone" going to the internal screen,
+// another going to the Google Dialer.
+//
+// Product decision (issue #438, option 1): the Android duplicate is hidden from
+// the home screen grid. This is an explicit alias list, not a heuristic: dialer
+// / messaging package names vary by OEM, so unlisted equivalents are simply not
+// deduped rather than being guessed at. The App Library (AppLibraryScreen) is
+// unaffected and keeps listing everything that is installed.
+export const BUILT_IN_APP_ANDROID_ALIASES: Record<string, readonly string[]> = {
+  'com.iostoandroid.phone': ['com.google.android.dialer', 'com.android.dialer'],
+  'com.iostoandroid.messages': ['com.google.android.apps.messaging', 'com.android.messaging'],
+  'com.iostoandroid.contacts': ['com.google.android.contacts', 'com.android.contacts'],
+  'com.iostoandroid.settings': ['com.android.settings'],
+  'com.iostoandroid.clock': ['com.google.android.deskclock', 'com.android.deskclock'],
+  'com.iostoandroid.camera': ['com.google.android.GoogleCamera', 'com.android.camera2'],
+  'com.iostoandroid.photos': ['com.google.android.apps.photos'],
+  'com.iostoandroid.calendar': ['com.google.android.calendar', 'com.android.calendar'],
+  'com.iostoandroid.calculator': ['com.google.android.calculator', 'com.android.calculator2'],
+};
+
+// Flat set of every Android package that duplicates a built-in app.
+export const BUILT_IN_DUPLICATE_PACKAGES: ReadonlySet<string> = new Set(
+  Object.values(BUILT_IN_APP_ANDROID_ALIASES).flat(),
+);
+
 // Icon config for virtual (built-in) apps rendered in dock/grid
 const VIRTUAL_ICON_CONFIG: Record<string, {
   icon: keyof typeof Ionicons.glyphMap;
@@ -823,8 +854,10 @@ export function LauncherHomeScreen() {
       items.push({ type: 'folder', folder });
     }
 
-    // Add real installed apps (not in dock, not in folders)
+    // Add real installed apps (not in dock, not in folders, and not an Android
+    // duplicate of a built-in app — see BUILT_IN_APP_ANDROID_ALIASES / #438)
     for (const app of nonDockApps) {
+      if (BUILT_IN_DUPLICATE_PACKAGES.has(app.packageName)) continue;
       if (!appsInFolders.has(app.packageName)) {
         items.push({ type: 'app', app });
       }

--- a/src/screens/__tests__/LauncherHomeScreen.test.tsx
+++ b/src/screens/__tests__/LauncherHomeScreen.test.tsx
@@ -1,6 +1,13 @@
 import React from 'react';
-import { render } from '../../test-utils';
-import { LauncherHomeScreen, NonAndroidFallback, computeWallpaperTranslateX, PARALLAX_OVERHANG } from '../LauncherHomeScreen';
+import { render, fireEvent } from '../../test-utils';
+import {
+  LauncherHomeScreen,
+  NonAndroidFallback,
+  computeWallpaperTranslateX,
+  PARALLAX_OVERHANG,
+  BUILT_IN_APP_ANDROID_ALIASES,
+  BUILT_IN_DUPLICATE_PACKAGES,
+} from '../LauncherHomeScreen';
 import * as DeviceStore from '../../store/DeviceStore';
 import * as AppsStore from '../../store/AppsStore';
 
@@ -210,5 +217,116 @@ describe('NonAndroidFallback battery widget', () => {
 
     expect(queryByText('72%')).toBeNull();
     expect(getByText('41%')).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #438: built-in apps rendered twice — the internal built-in icon plus the real
+// Android app with the same label (one goes to the internal screen, the other
+// launches e.g. the Google Dialer).
+// ---------------------------------------------------------------------------
+describe('LauncherHomeScreen built-in duplicate suppression (#438)', () => {
+  afterEach(() => { jest.restoreAllMocks(); });
+
+  function mockApps(allApps: AppsStore.InstalledApp[], dock: string[] = []) {
+    const dockApps = allApps.filter((a) => dock.includes(a.packageName));
+    const nonDockApps = allApps.filter((a) => !dock.includes(a.packageName));
+    const launchApp = jest.fn(() => Promise.resolve());
+    jest.spyOn(AppsStore, 'useApps').mockReturnValue({
+      apps: allApps,
+      homeApps: [],
+      dockApps,
+      nonDockApps,
+      recentPackages: [],
+      recentApps: [],
+      isLoading: false,
+      refreshApps: jest.fn(() => Promise.resolve()),
+      launchApp,
+      addToHome: jest.fn(),
+      removeFromHome: jest.fn(),
+      addToDock: jest.fn(),
+      removeFromDock: jest.fn(),
+      removeFromRecents: jest.fn(),
+      clearRecents: jest.fn(),
+      isDefaultLauncher: true,
+      openLauncherSettings: jest.fn(() => Promise.resolve()),
+    } as ReturnType<typeof AppsStore.useApps>);
+    return { launchApp };
+  }
+
+  const realApp = (name: string, packageName: string): AppsStore.InstalledApp => ({
+    name,
+    packageName,
+    icon: '',
+    isSystem: true,
+  });
+
+  const GOOGLE_DUPES = [
+    realApp('Phone', 'com.google.android.dialer'),
+    realApp('Messages', 'com.google.android.apps.messaging'),
+    realApp('Calendar', 'com.google.android.calendar'),
+  ];
+
+  it('renders each built-in label exactly once when the Google equivalents are installed', () => {
+    mockApps(GOOGLE_DUPES);
+    const { queryAllByLabelText } = render(<LauncherHomeScreen />);
+
+    for (const label of ['Open Phone', 'Open Messages', 'Open Calendar']) {
+      expect(queryAllByLabelText(label)).toHaveLength(1);
+    }
+  });
+
+  it('does not render the real Google packages at all (they are excluded, not relabelled)', () => {
+    mockApps(GOOGLE_DUPES);
+    const { queryAllByLabelText } = render(<LauncherHomeScreen />);
+    // 3 built-ins would become 6 icons if the real apps came through.
+    const total = ['Open Phone', 'Open Messages', 'Open Calendar']
+      .reduce((n, label) => n + queryAllByLabelText(label).length, 0);
+    expect(total).toBe(3);
+  });
+
+  it('keeps built-ins visible exactly once when NO real Android duplicates are installed', () => {
+    mockApps([]);
+    const { queryAllByLabelText } = render(<LauncherHomeScreen />);
+    expect(queryAllByLabelText('Open Phone')).toHaveLength(1);
+    expect(queryAllByLabelText('Open Weather')).toHaveLength(1);
+  });
+
+  it('still shows third-party apps that have no built-in equivalent', () => {
+    mockApps([realApp('Chess Deluxe', 'com.example.chess'), ...GOOGLE_DUPES]);
+    const { queryAllByLabelText } = render(<LauncherHomeScreen />);
+    expect(queryAllByLabelText('Open Chess Deluxe')).toHaveLength(1);
+  });
+
+  it('does not duplicate a built-in that lives in the dock', () => {
+    // Built-in in dock + real Android equivalent installed: the built-in must
+    // appear once (dock) and the real app not at all.
+    const builtInPhone = realApp('Phone', 'com.iostoandroid.phone');
+    mockApps([builtInPhone, ...GOOGLE_DUPES], ['com.iostoandroid.phone']);
+    const { queryAllByLabelText } = render(<LauncherHomeScreen />);
+    expect(queryAllByLabelText('Open Phone')).toHaveLength(1);
+  });
+
+  it('routes the surviving Phone icon to the internal screen, never launchApp', () => {
+    const { launchApp } = mockApps(GOOGLE_DUPES);
+    const { getByLabelText } = render(<LauncherHomeScreen />);
+    fireEvent.press(getByLabelText('Open Phone'));
+    expect(launchApp).not.toHaveBeenCalled();
+  });
+
+  it('the alias map only covers built-in packages and never lists a com.iostoandroid.* package as a duplicate', () => {
+    for (const [builtIn, aliases] of Object.entries(BUILT_IN_APP_ANDROID_ALIASES)) {
+      expect(builtIn.startsWith('com.iostoandroid.')).toBe(true);
+      for (const alias of aliases) {
+        expect(alias.startsWith('com.iostoandroid.')).toBe(false);
+        expect(BUILT_IN_DUPLICATE_PACKAGES.has(alias)).toBe(true);
+      }
+    }
+  });
+
+  it('leaves an unlisted OEM dialer visible (the filter is an explicit alias list, not a heuristic)', () => {
+    mockApps([realApp('Samsung Phone', 'com.samsung.android.dialer')]);
+    const { queryAllByLabelText } = render(<LauncherHomeScreen />);
+    expect(queryAllByLabelText('Open Samsung Phone')).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Resumo

fix(438): esconde da grelha do ecrã inicial as apps Android que duplicam um built-in

## Causa raiz

`src/screens/LauncherHomeScreen.tsx` constrói `gridItems` em três passos. O passo 1 (`:825-829`, numeração pós-fix) injecta as apps virtuais de `BUILT_IN_APPS` (`:98-109`) e filtra-as corretamente contra `dockPkgs` e `appsInFolders`. O passo 3 (`:858-864`) percorre `nonDockApps` — **todas** as apps reais devolvidas por `getInstalledApps()` (`src/store/AppsStore.tsx:270-272`) — e só as confronta com `appsInFolders`.

O mecanismo é a colisão de identidade: o built-in `com.iostoandroid.phone` e a app real `com.google.android.dialer` têm `packageName` diferentes, por isso os dois `.has()` do passo 3 nunca apanham a real. Ambas rendem um `AppIcon` com `accessibilityLabel={`Open ${app.name}`}` (`:263`), com o mesmo rótulo, mas `handleAppPress` (`:606-615`) faz `navigation.navigate` para o built-in e `launchApp(packageName)` para a real — daí os dois destinos.

Isto explica o padrão exacto do dump: os 4 built-ins do dock (`DEFAULT_DOCK`, `src/store/AppsStore.tsx:74-79`) aparecem 1x no dock + 1x na grelha (a app real), e os built-ins fora do dock aparecem 2x na grelha. Weather aparece 1x porque não há app Google de meteorologia com ícone de launcher — confirma que o mecanismo é a colisão built-in↔app-real e não duplicação genérica (essa é o #435, no `LauncherModule.kt`).

O issue está correcto no diagnóstico. Seguiu-se a decisão de produto já fechada pelo curator no issue: **opção 1 — esconder da grelha as apps Android reais que duplicam um built-in**.

## O que mudou

**`src/screens/LauncherHomeScreen.tsx`**
- Novo `BUILT_IN_APP_ANDROID_ALIASES` (exportado): mapa `com.iostoandroid.X → packageNames Android conhecidos`. Cobre os 9 built-ins do mapa do curator e acrescenta, para cada, o equivalente AOSP a par do Google (`com.android.dialer`, `com.android.messaging`, `com.android.deskclock`, `com.android.calendar`, `com.android.calculator2`, `com.android.camera2`, `com.android.contacts`), porque emuladores sem GMS usam esses.
- Novo `BUILT_IN_DUPLICATE_PACKAGES` (exportado): `Set` achatado desses aliases, derivado do mapa e não escrito à mão.
- Passo 3 do `useMemo` de `gridItems`: `if (BUILT_IN_DUPLICATE_PACKAGES.has(app.packageName)) continue;` antes do filtro de pastas. É a única alteração de comportamento — uma linha.
- O passo 1 (`virtualApps`) **não** foi tocado, conforme a armadilha registada pelo curator.

**`src/screens/__tests__/LauncherHomeScreen.test.tsx`**
- Novo bloco `LauncherHomeScreen built-in duplicate suppression (#438)` com 8 testes; import passa a incluir `fireEvent` e os dois novos símbolos exportados.

## Porque assim

O filtro fica do lado das apps **reais** (passo 3) porque é aí que falta a comparação — filtrar no passo 1 esconderia o built-in em vez do duplicado, invertendo a decisão de produto.

Alternativas descartadas: (a) resolução genérica por `queryIntentActivities`/categorias de intent — aumentava muito o âmbito e obrigava a mexer no módulo Kotlin, território do #435; (b) rótulo distinto na app real (opção 2 do issue) — mantém a superfície de fuga da máscara iOS; (c) filtrar em `AppsStore.nonDockApps` — contaminaria a `AppLibraryScreen`, que deve continuar a listar o que está instalado.

A lista de aliases é assumidamente incompleta (Samsung e outros OEMs usam outros pacotes). Está testado explicitamente que um dialer não listado continua visível, para que a limitação seja um comportamento conhecido e não uma surpresa.

## Critérios de aceitação

- [x] Decisão de produto (opção 1) registada — está no comentário do curator no issue e documentada no comentário de bloco acima de `BUILT_IN_APP_ANDROID_ALIASES`.
- [x] Com `com.google.android.dialer`, `com.google.android.apps.messaging` e `com.google.android.calendar` instalados, nenhum aparece na grelha — teste "does not render the real Google packages at all": total de ícones para os 3 rótulos é 3 e não 6.
- [x] O built-in equivalente continua a aparecer exactamente uma vez — teste "renders each built-in label exactly once" (grelha) e "does not duplicate a built-in that lives in the dock" (dock, com a real também instalada).
- [x] Tocar em "Phone" nunca sai para uma app Android — teste "routes the surviving Phone icon to the internal screen, never launchApp": `fireEvent.press` no único ícone e `expect(launchApp).not.toHaveBeenCalled()`.
- [x] Apps de terceiros continuam visíveis — testes "still shows third-party apps that have no built-in equivalent" (`com.example.chess`) e "leaves an unlisted OEM dialer visible" (`com.samsung.android.dialer`).
- [x] NÃO mudou: `AppLibraryScreen.tsx` e `AppsStore.tsx` não foram tocados — confirmado pelo `git status --porcelain`, que lista só 2 ficheiros.
- [x] NÃO mudou: sem duplicados instalados, a grelha rende os built-ins como antes — teste "keeps built-ins visible exactly once when NO real Android duplicates are installed" (Phone e Weather).
- [x] NÃO mudou: os 14 testes que já existiam em `LauncherHomeScreen.test.tsx` passam sem edição; 6 snapshots continuam a passar, nenhum foi actualizado (`npx jest -u` nunca foi corrido).

## Testes

**Passo vermelho.** Fix de produção revertido (removida só a linha do filtro, deixando os símbolos exportados no lugar para que a falha seja comportamental e não um erro de import), testes intactos:

```
● LauncherHomeScreen built-in duplicate suppression (#438) › renders each built-in label exactly once when the Google equivalents are installed

    expect(received).toHaveLength(expected)

    Expected length: 1
    Received length: 2
    Received array:  [{"_fiber": [FiberNode]}, {"_fiber": [FiberNode]}]

      273 |
      274 |     for (const label of ['Open Phone', 'Open Messages', 'Open Calendar']) {
    > 275 |       expect(queryAllByLabelText(label)).toHaveLength(1);
          |                                          ^
      276 |     }
      277 |   });

● LauncherHomeScreen built-in duplicate suppression (#438) › does not render the real Google packages at all (they are excluded, not relabelled)

    expect(received).toBe(expected) // Object.is equality

    Expected: 3
    Received: 6

      283 |     const total = ['Open Phone', 'Open Messages', 'Open Calendar']
      284 |       .reduce((n, label) => n + queryAllByLabelText(label).length, 0);
    > 285 |     expect(total).toBe(3);
          |                   ^

● LauncherHomeScreen built-in duplicate suppression (#438) › does not duplicate a built-in that lives in the dock

    Expected length: 1
    Received length: 2

    > 307 |     expect(queryAllByLabelText('Open Phone')).toHaveLength(1);

● LauncherHomeScreen built-in duplicate suppression (#438) › routes the surviving Phone icon to the internal screen, never launchApp

    Found multiple elements with accessibility label: Open Phone

    > 313 |     fireEvent.press(getByLabelText('Open Phone'));

Test Suites: 1 failed, 1 total
Tests:       4 failed, 18 passed, 22 total
```

Com o fix reposto:

```
Test Suites: 1 passed, 1 total
Tests:       22 passed, 22 total
```

Os testes montam o componente real via `render(<LauncherHomeScreen />)` com `AppsStore.useApps` mockado e consultam a árvore renderizada por `accessibilityLabel` — nenhuma lógica de produção foi reimplementada no ficheiro de teste. Confirmado com `git log -S`/leitura de `origin/main` que não existia antes qualquer filtro de duplicados: `BUILT_IN_DUPLICATE_PACKAGES` não existe em `main` e o passo 3 comparava só `appsInFolders`.

**Casos cobertos além do caminho feliz:** vazio (`allApps: []` — os built-ins têm de continuar a aparecer); o inverso do fix (app não listada — `com.example.chess` e `com.samsung.android.dialer` continuam visíveis, para que o filtro não se transforme numa whitelist); interacção com o dock (built-in no dock + real instalada, o caminho em que o passo 1 e o passo 3 se cruzam); comportamento de navegação, não só de rendering (`fireEvent.press` a provar que `launchApp` não é chamado); e uma invariante estrutural do mapa (nenhum alias é um pacote `com.iostoandroid.*`, o que impediria o próprio built-in de ser escondido por um erro de edição futuro). Cada um falha por razão distinta: os quatro primeiros do bloco falharam com o fix revertido, os restantes falhariam se o filtro fosse largo demais.

**Sanity-check:** fix de produção revertido com os testes intactos → a suite do ficheiro falhou (4 testes, output acima); restaurado → 22/22 a passar. Verificado por `grep` que a linha do filtro voltou (`:860`).

**Verificações:**
- `npm run lint`: 1 problema, 0 erros, 1 warning — `src/screens/ClockScreen.tsx:258 'tzTick' is assigned a value but never used`, pré-existente e em ficheiro não tocado. Igual à linha de base (0 erros).
- `npx tsc --noEmit`: limpo, sem output. Nenhum `any` novo.
- `npm test`: 8 falhas em 548 testes, 4 suites de 79. A linha de base tinha 9 falhas; as 8 restantes são exactamente um subconjunto de `baseline.json` (FoldersStore ×2, LockScreen ×3, SettingsScreen ×1, WeatherScreen ×2 — todas o gate de `firstSyncDone`). `CalculatorScreen › 0.1 + 0.2` já não falha. **Zero falhas novas**, nenhuma em ficheiros tocados.

## Testes

548 testes: 540 passaram, 8 falharam (as 8 são pré-existentes da baseline), 79 suites (75 passaram). O bloco novo #438: 8/8 a passar; LauncherHomeScreen.test.tsx 22/22.

## Linked Issue

Fixes #438