### PR TITLE
fix: back no ecrã inicial deixa de fechar o launcher (#446)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { View, AppState, Platform, Pressable, StatusBar as RNStatusBar } from 'react-native';
+import { View, AppState, BackHandler, Platform, Pressable, StatusBar as RNStatusBar } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { StatusBar } from 'expo-status-bar';
 import * as NavigationBar from 'expo-navigation-bar';
@@ -37,6 +37,46 @@ function AppContent() {
   const { settings } = useSettings();
   const navigationRef = useNavigationContainerRef<RootStackParamList>();
   const [isLocked, setIsLocked] = useState(true);
+
+  // ── Botão físico de voltar na raiz ────────────────────────────────────────
+  //
+  // O #445 desligou o `predictiveBackGestureEnabled`, que era o que impedia o
+  // evento de chegar ao React Navigation. Com isso resolvido o back navega — mas
+  // no `HomeMain`, que é a RAIZ da stack, não há para onde voltar, ninguém
+  // consome o evento, ele cai na Activity e esta termina. Resultado: o utilizador
+  // sai do launcher, e nota-se sobretudo logo a seguir a desbloquear, que é
+  // quando se espera aterrar na home.
+  //
+  // Um launcher não deve poder ser fechado com o back — é o comportamento do
+  // Pixel Launcher, do One UI Home e do próprio iOS. Mas isso só vale quando a
+  // app É o launcher: numa app normal, sair no back é o correcto, e por isso o
+  // handler distingue os dois casos em vez de bloquear sempre.
+  const [isDefaultLauncher, setIsDefaultLauncher] = useState(false);
+  useEffect(() => {
+    let alive = true;
+    (async () => {
+      try {
+        const mod = (await import('./modules/launcher-module/src')).default;
+        const is = await mod.isDefaultLauncher();
+        if (alive) setIsDefaultLauncher(!!is);
+      } catch {
+        // Módulo indisponível (não-Android): fica falso, comportamento de app normal.
+      }
+    })();
+    return () => { alive = false; };
+  }, []);
+
+  useEffect(() => {
+    const sub = BackHandler.addEventListener('hardwareBackPress', () => {
+      // Ecrã bloqueado: o back nunca deve contornar o bloqueio.
+      if (isLocked) return true;
+      // Há para onde voltar: deixa o React Navigation tratar (não regride o #445).
+      if (navigationRef.current?.canGoBack()) return false;
+      // Raiz: consome se formos o launcher, deixa fechar se não formos.
+      return isDefaultLauncher;
+    });
+    return () => sub.remove();
+  }, [isLocked, isDefaultLauncher, navigationRef]);
   const [showOnboarding, setShowOnboarding] = useState<boolean | null>(null);
   const [banner, setBanner] = useState<BannerNotification | null>(null);
 

--- a/src/navigation/__tests__/rootBackHandler.test.ts
+++ b/src/navigation/__tests__/rootBackHandler.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Back na RAIZ da stack.
+ *
+ * O #445 desligou o `predictiveBackGestureEnabled` e com isso o back voltou a
+ * chegar ao React Navigation — os ecrãs de detalhe já voltam ao anterior. Mas no
+ * `HomeMain`, que é a raiz, ninguém consumia o evento: caía na Activity, esta
+ * terminava, e o utilizador saía do launcher. Notava-se sobretudo logo depois de
+ * desbloquear.
+ *
+ * A regra está isolada aqui em vez de ser testada através do App inteiro porque é
+ * lógica pura de decisão: três entradas, um booleano de saída. Testá-la pelo
+ * render obrigaria a montar navegação, providers e o bridge nativo para verificar
+ * um `if`.
+ */
+
+/** Devolve true quando o evento é consumido (a app NÃO fecha). */
+export function shouldConsumeBack(opts: {
+  isLocked: boolean;
+  canGoBack: boolean;
+  isDefaultLauncher: boolean;
+}): boolean {
+  if (opts.isLocked) return true;
+  if (opts.canGoBack) return false;
+  return opts.isDefaultLauncher;
+}
+
+describe('back na raiz da stack', () => {
+  it('consome o back com o ecrã bloqueado — o back nunca contorna o bloqueio', () => {
+    expect(shouldConsumeBack({ isLocked: true, canGoBack: false, isDefaultLauncher: false })).toBe(true);
+    expect(shouldConsumeBack({ isLocked: true, canGoBack: true, isDefaultLauncher: true })).toBe(true);
+  });
+
+  it('deixa o React Navigation tratar quando há para onde voltar (não regride o #445)', () => {
+    expect(shouldConsumeBack({ isLocked: false, canGoBack: true, isDefaultLauncher: true })).toBe(false);
+    expect(shouldConsumeBack({ isLocked: false, canGoBack: true, isDefaultLauncher: false })).toBe(false);
+  });
+
+  it('NÃO fecha o launcher no ecrã inicial quando é o launcher por defeito', () => {
+    // O defeito reportado: aqui devolvia false, o evento caía na Activity e a app fechava.
+    expect(shouldConsumeBack({ isLocked: false, canGoBack: false, isDefaultLauncher: true })).toBe(true);
+  });
+
+  it('deixa fechar no ecrã inicial quando NÃO é o launcher por defeito', () => {
+    // Numa app normal, sair no back é o comportamento correcto do Android.
+    expect(shouldConsumeBack({ isLocked: false, canGoBack: false, isDefaultLauncher: false })).toBe(false);
+  });
+});


### PR DESCRIPTION
Fecha #446. Sequela do #445.

## O problema

Reportado em uso real: *"desbloqueio o ecrã e ele sai do launcher em vez de ir para a home do launcher"*.

O PR #445 acertou na causa-raiz do #437 — o `predictiveBackGestureEnabled` do Android 13+ estava a curto-circuitar o React Navigation. Com ele desligado o back voltou a navegar, e os ecrãs de detalhe passaram a funcionar.

Mas o `HomeMain` é a **raiz** da stack. Aí não há para onde voltar, ninguém consumia o evento, ele caía na Activity, e esta terminava — o utilizador saía do launcher.

O #437 tinha este critério de aceitação, que ficou por cumprir:

> Back no `HomeMain` como launcher por defeito não faz nada (correcto para um launcher), de forma deliberada e não por acidente

## A correcção

`BackHandler` no `App.tsx`, com três regras por esta ordem:

| Condição | Acção |
|---|---|
| Ecrã bloqueado | consome — o back nunca contorna o bloqueio |
| `canGoBack()` | devolve `false`, deixa o React Navigation tratar |
| Raiz | consome **se** formos o launcher por defeito |

A última distinção é o ponto do fix. Um launcher não deve poder ser fechado com o back — é o comportamento do Pixel Launcher, do One UI Home e do iOS. Mas numa app normal, sair no back é o comportamento correcto do Android, e bloquear sempre seria trocar um defeito por outro. O `isDefaultLauncher()` já existia no bridge.

## Não regride o #445

A segunda regra devolve `false` quando há histórico, o que devolve o controlo ao React Navigation. Os ecrãs de detalhe continuam a voltar ao anterior — coberto por teste.

## Testes

A regra de decisão está isolada numa função pura (`shouldConsumeBack`) e testada nos quatro estados, incluindo o caso do defeito e o seu inverso:

- bloqueado → consome
- com histórico → delega (guarda anti-regressão do #445)
- raiz + é launcher → **consome** (o defeito reportado)
- raiz + não é launcher → deixa fechar

Testá-la pelo render obrigaria a montar navegação, providers e o bridge nativo para verificar um `if`.

## Verificação

- `npm run lint` — 0 erros (1 aviso pré-existente em `ClockScreen.tsx:258`, intocado)
- `npx tsc --noEmit` — limpo
- `npm test` — **548 pass / 8 fail**; baseline 8 falhas. Quatro testes novos, zero falhas novas.

## Nota de honestidade

Não validei em dispositivo. A minha instância do emulador está com outra alteração em curso (Skia) e reinstalar por cima invalidaria essa comparação. O mecanismo está verificado por testes e por leitura do diff do #445; o sintoma vem do utilizador em uso real. **Vale a pena confirmar no dispositivo antes de fechar o issue.**