### PR TITLE
A última página do home agora É a App Library preenchida (grelha de categorias + pesquisa), em vez de um placeholder que exigia um toque extra (#434)

### DIFF
--- a/src/screens/AppLibraryScreen.tsx
+++ b/src/screens/AppLibraryScreen.tsx
@@ -203,7 +203,7 @@ function CategoryDetailModal({ visible, title, apps, onClose, onLaunch }: Catego
             <Pressable
               onPress={() => { onLaunch(item.packageName); onClose(); }}
               style={[styles.modalAppCell, { width: cellW }]}
-              accessibilityLabel={`Open ${item.name}`}
+              accessibilityLabel={`Open ${item.name}, App Library`}
               accessibilityRole="button"
             >
               <AppIcon app={item} size={iconSize} />
@@ -240,7 +240,7 @@ const AppStrip = React.memo(function AppStrip({
           key={app.packageName}
           onPress={() => onLaunch(app.packageName)}
           style={styles.stripItem}
-          accessibilityLabel={`Open ${app.name}`}
+          accessibilityLabel={`Open ${app.name}, App Library`}
           accessibilityRole="button"
         >
           <AppIcon app={app} size={stripIconSize} />
@@ -287,7 +287,7 @@ const SearchResults = React.memo(function SearchResults({
         <Pressable
           onPress={() => onLaunch(item.packageName)}
           style={({ pressed }) => [styles.searchRow, { opacity: pressed ? 0.7 : 1 }]}
-          accessibilityLabel={`Open ${item.name}`}
+          accessibilityLabel={`Open ${item.name}, App Library`}
           accessibilityRole="button"
         >
           <AppIcon app={item} size={46} />
@@ -313,8 +313,14 @@ function SectionHeader({ title, colors }: { title: string; colors: CupertinoColo
 // Main Screen
 // ---------------------------------------------------------------------------
 
-export function AppLibraryScreen({ navigation }: { navigation: AppNavigationProp }) {
-  const { theme, isDark, typography } = useTheme();
+// Shared body of the App Library: search bar, Recently Added / Suggestions
+// strips, category grid and the category detail modal. Rendered both by the
+// `AppLibrary` stack route (AppLibraryScreen, below) and directly as the last
+// page of the paginated home screen (LauncherHomeScreen) — see issue #434.
+// Keeping this in one place means the two call sites can't drift apart the
+// way twin overlays did in #384.
+export function AppLibraryContent() {
+  const { theme } = useTheme();
   const { colors } = theme;
   const { apps, launchApp, recentApps } = useApps();
   const insets = useSafeAreaInsets();
@@ -386,24 +392,6 @@ export function AppLibraryScreen({ navigation }: { navigation: AppNavigationProp
 
   return (
     <View style={[styles.root, { backgroundColor: colors.systemGroupedBackground }]}>
-      <StatusBar barStyle={isDark ? 'light-content' : 'dark-content'} />
-
-      {/* Navigation bar */}
-      <CupertinoNavigationBar
-        title="App Library"
-        largeTitle={false}
-        leftButton={
-          <Pressable
-            onPress={() => navigation.goBack()}
-            style={styles.backBtn}
-            accessibilityLabel="Back"
-          >
-            <Ionicons name="chevron-back" size={22} color={colors.systemBlue} />
-            <Text style={[typography.body, styles.backLabel, { color: colors.systemBlue }]}>Back</Text>
-          </Pressable>
-        }
-      />
-
       {/* Search bar */}
       <View style={styles.searchBarWrap}>
         <CupertinoSearchBar
@@ -473,11 +461,44 @@ export function AppLibraryScreen({ navigation }: { navigation: AppNavigationProp
 }
 
 // ---------------------------------------------------------------------------
+// Stack route wrapper — nav bar + back button, then the shared content
+// ---------------------------------------------------------------------------
+
+export function AppLibraryScreen({ navigation }: { navigation: AppNavigationProp }) {
+  const { theme, isDark, typography } = useTheme();
+  const { colors } = theme;
+
+  return (
+    <View style={styles.screenRoot}>
+      <StatusBar barStyle={isDark ? 'light-content' : 'dark-content'} />
+      <CupertinoNavigationBar
+        title="App Library"
+        largeTitle={false}
+        leftButton={
+          <Pressable
+            onPress={() => navigation.goBack()}
+            style={styles.backBtn}
+            accessibilityLabel="Back"
+          >
+            <Ionicons name="chevron-back" size={22} color={colors.systemBlue} />
+            <Text style={[typography.body, styles.backLabel, { color: colors.systemBlue }]}>Back</Text>
+          </Pressable>
+        }
+      />
+      <AppLibraryContent />
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Styles
 // ---------------------------------------------------------------------------
 
 const styles = StyleSheet.create({
   root: {
+    flex: 1,
+  },
+  screenRoot: {
     flex: 1,
   },
   backBtn: {

--- a/src/screens/LauncherHomeScreen.tsx
+++ b/src/screens/LauncherHomeScreen.tsx
@@ -35,6 +35,7 @@ import * as Haptics from 'expo-haptics';
 import * as NavigationBar from 'expo-navigation-bar';
 
 import { useApps, InstalledApp } from '../store/AppsStore';
+import { AppLibraryContent } from './AppLibraryScreen';
 import { useSettings } from '../store/SettingsStore';
 import { useTheme } from '../theme/ThemeContext';
 import { useDevice } from '../store/DeviceStore';
@@ -625,6 +626,14 @@ export function LauncherHomeScreen() {
     navigation.navigate(screen as any);
   }, [navigation]);
 
+  // The App Library is now the last page of this same pager (#434), so
+  // reaching it from a gesture means scrolling to the end of the ScrollView,
+  // not pushing a stack screen — `scrollToEnd` needs no page-count math and
+  // stays correct as apps are added/removed.
+  const scrollToLibraryPage = useCallback(() => {
+    scrollViewRef.current?.scrollToEnd({ animated: true });
+  }, []);
+
   // Vertical swipe gesture on the home body:
   //   up   → App Drawer
   //   down → Spotlight (progress tracked into spotlightProgress; navigate on commit)
@@ -669,10 +678,11 @@ export function LauncherHomeScreen() {
       'worklet';
       const { translationY, velocityY } = event;
 
-      // Up-swipe → App Library
+      // Up-swipe → App Library (now the last page of this pager, not a
+      // separate screen — see scrollToLibraryPage above)
       if (translationY < -60 && velocityY < -200) {
         spotlightProgress.value = settle(0, 'fastSettle', reduceMotionShared.value);
-        runOnJS(navigateTo)('AppLibrary');
+        runOnJS(scrollToLibraryPage)();
         return;
       }
 
@@ -1205,18 +1215,12 @@ export function LauncherHomeScreen() {
           </View>
         ))}
 
-        {/* App Library page — always the last swipeable page */}
-        <Pressable
-          key="app-library"
-          style={[styles.page, styles.appLibraryPage]}
-          onPress={() => navigation.navigate('AppLibrary')}
-          accessibilityLabel="Open App Library"
-          accessibilityRole="button"
-        >
-          <Ionicons name="grid" size={52} color="rgba(255,255,255,0.7)" />
-          <Text style={[styles.appLibraryText, { fontSize: 22 * textScale }]}>App Library</Text>
-          <Text style={[styles.appLibrarySubtext, { fontSize: 14 * textScale }]}>Tap to open all apps</Text>
-        </Pressable>
+        {/* App Library page — the App Library IS the last swipeable page
+            (#434), rendered inline via the shared AppLibraryContent instead
+            of a tap-through placeholder. */}
+        <View key="app-library" style={[styles.page, styles.appLibraryPage]}>
+          <AppLibraryContent />
+        </View>
       </ScrollView>
 
       {/* ---------------------------------------------------------------- */}
@@ -1593,24 +1597,10 @@ const styles = StyleSheet.create({
     fontWeight: '600',
   },
 
-  // App Library page
+  // App Library page — no horizontal padding: AppLibraryContent lays out its
+  // own edge-to-edge search bar/grid exactly like the standalone screen does.
   appLibraryPage: {
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: 12,
-  },
-  appLibraryText: {
-    color: 'rgba(255,255,255,0.9)',
-    fontSize: 22,
-    fontWeight: '700',
-    textShadowColor: 'rgba(0,0,0,0.5)',
-    textShadowOffset: { width: 0, height: 1 },
-    textShadowRadius: 4,
-  },
-  appLibrarySubtext: {
-    color: 'rgba(255,255,255,0.55)',
-    fontSize: 14,
-    fontWeight: '400',
+    paddingHorizontal: 0,
   },
 
   // Fallback

--- a/src/screens/__tests__/LauncherHomeScreen.test.tsx
+++ b/src/screens/__tests__/LauncherHomeScreen.test.tsx
@@ -330,3 +330,76 @@ describe('LauncherHomeScreen built-in duplicate suppression (#438)', () => {
     expect(queryAllByLabelText('Open Samsung Phone')).toHaveLength(1);
   });
 });
+
+// ---------------------------------------------------------------------------
+// #434: the last home page used to be a tap-through placeholder ("App
+// Library" / "Tap to open all apps") that pushed a separate stack screen.
+// On iOS the App Library IS the last page — swiping past the last app page
+// must show it already filled in, no extra tap.
+// ---------------------------------------------------------------------------
+describe('LauncherHomeScreen last page is the App Library itself (#434)', () => {
+  afterEach(() => { jest.restoreAllMocks(); });
+
+  // Mirrors the #438 describe block above: LauncherHomeScreen renders only
+  // a loading spinner while `isLoading` is true, and the real AppsProvider
+  // stays in that state synchronously in tests (its load is async, jest's
+  // render() does not await it) — so any test asserting on real page
+  // content must bypass the provider like this, or it fails for the wrong
+  // reason (stuck on the loading spinner) instead of the one under test.
+  function mockLoadedApps() {
+    jest.spyOn(AppsStore, 'useApps').mockReturnValue({
+      apps: [],
+      homeApps: [],
+      dockApps: [],
+      nonDockApps: [],
+      recentPackages: [],
+      recentApps: [],
+      isLoading: false,
+      refreshApps: jest.fn(() => Promise.resolve()),
+      launchApp: jest.fn(() => Promise.resolve()),
+      addToHome: jest.fn(),
+      removeFromHome: jest.fn(),
+      addToDock: jest.fn(),
+      removeFromDock: jest.fn(),
+      removeFromRecents: jest.fn(),
+      clearRecents: jest.fn(),
+      isDefaultLauncher: true,
+      openLauncherSettings: jest.fn(() => Promise.resolve()),
+    } as ReturnType<typeof AppsStore.useApps>);
+  }
+
+  it('shows the App Library search bar directly on mount, with no tap required', () => {
+    mockLoadedApps();
+    const { getByPlaceholderText } = render(<LauncherHomeScreen />);
+    expect(getByPlaceholderText('App Library')).toBeTruthy();
+  });
+
+  it('shows the Categories section directly, without navigating anywhere first', () => {
+    mockLoadedApps();
+    const { getByText } = render(<LauncherHomeScreen />);
+    expect(getByText('Categories')).toBeTruthy();
+  });
+
+  it('does not render the old "Tap to open all apps" placeholder anymore', () => {
+    mockLoadedApps();
+    const { queryByText } = render(<LauncherHomeScreen />);
+    expect(queryByText('Tap to open all apps')).toBeNull();
+  });
+
+  it('does not render the old placeholder "Open App Library" tap target anymore', () => {
+    mockLoadedApps();
+    const { queryByLabelText } = render(<LauncherHomeScreen />);
+    expect(queryByLabelText('Open App Library')).toBeNull();
+  });
+
+  it('the embedded library is the real interactive component, not a static copy: typing into its search bar filters results', () => {
+    mockLoadedApps();
+    const { getByPlaceholderText, getByText, queryByText } = render(<LauncherHomeScreen />);
+    // "Categories" heading is only shown outside search mode; typing switches
+    // to the search-results view, proving the search bar is wired to real
+    // state inside the embedded component, not just visually present.
+    expect(getByText('Categories')).toBeTruthy();
+    fireEvent.changeText(getByPlaceholderText('App Library'), 'zzz-no-such-app');
+    expect(queryByText('Categories')).toBeNull();
+  });
+});

--- a/src/screens/__tests__/LauncherHomeScreen.test.tsx
+++ b/src/screens/__tests__/LauncherHomeScreen.test.tsx
@@ -346,7 +346,7 @@ describe('LauncherHomeScreen last page is the App Library itself (#434)', () => 
   // render() does not await it) — so any test asserting on real page
   // content must bypass the provider like this, or it fails for the wrong
   // reason (stuck on the loading spinner) instead of the one under test.
-  function mockLoadedApps() {
+  function mockLoadedApps(over: Partial<ReturnType<typeof AppsStore.useApps>> = {}) {
     jest.spyOn(AppsStore, 'useApps').mockReturnValue({
       apps: [],
       homeApps: [],
@@ -365,8 +365,46 @@ describe('LauncherHomeScreen last page is the App Library itself (#434)', () => 
       clearRecents: jest.fn(),
       isDefaultLauncher: true,
       openLauncherSettings: jest.fn(() => Promise.resolve()),
+      ...over,
     } as ReturnType<typeof AppsStore.useApps>);
   }
+
+  // A MESMA APP NA GRELHA E NA BIBLIOTECA.
+  //
+  // Com a biblioteca a ser a ultima pagina do MESMO ScrollView, uma app que esteja
+  // na grelha do home E em "Recently Added" fica renderizada duas vezes na mesma
+  // arvore. Sem desambiguacao, ambas expoem `Open <nome>` e uma query por esse
+  // label passa a devolver dois nos: quebra os testes e, mais grave, deixa o
+  // TalkBack com dois botoes indistinguiveis que fazem coisas diferentes.
+  //
+  // O mock por omissao tem `recentApps: []`, portanto NUNCA exercita este caminho:
+  // os testes do caminho feliz passariam com a desambiguacao removida.
+  it('nao duplica o label de acessibilidade quando a app esta na grelha e em Recently Added', () => {
+    const app = { name: 'Chrome', packageName: 'com.android.chrome', icon: '', isSystem: false };
+    mockLoadedApps({
+      apps: [app],
+      nonDockApps: [app],   // grelha do home
+      // `recentApps` e ordenado por `launchedAt` e cruzado contra `apps` pelo
+      // packageName (AppLibraryScreen.tsx:355-364) — sem o timestamp a app nao
+      // chega a "Recently Added" e o teste passaria sem exercitar nada.
+      recentApps: [{ ...app, launchedAt: Date.now() }],
+      recentPackages: [app.packageName],
+    } as Partial<ReturnType<typeof AppsStore.useApps>>);
+
+    const { queryAllByLabelText } = render(<LauncherHomeScreen />);
+
+    // O que importa: o label da GRELHA continua unico. Sem a desambiguacao os
+    // nos da biblioteca partilhariam `Open Chrome` e isto daria 3.
+    expect(queryAllByLabelText('Open Chrome')).toHaveLength(1);
+
+    // A biblioteca renderiza a app em mais do que uma seccao ("Recently Added" e
+    // "Suggestions"), todas sob o sufixo proprio. Nao se afirma um numero exacto
+    // — isso prenderia o teste ao layout da biblioteca em vez de a colisao de
+    // labels, que e o que esta em causa. Afirma-se que existem e que estao todas
+    // desambiguadas.
+    const naBiblioteca = queryAllByLabelText('Open Chrome, App Library');
+    expect(naBiblioteca.length).toBeGreaterThan(0);
+  });
 
   it('shows the App Library search bar directly on mount, with no tap required', () => {
     mockLoadedApps();


### PR DESCRIPTION
## Resumo

A última página do home agora É a App Library preenchida (grelha de categorias + pesquisa), em vez de um placeholder que exigia um toque extra

## Causa raiz

`src/screens/LauncherHomeScreen.tsx:1209-1219` (antes do fix): a última página do `ScrollView` paginado do home era um `Pressable` estático ("App Library" / "Tap to open all apps") cujo `onPress` chamava `navigation.navigate('AppLibrary')`, empilhando `AppLibraryScreen` (`TabNavigator.tsx:137`) como um ecrã novo na stack. No iOS a App Library **é** a última página — não há navegação, o conteúdo já está lá ao deslizar. O conteúdo certo (grelha de categorias, pesquisa, Recently Added/Suggestions) já existia em `AppLibraryScreen.tsx`, só vivia no ecrã errado.

Um segundo mecanismo levava ao mesmo sítio: o gesto de swipe-up em `LauncherHomeScreen.tsx:673-677` (`panGesture.onEnd`) também fazia `runOnJS(navigateTo)('AppLibrary')`.

## O que mudou

- **`src/screens/AppLibraryScreen.tsx`** — extraído o corpo do ecrã (pesquisa, Recently Added, Suggestions, grelha de categorias, modal de detalhe de categoria) para um novo componente exportado `AppLibraryContent()`, sem dependência de `navigation`. `AppLibraryScreen` passou a ser um wrapper fino: `StatusBar` + `CupertinoNavigationBar` (com o botão "Back") + `<AppLibraryContent />`. A rota `AppLibrary` no stack (`TabNavigator.tsx:137`) mantém-se, agora apoiada neste wrapper.
  - Também corrigido: os três Pressables por-app dentro de `AppLibraryContent` (AppStrip, SearchResults, CategoryDetailModal) usavam `accessibilityLabel={\`Open ${app.name}\`}`, o mesmo padrão do `AppIcon` da grelha do home (`LauncherHomeScreen.tsx:269`). Como o `ScrollView` horizontal do home não desmonta páginas fora do ecrã, embutir `AppLibraryContent` como última página duplicava esse label para qualquer app que aparecesse nos dois sítios (ex.: "Phone" na grelha do home E em "Recently Added"), partindo `queryAllByLabelText`/leitores de ecrã. Passaram a `\`Open ${app.name}, App Library\`` para desambiguar.
- **`src/screens/LauncherHomeScreen.tsx`**
  - O `Pressable` placeholder da última página foi substituído por `<AppLibraryContent />` dentro de um `View` (sem `onPress` — o conteúdo é interactivo por si). Estilo `appLibraryPage` passou a só zerar o `paddingHorizontal` (a grelha de categorias já tem o seu próprio padding, igual ao ecrã standalone); os estilos `appLibraryText`/`appLibrarySubtext` do placeholder foram removidos (deixaram de ter uso).
  - Novo `scrollToLibraryPage` (via `scrollViewRef.current?.scrollToEnd({ animated: true })`) substitui o `navigateTo('AppLibrary')` no swipe-up gesture (`panGesture.onEnd`). Usar `scrollToEnd` em vez de calcular `pages.length * SCREEN_WIDTH` evita ter de reordenar hooks/memos só para expor a contagem de páginas a um `Gesture.Pan()` definido mais acima no componente.

## Porque assim

- Componente partilhado (`AppLibraryContent`) em vez de duplicar JSX entre a rota do stack e a página do home — é exactamente o problema apontado no issue (#384, overlays gémeos que divergiram).
- Mantive a rota `AppLibrary` no stack (o issue perguntava explicitamente se deveria ficar): não há mais nenhum sítio no código a navegar para lá por navegação directa (grep confirmou), mas removê-la seria scope creep não pedido pelo issue e partiria qualquer link/atalho externo que dependa dela.
- `scrollToEnd()` em vez de calcular o offset X manualmente: mais simples, e continua correcto se o número de apps (e por isso de páginas) mudar.

## Critérios de aceitação

- [x] Deslizar para além da última página de apps mostra a biblioteca já preenchida, sem toques adicionais — testado em `LauncherHomeScreen.test.tsx`: a pesquisa e a secção "Categories" aparecem logo no mount, sem qualquer `fireEvent.press`.
- [x] A grelha de categorias e a barra de pesquisa aparecem directamente — mesmo teste; `getByPlaceholderText('App Library')` e `getByText('Categories')` encontrados sem interacção prévia.
- [x] Deslizar para a direita volta à última página do home — decorre directamente de a biblioteca ser agora uma página do mesmo `ScrollView` paginado (não há `navigation.push` a criar uma stack nova); não há gesto de "voltar" a testar porque não há navegação a desfazer. Não escrevi um teste de simulação de swipe porque o `ScrollView` horizontal não é mockado ao nível de gesto neste repo (nenhum teste existente simula scroll real, só a função `computeWallpaperTranslateX` isoladamente) — confirmei o mecanismo por leitura de código, não por teste automatizado.
- [x] O código da biblioteca não é duplicado entre a página e a rota do stack — `AppLibraryScreen` e a última página do home renderizam ambos `<AppLibraryContent />`; verificado por teste ("the embedded library is the real interactive component, not a static copy") que confirma que o componente embutido tem estado real (a pesquisa filtra), não é uma cópia estática.
- [x] Nada que não devia mudar mudou: as suites de `AppLibraryScreen.test.tsx` (screen standalone) continuam todas verdes sem alteração ao próprio teste; as suites `#438`/`#433`/clock-interval de `LauncherHomeScreen.test.tsx` continuam verdes.

## Testes

**Passo vermelho** — com o fix de produção revertido (`git stash push -- src/screens/AppLibraryScreen.tsx src/screens/LauncherHomeScreen.tsx`, mantendo o teste), a suite nova falha pelas 5 asserções, todas pela razão certa (o placeholder antigo continua lá e o conteúdo real da biblioteca não está presente):

```
FAIL Android src/screens/__tests__/LauncherHomeScreen.test.tsx
    ✕ shows the App Library search bar directly on mount, with no tap required (314 ms)
    ✕ shows the Categories section directly, without navigating anywhere first (28 ms)
    ✕ does not render the old "Tap to open all apps" placeholder anymore (100 ms)
    ✕ does not render the old placeholder "Open App Library" tap target anymore (605 ms)
    ✕ the embedded library is the real interactive component, not a static copy: typing into its search bar filters results (69 ms)

  ● LauncherHomeScreen last page is the App Library itself (#434) › the embedded library is the real interactive component, not a static copy: typing into its search bar filters results

    Unable to find an element with text: Categories

      399 |     // to the search-results view, proving the search bar is wired to real
      400 |     // state inside the embedded component, not just visually present.
    > 401 |     expect(getByText('Categories')).toBeTruthy();
          |            ^

Test Suites: 1 failed, 1 total
Tests:       5 failed, 22 skipped, 27 total
```

Depois de `git stash pop` (fix restaurado), a mesma suite fica 100% verde (ver abaixo).

Nota sobre uma tentativa de armadilha inicial: a primeira versão destes testes usava o `AppsProvider` real (via `test-utils`), e 2 das 5 asserções negativas ("does not render...") passavam mesmo com o código antigo — não porque o fix já estivesse correcto, mas porque `LauncherHomeScreen` fica preso no `isLoading` (o provider real nunca resolve de forma síncrona em testes) e devolve só o spinner, sem placeholder nem conteúdo novo. Corrigido mockando `AppsStore.useApps` com `isLoading: false`, seguindo exactamente o padrão já usado no describe `#438` deste mesmo ficheiro. Sem essa correcção, o passo vermelho teria sido uma prova falsa.

**Casos cobertos** (além do caminho feliz):
- Ausência do placeholder antigo (texto "Tap to open all apps" e accessibility label "Open App Library") — o inverso do fix: garante que o que devia deixar de existir, deixou.
- Componente embutido é o real, não uma cópia estática: `fireEvent.changeText` no campo de pesquisa da página do home muda o estado (sai da vista de categorias para a vista de resultados) — prova acoplamento real, não uma screenshot.
- Regressão de accessibility label duplicado entre a grelha do home e as tiras "Recently Added"/"Suggestions" da App Library — descoberta ao correr a suite completa (`LauncherHomeScreen.test.tsx` + `AppLibraryScreen.test.tsx`), não fazia parte do plano inicial; ver secção "Causa raiz".

**Sanity-check**: reverti o fix de produção mantendo os testes (`git stash push` só nos 2 ficheiros de produção), corri a suite → 5 falhas (bloco acima), fiz `git stash pop` → fix restaurado, suite volta a verde.

**Resultados finais**:

```
$ npm run lint
0 erros, 1 warning (pré-existente em ClockScreen.tsx, não tocado aqui)

$ npx tsc --noEmit
(sem output — limpo)

$ npm test
Test Suites: 4 failed, 78 passed, 82 total
Tests:       8 failed, 567 passed, 575 total
```

As 8 falhas restantes são exactamente 8 das 9 falhas já documentadas na LINHA DE BASE (FoldersStore ×2, LockScreen ×3, SettingsScreen ×1, WeatherScreen ×2) — nenhuma nova, nenhuma em ficheiro tocado por este trabalho. A 9ª falha da baseline (`CalculatorScreen › 0.1 + 0.2 equals 0.3 without float artifacts`) passou nesta corrida — melhoria, não regressão.

## Testes

567 passaram, 8 falharam (as mesmas 8 já falhavam na linha de base; a 9ª falha da baseline passou agora), 82 suites

## Linked Issue

Fixes #434