### PR TITLE
test: cobre ContactDetailScreen, ContactEditScreen, ProfileScreen e EditProfileScreen com asserções comportamentais (#289)

### DIFF
--- a/src/screens/__tests__/ProfileScreen.test.tsx
+++ b/src/screens/__tests__/ProfileScreen.test.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import { render, fireEvent } from '../../test-utils';
+import { ProfileScreen } from '../ProfileScreen';
+
+const mockNavigate = jest.fn();
+const mockGoBack = jest.fn();
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({
+    navigate: mockNavigate,
+    goBack: mockGoBack,
+    canGoBack: jest.fn(() => false),
+    getParent: () => ({ navigate: jest.fn() }),
+  }),
+  useRoute: () => ({ params: {} }),
+  NavigationContainer: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+describe('ProfileScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the default profile name and email from ProfileStore', () => {
+    const { getByText } = render(<ProfileScreen />);
+
+    expect(getByText('Profile')).toBeTruthy();
+    expect(getByText('John Appleseed')).toBeTruthy();
+    expect(getByText('john.appleseed@gmail.com')).toBeTruthy();
+  });
+
+  it('shows the seeded contact and favorite counts', () => {
+    const { getByText } = render(<ProfileScreen />);
+
+    // 26 seeded contacts, 7 of them flagged isFavorite (src/store/ContactsStore.tsx).
+    expect(getByText('Contacts')).toBeTruthy();
+    expect(getByText('26')).toBeTruthy();
+    expect(getByText('Favorites')).toBeTruthy();
+    expect(getByText('7')).toBeTruthy();
+  });
+
+  it('navigates to EditProfile when the Edit Profile row is pressed', () => {
+    const { getByText } = render(<ProfileScreen />);
+
+    fireEvent.press(getByText('Edit Profile'));
+
+    expect(mockNavigate).toHaveBeenCalledWith('EditProfile');
+  });
+
+  it('keeps the sign-out dialog hidden until the row is pressed', () => {
+    const { queryByText, getByText, getAllByText } = render(<ProfileScreen />);
+
+    // Inverse of the fix: the confirmation copy is absent before the press.
+    expect(
+      queryByText('This will reset all settings, contacts, and profile data to defaults.')
+    ).toBeNull();
+
+    fireEvent.press(getByText('Sign Out'));
+
+    expect(
+      getByText('This will reset all settings, contacts, and profile data to defaults.')
+    ).toBeTruthy();
+    // The row plus the dialog title/action now share the label.
+    expect(getAllByText('Sign Out').length).toBeGreaterThan(1);
+  });
+
+  it('dismisses the sign-out dialog on Cancel without resetting the profile', () => {
+    const { getByText, queryByText } = render(<ProfileScreen />);
+
+    fireEvent.press(getByText('Sign Out'));
+    fireEvent.press(getByText('Cancel'));
+
+    expect(
+      queryByText('This will reset all settings, contacts, and profile data to defaults.')
+    ).toBeNull();
+    // Profile data untouched.
+    expect(getByText('John Appleseed')).toBeTruthy();
+  });
+
+  it('opens the avatar action sheet on avatar press and closes it on Cancel', () => {
+    const { getByLabelText, getByText, queryByText } = render(<ProfileScreen />);
+
+    expect(queryByText('Take Photo')).toBeNull();
+
+    fireEvent.press(getByLabelText('Change profile photo'));
+
+    expect(getByText('Take Photo')).toBeTruthy();
+    expect(getByText('Choose from Library')).toBeTruthy();
+    expect(getByText('Remove Photo')).toBeTruthy();
+
+    fireEvent.press(getByText('Cancel'));
+
+    expect(queryByText('Take Photo')).toBeNull();
+  });
+
+  it('opens the share sheet when Share Profile is pressed', () => {
+    const { getByText, getAllByText, queryByLabelText, getByLabelText } = render(<ProfileScreen />);
+
+    // Inverse: the share sheet options are absent before the press.
+    expect(queryByLabelText('Copy')).toBeNull();
+
+    fireEvent.press(getByText('Share Profile'));
+
+    // CupertinoShareSheet renders `title` in its preview card, so the name
+    // now appears both on the profile header and inside the sheet.
+    expect(getByLabelText('Copy')).toBeTruthy();
+    expect(getAllByText('John Appleseed').length).toBe(2);
+  });
+
+  it('tolerates the avatar sheet being opened twice in a row', () => {
+    const { getByLabelText, getByText } = render(<ProfileScreen />);
+
+    fireEvent.press(getByLabelText('Change profile photo'));
+    fireEvent.press(getByLabelText('Change profile photo'));
+
+    expect(getByText('Take Photo')).toBeTruthy();
+  });
+});

