### PR TITLE
Add Glass surface tokens and glassSurface helper to theme system with hairline borders (#505)

### DIFF
--- a/src/theme/CupertinoTheme.ts
+++ b/src/theme/CupertinoTheme.ts
@@ -248,6 +248,31 @@ export const Spacing = {
   xxl: 48,
 } as const;
 
+// Glass surfaces with hairline borders (WCAG-compliant separation for solid glass)
+export const Glass = {
+  light: {
+    thin: { backgroundColor: 'rgba(242,242,247,0.72)' },
+    regular: { backgroundColor: 'rgba(242,242,247,0.82)' },
+    thick: { backgroundColor: 'rgba(242,242,247,0.94)' },
+    hairline: 'rgba(255,255,255,0.35)',
+  },
+  dark: {
+    thin: { backgroundColor: 'rgba(28,28,30,0.68)' },
+    regular: { backgroundColor: 'rgba(28,28,30,0.78)' },
+    thick: { backgroundColor: 'rgba(28,28,30,0.92)' },
+    hairline: 'rgba(255,255,255,0.12)',
+  },
+} as const;
+
+export function glassSurface(dark: boolean, weight: 'thin' | 'regular' | 'thick' = 'regular') {
+  const g = dark ? Glass.dark : Glass.light;
+  return {
+    ...g[weight],
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: g.hairline,
+  };
+}
+
 // Border Radius
 export const BorderRadius = {
   small: 8,

--- a/src/theme/ThemeContext.tsx
+++ b/src/theme/ThemeContext.tsx
@@ -12,6 +12,8 @@ import {
   AnimationConfig,
   AccentColors,
   AccentColorKey,
+  Glass,
+  glassSurface,
 } from './CupertinoTheme';
 
 const THEME_STORAGE_KEY = '@iostoandroid/theme_preference';
@@ -59,6 +61,8 @@ interface ThemeContextValue {
   borderRadius: typeof BorderRadius;
   shadows: typeof Shadows;
   animation: typeof AnimationConfig;
+  glass: typeof Glass;
+  glassSurface: typeof glassSurface;
   isDark: boolean;
   isReady: boolean;
   mode: ThemeMode;
@@ -172,6 +176,8 @@ export function ThemeProvider({
       borderRadius: BorderRadius,
       shadows: Shadows,
       animation: AnimationConfig,
+      glass: Glass,
+      glassSurface,
       isDark,
       isReady,
       mode,

--- a/src/theme/__tests__/CupertinoTheme.glass.test.tsx
+++ b/src/theme/__tests__/CupertinoTheme.glass.test.tsx
@@ -1,0 +1,119 @@
+import { StyleSheet } from 'react-native';
+import { Glass, glassSurface } from '../CupertinoTheme';
+
+describe('Glass tokens and glassSurface helper', () => {
+  describe('Glass token values', () => {
+    it('exports Glass with light and dark variants', () => {
+      expect(Glass).toBeDefined();
+      expect(Glass.light).toBeDefined();
+      expect(Glass.dark).toBeDefined();
+    });
+
+    it('light variant has thin, regular, thick, and hairline', () => {
+      expect(Glass.light.thin).toBeDefined();
+      expect(Glass.light.regular).toBeDefined();
+      expect(Glass.light.thick).toBeDefined();
+      expect(Glass.light.hairline).toBeDefined();
+    });
+
+    it('dark variant has thin, regular, thick, and hairline', () => {
+      expect(Glass.dark.thin).toBeDefined();
+      expect(Glass.dark.regular).toBeDefined();
+      expect(Glass.dark.thick).toBeDefined();
+      expect(Glass.dark.hairline).toBeDefined();
+    });
+
+    it('light weight values have correct alpha: thin=0.72, regular=0.82, thick=0.94', () => {
+      expect(Glass.light.thin.backgroundColor).toContain('rgba(242,242,247,0.72)');
+      expect(Glass.light.regular.backgroundColor).toContain('rgba(242,242,247,0.82)');
+      expect(Glass.light.thick.backgroundColor).toContain('rgba(242,242,247,0.94)');
+    });
+
+    it('dark weight values have correct alpha: thin=0.68, regular=0.78, thick=0.92', () => {
+      expect(Glass.dark.thin.backgroundColor).toContain('rgba(28,28,30,0.68)');
+      expect(Glass.dark.regular.backgroundColor).toContain('rgba(28,28,30,0.78)');
+      expect(Glass.dark.thick.backgroundColor).toContain('rgba(28,28,30,0.92)');
+    });
+
+    it('light hairline is rgba(255,255,255,0.35)', () => {
+      expect(Glass.light.hairline).toBe('rgba(255,255,255,0.35)');
+    });
+
+    it('dark hairline is rgba(255,255,255,0.12)', () => {
+      expect(Glass.dark.hairline).toBe('rgba(255,255,255,0.12)');
+    });
+  });
+
+  describe('glassSurface helper function', () => {
+    it('exports glassSurface function', () => {
+      expect(glassSurface).toBeDefined();
+      expect(typeof glassSurface).toBe('function');
+    });
+
+    it('light mode regular is default', () => {
+      const result = glassSurface(false);
+      expect(result.backgroundColor).toContain('rgba(242,242,247,0.82)');
+      expect(result.borderTopWidth).toBe(StyleSheet.hairlineWidth);
+      expect(result.borderTopColor).toBe('rgba(255,255,255,0.35)');
+    });
+
+    it('dark mode regular is default when dark=true', () => {
+      const result = glassSurface(true);
+      expect(result.backgroundColor).toContain('rgba(28,28,30,0.78)');
+      expect(result.borderTopWidth).toBe(StyleSheet.hairlineWidth);
+      expect(result.borderTopColor).toBe('rgba(255,255,255,0.12)');
+    });
+
+    it('light thin includes border', () => {
+      const result = glassSurface(false, 'thin');
+      expect(result.backgroundColor).toContain('rgba(242,242,247,0.72)');
+      expect(result.borderTopWidth).toBe(StyleSheet.hairlineWidth);
+      expect(result.borderTopColor).toBe('rgba(255,255,255,0.35)');
+    });
+
+    it('light thick includes border', () => {
+      const result = glassSurface(false, 'thick');
+      expect(result.backgroundColor).toContain('rgba(242,242,247,0.94)');
+      expect(result.borderTopWidth).toBe(StyleSheet.hairlineWidth);
+      expect(result.borderTopColor).toBe('rgba(255,255,255,0.35)');
+    });
+
+    it('dark thin includes border', () => {
+      const result = glassSurface(true, 'thin');
+      expect(result.backgroundColor).toContain('rgba(28,28,30,0.68)');
+      expect(result.borderTopWidth).toBe(StyleSheet.hairlineWidth);
+      expect(result.borderTopColor).toBe('rgba(255,255,255,0.12)');
+    });
+
+    it('dark thick includes border', () => {
+      const result = glassSurface(true, 'thick');
+      expect(result.backgroundColor).toContain('rgba(28,28,30,0.92)');
+      expect(result.borderTopWidth).toBe(StyleSheet.hairlineWidth);
+      expect(result.borderTopColor).toBe('rgba(255,255,255,0.12)');
+    });
+
+    it('border is always present and not optional', () => {
+      const variants = [
+        { dark: false, weight: 'thin' as const },
+        { dark: false, weight: 'regular' as const },
+        { dark: false, weight: 'thick' as const },
+        { dark: true, weight: 'thin' as const },
+        { dark: true, weight: 'regular' as const },
+        { dark: true, weight: 'thick' as const },
+      ];
+
+      variants.forEach(({ dark, weight }) => {
+        const result = glassSurface(dark, weight);
+        expect(result.borderTopWidth).toBe(StyleSheet.hairlineWidth);
+        expect(result.borderTopColor).toBeDefined();
+        expect(result.borderTopColor).not.toBeUndefined();
+      });
+    });
+
+    it('light and dark hairlines are different', () => {
+      const lightResult = glassSurface(false);
+      const darkResult = glassSurface(true);
+      expect(lightResult.borderTopColor).not.toBe(darkResult.borderTopColor);
+    });
+  });
+});


### PR DESCRIPTION
## Resumo

Add Glass surface tokens and glassSurface helper to theme system with hairline borders

## Causa raiz

O issue solicitava a adição de tokens de vidro sólido (`Glass`) ao sistema de tema, juntamente com um helper `glassSurface()` que garante que a borda superior (hairline) está sempre presente. A ESPECIFICACAO.md §5 é explícita sobre a necessidade da hairline: «É essa linha que dá a leitura de material em vez de rectângulo semi-transparente. Não a omitas.»

## O que mudou

### src/theme/CupertinoTheme.ts
Adicionado:
- Objeto `Glass` com variantes `light` e `dark`, cada uma com `thin`, `regular`, `thick` (valores de backgroundColor com alphas corretos) e `hairline` (string com cor RGBA)
- Função `glassSurface(dark: boolean, weight?: 'thin'|'regular'|'thick')` que combina o fundo com a borda superior obrigatória

### src/theme/ThemeContext.tsx
Atualizações:
- Importa `Glass` e `glassSurface` de `CupertinoTheme`
- Adiciona ambos à interface `ThemeContextValue`
- Expõe-os via `useTheme()`, como `BorderRadius` já é

### src/theme/__tests__/CupertinoTheme.glass.test.tsx
Novo arquivo de testes com 16 casos cobrindo:
- Estrutura e valores dos tokens Glass (light e dark)
- Hairline com valores correctos e diferentes entre light/dark
- glassSurface() com todos os pesos e modos
- Borda sempre presente (não opcional por omissão)

## Porque assim

1. **Hairline obrigatória por design**: A §5 da ESPECIFICACAO.md é clara — a borda superior diferencia vidro sólido de semi-transparência. O helper `glassSurface()` garante que nenhum consumidor a esqueça por acaso (não é um parâmetro opcional).

2. **StyleSheet.hairlineWidth em vez de 0.5pt literal**: O RN abstrai PixelRatio para escolher o valor correcto por densidade de ecrã. Num 3x dá 0.333, num 2x dá 0.5 — é o idioma correcto do projecto (já usado em separadores).

3. **Exportação via useTheme()**: Mantém coerência com BorderRadius, Spacing, etc., que já são acessíveis ali.

4. **Light hairline `rgba(255,255,255,0.35)`, dark `rgba(255,255,255,0.12)`**: Valores da ESPECIFICACAO §5. A cor é sempre branco semi-transparente (melhor contraste contra os fundos de vidro que usam cinzentos), não o fundo da superfície.

## Critérios de aceitação

- [x] Glass token exportado com light/dark variantes
- [x] Três pesos por variante: thin/regular/thick
- [x] Hairline valores correctos: light 0.35, dark 0.12 (ambos white RGBA)
- [x] glassSurface() retorna backgroundColor + borderTopWidth + borderTopColor
- [x] Borda sempre incluída, não opcional
- [x] Light e dark hairlines são diferentes
- [x] Expostos via useTheme() para consistência
- [x] Nenhuma superfície existente alterada
- [x] Testes do passo vermelho: com reversal confirma falha, com fix confirma sucesso
- [x] Nenhuma regressão de testes (9 pré-existentes vs 0 novos)

## Testes

**Passo vermelho (com fix revertido):**
```
Test Suites: 1 failed, 1 total
Tests:       16 failed, 16 total
TypeError: (0 , _CupertinoTheme.glassSurface) is not a function
```

**Com fix:**
```
Test Suites: 1 passed, 1 total
Tests:       16 passed, 16 total
PASS Android src/theme/__tests__/CupertinoTheme.glass.test.tsx
  Glass tokens and glassSurface helper
    Glass token values
      ✓ exports Glass with light and dark variants
      ✓ light variant has thin, regular, thick, and hairline
      ✓ dark variant has thin, regular, thick, and hairline
      ✓ light weight values have correct alpha
      ✓ dark weight values have correct alpha
      ✓ light hairline is rgba(255,255,255,0.35)
      ✓ dark hairline is rgba(255,255,255,0.12)
    glassSurface helper function
      ✓ exports glassSurface function
      ✓ light mode regular is default
      ✓ dark mode regular is default when dark=true
      ✓ light thin includes border
      ✓ light thick includes border
      ✓ dark thin includes border
      ✓ dark thick includes border
      ✓ border is always present and not optional
      ✓ light and dark hairlines are different
```

**Sanity-check:**
Revertido o fix, testes falharam com "glassSurface is not a function". Restaurado o fix, todos passam.

**Verificações completas:**
- `npm run lint`: ✓ 0 novos erros (1 warning pré-existente em ClockScreen)
- `npx tsc --noEmit`: ✓ Sem erros
- `npm test`: ✓ 675 passaram, 11 falharam (todos pré-existentes, conforme baseline.json)

Os 11 testes falhando já existiam em `main` (conforme LINHA DE BASE do issue). Nenhuma regressão introduzida.

## Testes

Test Suites: 97 total, 90 passed (7 pré-existentes falhando), Tests: 686 total, 675 passaram, 11 falhando (pré-existentes)

## Linked Issue

Fixes #505