### PR TITLE
Compor mensagem nova mostra um campo de destinatário e o envio recusa-se sem destinatário (#439)

### DIFF
--- a/src/screens/ConversationScreen.tsx
+++ b/src/screens/ConversationScreen.tsx
@@ -10,6 +10,7 @@ import {
   Platform,
   PermissionsAndroid,
   ActivityIndicator,
+  TextInput,
 } from 'react-native';
 import * as Clipboard from 'expo-clipboard';
 import AsyncStorage from '@react-native-async-storage/async-storage';
@@ -21,7 +22,7 @@ import { BlurView } from 'expo-blur';
 import { StatusBar } from 'expo-status-bar';
 import * as Haptics from 'expo-haptics';
 import { useTheme } from '../theme/ThemeContext';
-import { useDevice, DeviceSms } from '../store/DeviceStore';
+import { useDevice, DeviceSms, DeviceContact } from '../store/DeviceStore';
 import { migrateAsyncStorageKey, draftStorageKey, draftLegacyStorageKey } from '../store/storage';
 import { CupertinoTextField, useAlert } from '../components';
 import { findContactByPhone } from '../utils/contacts';
@@ -152,13 +153,47 @@ interface ConversationScreenProps {
 }
 
 export function ConversationScreen({ navigation, route }: ConversationScreenProps) {
-  const { address } = route.params;
+  const { address: initialAddress } = route.params;
 
   const { theme, typography, spacing } = useTheme();
   const { colors, dark } = theme;
   const insets = useSafeAreaInsets();
   const device = useDevice();
   const alert = useAlert();
+
+  // Composing a new message navigates here with an empty address (no recipient
+  // chosen yet — see MessagesScreen/LauncherHomeScreen "compose" actions). Track
+  // the chosen recipient locally so the rest of the screen (message filtering,
+  // draft key, send target) can keep treating `address` as the effective one.
+  const [selectedRecipient, setSelectedRecipient] = useState<string | null>(initialAddress || null);
+  const [recipientQuery, setRecipientQuery] = useState('');
+  const address = selectedRecipient ?? '';
+  const isChoosingRecipient = address === '';
+
+  const recipientSuggestions = useMemo(() => {
+    const q = recipientQuery.trim().toLowerCase();
+    if (!q) return [];
+    const qDigits = q.replace(/\D/g, '');
+    return device.contacts.filter((c) => {
+      const name = `${c.firstName} ${c.lastName}`.toLowerCase();
+      const nameMatch = name.includes(q);
+      const phoneMatch = qDigits.length > 0 && c.phone.replace(/\D/g, '').includes(qDigits);
+      return nameMatch || phoneMatch;
+    }).slice(0, 5);
+  }, [recipientQuery, device.contacts]);
+
+  const handleSelectRecipient = useCallback((c: DeviceContact) => {
+    setSelectedRecipient(c.phone);
+    setRecipientQuery('');
+  }, []);
+
+  const handleSubmitRecipient = useCallback(() => {
+    const trimmed = recipientQuery.trim();
+    if (trimmed) {
+      setSelectedRecipient(trimmed);
+      setRecipientQuery('');
+    }
+  }, [recipientQuery]);
 
   const [inputText, setInputText] = useState('');
   const [isSending, setIsSending] = useState(false);
@@ -252,12 +287,17 @@ export function ConversationScreen({ navigation, route }: ConversationScreenProp
     [address, device.contacts],
   );
 
-  const displayName = contact
-    ? `${contact.firstName} ${contact.lastName}`.trim()
-    : address;
+  const displayName = isChoosingRecipient
+    ? 'New Message'
+    : contact
+      ? `${contact.firstName} ${contact.lastName}`.trim()
+      : address;
 
-  // Filter messages for this address (including local image messages)
+  // Filter messages for this address (including local image messages).
+  // Guard the empty (no recipient chosen yet) case explicitly so it can never
+  // accidentally match a stray message with an empty/undefined address.
   const rawMessages = useMemo(() => {
+    if (!address) return [] as DeviceSms[];
     const deviceMsgs = device.messages
       .filter((m) => m.address === address)
       .sort((a, b) => {
@@ -317,6 +357,7 @@ export function ConversationScreen({ navigation, route }: ConversationScreenProp
   }, [alert, addImageMessage]);
 
   const handleCall = useCallback(async () => {
+    if (!address) return;
     const mod = await getLauncher();
     if (mod) {
       try {
@@ -331,6 +372,14 @@ export function ConversationScreen({ navigation, route }: ConversationScreenProp
   const handleSend = useCallback(async () => {
     const text = inputText.trim();
     if (!text || isSending) return;
+
+    // Reject before touching permissions or the native bridge — a missing
+    // recipient isn't a permissions problem, and the bridge would otherwise
+    // just return false, surfacing a misleading "check permissions" alert.
+    if (!address) {
+      alert('No Recipient', 'Choose a contact or enter a phone number before sending.');
+      return;
+    }
 
     // Ensure SEND_SMS permission is granted BEFORE hitting the native module
     // so the user gets a system prompt instead of a silent failure.
@@ -490,14 +539,63 @@ export function ConversationScreen({ navigation, route }: ConversationScreenProp
             <Pressable
               onPress={handleCall}
               hitSlop={8}
+              disabled={isChoosingRecipient}
               accessibilityRole="button"
               accessibilityLabel={`Call ${displayName}`}
             >
-              <Ionicons name="call-outline" size={22} color={colors.systemBlue} />
+              <Ionicons
+                name="call-outline"
+                size={22}
+                color={isChoosingRecipient ? colors.systemGray3 : colors.systemBlue}
+              />
             </Pressable>
           </View>
         </View>
       </BlurView>
+
+      {/* Recipient picker — shown while composing a new message (no address yet) */}
+      {isChoosingRecipient && (
+        <View
+          style={[
+            styles.recipientRow,
+            { borderBottomColor: colors.separator, borderBottomWidth: StyleSheet.hairlineWidth },
+          ]}
+        >
+          <Text style={[typography.body, { color: colors.secondaryLabel }]}>To:</Text>
+          <TextInput
+            style={[typography.body, styles.recipientInput, { color: colors.label }]}
+            placeholder="Name or phone number"
+            placeholderTextColor={colors.systemGray}
+            value={recipientQuery}
+            onChangeText={setRecipientQuery}
+            onSubmitEditing={handleSubmitRecipient}
+            autoFocus
+            returnKeyType="done"
+            accessibilityLabel="Recipient"
+          />
+        </View>
+      )}
+      {isChoosingRecipient && recipientSuggestions.length > 0 && (
+        <View style={[styles.suggestionsList, { backgroundColor: colors.systemBackground }]}>
+          {recipientSuggestions.map((c) => {
+            const name = `${c.firstName} ${c.lastName}`.trim();
+            return (
+              <Pressable
+                key={c.id}
+                onPress={() => handleSelectRecipient(c)}
+                style={[styles.suggestionRow, { borderBottomColor: colors.separator, borderBottomWidth: StyleSheet.hairlineWidth }]}
+                accessibilityRole="button"
+                accessibilityLabel={`Send to ${name || c.phone}`}
+              >
+                <Text style={[typography.body, { color: colors.label }]}>{name || c.phone}</Text>
+                {!!name && (
+                  <Text style={[typography.subhead, { color: colors.secondaryLabel }]}>{c.phone}</Text>
+                )}
+              </Pressable>
+            );
+          })}
+        </View>
+      )}
 
       {/* Dismiss reaction picker on tap */}
       {selectedMsgId && (
@@ -622,6 +720,24 @@ const styles = StyleSheet.create({
   listContent: {
     paddingHorizontal: 12,
     paddingVertical: 8,
+  },
+  recipientRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    gap: 8,
+  },
+  recipientInput: {
+    flex: 1,
+    paddingVertical: 0,
+  },
+  suggestionsList: {
+    maxHeight: 220,
+  },
+  suggestionRow: {
+    paddingHorizontal: 16,
+    paddingVertical: 10,
   },
   dateSeparator: {
     alignItems: 'center',

--- a/src/screens/__tests__/ConversationScreen.test.tsx
+++ b/src/screens/__tests__/ConversationScreen.test.tsx
@@ -1,8 +1,22 @@
 import React from 'react';
+import { PermissionsAndroid } from 'react-native';
 import { render, fireEvent, waitFor } from '../../test-utils';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { ConversationScreen } from '../ConversationScreen';
-import { DeviceContext, type DeviceContextValue } from '../../store/DeviceStore';
+import { DeviceContext, type DeviceContextValue, type DeviceContact } from '../../store/DeviceStore';
+
+// useAlert() resolves to a no-op in AllProviders (test-utils does not mount
+// AlertProvider), so alert() calls are invisible to assertions by default.
+// Mock it here to capture what ConversationScreen tells the user.
+const mockAlert = jest.fn();
+jest.mock('../../components', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const actual = jest.requireActual('../../components');
+  return { ...actual, useAlert: () => mockAlert };
+});
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const launcherMock = require('../../__mocks__/launcherModule').default;
 
 // Mock MessageBubble so we can count how many times it renders.
 // ConversationScreen imports MessageBubble from ./MessageBubble; this mock
@@ -28,6 +42,41 @@ jest.mock('../MessageBubble', () => {
 
 const mockNavigation = { navigate: jest.fn(), goBack: jest.fn(), push: jest.fn() };
 const mockRoute = { params: { address: '+15551234567' } };
+const mockComposeRoute = { params: { address: '' } };
+
+const CONTACTS: DeviceContact[] = [
+  { id: 'c1', firstName: 'Ana', lastName: 'Silva', phone: '+351911111111' },
+  { id: 'c2', firstName: 'Bruno', lastName: 'Costa', phone: '+351922222222' },
+];
+
+function deviceCtxWith(overrides: Partial<DeviceContextValue>): DeviceContextValue {
+  return {
+    messages: [],
+    contacts: [],
+    battery: { level: 0.72, isCharging: false },
+    brightness: 0.5,
+    volume: 0.5,
+    wifi: { enabled: true, ssid: 'TestWifi', rssi: -50, linkSpeed: 0, ip: '192.168.1.100', networks: [] },
+    wifiError: false,
+    bluetooth: { enabled: true, name: 'TestDevice', address: '', pairedDevices: [] },
+    bluetoothError: false,
+    storage: { totalGB: '128', usedGB: '89', freeGB: '39', usedPercentage: 70 },
+    storageError: false,
+    network: { isConnected: true, isWifi: true, isCellular: false },
+    weather: { temp: 22, condition: 'Sunny', icon: 'sunny', city: 'Test City' },
+    notificationAccessGranted: false,
+    isReady: true,
+    refresh: jest.fn(() => Promise.resolve()),
+    setBrightness: jest.fn(() => Promise.resolve()),
+    setVolume: jest.fn(() => Promise.resolve()),
+    toggleWifi: jest.fn(() => Promise.resolve()),
+    toggleBluetooth: jest.fn(() => Promise.resolve()),
+    openSystemPanel: jest.fn(() => Promise.resolve()),
+    requestContactsPermission: jest.fn(() => Promise.resolve(false)),
+    requestSmsPermission: jest.fn(() => Promise.resolve(false)),
+    ...overrides,
+  };
+}
 
 // Stateful in-memory AsyncStorage mock: setItem persists so a subsequent
 // getItem returns what was written — unlike the stateless default mock.
@@ -212,5 +261,116 @@ describe('ConversationScreen', () => {
     // Sanity: input value reflects the last keystroke.
     const input = getByPlaceholderText('Message') as unknown as { props: { value: string } };
     expect(input.props.value).toBe('Hel');
+  });
+});
+
+describe('ConversationScreen — compose new message (#439)', () => {
+  let checkSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    // Spies through to the real (mocked-native) implementation — just gives
+    // us call-history assertions on top of the existing behaviour.
+    checkSpy = jest.spyOn(PermissionsAndroid, 'check');
+  });
+
+  it('shows a recipient field when opened with no address', () => {
+    const { getByLabelText, getByText } = render(
+      <ConversationScreen navigation={mockNavigation as never} route={mockComposeRoute as never} />
+    );
+    expect(getByLabelText('Recipient')).toBeTruthy();
+    expect(getByText('New Message')).toBeTruthy();
+  });
+
+  it('does NOT show a recipient field for an existing conversation (no regression)', () => {
+    const { queryByLabelText, getByText } = render(
+      <ConversationScreen navigation={mockNavigation as never} route={mockRoute as never} />
+    );
+    expect(queryByLabelText('Recipient')).toBeNull();
+    expect(getByText('+15551234567')).toBeTruthy();
+  });
+
+  it('filters contact suggestions by typed name and selects one as the recipient', () => {
+    const { getByLabelText, getByText, queryByLabelText, queryByText } = render(
+      <DeviceContext.Provider value={deviceCtxWith({ contacts: CONTACTS })}>
+        <ConversationScreen navigation={mockNavigation as never} route={mockComposeRoute as never} />
+      </DeviceContext.Provider>
+    );
+
+    fireEvent.changeText(getByLabelText('Recipient'), 'ana');
+
+    expect(getByText('Ana Silva')).toBeTruthy();
+    expect(queryByText('Bruno Costa')).toBeNull();
+
+    fireEvent.press(getByText('Ana Silva'));
+
+    // Field disappears once a recipient is chosen, and the nav title updates.
+    expect(queryByLabelText('Recipient')).toBeNull();
+    expect(getByText('Ana Silva')).toBeTruthy();
+  });
+
+  it('accepts a typed phone number as the recipient on submit, without a matching contact', () => {
+    const { getByLabelText, queryByLabelText, getByText } = render(
+      <ConversationScreen navigation={mockNavigation as never} route={mockComposeRoute as never} />
+    );
+
+    const recipientField = getByLabelText('Recipient');
+    fireEvent.changeText(recipientField, '+351933333333');
+    fireEvent(recipientField, 'submitEditing');
+
+    expect(queryByLabelText('Recipient')).toBeNull();
+    expect(getByText('+351933333333')).toBeTruthy();
+  });
+
+  it('refuses to send without a recipient, with a message that does not blame permissions', async () => {
+    const { getByPlaceholderText, getByLabelText } = render(
+      <ConversationScreen navigation={mockNavigation as never} route={mockComposeRoute as never} />
+    );
+
+    fireEvent.changeText(getByPlaceholderText('Message'), 'Hello there');
+
+    fireEvent.press(getByLabelText('Send message'));
+
+    // waitFor (not a fixed microtask flush) so the assertion only passes once
+    // the async handleSend chain has genuinely settled — a fixed flush can look
+    // green just because it ran out of ticks before reaching the bridge call.
+    // Filtered by title: AppsStore also calls useAlert() in this tree (an
+    // unrelated "Could not load apps" background alert unmocked in this test
+    // env), so a raw call-count assertion on the shared mock would be noise.
+    await waitFor(() => {
+      expect(mockAlert.mock.calls.some(([title]) => title === 'No Recipient')).toBe(true);
+    }, { timeout: 2000 });
+
+    expect(launcherMock.sendSms).not.toHaveBeenCalled();
+    // The guard must short-circuit before the native SEND_SMS permission
+    // negotiation even starts — a missing recipient isn't a permissions problem.
+    expect(checkSpy).not.toHaveBeenCalled();
+    const [, message] = mockAlert.mock.calls.find(([title]) => title === 'No Recipient')!;
+    expect(String(message)).not.toMatch(/permission/i);
+    expect(String(message)).not.toBe('Could not send message. Check permissions and try again.');
+  });
+
+  it('sends to the chosen recipient once one has been picked (compose → pick → send)', async () => {
+    const { getByLabelText, getByText, getByPlaceholderText } = render(
+      <DeviceContext.Provider value={deviceCtxWith({ contacts: CONTACTS })}>
+        <ConversationScreen navigation={mockNavigation as never} route={mockComposeRoute as never} />
+      </DeviceContext.Provider>
+    );
+
+    fireEvent.changeText(getByLabelText('Recipient'), 'bruno');
+    fireEvent.press(getByText('Bruno Costa'));
+    fireEvent.changeText(getByPlaceholderText('Message'), 'Hey Bruno');
+
+    fireEvent.press(getByLabelText('Send message'));
+
+    // Reaching the real SEND_SMS permission negotiation (a genuine, spy-able
+    // side effect, unlike the native launcher bridge behind a dynamic import()
+    // that this Jest environment cannot execute — see PR description) proves
+    // the picked recipient cleared the "No Recipient" guard and the send
+    // attempt proceeded, exactly as it does for a pre-existing conversation.
+    await waitFor(() => {
+      expect(checkSpy).toHaveBeenCalledWith(PermissionsAndroid.PERMISSIONS.SEND_SMS);
+    }, { timeout: 2000 });
+
+    expect(mockAlert.mock.calls.some(([title]) => title === 'No Recipient')).toBe(false);
   });
 });


### PR DESCRIPTION
## Resumo

Compor mensagem nova mostra um campo de destinatário e o envio recusa-se sem destinatário

## Causa raiz

`src/screens/MessagesScreen.tsx:445-447` e `LauncherHomeScreen.tsx:930` navegam para `Conversation` com `address: ''` quando o utilizador toca em compor. `ConversationScreen.tsx` usava esse `address` diretamente (linha `const { address } = route.params;`) só para filtrar mensagens (`m.address === address`) — nunca oferecia UI para o definir quando vinha vazio. `handleSend` (linha ~331) só validava o texto da mensagem, nunca o destinatário, pelo que uma mensagem sem destino chegava ao bridge nativo com `address` vazio e o `false` devolvido produzia o alerta genérico "Could not send message. Check permissions and try again." — confirma o mecanismo descrito no issue.

## O que mudou

**`src/screens/ConversationScreen.tsx`**
- `address` deixou de ser o parâmetro de rota diretamente: agora é derivado de `selectedRecipient` (estado local, inicializado ao `address` da rota quando não vazio). Isto mantém o resto do ficheiro inalterado onde já usava `address` (draft key, filtragem de mensagens, envio, etc.) — só muda a fonte do valor.
- Quando `address` é `''` (`isChoosingRecipient`), o ecrã mostra uma linha "To:" com um `TextInput` (accessibilityLabel `"Recipient"`) por baixo da nav bar, e uma lista de sugestões de contactos filtrados por nome ou número (via `device.contacts`, máx. 5), tocáveis para escolher.
- Submeter o campo (`onSubmitEditing`) com texto livre define esse texto como destinatário diretamente, sem exigir um contacto correspondente.
- `handleSend` agora recusa logo no início — antes de tocar em `PermissionsAndroid` ou no bridge nativo — quando não há destinatário, com um alerta próprio: `alert('No Recipient', 'Choose a contact or enter a phone number before sending.')`.
- `rawMessages` passa a devolver `[]` explicitamente quando `address` está vazio (evita, por construção, que uma mensagem com `address` vazio/mal formado apareça na "conversa" de compose).
- `handleCall` recusa (`return`) quando não há destinatário, e o botão de chamada fica desativado enquanto se escolhe o destinatário — evita chamar `tel:` com uma string vazia, um efeito colateral direto de passar a permitir que o ecrã seja visitado com `address` vazio.
- `displayName` mostra "New Message" enquanto não há destinatário escolhido.

**`src/screens/__tests__/ConversationScreen.test.tsx`** — 6 testes novos (descritos abaixo).

## Porque assim

Escolhi o campo inline ("To:" + sugestões) dentro do próprio `ConversationScreen`, e não um ecrã de escolha de contacto à parte (a alternativa que o issue também sugeria) — evita uma rota nova, um novo padrão de navegação, e mantém a paridade com o iOS Messages, onde o campo de destinatário aparece no topo do próprio ecrã de conversa. Não toquei em `MessagesScreen.tsx` nem `LauncherHomeScreen.tsx`: ambos já navegam corretamente com `address: ''` para sinalizar "compor nova"; o defeito estava inteiramente em como `ConversationScreen` lidava (ou não) com esse caso, por isso o fix ficou contido a um único ficheiro de produção.

Não implementei a normalização/validação de formato de número de telefone (E.164, etc.) para o destinatário digitado livremente — fora do âmbito do issue, que pede apenas que seja possível endereçar a mensagem e que o envio sem destinatário dê um erro claro.

## Critérios de aceitação

- [x] Compor uma mensagem nova permite escolher ou escrever um destinatário — campo "To:" com sugestões de contactos, e aceita texto livre ao submeter (testes 1, 3, 4).
- [x] Enviar sem destinatário mostra uma mensagem que diz isso, e não um erro de permissões — `handleSend` recusa antes de chegar a `PermissionsAndroid.check`/ao bridge, com o alerta `'No Recipient'` (teste 5); confirmado que `PermissionsAndroid.check` nunca é chamado nesse caminho.
- [x] A mensagem enviada aparece na conversa — mecanismo pré-existente e inalterado (o `sendSms` bem-sucedido já disparava `device.refresh()`, que repõe `device.messages` e por consequência a lista filtrada por `address`); não é algo que este fix introduz. **Não consegui verificar isto num teste automatizado**: `getLauncher()` (linha 37) usa `await import('../../modules/launcher-module/src')`, e nesta suite Jest esse `import()` dinâmico falha sempre com `TypeError: A dynamic import callback was invoked without --experimental-vm-modules` — uma limitação **pré-existente e global** do ambiente de testes (não introduzida por mim; reproduz-se identicamente em código de `main` sem qualquer alteração minha, e afeta também `AppsStore.tsx`, que usa o mesmo padrão — é a causa do alerta "Could not load apps" que aparece em quase todos os testes desta suite, incluindo os que já existiam). Corrigir isso está fora do âmbito deste issue (implicaria mexer em `jest.config.js`/`babel.config.js`, risco de blast radius em toda a suite). Em vez disso, o teste 6 prova que o destinatário escolhido desbloqueia o fluxo até ao ponto onde a negociação real de permissão SEND_SMS arranca (`PermissionsAndroid.check` chamado com o valor certo) — a fronteira do que é testável neste ambiente.
- [x] Teste que cubra compose → escolher destinatário → enviar — teste 6 (`sends to the chosen recipient once one has been picked`).
- [x] O que NÃO devia mudar: uma conversa já existente (`address` não vazio na navegação) continua sem campo "To:" e sem alterações de comportamento — confirmado pelo teste `does NOT show a recipient field for an existing conversation (no regression)`, e pelos 9 testes pré-existentes do ficheiro (drafts, memoização, render), todos ainda a passar sem alteração.

## Testes

**Passo vermelho** (fix de produção retirado via `git stash push -- src/screens/ConversationScreen.tsx`, testes mantidos):

```
$ npx jest src/screens/__tests__/ConversationScreen.test.tsx -t "compose new message" --verbose
  ConversationScreen — compose new message (#439)
    ✕ shows a recipient field when opened with no address (255 ms)
    ✓ does NOT show a recipient field for an existing conversation (no regression) (33 ms)
    ✕ filters contact suggestions by typed name and selects one as the recipient (20 ms)
    ✕ accepts a typed phone number as the recipient on submit, without a matching contact (17 ms)
    ✕ refuses to send without a recipient, with a message that does not blame permissions (2015 ms)
    ✕ sends to the chosen recipient once one has been picked (compose → pick → send) (178 ms)
Tests:       5 failed, 9 skipped, 1 passed, 15 total
```

Detalhe do primeiro:
```
  ● ConversationScreen — compose new message (#439) › shows a recipient field when opened with no address

    Unable to find an element with accessibility label: Recipient

    > 280 |     expect(getByLabelText('Recipient')).toBeTruthy();
          |            ^
      281 |     expect(getByText('New Message')).toBeTruthy();

      at Object.getByLabelText (src/screens/__tests__/ConversationScreen.test.tsx:280:12)
```

(O teste `does NOT show a recipient field...` passa mesmo sem o fix, por construção — é a asserção de não-regressão, verdadeira antes e depois.)

**Casos cobertos** (além do caminho feliz):
- **Não-regressão**: conversa existente não mostra o campo "To:" (o `address` não-vazio da rota é preservado, comportamento anterior intacto).
- **Filtragem de sugestões**: só o contacto cujo nome contém a query aparece (`Ana` não aparece ao procurar por `bruno`) — evita o bug de `String.prototype.includes('')` que faria uma query só-de-letras (sem dígitos) corresponder a qualquer número de telefone.
- **Texto livre sem contacto correspondente**: submeter um número que não está nos contactos ainda define o destinatário — cobre o "ou escrever" do critério de aceitação, não só "escolher".
- **Vazio (ausência de destinatário)**: enviar sem escolher nada é rejeitado com mensagem específica, e a negociação de permissão nem chega a arrancar (`PermissionsAndroid.check` não chamado) — prova que a rejeição acontece antes de qualquer efeito lateral, não é só uma mensagem de erro cosmética.
- **Inverso do fix**: confirma explicitamente que a mensagem do novo alerta nunca é a antiga mensagem genérica de permissões (`'Could not send message. Check permissions and try again.'`).

**Sanity-check**: `git stash push -- src/screens/ConversationScreen.tsx` (fix de produção fora, testes dentro) → 5/6 testes novos falham (a 6ª é a asserção de não-regressão, verdadeira em ambos os estados) → `git stash pop` restaura o fix → suite completa volta a verde. Confirmado nesta sessão imediatamente antes de escrever este veredicto.

**Resultado final:**
- `npm run lint`: 0 erros (1 warning pré-existente e não relacionado em `ClockScreen.tsx:258`, igual à linha de base).
- `npx tsc --noEmit`: limpo.
- `npm test`: 558 passaram, 8 falharam, 566 total, 81 suites (4 suites a falhar). As 8 falhas são todas em `FoldersStore`, `SettingsScreen`, `LockScreen`, `WeatherScreen` — nenhuma em `ConversationScreen`/`MessagesScreen`, nenhuma introduzida por este trabalho. **Nota sobre a linha de base fornecida**: `/home/luis-monteiro/Documentos/iostoandroid-verdicts/state/baseline.json` foi medido em `470a816` com 180 testes totais; o HEAD atual (`e40b207`) já tem 566 testes (muitos commits de outras issues entretanto integrados), pelo que a contagem bruta não é comparável — mas as categorias de falha pré-existentes batem certo (o baseline listava `CalculatorScreen`, `FoldersStore`, `LockScreen`, `SettingsScreen`, `WeatherScreen`; o estado atual tem as mesmas 4 últimas a falhar, `CalculatorScreen` já não). Sem falhas novas.

## Testes

566 total (81 suites), 558 passaram, 8 falharam (todas pré-existentes em FoldersStore/SettingsScreen/LockScreen/WeatherScreen, nenhuma em ConversationScreen — os 15 testes de ConversationScreen.test.tsx, incluindo os 6 novos, passam todos)

## Linked Issue

Fixes #439