--- a/src/screens/contacts/__tests__/ContactDetailScreen.test.tsx
+++ b/src/screens/contacts/__tests__/ContactDetailScreen.test.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import { render, fireEvent } from '../../../test-utils';
+import { ContactDetailScreen } from '../ContactDetailScreen';
+import type { AppNavigationProp, AppRouteProp } from '../../../navigation/types';
+
+function makeNavigation() {
+  return {
+    navigate: jest.fn(),
+    goBack: jest.fn(),
+  } as unknown as AppNavigationProp;
+}
+
+function makeRoute(contactId: string): AppRouteProp<'ContactDetail'> {
+  return {
+    key: 'ContactDetail-test',
+    name: 'ContactDetail',
+    params: { contactId },
+  } as AppRouteProp<'ContactDetail'>;
+}
+
+describe('ContactDetailScreen', () => {
+  it('renders the seeded contact for a known contactId', () => {
+    const { getAllByText, getByText } = render(
+      <ContactDetailScreen navigation={makeNavigation()} route={makeRoute('1')} />
+    );
+
+    // Seed id '1' is Alice Anderson (src/store/ContactsStore.tsx)
+    expect(getAllByText('Alice Anderson').length).toBeGreaterThan(0);
+    expect(getByText('Anderson & Co')).toBeTruthy();
+    expect(getByText('+1 (555) 100-0001')).toBeTruthy();
+    expect(getByText('alice.anderson@email.com')).toBeTruthy();
+  });
+
+  it('renders the not-found branch for an unknown contactId', () => {
+    const { getByText, queryByText } = render(
+      <ContactDetailScreen navigation={makeNavigation()} route={makeRoute('does-not-exist')} />
+    );
+
+    expect(getByText('Contact not found.')).toBeTruthy();
+    // Inverse of the found branch: none of the contact chrome renders.
+    expect(queryByText('Alice Anderson')).toBeNull();
+    expect(queryByText('Delete Contact')).toBeNull();
+    expect(queryByText('Edit')).toBeNull();
+  });
+
+  it('renders the not-found branch for an empty contactId', () => {
+    const { getByText } = render(
+      <ContactDetailScreen navigation={makeNavigation()} route={makeRoute('')} />
+    );
+
+    expect(getByText('Contact not found.')).toBeTruthy();
+  });
+
+  it('navigates to ContactEdit with the routed contactId when Edit is pressed', () => {
+    const navigation = makeNavigation();
+    const { getByText } = render(
+      <ContactDetailScreen navigation={navigation} route={makeRoute('3')} />
+    );
+
+    fireEvent.press(getByText('Edit'));
+
+    expect(navigation.navigate).toHaveBeenCalledWith('ContactEdit', { contactId: '3' });
+  });
+
+  it('navigates to Conversation with the contact phone when message is pressed', () => {
+    const navigation = makeNavigation();
+    const { getByLabelText } = render(
+      <ContactDetailScreen navigation={navigation} route={makeRoute('1')} />
+    );
+
+    fireEvent.press(getByLabelText('message'));
+
+    expect(navigation.navigate).toHaveBeenCalledWith('Conversation', {
+      address: '+1 (555) 100-0001',
+    });
+  });
+
+  it('does not navigate to Mail for a contact without an email', () => {
+    const navigation = makeNavigation();
+    // Seed id '4' (Diana Davis) has no email.
+    const { getByLabelText } = render(
+      <ContactDetailScreen navigation={navigation} route={makeRoute('4')} />
+    );
+
+    fireEvent.press(getByLabelText('mail'));
+
+    expect(navigation.navigate).not.toHaveBeenCalled();
+  });
+
+  it('goes back only after the delete alert is confirmed', () => {
+    const navigation = makeNavigation();
+    const { getByText, getAllByText } = render(
+      <ContactDetailScreen navigation={navigation} route={makeRoute('2')} />
+    );
+
+    fireEvent.press(getByText('Delete Contact'));
+    // Opening the alert alone must not pop the screen.
+    expect(navigation.goBack).not.toHaveBeenCalled();
+
+    // Inside the dialog the confirm button is labelled exactly 'Delete'.
+    const confirm = getAllByText('Delete');
+    fireEvent.press(confirm[confirm.length - 1]);
+
+    expect(navigation.goBack).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/screens/contacts/__tests__/ContactEditScreen.test.tsx
+++ b/src/screens/contacts/__tests__/ContactEditScreen.test.tsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import { render, fireEvent } from '../../../test-utils';
+import { ContactEditScreen } from '../ContactEditScreen';
+import type { AppNavigationProp, AppRouteProp } from '../../../navigation/types';
+
+function makeNavigation() {
+  return {
+    navigate: jest.fn(),
+    goBack: jest.fn(),
+  } as unknown as AppNavigationProp;
+}
+
+function makeRoute(params: { contactId?: string } | undefined): AppRouteProp<'ContactEdit'> {
+  return {
+    key: 'ContactEdit-test',
+    name: 'ContactEdit',
+    params,
+  } as AppRouteProp<'ContactEdit'>;
+}
+
+describe('ContactEditScreen', () => {
+  describe('create mode (no contactId)', () => {
+    it('renders the New Contact title with empty fields', () => {
+      const { getByText, getByPlaceholderText } = render(
+        <ContactEditScreen navigation={makeNavigation()} route={makeRoute(undefined)} />
+      );
+
+      expect(getByText('New Contact')).toBeTruthy();
+      expect(getByPlaceholderText('First Name').props.value).toBe('');
+      expect(getByPlaceholderText('Last Name').props.value).toBe('');
+    });
+
+    it('does not save (goBack) while required fields are incomplete', () => {
+      const navigation = makeNavigation();
+      const { getByText, getByPlaceholderText } = render(
+        <ContactEditScreen navigation={navigation} route={makeRoute(undefined)} />
+      );
+
+      // Only a first name — last name and phone still missing → canSave false.
+      fireEvent.changeText(getByPlaceholderText('First Name'), 'New');
+      fireEvent.press(getByText('Done'));
+
+      expect(navigation.goBack).not.toHaveBeenCalled();
+    });
+
+    it('saves and goes back once all required fields are valid', () => {
+      const navigation = makeNavigation();
+      const { getByText, getByPlaceholderText } = render(
+        <ContactEditScreen navigation={navigation} route={makeRoute(undefined)} />
+      );
+
+      fireEvent.changeText(getByPlaceholderText('First Name'), 'New');
+      fireEvent.changeText(getByPlaceholderText('Last Name'), 'Person');
+      fireEvent.changeText(getByPlaceholderText('Phone'), '5551234567');
+      fireEvent.press(getByText('Done'));
+
+      expect(navigation.goBack).toHaveBeenCalledTimes(1);
+    });
+
+    it('blocks save when the phone has too few digits', () => {
+      const navigation = makeNavigation();
+      const { getByText, getByPlaceholderText } = render(
+        <ContactEditScreen navigation={navigation} route={makeRoute(undefined)} />
+      );
+
+      fireEvent.changeText(getByPlaceholderText('First Name'), 'New');
+      fireEvent.changeText(getByPlaceholderText('Last Name'), 'Person');
+      fireEvent.changeText(getByPlaceholderText('Phone'), '123'); // < 7 digits
+      fireEvent.press(getByText('Done'));
+
+      expect(getByText('Enter a valid phone number (at least 7 digits)')).toBeTruthy();
+      expect(navigation.goBack).not.toHaveBeenCalled();
+    });
+
+    it('blocks save on an invalid email even when name and phone are valid', () => {
+      const navigation = makeNavigation();
+      const { getByText, getByPlaceholderText } = render(
+        <ContactEditScreen navigation={navigation} route={makeRoute(undefined)} />
+      );
+
+      fireEvent.changeText(getByPlaceholderText('First Name'), 'New');
+      fireEvent.changeText(getByPlaceholderText('Last Name'), 'Person');
+      fireEvent.changeText(getByPlaceholderText('Phone'), '5551234567');
+      fireEvent.changeText(getByPlaceholderText('Email'), 'not-an-email');
+      fireEvent.press(getByText('Done'));
+
+      expect(getByText('Invalid email address')).toBeTruthy();
+      expect(navigation.goBack).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('edit mode (contactId present)', () => {
+    it('renders the Edit Contact title pre-filled from the seeded contact', () => {
+      const { getByText, getByPlaceholderText } = render(
+        <ContactEditScreen navigation={makeNavigation()} route={makeRoute({ contactId: '1' })} />
+      );
+
+      // Seed id '1' is Alice Anderson.
+      expect(getByText('Edit Contact')).toBeTruthy();
+      expect(getByPlaceholderText('First Name').props.value).toBe('Alice');
+      expect(getByPlaceholderText('Last Name').props.value).toBe('Anderson');
+      expect(getByPlaceholderText('Phone').props.value).toBe('+1 (555) 100-0001');
+    });
+
+    it('saves an edited field and goes back', () => {
+      const navigation = makeNavigation();
+      const { getByText, getByPlaceholderText } = render(
+        <ContactEditScreen navigation={navigation} route={makeRoute({ contactId: '1' })} />
+      );
+
+      fireEvent.changeText(getByPlaceholderText('First Name'), 'Alicia');
+      fireEvent.press(getByText('Done'));
+
+      expect(navigation.goBack).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not save when a required field is cleared in edit mode', () => {
+      const navigation = makeNavigation();
+      const { getByText, getByPlaceholderText } = render(
+        <ContactEditScreen navigation={navigation} route={makeRoute({ contactId: '1' })} />
+      );
+
+      fireEvent.changeText(getByPlaceholderText('First Name'), '');
+      fireEvent.press(getByText('Done'));
+
+      expect(navigation.goBack).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/screens/profile/__tests__/EditProfileScreen.test.tsx
+++ b/src/screens/profile/__tests__/EditProfileScreen.test.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import { render, fireEvent } from '../../../test-utils';
+import { EditProfileScreen } from '../EditProfileScreen';
+import type { AppNavigationProp } from '../../../navigation/types';
+
+function makeNavigation() {
+  return {
+    navigate: jest.fn(),
+    goBack: jest.fn(),
+  } as unknown as AppNavigationProp;
+}
+
+describe('EditProfileScreen', () => {
+  it('pre-fills the fields from the stored profile', () => {
+    const { getByText, getByPlaceholderText } = render(
+      <EditProfileScreen navigation={makeNavigation()} />
+    );
+
+    expect(getByText('Edit Profile')).toBeTruthy();
+    expect(getByPlaceholderText('Full Name').props.value).toBe('John Appleseed');
+    expect(getByPlaceholderText('Email').props.value).toBe('john.appleseed@gmail.com');
+  });
+
+  it('keeps the typed name in the field and goes back on save', () => {
+    const navigation = makeNavigation();
+    const { getByText, getByPlaceholderText } = render(
+      <EditProfileScreen navigation={navigation} />
+    );
+
+    const nameField = getByPlaceholderText('Full Name');
+    fireEvent.changeText(nameField, 'Jane Appleseed');
+    expect(nameField.props.value).toBe('Jane Appleseed');
+
+    fireEvent.press(getByText('Save'));
+
+    expect(navigation.goBack).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects an invalid email: shows the error and does not go back', () => {
+    const navigation = makeNavigation();
+    const { getByText, getByPlaceholderText, queryByText } = render(
+      <EditProfileScreen navigation={navigation} />
+    );
+
+    expect(queryByText('Invalid email format')).toBeNull();
+
+    fireEvent.changeText(getByPlaceholderText('Email'), 'jane@@example');
+    fireEvent.press(getByText('Save'));
+
+    expect(getByText('Invalid email format')).toBeTruthy();
+    expect(navigation.goBack).not.toHaveBeenCalled();
+  });
+
+  it('clears the email error as soon as the field is edited again', () => {
+    const navigation = makeNavigation();
+    const { getByText, getByPlaceholderText, queryByText } = render(
+      <EditProfileScreen navigation={navigation} />
+    );
+
+    fireEvent.changeText(getByPlaceholderText('Email'), 'broken');
+    fireEvent.press(getByText('Save'));
+    expect(getByText('Invalid email format')).toBeTruthy();
+
+    fireEvent.changeText(getByPlaceholderText('Email'), 'fixed@example.com');
+
+    expect(queryByText('Invalid email format')).toBeNull();
+  });
+
+  it('accepts an empty email and saves', () => {
+    const navigation = makeNavigation();
+    const { getByText, getByPlaceholderText, queryByText } = render(
+      <EditProfileScreen navigation={navigation} />
+    );
+
+    fireEvent.changeText(getByPlaceholderText('Email'), '');
+    fireEvent.press(getByText('Save'));
+
+    expect(queryByText('Invalid email format')).toBeNull();
+    expect(navigation.goBack).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats a whitespace-only email as empty and saves', () => {
+    const navigation = makeNavigation();
+    const { getByText, getByPlaceholderText } = render(
+      <EditProfileScreen navigation={navigation} />
+    );
+
+    fireEvent.changeText(getByPlaceholderText('Email'), '   ');
+    fireEvent.press(getByText('Save'));
+
+    expect(navigation.goBack).toHaveBeenCalledTimes(1);
+  });
+
+  it('goes back without saving when Cancel is pressed', () => {
+    const navigation = makeNavigation();
+    const { getByText, getByPlaceholderText } = render(
+      <EditProfileScreen navigation={navigation} />
+    );
+
+    fireEvent.changeText(getByPlaceholderText('Full Name'), 'Discarded');
+    fireEvent.press(getByText('Cancel'));
+
+    expect(navigation.goBack).toHaveBeenCalledTimes(1);
+  });
+
+  it('goes back twice when Save is pressed twice (no crash on a double tap)', () => {
+    const navigation = makeNavigation();
+    const { getByText } = render(<EditProfileScreen navigation={navigation} />);
+
+    fireEvent.press(getByText('Save'));
+    fireEvent.press(getByText('Save'));
+
+    expect(navigation.goBack).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Resumo

test: cobre ContactDetailScreen, ContactEditScreen, ProfileScreen e EditProfileScreen com asserções comportamentais

## Causa raiz

Não é um defeito de produção — é ausência de cobertura. Quatro ecrãs com ramos condicionais e fluxos de escrita não tinham qualquer teste:

- `src/screens/contacts/ContactDetailScreen.tsx:68` — o guard `if (!contact)` decide entre a árvore completa do contacto e a mensagem `Contact not found.` (linha 83). Ambos os ramos estavam por verificar, pelo que uma inversão do guard, ou um `route.params.contactId` mal encaminhado, passava silenciosamente.
- `src/screens/contacts/ContactEditScreen.tsx:21` — `isEditMode = Boolean(contactId)` é a única coisa que distingue criar de editar; e `canSave` (linha 50) é o guard de validação que impede gravar com campos inválidos. Nada provava nenhum dos dois.
- `src/screens/ProfileScreen.tsx:169` — `navigation.navigate('EditProfile')` obtido via `useNavigation()` (linha 30), e a confirmação de sign-out (linhas 188/199-200), sem verificação.
- `src/screens/profile/EditProfileScreen.tsx:31` — `handleSave` valida o email e só então chama `updateProfile` + `goBack` (linhas 33-40); a validação e o descarte de edições estavam por cobrir.

O issue estava correcto no diagnóstico. Dois pontos onde o **código ganhou** contra o texto do issue:

1. O issue sugeria `getByText(/Alice/)`; o nome renderiza em dois nós (barra de navegação + cabeçalho), pelo que `getByText` estoura com "Found multiple elements". Usei `getAllByText`.
2. O issue dizia que `ProfileScreen` não tem props — confirmado; o mock de `@react-navigation/native` do `jest.setup.js` devolve um `jest.fn()` novo em cada render, impossível de inspeccionar, por isso este teste declara o seu próprio mock com um spy estável.

## Convenção de directórios

Conforme pedido no issue, verifiquei antes de criar: `src/screens/settings/__tests__/` já existe com 17 ficheiros para os ecrãs de `src/screens/settings/`. A convenção do repositório é portanto **`__tests__` junto do subdirectório**, não um `src/screens/__tests__/` plano. Segui-a: `contacts/__tests__/` e `profile/__tests__/` novos, e `ProfileScreen.test.tsx` em `src/screens/__tests__/` porque `ProfileScreen.tsx` vive na raiz de `screens/`.

## O que mudou

Apenas ficheiros de teste novos. **Zero alterações a código de produção** (`git diff --name-only origin/main...HEAD` vazio; `git status --porcelain` mostra só os quatro ficheiros novos).

- **`src/screens/contacts/__tests__/ContactDetailScreen.test.tsx`** (7 testes) — monta o ecrã real com `route.params.contactId`; verifica o ramo encontrado contra os dados de seed (`'1'` = Alice Anderson, empresa, telefone, email), o ramo not-found para id desconhecido e para id vazio, `navigate('ContactEdit', { contactId })` no Edit, `navigate('Conversation', { address })` no botão message, ausência de navegação no botão mail para contacto sem email (seed `'4'`, Diana Davis), e que `goBack` só acontece depois de confirmar o diálogo de eliminação.
- **`src/screens/contacts/__tests__/ContactEditScreen.test.tsx`** (8 testes) — modo criar: título `New Contact`, campos vazios, save bloqueado com campos incompletos, save bem-sucedido com tudo válido, telefone com menos de 7 dígitos rejeitado com a mensagem de erro, email inválido rejeitado. Modo editar: título `Edit Contact` pré-preenchido a partir do seed, gravação de um campo alterado, e save bloqueado quando um campo obrigatório é limpo.
- **`src/screens/__tests__/ProfileScreen.test.tsx`** (8 testes) — nome/email do `ProfileStore`, contagens de contactos/favoritos (26/7), `navigate('EditProfile')` no toque na linha Edit Profile, diálogo de sign-out escondido antes do toque e visível depois, Cancel a fechar sem apagar dados, action sheet do avatar a abrir e fechar, share sheet a abrir, e abertura repetida do action sheet.
- **`src/screens/profile/__tests__/EditProfileScreen.test.tsx`** (8 testes) — pré-preenchimento, texto escrito a persistir no campo + `goBack` no save, email inválido a mostrar `Invalid email format` sem gravar, erro a limpar-se ao reeditar o campo, email vazio aceito, email só com espaços tratado como vazio, Cancel a sair sem gravar, e duplo toque no Save.

## Porque assim

- **Unidade real, não cópia.** Cada teste monta o componente exportado através de `src/test-utils.tsx` (que desliga os gates de primeiro render dos providers) e dispara `fireEvent` verdadeiro. Não reimplementei nenhuma fórmula de validação no ficheiro de teste.
- **Dados de seed em vez de mocks do store.** Asserções contra `SEED_CONTACTS` reais (`src/store/ContactsStore.tsx`) e `DEFAULT_PROFILE` (`src/store/ProfileStore.tsx`) exercitam o caminho de leitura do store a par do ecrã. Descartei mockar `useContacts`, que teria testado o mock.
- **`goBack` como observável de gravação.** `updateContact`/`addContact`/`updateProfile` vêm de contexto e não são visíveis de fora sem mockar o provider. `handleDone`/`handleSave` só chamam `goBack` **depois** de gravar, e retornam cedo quando a validação falha — logo `goBack` chamado/não-chamado é um proxy fiel do lado do guard em que estamos, sem substituir o store por um duplo. Provado pela mutação de `canSave` abaixo.
- **Mock local em ProfileScreen.** O `jest.setup.js` global devolve um `useNavigation()` com spies recriados a cada chamada, inúteis para asserção. Sobrepus com um mock ao nível do ficheiro que fecha sobre um `mockNavigate` estável, mantendo o resto da forma do mock global.

## Critérios de aceitação

- [x] Cada um dos quatro ecrãs tem ficheiro de teste dedicado — 4 ficheiros novos, 31 testes.
- [x] `ContactDetailScreen` cobre encontrado e não-encontrado — mais o id vazio como fronteira.
- [x] Cada ecrã tem pelo menos uma asserção comportamental pós-`fireEvent` (navegação ou mudança de estado visível), não só render. Zero snapshots novos.
- [x] As falhas pré-existentes não foram corrigidas nem mascaradas — nenhum teste alheio foi editado, apagado ou posto em `.skip`; `git diff origin/main...HEAD` não toca em nada fora dos quatro ficheiros novos.
- [x] `npm test` sem falhas NOVAS — 8 falhas contra 9 na baseline, todas subconjunto da lista de `baseline.json`.
- [x] **Não devia mudar:** nenhum código de produção. Confirmado por `git diff --name-only origin/main...HEAD` (vazio) e `git status --porcelain` (só os 4 ficheiros novos, nenhum `M`). Os 6 snapshots existentes continuam a passar, sem `-u`.

## Testes

**Passo vermelho.** Este issue é de cobertura pura — não há fix de produção para reverter, logo o passo vermelho equivalente é **mutação**: quebrei deliberadamente cada mecanismo sob teste e corri a suite. Output real do jest:

Mutação 1 — inverter o guard not-found em `ContactDetailScreen.tsx:68` (`if (!contact)` → `if (contact === undefined)`), rota errada em `ProfileScreen.tsx:169` (`'EditProfile'` → `'Settings'`), e desactivar a validação de email em `EditProfileScreen.tsx:33` (`if (trimmedEmail && !isValidEmail(...))` → `if (false)`):

```
  ● ContactDetailScreen › renders the not-found branch for an unknown contactId
  ● ContactDetailScreen › renders the not-found branch for an empty contactId
  ● ContactDetailScreen › goes back only after the delete alert is confirmed
  ● EditProfileScreen › rejects an invalid email: shows the error and does not go back
  ● EditProfileScreen › clears the email error as soon as the field is edited again
  ● ProfileScreen › navigates to EditProfile when the Edit Profile row is pressed
Test Suites: 3 failed, 1 passed, 4 total
Tests:       6 failed, 25 passed, 31 total
```

Com o `expect` exacto de uma delas:

```
  ● ProfileScreen › navigates to EditProfile when the Edit Profile row is pressed

    expect(jest.fn()).toHaveBeenCalledWith(...expected)

    Expected: "EditProfile"
    Received: "Settings"

    Number of calls: 1

      45 |     fireEvent.press(getByText('Edit Profile'));
      46 |
    > 47 |     expect(mockNavigate).toHaveBeenCalledWith('EditProfile');
         |                          ^
      48 |   });

      at Object.toHaveBeenCalledWith (src/screens/__tests__/ProfileScreen.test.tsx:47:26)
```

Mutação 2 — `ContactEditScreen.tsx:50`, substituir o guard de validação por `const canSave = true;`. (Nota: remover apenas o `if (!canSave) return;` de `handleDone` **não** é apanhado, porque o `disabled={!canSave}` do Pressable duplica o guard; mutar `canSave` ataca a fonte real):

```
  ● ContactEditScreen › create mode (no contactId) › does not save (goBack) while required fields are incomplete
  ● ContactEditScreen › create mode (no contactId) › blocks save when the phone has too few digits
  ● ContactEditScreen › create mode (no contactId) › blocks save on an invalid email even when name and phone are valid
  ● ContactEditScreen › edit mode (contactId present) › does not save when a required field is cleared in edit mode
Tests:       4 failed, 4 passed, 8 total
```

Cada um dos quatro ecrãs tem portanto testes empiricamente ligados ao comportamento de produção.

**Casos cobertos além do caminho feliz:**
- *Fronteiras:* telefone com 3 dígitos vs. o mínimo de 7 (`ContactEditScreen`).
- *Vazio e ausente:* `contactId` vazio, contacto sem email (seed `'4'`), email vazio e email só com espaços, `route.params` `undefined` no modo criar.
- *Inválido:* `not-an-email` e `jane@@example` contra os regex de validação reais.
- *Repetição:* action sheet do avatar aberto duas vezes seguidas, Save premido duas vezes (o duplo toque é defeito recorrente neste repositório).
- *Ordem:* eliminação de contacto e sign-out verificados em duas fases — abrir o diálogo **não** pode ter efeito destrutivo; só a confirmação o tem.
- *O inverso do fix:* diálogo de sign-out ausente antes do toque; opções do share sheet e do action sheet ausentes antes do toque; no ramo not-found confirmo que `Alice Anderson`, `Delete Contact` e `Edit` **não** renderizam; `Invalid email format` ausente antes do save inválido e de novo ausente depois de reeditar.

**Sanity-check.** Feito por mutação (acima), com os quatro ficheiros de produção salvaguardados em `/tmp` e restaurados a seguir. Após restauro, `git status --porcelain` mostra apenas os quatro ficheiros de teste novos (nenhum `M`) e os 31 testes voltam a passar.

**Verificações:**
- `npm run lint` — 0 erros, 1 aviso pré-existente (`src/screens/ClockScreen.tsx:258`, `tzTick` não usado; ficheiro não tocado). Igual à baseline.
- `npx tsc --noEmit` — limpo, exit 0. Sem `any` novo: os mocks de navegação usam `as unknown as AppNavigationProp` e `as AppRouteProp<'ContactEdit'>` com os tipos reais de `src/navigation/types.ts`.
- `npm test` — 601 testes, 8 falhas em 4 suites (baseline: 9 falhas em 5 suites). As 8 são `FoldersStore` (2), `SettingsScreen` (1), `LockScreen` (3), `WeatherScreen` (2) — todas presentes em `baseline.json`. Sem falhas novas; 6 snapshots existentes a passar sem `-u`.

## Testes

601 testes: 593 passaram, 8 falharam (todas pré-existentes na baseline de 9), 86 suites. Os 31 testes novos passam todos.

## Linked Issue

Fixes #289