### PR TITLE
fix(455): liga TodayView a um swipe-right na 1a pagina do home (#455)

### DIFF
--- a/src/navigation/__tests__/routeReachability.test.ts
+++ b/src/navigation/__tests__/routeReachability.test.ts
@@ -1,0 +1,100 @@
+import fs from 'fs';
+import path from 'path';
+
+// #455: TodayViewScreen was registered in TabNavigator and typed in
+// RootStackParamList, but nothing in the app ever navigated to it — it was
+// dead code, reachable only by a deep link the app doesn't even configure
+// (no `scheme` in app.json). This issue wires the right-swipe-on-first-page
+// gesture that reaches it; the gesture lives in LauncherHomeScreen.tsx and
+// calls `navigateTo('TodayView')` from the gesture's onEnd worklet.
+//
+// This is a static-analysis guard, not a rendering test: it parses the
+// registered route names out of TabNavigator.tsx and greps the rest of src/
+// for anything that looks like a real entry point (a literal
+// `navigate('X')`/`navigateTo('X')` call — including `runOnJS(navigateTo)('X')`
+// — a route embedded in a dispatch table like `BUILT_IN_APPS`/the Settings
+// screen list — `key: 'X'` — or an `initialRouteName`). It cannot prove a
+// route is reachable in the way a rendered interaction test can (that's what
+// LauncherHomeScreen.entryPoints.test.tsx does for the TodayView route this
+// issue is about) — it can only catch the specific shape of this bug again:
+// a screen added to the navigator with no textual trace of any code ever
+// trying to reach it.
+const SRC_ROOT = path.join(__dirname, '..', '..');
+const TAB_NAVIGATOR_PATH = path.join(__dirname, '..', 'TabNavigator.tsx');
+const TYPES_PATH = path.join(__dirname, '..', 'types.ts');
+
+function collectSourceFiles(dir: string, out: string[] = []): string[] {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === '__tests__' || entry.name === 'node_modules') continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      collectSourceFiles(full, out);
+    } else if (/\.(tsx|ts)$/.test(entry.name) && !/\.test\.tsx?$/.test(entry.name)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function readRegisteredRoutes(): string[] {
+  const source = fs.readFileSync(TAB_NAVIGATOR_PATH, 'utf8');
+  const matches = [...source.matchAll(/<Stack\.Screen\s+name="([A-Za-z]+)"/g)];
+  return matches.map((m) => m[1]);
+}
+
+function buildUsageCorpus(): string {
+  // Excludes TabNavigator.tsx (the registration itself — every route name
+  // trivially appears there) and types.ts (the type declaration — same
+  // reason). Everything else in src/ counts as a potential entry point.
+  const excluded = new Set([TAB_NAVIGATOR_PATH, TYPES_PATH]);
+  return collectSourceFiles(SRC_ROOT)
+    .filter((f) => !excluded.has(f))
+    .map((f) => fs.readFileSync(f, 'utf8'))
+    .join('\n');
+}
+
+function hasEntryPoint(corpus: string, route: string): boolean {
+  const patterns = [
+    // navigation.navigate('X') / navigateTo('X') / runOnJS(navigateTo)('X')
+    new RegExp(`navigate(?:To)?\\)?\\(\\s*['"]${route}['"]`),
+    // dispatch-table entries: BUILT_IN_APPS values, Settings screen `route: 'X'`
+    new RegExp(`:\\s*['"]${route}['"]\\s*[,}]`),
+    new RegExp(`initialRouteName=['"]${route}['"]`),
+  ];
+  return patterns.some((p) => p.test(corpus));
+}
+
+describe('every registered route has a discoverable entry point (#455)', () => {
+  // Pre-existing, unrelated to #455: MapsScreen is registered and typed but
+  // has no caller anywhere (confirmed by hand — the only "Maps" text in the
+  // app is a `title="Maps"` JSX prop and code comments, not a navigation
+  // call). It is a separate bug with the same shape as this issue; fixing it
+  // is out of scope here (see PR description). Documented explicitly instead
+  // of silently excluded so this allowlist can't grow without a comment.
+  //
+  // NOTE: an earlier analysis (and the reference commit 8cb7409) listed
+  // Notes/Reminders/Mail as unreachable gaps. That is incorrect against the
+  // current main: SpotlightSearchScreen.tsx already calls
+  // `navigation.navigate('Notes' | 'Mail' | 'Reminders')` for matching search
+  // results, so those routes DO have a discoverable entry point. They are not
+  // gaps. (Wiring them as home-screen icons is the mechanical half of #442 —
+  // out of scope for this issue either way.)
+  const KNOWN_PRE_EXISTING_GAPS = ['Maps'];
+
+  const registeredRoutes = readRegisteredRoutes();
+  const corpus = buildUsageCorpus();
+
+  it('registers a sane, non-empty set of routes to check (sanity check on the parser itself)', () => {
+    expect(registeredRoutes.length).toBeGreaterThan(40);
+    expect(registeredRoutes).toContain('HomeMain');
+  });
+
+  it('has no unreachable routes beyond the documented pre-existing gap', () => {
+    const unreachable = registeredRoutes.filter((r) => !hasEntryPoint(corpus, r));
+    expect(unreachable.slice().sort()).toEqual(KNOWN_PRE_EXISTING_GAPS.slice().sort());
+  });
+
+  it('TodayView (this issue) has an entry point now via the right-swipe gesture', () => {
+    expect(hasEntryPoint(corpus, 'TodayView')).toBe(true);
+  });
+});

--- a/src/screens/LauncherHomeScreen.tsx
+++ b/src/screens/LauncherHomeScreen.tsx
@@ -54,7 +54,7 @@ import { NotificationCenterOverlay } from '../components/NotificationCenterOverl
 import { SpotlightReveal } from '../components/SpotlightReveal';
 import { zones, gestureConfig } from '../utils/gestureConfig';
 import { useVelocityBuffer, pushSample, sampledVelocity } from '../utils/gestureVelocity';
-import { commitForSpotlight } from '../utils/gestureMachine';
+import { commitForSpotlight, commitForTodayView } from '../utils/gestureMachine';
 import { settle, useGestureReduceMotion } from '../utils/useGestureReduceMotion';
 import type { AppNavigationProp } from '../navigation/types';
 import type { SettingsState } from '../store/SettingsStore';
@@ -1043,8 +1043,30 @@ export function LauncherHomeScreen() {
     return options;
   })();
 
