### PR TITLE
pipeline: implementador Hermes em paralelo + 3 bugs que destruíam trabalho dos agentes

### DIFF
--- a/scripts/team/implement.sh
+++ b/scripts/team/implement.sh
@@ -190,7 +190,10 @@ fi
 
 rm -f "$VERDICT_FILE"
 agent_log_header "$LOG_DIR/implement-$ISSUE.log" "implement #$ISSUE modelo=$MODEL"
-AGENT_SLOT=main CLAUDE_MODEL="$MODEL" \
+# O slot é o que separa os locks do run-agent.sh, e por isso é o que permite dois
+# implementadores em simultâneo. O orquestrador lança o par Hermes com
+# TEAM_SLOT=hermes AGENT_ENGINE=hermes; sem override fica tudo em 'main', como antes.
+AGENT_SLOT="${TEAM_SLOT:-main}" CLAUDE_MODEL="$MODEL" AGENT_ENGINE="${AGENT_ENGINE:-}" \
   bash "$SCRIPT_DIR/run-agent.sh" "$PROMPT" "$WT" "${IMPLEMENT_TIMEOUT:-2700}" \
   >> "$LOG_DIR/implement-$ISSUE.log" 2>&1; AGENT_RC=$?
 
@@ -265,10 +268,28 @@ TESTS=$(printf '%s' "$TESTS" | sanitize_closing_keywords)
 # real work and lied about why.
 #
 # Work exists if the tree is dirty OR the branch differs from the base.
+#
+# O PADRÃO TEM DE ESTAR ANCORADO. A versão anterior usava
+# `grep -vE '(^.. )?(node_modules|android/|ios/|\.expo/)'`, em que o prefixo de
+# estado é OPCIONAL e portanto nada ancora a alternação ao início do caminho:
+# `android/` passava a casar em qualquer posição da linha. O efeito é que
+# `modules/launcher-module/android/src/main/java/.../X.kt` — código-fonte do
+# módulo nativo — era filtrado como se fosse a pasta `android/` gerada pelo
+# `expo prebuild`.
+#
+# Consequência medida no #435: o agente escreveu Kotlin real (um deduper novo,
+# duas chamadas alteradas, seis testes), o grep comeu tudo, DIRTY saiu vazio, e o
+# harness rejeitou como "sem alterações reais no código" — DUAS rondas seguidas,
+# contando rejeições que empurram o issue para o tier forte. Qualquer issue cujo
+# fix seja apenas nativo era impossível de entregar.
+#
+# Ancorar ao início do caminho (com o prefixo de 3 caracteres do --porcelain
+# opcional) resolve: só a `android/` de topo é ignorada, a do módulo passa.
+IGNORE_RE='^(..[ ])?(node_modules|android|ios|\.expo)/'
 DIRTY=$(git -C "$WT" status --porcelain 2>/dev/null \
-  | grep -vE '(^.. )?(node_modules|android/|ios/|\.expo/)' | head -1 || true)
+  | grep -vE "$IGNORE_RE" | head -1 || true)
 BRANCH_WORK=$(git -C "$WT" diff --name-only "origin/$BASE_BRANCH...HEAD" 2>/dev/null \
-  | grep -vE '^(node_modules|android/|ios/|\.expo/)' | head -1 || true)
+  | grep -vE '^(node_modules|android|ios|\.expo)/' | head -1 || true)
 CHANGED="${DIRTY:-$BRANCH_WORK}"
 
 log "outcome=$OUTCOME árvore=${DIRTY:+suja}${DIRTY:-limpa} branch=${BRANCH_WORK:+com trabalho}${BRANCH_WORK:-vazio}"

--- a/scripts/team/orchestrator.sh
+++ b/scripts/team/orchestrator.sh
@@ -185,6 +185,27 @@ first_with() {
   return 0
 }
 
