### PR TITLE
fix/440: sendSms usa SmsManager por contexto em API 31+, divide mensagens acentuadas em multipart e propaga o erro real em vez de o engolir (#440)

### DIFF
--- a/modules/launcher-module/android/src/main/java/com/iostoandroid/launcher/LauncherModule.kt
+++ b/modules/launcher-module/android/src/main/java/com/iostoandroid/launcher/LauncherModule.kt
@@ -702,13 +702,27 @@ class LauncherModule : Module() {
         // ── SMS Send ─────────────────────────────────────────────────────
 
         AsyncFunction("sendSms") { address: String, body: String ->
-            try {
-                val smsManager = android.telephony.SmsManager.getDefault()
-                smsManager.sendTextMessage(address, null, body, null, null)
-                true
-            } catch (e: Exception) {
-                false
+            SmsRequestValidator.validate(address, body)?.let { reason -> throw Exception(reason) }
+            if (!hasPermission(android.Manifest.permission.SEND_SMS)) {
+                throw Exception("SMS não enviado: permissão SEND_SMS não concedida")
             }
+
+            val smsManager =
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                    context.getSystemService(android.telephony.SmsManager::class.java)
+                        ?: throw Exception("SMS não enviado: sem SmsManager (dispositivo sem telefonia)")
+                } else {
+                    @Suppress("DEPRECATION")
+                    android.telephony.SmsManager.getDefault()
+                }
+
+            val parts = smsManager.divideMessage(body)
+            if (parts.size > 1) {
+                smsManager.sendMultipartTextMessage(address, null, parts, null, null)
+            } else {
+                smsManager.sendTextMessage(address, null, body, null, null)
+            }
+            true
         }
 
         // ── Calendar ─────────────────────────────────────────────────────

--- a/modules/launcher-module/android/src/main/java/com/iostoandroid/launcher/SmsRequestValidator.kt
+++ b/modules/launcher-module/android/src/main/java/com/iostoandroid/launcher/SmsRequestValidator.kt
@@ -1,0 +1,14 @@
+package com.iostoandroid.launcher
+
+/**
+ * Pure-JVM validation for the arguments to [LauncherModule.sendSms].
+ * Kept free of android.* imports so it can be unit-tested without a device.
+ */
+object SmsRequestValidator {
+    /** Returns a Portuguese error message when [address]/[body] are unusable, or null when valid. */
+    fun validate(address: String, body: String): String? {
+        if (address.isBlank()) return "SMS não enviado: destinatário vazio"
+        if (body.isEmpty()) return "SMS não enviado: mensagem vazia"
+        return null
+    }
+}

--- a/modules/launcher-module/android/src/test/java/com/iostoandroid/launcher/SmsRequestValidatorTest.kt
+++ b/modules/launcher-module/android/src/test/java/com/iostoandroid/launcher/SmsRequestValidatorTest.kt
@@ -1,0 +1,34 @@
+package com.iostoandroid.launcher
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Pure-JVM unit tests for [SmsRequestValidator] — no android.* imports,
+ * runs without a device or the Android SDK.
+ */
+class SmsRequestValidatorTest {
+
+    @Test
+    fun `accepts non-blank address and non-empty body`() {
+        assertNull(SmsRequestValidator.validate("912345678", "Olá, como estás?"))
+        assertNull(SmsRequestValidator.validate("+351912345678", "a"))
+    }
+
+    @Test
+    fun `rejects blank address`() {
+        assertEquals("SMS não enviado: destinatário vazio", SmsRequestValidator.validate("", "corpo"))
+        assertEquals("SMS não enviado: destinatário vazio", SmsRequestValidator.validate("   ", "corpo"))
+    }
+
+    @Test
+    fun `rejects empty body`() {
+        assertEquals("SMS não enviado: mensagem vazia", SmsRequestValidator.validate("912345678", ""))
+    }
+
+    @Test
+    fun `reports address reason first when both are invalid`() {
+        assertEquals("SMS não enviado: destinatário vazio", SmsRequestValidator.validate("", ""))
+    }
+}


### PR DESCRIPTION
## Resumo

fix/440: sendSms usa SmsManager por contexto em API 31+, divide mensagens acentuadas em multipart e propaga o erro real em vez de o engolir

## Causa raiz

`modules/launcher-module/android/src/main/java/com/iostoandroid/launcher/LauncherModule.kt:694` (antes do fix) tinha três defeitos independentes na mesma função nativa, todos confirmados por leitura directa do código (o issue estava correcto na descrição técnica):

1. `android.telephony.SmsManager.getDefault()` está deprecated desde a API 31 e resolve uma subscrição SMS ambígua em dispositivos multi-SIM. O módulo tem `targetSdkVersion 35` (`modules/launcher-module/android/build.gradle:14`).
2. `sendTextMessage` envia sempre **um** SMS, sem dividir. Qualquer carácter fora de GSM-7 (`ã`, `é`, `ç`, `õ`, `à` — comuns em português) força UCS-2 e baixa o limite de 160 para 70 caracteres; acima disso a mensagem simplesmente não chega, sem erro visível.
3. `catch (e: Exception) { false }` engolia a excepção real. O wrapper TS (`modules/launcher-module/src/index.ts:485-488`) já captura e chama `reportBridgeError('sendSms', e)` — só faltava a excepção nativa propagar com uma razão.

## O que mudou

- **`modules/launcher-module/android/src/main/java/com/iostoandroid/launcher/LauncherModule.kt`** — `sendSms` (linha ~704): valida endereço/corpo via `SmsRequestValidator`, verifica a permissão `SEND_SMS` explicitamente, obtém o `SmsManager` via `context.getSystemService` em API >= 31 (`Build.VERSION_CODES.S`) com fallback a `getDefault()` (suprimido com `@Suppress("DEPRECATION")`) só em API < 31, usa `divideMessage`/`sendMultipartTextMessage` quando a mensagem excede uma parte, e deixa propagar excepções com mensagens específicas em vez de as engolir.
- **`modules/launcher-module/android/src/main/java/com/iostoandroid/launcher/SmsRequestValidator.kt`** (novo) — validador JVM-puro (sem imports `android.*`, no padrão de `PhoneNumberValidator.kt`) que verifica endereço em branco e corpo vazio, devolvendo a mensagem de erro em português ou `null` quando válido.
- **`modules/launcher-module/android/src/test/java/com/iostoandroid/launcher/SmsRequestValidatorTest.kt`** (novo) — 4 testes JUnit puros para `SmsRequestValidator`.

## Porque assim

Segui o fix proposto no issue quase literalmente — já estava correcto. Única decisão própria: usar `SmsRequestValidator.validate(...)?.let { throw ... }` em vez de dois `if` separados no bridge, para poder extrair a lógica de validação para uma classe JVM-pura testável (sem `android.*`), no mesmo padrão que `PhoneNumberValidator` já estabeleceu para `makeCall` (#429). A divisão multipart e a obtenção do `SmsManager` continuam dentro do bridge porque dependem de `android.telephony.SmsManager`, que não pode ser testado em JVM puro sem emulador com rádio GSM — a mesma limitação que o autor do issue já assinalou.

O contrato TS não mudou: o wrapper já apanha qualquer excepção e devolve `false`, chamando `reportBridgeError`. O que muda é que a excepção deixa de estar sempre em branco.

## Critérios de aceitação

- [x] **Sem chamadas a `getDefault()` em API >= 31** — confirmado por leitura: `getDefault()` só corre no ramo `else` (`Build.VERSION.SDK_INT < Build.VERSION_CODES.S`); em API >= 31 usa-se `context.getSystemService(SmsManager::class.java)`.
- [ ] **Mensagem de 200 caracteres com acentos chega inteira** — não verificável neste ambiente: não há emulador com rádio GSM real neste worktree (mesma limitação documentada pelo autor do issue). O código delega a divisão a `smsManager.divideMessage(body)` + `sendMultipartTextMessage`, que é o mecanismo correcto documentado pela API Android para este caso; fica pendente de validação em hardware com SIM.
- [x] **Falhas distinguíveis: destinatário vazio, sem permissão, sem telefonia dão razões diferentes** — cada caso lança uma `Exception` com mensagem própria ("destinatário vazio", "mensagem vazia", "permissão SEND_SMS não concedida", "sem SmsManager (dispositivo sem telefonia)"), coberto por `SmsRequestValidatorTest` para os dois primeiros casos (os dois últimos exigem `android.*` e não são testáveis em JVM puro).
- [x] **Testes JVM puros para a lógica de validação, no padrão do `PhoneNumberValidatorTest`** — `SmsRequestValidatorTest.kt`, 4 testes, ver secção de testes abaixo.
- [x] **O que não devia mudar**: a assinatura da função (`address: String, body: String -> Boolean`), o contrato TS (`sendSms(address, body): Promise<boolean>` em `index.ts:205`), e o comportamento visível para o utilizador (o wrapper continua a devolver `false` em qualquer falha) — confirmados por leitura de `index.ts:485-488`, que não foi tocado.

## Testes

Este módulo Kotlin não tem infraestrutura Gradle/Android no worktree (sem `android/`, sem `gradlew` — são gerados por `expo prebuild`), por isso os testes de `SmsRequestValidator` correm em JVM puro com `kotlinc` + JUnit 4, seguindo o mesmo padrão já usado para `PhoneNumberValidatorTest`. Não corre via `npx jest` porque é código Kotlin, não TS.

**Passo vermelho** — com `SmsRequestValidatorTest.kt` escrito e `SmsRequestValidator.kt` ainda inexistente, a compilação falhou pela razão certa (a classe não existe, não um erro de configuração):

```
$ kotlinc -classpath "$JUNIT:$STDLIB" -d out SmsRequestValidatorTest.kt
modules/launcher-module/android/src/test/java/com/iostoandroid/launcher/SmsRequestValidatorTest.kt:15:20: error: unresolved reference: SmsRequestValidator
        assertNull(SmsRequestValidator.validate("912345678", "Olá, como estás?"))
                   ^
(+ 5 erros iguais nas outras chamadas a SmsRequestValidator.validate)
```

Depois de criar `SmsRequestValidator.kt`:

```
$ kotlinc -classpath "$JUNIT:$STDLIB:$TROVE" -d out SmsRequestValidator.kt SmsRequestValidatorTest.kt
$ java -cp "out:$JUNIT:$STDLIB:$HAMCREST" org.junit.runner.JUnitCore com.iostoandroid.launcher.SmsRequestValidatorTest
JUnit version 4.13.2
....
Time: 0,074

OK (4 tests)
```

**Casos cobertos** em `SmsRequestValidatorTest.kt`: endereço válido + corpo com acentos (caminho feliz e o caso que o issue diz que falha na app antiga, aqui a nível de validação); endereço em branco (vazio e só espaços — fronteira de `isBlank()`); corpo vazio; e o caso de ambos inválidos, para confirmar que a razão do endereço tem prioridade sobre a do corpo (evita mensagens de erro ambíguas quando há mais que uma causa).

**Sanity-check**: substituí `SmsRequestValidator.kt` por uma implementação que devolve sempre `null` (fix revertido, testes mantidos) e corri a suite — 3 dos 4 testes falharam com `AssertionError: expected:<SMS não enviado: ...> but was:<null>`. Restaurei o ficheiro original e a suite voltou a passar (4/4). Isto prova que os testes estão ligados ao comportamento real do validador.

**Verificações obrigatórias** (comparado com a linha de base em `main@470a816`: lint 0 erros, tsc limpo, 9/180 testes jest a falhar):

- `npm run lint` → 0 erros, 1 warning pré-existente e não relacionado (`ClockScreen.tsx:258`, `tzTick` não usado) — igual à linha de base.
- `npx tsc --noEmit` → sem output, limpo.
- `npm test` → `Test Suites: 4 failed, 77 passed, 81 total` / `Tests: 8 failed, 558 passed, 566 total`. As 8 falhas (`FoldersStore`, `SettingsScreen`, `LockScreen` ×2, `WeatherScreen` ×2, e mais duas do mesmo grupo) são as mesmas da linha de base (`firstSyncDone`/`AsyncStorage` assíncrono vs. render síncrono nos testes) — nenhuma falha nova, e o total de falhas até desceu de 9 para 8 (uma das falhas da baseline, `CalculatorScreen`, já não falha, por trabalho alheio a este fix). Nenhuma falha toca `LauncherModule` ou `sendSms`.

## Testes

JS/TS (jest): 558 passaram, 8 falharam (pré-existentes na baseline, nenhuma nova), 77/81 suites; Kotlin JVM puro (SmsRequestValidatorTest, via kotlinc+JUnit): 4 passaram, 0 falharam

## Linked Issue

Fixes #440