### PR TITLE
AssistiveTouch já não lê a rota de navegação antes de o NavigationContainer estar pronto (#460)

### DIFF
--- a/src/components/AssistiveTouch.tsx
+++ b/src/components/AssistiveTouch.tsx
@@ -101,10 +101,11 @@ export function AssistiveTouch({ navigationRef }: AssistiveTouchProps) {
   } = useAssistiveTouch();
 
   // ── Current route (for context menu + auto-hide) ──────────────────────────
-  const [currentRoute, setCurrentRoute] = useState<string | undefined>(
-    () => navigationRef.getCurrentRoute()?.name,
-  );
+  // Starts undefined: reading getCurrentRoute() before the NavigationContainer
+  // has mounted logs React Navigation's "not initialized" console error.
+  const [currentRoute, setCurrentRoute] = useState<string | undefined>(undefined);
   useEffect(() => {
+    if (navigationRef.isReady()) setCurrentRoute(navigationRef.getCurrentRoute()?.name);
     const unsub = navigationRef.addListener('state', () => {
       setCurrentRoute(navigationRef.getCurrentRoute()?.name);
     });

--- a/src/components/__tests__/AssistiveTouch.test.tsx
+++ b/src/components/__tests__/AssistiveTouch.test.tsx
@@ -73,6 +73,7 @@ function EnableAssistiveTouch() {
 
 function makeNavigationRef() {
   return {
+    isReady: () => true,
     getCurrentRoute: () => ({ name: 'HomeMain', key: 'home', params: undefined }),
     addListener: jest.fn(() => () => {}),
     navigate: jest.fn(),
@@ -108,6 +109,61 @@ const advance = (ms: number) => {
     jest.advanceTimersByTime(ms);
   });
 };
+
+describe('AssistiveTouch antes do NavigationContainer estar pronto', () => {
+  it('não lê a rota (nem dispara o erro not-initialized) enquanto isReady() é false', () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    // Espelha o comportamento real de createNavigationContainerRef: chamar
+    // qualquer método (exceto addListener/isReady) antes do container montar
+    // dispara console.error(NOT_INITIALIZED_ERROR).
+    const getCurrentRoute = jest.fn(() => {
+      console.error(
+        "The 'navigation' object hasn't been initialized yet. This might happen if you don't have a navigator mounted, or if the navigator hasn't finished mounting.",
+      );
+      return undefined;
+    });
+    const navigationRef = {
+      isReady: jest.fn(() => false),
+      getCurrentRoute,
+      addListener: jest.fn(() => () => {}),
+      navigate: jest.fn(),
+    } as unknown as NavigationContainerRefWithCurrent<RootStackParamList>;
+
+    renderAssistiveTouch(navigationRef);
+
+    expect(getCurrentRoute).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+});
+
+describe('AssistiveTouch esconde-se em rotas fullscreen', () => {
+  const BUTTON_LABEL = 'AssistiveTouch button';
+
+  function makeReadyRef(routeName: string) {
+    return {
+      isReady: () => true,
+      getCurrentRoute: () => ({ name: routeName, key: routeName, params: undefined }),
+      addListener: jest.fn(() => () => {}),
+      navigate: jest.fn(),
+    } as unknown as NavigationContainerRefWithCurrent<RootStackParamList>;
+  }
+
+  it('não renderiza o botão quando a rota actual é Camera', () => {
+    const { queryByLabelText } = renderAssistiveTouch(makeReadyRef('Camera'));
+    expect(queryByLabelText(BUTTON_LABEL)).toBeNull();
+  });
+
+  it('não renderiza o botão quando a rota actual é CallScreen', () => {
+    const { queryByLabelText } = renderAssistiveTouch(makeReadyRef('CallScreen'));
+    expect(queryByLabelText(BUTTON_LABEL)).toBeNull();
+  });
+
+  it('renderiza o botão numa rota normal', () => {
+    const { queryByLabelText } = renderAssistiveTouch(makeReadyRef('HomeMain'));
+    expect(queryByLabelText(BUTTON_LABEL)).toBeTruthy();
+  });
+});
 
 describe('AssistiveTouch menu backdrop', () => {
   beforeEach(() => {


### PR DESCRIPTION
## Resumo

AssistiveTouch já não lê a rota de navegação antes de o NavigationContainer estar pronto

## Causa raiz

Em `src/components/AssistiveTouch.tsx:104-106` (antes do fix), o inicializador do `useState` chamava `navigationRef.getCurrentRoute()?.name` de forma síncrona no primeiro render. `AssistiveTouch` é montado como irmão de `NavigationContainer` em `App.tsx:277-298`, não como filho — por isso, nesse primeiro render, o `navigationRef.current` (interno ao objecto criado por `createNavigationContainerRef`) ainda é `null`. Confirmado em `node_modules/@react-navigation/core/src/createNavigationContainerRef.tsx:61-93`: qualquer método chamado sobre o ref enquanto `current == null` — excepto `addListener`/`removeListener`/`isReady` — cai no `default: console.error(NOT_INITIALIZED_ERROR)`. É exactamente o aviso reportado no issue, e o `useEffect` a seguir (linha 108-113, já correcto) confirma que o padrão certo — subscrever `addListener('state', …)` — já existia, só o inicializador do `useState` corria cedo demais.

O issue estava certo na causa e no mecanismo. Confirmei com `git log -S` que a linha do inicializador remonta ao commit do #187, não ao #422 — o issue também tem razão em dizer que não é regressão do #422.

## O que mudou

- `src/components/AssistiveTouch.tsx`: `currentRoute` passa a arrancar `undefined` (sem chamar `getCurrentRoute()` no inicializador). O `useEffect` que já existia ganhou uma linha: se `navigationRef.isReady()` já for verdade nesse tick, lê a rota imediatamente (mantém o comportamento de ter a rota no primeiro frame quando possível, sem o custo do inicializador). O listener `addListener('state', …)` mantém-se inalterado.
- `src/components/__tests__/AssistiveTouch.test.tsx`: adicionei um novo describe `AssistiveTouch antes do NavigationContainer estar pronto` com o teste do passo vermelho, e outro describe `AssistiveTouch esconde-se em rotas fullscreen` com 3 testes (Camera, CallScreen, rota normal) para cobrir explicitamente o 2º critério de aceitação do issue. Também ajustei o `makeNavigationRef()` existente (usado pelos testes do backdrop) para incluir `isReady: () => true` — sem isso os 5 testes já existentes rebentavam com `TypeError: navigationRef.isReady is not a function`, porque o mock não replicava a forma real do ref.

## Porque assim

A alternativa mais simples seria envolver a chamada original num `navigationRef.isReady()` dentro do próprio inicializador do `useState`. Rejeitei-a porque o inicializador corre antes de qualquer efeito — nesse instante `isReady()` é sempre `false` (o container ainda nem montou), tornando o guard inútil ali; o `useEffect` é o sítio certo porque só corre depois do commit inicial, dando ao `NavigationContainer` oportunidade de já estar montado (é o próprio issue que propõe isto, e concordo com o raciocínio: resolve no mesmo tick em que o container fica pronto, sem esperar pelo primeiro evento `state`).

## Critérios de aceitação

- [x] Zero erros de consola no arranque — comprovado pelo teste vermelho→verde: com o fix, `getCurrentRoute` só é chamado depois de `isReady()` ser verdade, nunca antes, logo o `console.error(NOT_INITIALIZED_ERROR)` do React Navigation não dispara.
- [x] O AssistiveTouch continua a esconder-se em `Camera` e `CallScreen` — 2 novos testes (`não renderiza o botão quando a rota actual é Camera/CallScreen`) confirmam que `hiddenForFullscreen` continua a funcionar com o novo fluxo de `currentRoute`; um 3º teste confirma que numa rota normal o botão continua visível (o inverso do fix, para provar que não regredi o caminho feliz).
- [x] Teste que monte o componente sem `NavigationContainer` pronto e verifique que não lança/não avisa — é o teste do passo vermelho, com um `navigationRef` cujo `getCurrentRoute` espelha o `console.error` real do React Navigation quando chamado com `current == null`.

## Testes

**Passo vermelho** (fix revertido via `git stash push -- src/components/AssistiveTouch.tsx`, teste mantido):

```
FAIL Android src/components/__tests__/AssistiveTouch.test.tsx
  AssistiveTouch antes do NavigationContainer estar pronto
    ✕ não lê a rota (nem dispara o erro not-initialized) enquanto isReady() é false (37 ms)
  ...
  ● AssistiveTouch antes do NavigationContainer estar pronto › não lê a rota (nem dispara o erro not-initialized) enquanto isReady() é false

    expect(jest.fn()).not.toHaveBeenCalled()

    Expected number of calls: 0
    Received number of calls: 1

    1: called with 0 arguments

      132 |     renderAssistiveTouch(navigationRef);
      133 |
    > 134 |     expect(getCurrentRoute).not.toHaveBeenCalled();
          |                                 ^
      135 |     expect(errorSpy).not.toHaveBeenCalled();
      136 |     errorSpy.mockRestore();
      137 |   });

Test Suites: 1 failed, 1 total
Tests:       1 failed, 8 passed, 9 total
```

Os outros 8 testes passaram mesmo sem o fix porque testam outro comportamento (backdrop do menu, auto-hide) — só o teste novo do passo vermelho depende do mecanismo corrigido. Depois de `git stash pop`, os 9 voltam a passar.

**Casos cobertos além do caminho feliz:**
- Estado "navigator ainda não montado" (`isReady() === false`) — o caso central do issue.
- Fronteiras do comportamento existente que o fix toca: rota fullscreen (`Camera`, `CallScreen`) esconde o botão; rota normal mostra-o — o inverso do fix, para garantir que não regredi `hiddenForFullscreen`.
- Os 5 testes pré-existentes do backdrop do menu continuam a passar inalterados (só precisaram do `isReady` no mock, que reflecte a forma real do ref).

**Sanity-check:** feito com `git stash push -- src/components/AssistiveTouch.tsx` (reverte só o fix, mantém os testes), correu a suite, confirmou a falha no teste novo pela razão certa (chamada real a `getCurrentRoute`), e `git stash pop` para restaurar. Ver bloco do passo vermelho acima — é o mesmo procedimento.

**Verificações:**
- `npm run lint`: 0 erros (1 warning pré-existente em `ClockScreen.tsx:258`, não tocado).
- `npx tsc --noEmit`: limpo, sem output.
- `npm test`: 641 testes, 8 falhas — todas dentro do conjunto de 9 falhas pré-existentes documentado na linha de base (`FoldersStore` ×2, `LockScreen` ×3, `SettingsScreen` ×1, `WeatherScreen` ×2; `CalculatorScreen` é intermitente e passou nesta corrida). Nenhuma falha nova. A suite `AssistiveTouch.test.tsx` completa: 9 de 9 a passar.

## Testes

641 testes totais, 633 passaram, 8 falharam (todas pré-existentes na linha de base), 93 suites (89 passaram, 4 falharam por falhas pré-existentes). A suite AssistiveTouch.test.tsx: 9 de 9 testes passaram.

## Linked Issue

Fixes #460