+# Nth actionable issue for a label (0-indexed), para o par Hermes.
+#
+# PORQUE NÃO first_with NOS DOIS: o implementador só marca qa:wip depois de
+# preparar o worktree, e o cache de issues é lido uma vez por ciclo. Se ambos
+# chamassem first_with, ambos liam a mesma fila antes de qualquer um marcar e
+# pegavam no MESMO issue — dois agentes, dois worktrees, o mesmo branch. A corrida
+# é evitada por construção: o Claude leva o índice 0, o Hermes o índice 1.
+#
+# Sem `on_fallback`: o Hermes é um motor próprio e não está sujeito ao cooldown
+# da subscrição Claude, portanto os filtros de degradação não se lhe aplicam.
+nth_with() {
+  local label="$1" want="$2" n i=0
+  while IFS= read -r n; do
+    [ -n "$n" ] || continue
+    is_deferred "$n" && continue
+    if [ "$i" -eq "$want" ]; then echo "$n"; return 0; fi
+    i=$((i + 1))
+  done < <(issues_with "$label")
+  return 0
+}
+
 # Labels on one issue, straight from the cache.
 labels_of() {
   printf '%s' "$ISSUE_CACHE" \
@@ -308,7 +329,21 @@ cleanup_stale() {
     # agent running in another slot is exactly the bug that destroyed the critic's
     # findings in the sibling project — four real findings lost, which from the
     # outside looked like "it found nothing".
-    local roles="implement review"
+    # O SLOT HERMES CONTA COMO OCUPADO. O implementador paralelo escreve
+    # `implement-N.json` tal como o do slot main, portanto apagar os veredictos de
+    # `implement` com o hermes vivo destrói o trabalho dele a meio — e o worktree
+    # dele é podado a seguir. Medido no #442: o agente reportou que o worktree foi
+    # "recriado de origin/main pelo menos 2 vezes" e que perdeu os edits, nunca
+    # chegou a commitar nem a escrever veredicto, e o issue voltou a qa:ready num
+    # ciclo infinito. É exactamente o modo de falha que o comentário acima descreve,
+    # e passou a ser possível quando o slot hermes foi acrescentado sem estender
+    # esta guarda.
+    local roles="review"
+    if flock -w 0 -n "$LOCK_PREFIX.hermes.lock" true 2>/dev/null; then
+      roles="implement $roles"
+    else
+      log "hermes a correr — não mexo nos veredictos de implement"
+    fi
     if flock -w 0 -n "$LOCK_PREFIX.curator.lock" true 2>/dev/null; then
       roles="curator $roles"
     fi
@@ -458,6 +493,36 @@ launch_curator_if_needed() {
   nohup bash "$SCRIPT_DIR/curator.sh" "$i" >> "$LOG_DIR/curator-bg.log" 2>&1 &
 }
 
+# ── Implementador paralelo (Hermes/Nous) ───────────────────────────────────
+#
+# Um SEGUNDO implementador, a correr ao mesmo tempo que o Claude, num motor
+# diferente. Desligado por defeito: só arranca com TEAM_HERMES=1.
+#
+# Três coisas mantêm os dois agentes fora do caminho um do outro:
+#   * slot próprio (TEAM_SLOT=hermes) -> lock próprio no run-agent.sh;
+#   * issue diferente por construção (nth_with índice 1, não first_with);
+#   * worktree próprio, que o implement.sh já cria por issue.
+#
+# Tal como o curator, vai ANTES dos despachos bloqueantes e não mexe no DID: se
+# ficasse depois, nunca seria alcançado enquanto o role pesado não terminasse, e
+# "destacado mas em último" é a mesma ordem em série com mais maquinaria.
+launch_hermes_if_needed() {
+  [ "${TEAM_HERMES:-0}" = "1" ] || return 0
+  command -v hermes >/dev/null 2>&1 || { log "TEAM_HERMES=1 mas o hermes não está no PATH"; return 0; }
+
+  local i
+  i=$(nth_with "$L_READY" 1)
+  [ -n "$i" ] || return 0   # menos de dois issues na fila: o Claude leva o único
+
+  if ! flock -w 0 -n "$LOCK_PREFIX.hermes.lock" true 2>/dev/null; then
+    log "hermes já a correr no seu slot — #$i espera a vez"
+    return 0
+  fi
+  log "IMPLEMENTADOR HERMES (paralelo) -> #$i"
+  TEAM_SLOT=hermes AGENT_ENGINE=hermes \
+    nohup bash "$SCRIPT_DIR/implement.sh" "$i" >> "$LOG_DIR/hermes-bg.log" 2>&1 &
+}
+
 # ── Explicit targets ───────────────────────────────────────────────────────
 if [ -n "$TARGET_PR" ]; then run_review "$TARGET_PR"; exit 0; fi
 
@@ -520,6 +585,9 @@ while true; do
 
   # Repair analysis runs alongside delivery, never in front of it.
   launch_curator_if_needed
+
+  # Second implementer on a different engine and a different issue.
+  launch_hermes_if_needed
 
   DID=0
 

--- a/scripts/team/run-agent.sh
+++ b/scripts/team/run-agent.sh
@@ -238,6 +238,37 @@ diz isso explicitamente no veredicto em vez de a inventares.
 EOF
 }
 
+# ── 0. Hermes (Nous) — motor alternativo, escolhido explicitamente ─────────
+#
+# NÃO é um degrau da ladder: é um motor à parte, pedido por AGENT_ENGINE=hermes.
+# A razão é o paralelismo. A ladder existe para degradar quando a subscrição
+# Claude seca; o Hermes serve para correr um SEGUNDO implementador ao mesmo
+# tempo que o Claude, num slot próprio (AGENT_SLOT=hermes) e portanto com o seu
+# próprio lock. Metê-lo como degrau faria dele um substituto em vez de um par.
+#
+# `--yolo` é o equivalente ao --permission-mode acceptEdits do Claude Code: sem
+# ele o hermes pára à espera de aprovação e o agente morre no timeout sem
+# produzir veredicto — o mesmo modo de falha que o `< /dev/null` do ollama
+# resolveu. Não há --allowedTools equivalente; o isolamento vem do worktree.
+if [ "${AGENT_ENGINE:-}" = "hermes" ]; then
+  if ! command -v hermes >/dev/null 2>&1; then
+    echo "[run-agent] ERRO: AGENT_ENGINE=hermes mas o hermes não está no PATH" >&2
+    exit 1
+  fi
+  HERMES_MODEL="${HERMES_MODEL:-${AGENT_HERMES_MODEL:-}}"
+  USED="hermes/${HERMES_MODEL:-default}"
+  if [ -n "$HERMES_MODEL" ]; then
+    run_harness "hermes" "$HERMES_MODEL" \
+      hermes -z "$PROMPT" --model "$HERMES_MODEL" --yolo --cli
+  else
+    run_harness "hermes" "default" \
+      hermes -z "$PROMPT" --yolo --cli
+  fi
+  RC=$?
+  echo "$USED" > "$LOCK_PREFIX.$AGENT_SLOT.engine" 2>/dev/null || true
+  exit "$RC"
+fi
+
 # ── 1. Subscription (claude CLI) ───────────────────────────────────────────
 if [ "${AGENT_FORCE_FALLBACK:-0}" != "1" ] && ! in_cooldown && command -v claude >/dev/null 2>&1; then
   USED="claude/$CLAUDE_MODEL"

--- a/scripts/team/start.sh
+++ b/scripts/team/start.sh
@@ -147,10 +147,24 @@ fi
 LOGFILE="$LOG_DIR/orchestrator-$(date +%Y%m%d-%H%M%S).log"
 log "a arrancar em tmux '$SESSION'; log: $LOGFILE"
 
+# Variáveis de ambiente injectadas EXPLICITAMENTE no comando.
+#
+# `tmux new-session` NÃO herda o ambiente de quem a invoca: herda o do SERVIDOR
+# tmux, que pode estar a correr desde uma sessão anterior com um ambiente
+# completamente diferente. Correr `TEAM_HERMES=1 bash start.sh` com um servidor
+# tmux já vivo lança um orquestrador sem TEAM_HERMES nenhum, em silêncio — foi
+# exactamente o que aconteceu na primeira tentativa de ligar o par Hermes.
+#
+# Passar no comando é a única forma que não depende do estado do servidor.
+TEAM_ENV=""
+for v in TEAM_HERMES TEAM_USE_FALLBACK TEAM_SESSION AGENT_HERMES_MODEL HERMES_MODEL; do
+  [ -n "${!v:-}" ] && TEAM_ENV="$TEAM_ENV $v='${!v}'"
+done
+
 # `tee` into a file as well as the pane: once a pane closes there is no way to
 # inspect what happened, and this thing runs for hours unattended.
 tmux new-session -d -s "$SESSION" -n orchestrator \
-  "cd '$SCRIPT_DIR' && bash orchestrator.sh ${ORCH_ARGS[*]:-} 2>&1 | tee '$LOGFILE'; echo '--- TERMINOU ---'; read -r"
+  "cd '$SCRIPT_DIR' &&${TEAM_ENV:+ export$TEAM_ENV &&} bash orchestrator.sh ${ORCH_ARGS[*]:-} 2>&1 | tee '$LOGFILE'; echo '--- TERMINOU ---'; read -r"
 
 cat <<EOF
 Pipeline a correr.


### PR DESCRIPTION
## Hermes como segundo implementador

Um segundo implementador, noutro motor, a correr **ao mesmo tempo** que o Claude. Desligado por omissão — só arranca com `TEAM_HERMES=1`.

| Ficheiro | Alteração |
|---|---|
| `run-agent.sh` | motor hermes por `AGENT_ENGINE=hermes`, com `--yolo` |
| `implement.sh` | slot configurável por `TEAM_SLOT` — é o que separa os locks |
| `orchestrator.sh` | `nth_with()` + `launch_hermes_if_needed()`, no padrão do curator |

Três garantias mantêm os agentes fora do caminho um do outro: **slot próprio** (lock próprio), **issue diferente por construção** (`nth_with` índice 1, não `first_with` — evita a corrida em vez de depender dela) e **worktree próprio**, que o `implement.sh` já criava.

Verificado ponta a ponta: `motor=hermes workdir=.../implement-437` em paralelo com o Claude noutro issue.

---

## Bug 1 — `cleanup_stale` destruía o trabalho do slot hermes

A guarda só verificava o lock `main`. Com esse livre e o hermes a trabalhar, apagava os veredictos `implement-*.json` — **incluindo os dele** — e podava-lhe o worktree a seguir.

Medido no #442, nas palavras do próprio agente:

> o worktree tem sido repetidamente podado pelo ambiente (…) recriado de `origin/main` pelo menos 2 vezes, e os meus edits perderam-se

Ciclo resultante: agente perde o trabalho → sem veredicto → issue volta a `qa:ready` → re-despacho → repete. O quadro nunca mostrava nada em `qa:wip` apesar de haver agentes a correr.

O comentário imediatamente acima do código já avisava deste modo exacto de falha. Foi introduzido ao acrescentar o slot hermes sem estender a guarda.

## Bug 2 — o filtro de alterações comia o módulo nativo

```bash
grep -vE '(^.. )?(node_modules|android/|ios/|\.expo/)'
```

O prefixo de estado é **opcional**, portanto nada ancorava a alternação ao início do caminho: `android/` casava em qualquer posição. Ficheiros em `modules/launcher-module/android/src/...` — código-fonte — eram filtrados como se fossem a pasta `android/` gerada pelo prebuild.

Qualquer issue de fix apenas nativo era rejeitado como *"implemented (sem alterações reais no código)"*. Aconteceu duas vezes no #435, contando rejeições que empurram o issue para o tier forte.

Corrigido com padrão ancorado: `^(..[ ])?(node_modules|android|ios|\.expo)/`

## Bug 3 — `start.sh` perdia as variáveis de ambiente

`tmux new-session` herda o ambiente do **servidor** tmux, não de quem a invoca. Com um servidor já vivo, `TEAM_HERMES=1 bash start.sh` lançava um orquestrador sem `TEAM_HERMES` nenhum, **em silêncio**. As variáveis passam agora explícitas no comando.

---

## Aplicar

O orquestrador tem os scripts antigos em memória. Depois do merge:

```bash
bash scripts/team/start.sh --stop
TEAM_HERMES=1 bash scripts/team/start.sh
```