+  // Right-swipe on the first home page → Today View (#455).
+  //
+  // TodayViewScreen was registered in RootStackParamList and given a
+  // `slide_from_left` transition (TabNavigator.tsx) but nothing in the app
+  // ever called `navigate('TodayView')` — the gesture that transition was
+  // built for was never wired up. This mirrors the existing vertical
+  // panGesture: built fresh every render (not memoized, same as panGesture
+  // above) so `.enabled()` always reflects the current page/mode, and
+  // `activeOffsetX([-Infinity, 20])` activates only for RIGHTWARD drags —
+  // leftward drags are left untouched so paging to the next app page still
+  // works.
+  const todayViewGesture = Gesture.Pan()
+    .enabled(canSpotlight && currentPage === 0)
+    .activeOffsetX([-Infinity, 20])
+    .onEnd((event) => {
+      'worklet';
+      const progress = Math.max(0, event.translationX) / gestureConfig.todayViewCommitDp;
+      if (commitForTodayView({ progress, velocity: 0, holdMs: 0 }) !== 'none') {
+        runOnJS(navigateTo)('TodayView');
+      }
+    });
+
   return (
-    <GestureDetector gesture={panGesture}>
+    <GestureDetector gesture={Gesture.Race(panGesture, todayViewGesture)}>
       <Animated.View style={[styles.root, { overflow: 'hidden' }]}>
         {/* Parallax wallpaper — absolute layer, slightly oversized to allow horizontal shift */}
         <Animated.View

--- a/src/screens/__tests__/LauncherHomeScreen.entryPoints.test.tsx
+++ b/src/screens/__tests__/LauncherHomeScreen.entryPoints.test.tsx
@@ -1,0 +1,161 @@
+import React from 'react';
+import { render, fireEvent } from '../../test-utils';
+import { gestureConfig } from '../../utils/gestureConfig';
+import * as AppsStore from '../../store/AppsStore';
+
+// #455: TodayViewScreen was a fully-implemented screen with zero reachable
+// entry points — registered in TabNavigator with a `slide_from_left`
+// transition that was clearly meant for a swipe gesture, but nothing in the
+// app ever called `navigate('TodayView')`. This test exercises the real fix:
+// the actual `todayViewGesture` wired into LauncherHomeScreen (a Gesture.Pan
+// built fresh every render, gated by `canSpotlight && currentPage === 0`,
+// with `activeOffsetX([-Infinity, 20])` so it only fires for rightward drags)
+// — not a reimplementation of the routing/commit logic.
+
+const mockNavigate = jest.fn();
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({
+    navigate: mockNavigate,
+    goBack: jest.fn(),
+    canGoBack: jest.fn(() => false),
+    getParent: () => ({ navigate: jest.fn() }),
+  }),
+  useRoute: () => ({ params: {} }),
+  NavigationContainer: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+// jest.setup.js mocks react-native-gesture-handler with a Gesture API that
+// discards every callback passed to it, so a real swipe could never be
+// simulated. This file re-mocks the module and records every `Gesture.Pan()`
+// call (tagged by which axis it configures) so the test can reach in and
+// fire the captured `onEnd` directly — the same technique already
+// established in AssistiveTouch.test.tsx. The `mock` prefix on the array is
+// required: jest.mock factories may only close over `mock*`-named bindings.
+const mockPanRecords: Array<{
+  axis?: 'x' | 'y';
+  enabled?: unknown;
+  onEnd?: (e: { translationX: number; translationY: number }) => void;
+}> = [];
+
+jest.mock('react-native-gesture-handler', () => {
+  const chain = (record: Record<string, unknown>) => {
+    const g: Record<string, unknown> = {};
+    [
+      'onUpdate', 'onBegin', 'onFinalize', 'minDistance', 'simultaneousWithExternalGesture',
+      'withRef', 'onChange', 'onStart', 'onTouchesBegan', 'onTouchesMove', 'onTouchesUp',
+      'onTouchesCancelled', 'hitSlop', 'maxPointers', 'minPointers', 'averageTouches',
+      'failOffsetX', 'failOffsetY',
+    ].forEach((m) => { g[m] = () => g; });
+    g.activeOffsetX = () => { record.axis = 'x'; return g; };
+    g.activeOffsetY = () => { record.axis = 'y'; return g; };
+    g.enabled = (v: unknown) => { record.enabled = v; return g; };
+    g.onEnd = (fn: unknown) => { record.onEnd = fn; return g; };
+    return g;
+  };
+  return {
+    GestureHandlerRootView: 'View',
+    GestureDetector: 'View',
+    Gesture: {
+      Pan: () => {
+        const record: Record<string, unknown> = { enabled: true };
+        mockPanRecords.push(record as never);
+        return chain(record);
+      },
+      Tap: () => chain({}),
+      LongPress: () => chain({}),
+      Fling: () => chain({}),
+      Exclusive: (...gs: unknown[]) => gs[0],
+      Simultaneous: (...gs: unknown[]) => gs[0],
+      Race: (...gs: unknown[]) => gs[0],
+    },
+    Swipeable: 'View',
+    DrawerLayout: 'View',
+    State: {},
+    PanGestureHandler: 'View',
+    TapGestureHandler: 'View',
+    FlatList: 'FlatList',
+    ScrollView: 'ScrollView',
+  };
+});
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { LauncherHomeScreen } = require('../LauncherHomeScreen');
+
+function lastHorizontalPan() {
+  for (let i = mockPanRecords.length - 1; i >= 0; i--) {
+    if (mockPanRecords[i].axis === 'x') return mockPanRecords[i];
+  }
+  throw new Error('no horizontal (activeOffsetX) pan gesture captured');
+}
+
+// AppsStore starts with isLoading: true until the native app list resolves
+// (AppsStore.tsx), and the screen renders only a spinner while loading —
+// every test here needs the loaded state to see the grid at all.
+function mockLoadedApps() {
+  jest.spyOn(AppsStore, 'useApps').mockReturnValue({
+    apps: [],
+    homeApps: [],
+    dockApps: [],
+    nonDockApps: [],
+    recentPackages: [],
+    recentApps: [],
+    isLoading: false,
+    refreshApps: jest.fn(() => Promise.resolve()),
+    launchApp: jest.fn(() => Promise.resolve()),
+    addToHome: jest.fn(),
+    removeFromHome: jest.fn(),
+    addToDock: jest.fn(),
+    removeFromDock: jest.fn(),
+    removeFromRecents: jest.fn(),
+    clearRecents: jest.fn(),
+    isDefaultLauncher: true,
+    openLauncherSettings: jest.fn(() => Promise.resolve()),
+  } as ReturnType<typeof AppsStore.useApps>);
+}
+
+beforeEach(() => {
+  mockNavigate.mockClear();
+  mockPanRecords.length = 0;
+  mockLoadedApps();
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('LauncherHomeScreen TodayView reachable via right-swipe on the first page (#455)', () => {
+  it('navigates to TodayView once the right-swipe reaches the commit distance', () => {
+    render(<LauncherHomeScreen />);
+    const pan = lastHorizontalPan();
+    expect(pan.onEnd).toBeTruthy();
+    pan.onEnd!({ translationX: gestureConfig.todayViewCommitDp, translationY: 0 });
+    expect(mockNavigate).toHaveBeenCalledWith('TodayView');
+  });
+
+  it('does not navigate for a short drag that never reaches the commit distance', () => {
+    render(<LauncherHomeScreen />);
+    const pan = lastHorizontalPan();
+    pan.onEnd!({ translationX: gestureConfig.todayViewCommitDp / 2, translationY: 0 });
+    expect(mockNavigate).not.toHaveBeenCalledWith('TodayView');
+  });
+
+  it('does not navigate for a drag in the wrong direction (leftward)', () => {
+    render(<LauncherHomeScreen />);
+    const pan = lastHorizontalPan();
+    pan.onEnd!({ translationX: -gestureConfig.todayViewCommitDp, translationY: 0 });
+    expect(mockNavigate).not.toHaveBeenCalledWith('TodayView');
+  });
+
+  it('does not navigate when there is no movement at all', () => {
+    render(<LauncherHomeScreen />);
+    const pan = lastHorizontalPan();
+    pan.onEnd!({ translationX: 0, translationY: 0 });
+    expect(mockNavigate).not.toHaveBeenCalledWith('TodayView');
+  });
+
+  it('the gesture starts enabled on the first home page', () => {
+    render(<LauncherHomeScreen />);
+    const pan = lastHorizontalPan();
+    expect(pan.enabled).toBe(true);
+  });
+});

--- a/src/screens/__tests__/LauncherHomeScreen.entryPoints.test.tsx
+++ b/src/screens/__tests__/LauncherHomeScreen.entryPoints.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent } from '../../test-utils';
+import { render } from '../../test-utils';
 import { gestureConfig } from '../../utils/gestureConfig';
 import * as AppsStore from '../../store/AppsStore';
 

--- a/src/utils/__tests__/gestureMachine.test.ts
+++ b/src/utils/__tests__/gestureMachine.test.ts
@@ -6,6 +6,7 @@ import {
   commitForPanel,
   commitForNC,
   commitForSpotlight,
+  commitForTodayView,
 } from '../gestureMachine';
 import type { CommitPredicate } from '../gestureMachine';
 import { gestureConfig } from '../gestureConfig';
@@ -195,5 +196,35 @@ describe('commitForSpotlight', () => {
 
   it('returns none when below all thresholds', () => {
     expect(commitForSpotlight(pred({ progress: 0, velocity: 0 }))).toBe('none');
+  });
+});
+});
+
+// #455: TodayViewScreen was registered in RootStackParamList and rendered in
+// TabNavigator with a `slide_from_left` transition, but nothing in the app
+// ever called `navigate('TodayView')` — the gesture the transition was built
+// for was never wired up (see LauncherHomeScreen.tsx `todayViewGesture`).
+// This is the pure commit predicate for the right-swipe-on-first-page gesture
+// that now reaches it. Distance-only: it commits solely on how far the finger
+// travelled, with no velocity component.
+describe('commitForTodayView', () => {
+  it('returns distance once translationX reaches todayViewCommitDp (progress >= 1)', () => {
+    expect(commitForTodayView(pred({ progress: 1 }))).toBe('distance');
+  });
+
+  it('returns none for a partial drag that never reaches the commit distance', () => {
+    expect(commitForTodayView(pred({ progress: 0.5 }))).toBe('none');
+  });
+
+  it('returns none for no movement at all', () => {
+    expect(commitForTodayView(pred({ progress: 0, velocity: 0 }))).toBe('none');
+  });
+
+  it('returns none for a leftward drag (negative progress), never committing on the wrong direction', () => {
+    expect(commitForTodayView(pred({ progress: -1 }))).toBe('none');
+  });
+
+  it('is not swayed by velocity alone — this gesture only commits on distance', () => {
+    expect(commitForTodayView(pred({ progress: 0, velocity: 999 }))).toBe('none');
   });
 });

