### PR TITLE
P0: main não arranca — falta a directiva worklet em computeWallpaperTranslateX

### DIFF
--- a/src/screens/LauncherHomeScreen.tsx
+++ b/src/screens/LauncherHomeScreen.tsx
@@ -88,8 +88,13 @@ export const PARALLAX_OVERHANG = 20;
 export function computeWallpaperTranslateX(
   scrollX: number,
   maxScrollX: number,
-  overhang: number = PARALLAX_OVERHANG,
+  overhang: number,
 ): number {
+  // A directiva é OBRIGATÓRIA: esta função é chamada de dentro de um
+  // useAnimatedStyle, que corre na thread de UI. Sem ela o Reanimated rebenta com
+  // "Tried to synchronously call a non-worklet function on the UI thread" e a app
+  // não chega sequer a mostrar o ecrã inicial.
+  'worklet';
   const progress = Math.min(1, Math.max(0, scrollX / Math.max(1, maxScrollX)));
   return overhang * (1 - 2 * progress);
 }
@@ -758,7 +763,7 @@ export function LauncherHomeScreen() {
   const scrollX = useSharedValue(0);
   const maxScrollX = useSharedValue(1);
   const wallpaperAnimStyle = useAnimatedStyle(() => ({
-    transform: [{ translateX: computeWallpaperTranslateX(scrollX.value, maxScrollX.value) }],
+    transform: [{ translateX: computeWallpaperTranslateX(scrollX.value, maxScrollX.value, PARALLAX_OVERHANG) }],
   }));
 
   // Custom wallpaper URI (loaded from AsyncStorage when wallpaperIndex === 6)


### PR DESCRIPTION
## P0 — a app não abre

O PR #441 (fix do #433, parallax) extraiu a função pura `computeWallpaperTranslateX`. Extrair foi boa ideia — torna-a testável. Mas a função é chamada de dentro de um `useAnimatedStyle`, que corre na **thread de UI**, e ficou sem a directiva `'worklet'`.

```
[Worklets] Tried to synchronously call a non-worklet function
`computeWallpaperTranslateX` on the UI thread
```

A app crasha **antes de mostrar o ecrã inicial**. Não é subtil: main não arranca.

## Duas alterações, a segunda exposta pela primeira

1. `'worklet';` na função.
2. `overhang` passa a parâmetro obrigatório em vez de ter `PARALLAX_OVERHANG` como valor por omissão. Com a directiva posta, o erro mudou para `Property 'PARALLAX_OVERHANG' doesn't exist` — worklets não capturam constantes de módulo usadas em parâmetros por omissão. Passa-se explicitamente na chamada.

## Verificação

Empírica, no emulador, contra o main de que este branch sai:

| | |
|---|---|
| Antes | ecrã de erro do Reanimated, zero elementos |
| Depois | home renderiza, **24 ícones** |

## Como isto passou

O #441 foi implementado, revisto e integrado sem que ninguém tenha aberto a app. Os testes unitários da função passam — ela está correcta como função pura; o que falha é a ponte para a thread de UI, que só se vê a correr.

É o mesmo padrão do #446: o reviewer valida que o código parece certo, não que a app arranca. Vale a pena um smoke test no pipeline que instale o APK e confirme que o ecrã inicial renderiza — teria apanhado isto e o #446.