--- a/src/utils/__tests__/gestureMachine.test.ts
+++ b/src/utils/__tests__/gestureMachine.test.ts
@@ -198,7 +198,6 @@ describe('commitForSpotlight', () => {
     expect(commitForSpotlight(pred({ progress: 0, velocity: 0 }))).toBe('none');
   });
 });
-});
 
 // #455: TodayViewScreen was registered in RootStackParamList and rendered in
 // TabNavigator with a `slide_from_left` transition, but nothing in the app

--- a/src/utils/gestureConfig.ts
+++ b/src/utils/gestureConfig.ts
@@ -53,6 +53,9 @@ export const gestureConfig = {
   spotlightCommitDp: 32,
   spotlightCommitVelocity: 0.55,
 
+  // Today View (right-swipe reveal from the first home page — #455)
+  todayViewCommitDp: 64,
+
   // Swipe row actions
   swipeActionRevealDp: 10,
   swipeActionFirstExposedDp: 64,

--- a/src/utils/gestureMachine.ts
+++ b/src/utils/gestureMachine.ts
@@ -148,3 +148,13 @@ export const commitForSpotlight = (p: CommitPredicate): CommitReason => {
   if (p.velocity >= gestureConfig.spotlightCommitVelocity) return 'velocity';
   return 'none';
 };
+
+// Distance-only on purpose: unlike the other panels, this gesture only fires
+// on the first home page and has no bounce-back affordance to recover from a
+// mis-fired velocity flick, so it commits solely on how far the finger
+// travelled (see LauncherHomeScreen.tsx `todayViewGesture`).
+export const commitForTodayView = (p: CommitPredicate): CommitReason => {
+  'worklet';
+  if (p.progress >= 1) return 'distance';
+  return 'none';
+};


### PR DESCRIPTION
## Resumo

fix(455): liga TodayView a um swipe-right na 1a pagina do home

## Causa raiz

`TodayViewScreen` está implementado, registado em `src/screens/TabNavigator.tsx:53,139` com `animation: settings.reduceMotion ? 'none' : 'slide_from_left'`, e tipado em `RootStackParamList` (`src/navigation/types.ts:61`). Grep confirma zero ocorrências de `navigate('TodayView'`/`navigateTo('TodayView'` em `src/` ou `App.tsx`, e `app.json` não define `scheme`. Mecanismo: a transição `slide_from_left` só faz sentido para um painel que entra pela esquerda — o ecrã e a transição foram construídos para um gesto de entrada que nunca foi escrito no `LauncherHomeScreen`. Não é regressão: é feature a meio, código inalcançável em produção.

Dois factos desta corrida que o issue não previa:

1. A ronda anterior deixou de facto um commit no branch (`acb77d5`) — ao contrário do que o curator concluiu. O commit tem os hunks de produção corretos.
2. Mas esse commit deixou um **erro de sintaxe real** em `src/utils/__tests__/gestureMachine.test.ts:201` — uma `}` a mais que fazia a suite nem sequer parsear (`SyntaxError: Unexpected token (201:0)`), pelo que os 5 testes de `commitForTodayView` nunca corriam. Corrigido nesta corrida, mais um import não usado (`fireEvent`) que dava warning de lint no ficheiro novo.

## O que mudou

- `src/utils/gestureConfig.ts` — adicionado `todayViewCommitDp: 64` (distância de disparo).
- `src/utils/gestureMachine.ts` — adicionado `commitForTodayView(p)`: devolve `'distance'` se `progress >= 1`, senão `'none'`. Distance-only de propósito (sem componente de velocidade), porque este gesto não tem bounce-back para recuperar de um flick mal disparado.
- `src/screens/LauncherHomeScreen.tsx` — três alterações: (1) import passa a incluir `commitForTodayView`; (2) novo `todayViewGesture = Gesture.Pan().enabled(canSpotlight && currentPage === 0).activeOffsetX([-Infinity, 20]).onEnd(...)` que calcula `progress = Math.max(0, event.translationX) / gestureConfig.todayViewCommitDp` e chama `runOnJS(navigateTo)('TodayView')` quando comita; (3) `<GestureDetector gesture={panGesture}>` passa a `Gesture.Race(panGesture, todayViewGesture)`.
- `src/utils/__tests__/gestureMachine.test.ts` — 5 casos novos para `commitForTodayView`, e correção da `}` extra que impedia o parse da suite.
- `src/navigation/__tests__/routeReachability.test.ts` (novo) — análise estática: rotas registadas em `TabNavigator.tsx` vs. ocorrências de `navigate('X'`/`navigateTo('X'` em `src/`.
- `src/screens/__tests__/LauncherHomeScreen.entryPoints.test.tsx` (novo) — mock local de `react-native-gesture-handler` que captura `activeOffsetX`/`enabled`/`onEnd` por chamada de `Gesture.Pan()`, e dispara o `onEnd` real do componente montado.

`BUILT_IN_APPS` e `VIRTUAL_ICON_CONFIG` **não** aparecem no diff — âmbito exclusivo do #442.

## Porque assim

Opção 1 do issue (swipe-right na 1ª página do home), decisão de produto já registada pelo curator: fiel ao iOS, reaproveita `Gesture.Pan`/`Gesture.Race` e o guard `canSpotlight` que já protege o Spotlight. `activeOffsetX([-Infinity, 20])` faz o gesto activar só em drags para a direita, pelo que o swipe-left continua a chegar ao `ScrollView pagingEnabled`. `Gesture.Race` (em vez de `Simultaneous`) garante que só um dos dois vence. Opção 3 (remover) descartada — o issue e a implementação de referência optaram por manter e ligar.

Desvio documentado face à análise do curator: ele pedia `KNOWN_PRE_EXISTING_GAPS = ['Maps','Notes','Reminders','Mail']`. O código contradiz — `Notes`/`Reminders`/`Mail` **já** têm entry point via `SpotlightSearchScreen`, pelo que o único gap pré-existente real é `Maps`. O teste reflecte o código, não a análise; se reflectisse a análise, seria um teste que passa por afirmar algo falso.

## Critérios de aceitação

- [x] `Gesture.Pan` adicional em `LauncherHomeScreen`, activo só com `currentPage === 0` e translação positiva — verificado em `LauncherHomeScreen.entryPoints.test.tsx` (captura do Pan com `activeOffsetX` do componente montado).
- [x] Ao ultrapassar `gestureConfig.todayViewCommitDp` (64dp) chama `navigateTo('TodayView')` — testado com `translationX: todayViewCommitDp`.
- [x] Gesto desactivado quando `canSpotlight` é falso — `.enabled(canSpotlight && currentPage === 0)`, exactamente a mesma condição do Spotlight (jiggle mode / action sheet / folder aberto).
- [x] Swipe-left na 1ª página não dispara TodayView — testado com `translationX: -todayViewCommitDp`; `activeOffsetX([-Infinity, 20])` exclui deslocamentos negativos, pelo que a paginação continua a receber o gesto.
- [x] `BUILT_IN_APPS`/`VIRTUAL_ICON_CONFIG` inalterados — confirmado por `git diff --name-only origin/main...HEAD` (6 ficheiros) e pelo diff de `LauncherHomeScreen.tsx` ter só 3 hunks (import, bloco do gesto, `GestureDetector`).
- [x] `routeReachability.test.ts` confirma que `TodayView` passou a ter entry point real em `src/` e não regride outras rotas (`Maps` continua como único gap documentado).
- [x] Não deve mudar: zero falhas novas em `npm test` (8 falhas, todas do baseline); `npx tsc --noEmit` limpo; 0 erros de lint; 6 snapshots passam sem `-u`.

## Testes

**Passo vermelho** — fix de produção revertido com `git checkout acb77d5^ -- src/utils/gestureConfig.ts src/utils/gestureMachine.ts src/screens/LauncherHomeScreen.tsx`, testes mantidos (e já com a `}` extra corrigida, senão a suite nem parseava):

```
● every registered route has a discoverable entry point (#455) › has no unreachable routes beyond the documented pre-existing gap
    expect(received).toEqual(expected) // deep equality
    - Expected  - 0
    + Received  + 1
      Array [
        "Maps",
    +   "TodayView",
      ]
    > 94 |     expect(unreachable.slice().sort()).toEqual(KNOWN_PRE_EXISTING_GAPS.slice().sort());

● every registered route has a discoverable entry point (#455) › TodayView (this issue) has an entry point now via the right-swipe gesture
    expect(received).toBe(expected) // Object.is equality
    Expected: true
    Received: false
    >  98 |     expect(hasEntryPoint(corpus, 'TodayView')).toBe(true);

● commitForTodayView › returns distance once translationX reaches todayViewCommitDp (progress >= 1)
    TypeError: (0 , _gestureMachine.commitForTodayView) is not a function
    > 211 |     expect(commitForTodayView(pred({ progress: 1 }))).toBe('distance');

● commitForTodayView › returns none for a partial drag that never reaches the commit distance
    TypeError: (0 , _gestureMachine.commitForTodayView) is not a function
    > 215 |     expect(commitForTodayView(pred({ progress: 0.5 }))).toBe('none');

● commitForTodayView › returns none for no movement at all
    TypeError: (0 , _gestureMachine.commitForTodayView) is not a function
    > 219 |     expect(commitForTodayView(pred({ progress: 0, velocity: 0 }))).toBe('none');

● commitForTodayView › returns none for a leftward drag (negative progress), never committing on the wrong direction
    TypeError: (0 , _gestureMachine.commitForTodayView) is not a function
    > 223 |     expect(commitForTodayView(pred({ progress: -1 }))).toBe('none');

● commitForTodayView › is not swayed by velocity alone — this gesture only commits on distance
    TypeError: (0 , _gestureMachine.commitForTodayView) is not a function
    > 227 |     expect(commitForTodayView(pred({ progress: 0, velocity: 999 }))).toBe('none');

● LauncherHomeScreen TodayView reachable via right-swipe on the first page (#455) › navigates to TodayView once the right-swipe reaches the commit distance
    no horizontal (activeOffsetX) pan gesture captured
    > 88 |   throw new Error('no horizontal (activeOffsetX) pan gesture captured');
         |         ^
      at lastHorizontalPan (src/screens/__tests__/LauncherHomeScreen.entryPoints.test.tsx:88:9)
  (idem, mesma linha 88, para: 'does not navigate for a short drag that never reaches the commit distance',
   'does not navigate for a drag in the wrong direction (leftward)',
   'does not navigate when there is no movement at all',
   'the gesture starts enabled on the first home page')

Test Suites: 3 failed, 3 total
Tests:       12 failed, 27 passed, 39 total
```

Com o fix restaurado (`git checkout HEAD -- <os 3 ficheiros de produção>`):

```
Test Suites: 3 passed, 3 total
Tests:       39 passed, 39 total
```

**Casos cobertos além do caminho feliz:**

- Fronteira: drag exactamente em `todayViewCommitDp` navega; `todayViewCommitDp / 2` não navega; `progress: 0.5` → `'none'`.
- Direcção errada (o inverso do fix): `translationX` negativo não navega — protege a paginação horizontal, que é o conflito que o issue levantava.
- Vazio/ausente: `translationX: 0` e `progress: 0` não navegam.
- Inválido/hostil: `velocity: 999` com `progress: 0` → `'none'` (prova que é distance-only e que um flick acidental não abre o painel); `progress: -1` → `'none'`.
- Estado/guard: gesto arranca `enabled` na página 0; `enabled(canSpotlight && currentPage === 0)` cobre jiggle mode, action sheet e folder aberto.
- O inverso do fix a nível estático: `routeReachability` exige entry point textual — se o gesto for removido, `TodayView` volta a aparecer no array `unreachable`, o que foi exactamente observado no passo vermelho acima.

Cada teste falha por uma razão distinta (função inexistente / gesto inexistente / limiar / direcção / guard / alcançabilidade estática) — nenhum é redundante.

**Sanity-check:** com o fix de produção revertido, 12 testes falham em 3 suites; restaurado, 39 passam. Os testes exercitam a unidade real: `commitForTodayView` é importada de `../gestureMachine` (não reimplementada no teste) e o Pan é capturado do `LauncherHomeScreen` efectivamente montado, com o `onEnd` real a ser disparado.

**Verificações obrigatórias:**

- `npm run lint`: **0 erros**, 1 warning pré-existente (`ClockScreen.tsx:258` `tzTick`, fora de âmbito).
- `npx tsc --noEmit`: limpo, sem output.
- `npm test`: **609 passaram, 8 falharam, 89 suites**, 6 snapshots passam. As 8 falhas são todas do baseline (`FoldersStore`×2, `SettingsScreen`×1, `LockScreen`×3, `WeatherScreen`×2 — causa conhecida: `SettingsStore` devolve `null` até `firstSyncDone`). **Zero falhas novas**; nenhuma delas em ficheiros que toquei. Nenhum teste alheio apagado ou marcado `.skip`.

**Verificação manual necessária (não coberta por jest):** o mock de `react-native-gesture-handler` colapsa `Gesture.Race(...)` para o primeiro argumento, pelo que o teste unitário prova a lógica de `enabled`/`activeOffsetX`/`onEnd` mas **não** prova que em runtime real este Pan não colide com o `ScrollView pagingEnabled` (`LauncherHomeScreen.tsx:1158-1161`) nem com o Spotlight (gesto vertical). Precisa de validação em emulador/dispositivo real ou Detox antes de se considerar o comportamento de gesto confirmado.

**Nota operacional:** o worktree foi apagado por outro processo a meio desta corrida e tive de o recriar (`git worktree add`) e repor o symlink `node_modules` → `../../iosToAndroid/node_modules`, que não é versionado. As duas correcções de teste (`}` extra e import `fireEvent`) estão no worktree como modificações não-commitadas, por cima do commit `acb77d5`; sem elas a suite `gestureMachine.test.ts` não parseia, por isso têm de entrar no commit final.

## Testes

609 passaram, 8 falharam (todas do baseline, 0 novas), 89 suites; os 39 testes deste trabalho passam todos

## Linked Issue

Fixes #455