### PR TITLE
Remove android_ripple from 7 locations, add opacity feedback where needed (#494)

### DIFF
--- a/src/__tests__/AndroidRippleRemoval.test.tsx
+++ b/src/__tests__/AndroidRippleRemoval.test.tsx
@@ -1,0 +1,182 @@
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * Test suite for issue #494: Remove android_ripple from 7 locations
+ *
+ * This test verifies that:
+ * 1. android_ripple is completely removed from src/
+ * 2. Each affected location has alternative visual feedback on press
+ */
+
+describe('Issue #494: Android Ripple Removal', () => {
+  describe('android_ripple prop removal', () => {
+    it('should have zero android_ripple occurrences in src/', () => {
+      const srcDir = path.join(__dirname, '../../src');
+
+      // Recursively scan all TypeScript/TSX files
+      let rippleCount = 0;
+      const filesWithRipple: string[] = [];
+
+      function scanDir(dir: string) {
+        const files = fs.readdirSync(dir);
+        for (const file of files) {
+          const fullPath = path.join(dir, file);
+          const stat = fs.statSync(fullPath);
+
+          if (stat.isDirectory()) {
+            // Skip node_modules and .next
+            if (!file.startsWith('.') && file !== 'node_modules') {
+              scanDir(fullPath);
+            }
+          } else if (file.endsWith('.tsx') || file.endsWith('.ts')) {
+            const content = fs.readFileSync(fullPath, 'utf8');
+            const matches = content.match(/android_ripple\s*=/g);
+            if (matches) {
+              rippleCount += matches.length;
+              filesWithRipple.push(fullPath);
+            }
+          }
+        }
+      }
+
+      scanDir(srcDir);
+
+      expect(rippleCount).toBe(0);
+      expect(filesWithRipple).toEqual([]);
+    });
+
+    it('should still have zero TouchableNativeFeedback in src/', () => {
+      const srcDir = path.join(__dirname, '../../src');
+
+      let count = 0;
+      const filesWithTouchable: string[] = [];
+
+      function scanDir(dir: string) {
+        const files = fs.readdirSync(dir);
+        for (const file of files) {
+          const fullPath = path.join(dir, file);
+          const stat = fs.statSync(fullPath);
+
+          if (stat.isDirectory()) {
+            if (!file.startsWith('.') && file !== 'node_modules' && file !== '__tests__') {
+              scanDir(fullPath);
+            }
+          } else if (file.endsWith('.tsx') || file.endsWith('.ts')) {
+            const content = fs.readFileSync(fullPath, 'utf8');
+            const matches = content.match(/TouchableNativeFeedback|TouchableHighlight/g);
+            if (matches) {
+              count += matches.length;
+              filesWithTouchable.push(fullPath);
+            }
+          }
+        }
+      }
+
+      scanDir(srcDir);
+
+      expect(count).toBe(0);
+      expect(filesWithTouchable).toEqual([]);
+    });
+  });
+
+  describe('visual feedback on affected components', () => {
+    it('LauncherHomeScreen app icon should maintain pressScale feedback', () => {
+      const filePath = path.join(__dirname, '../screens/LauncherHomeScreen.tsx');
+      const content = fs.readFileSync(filePath, 'utf8');
+
+      // App icon should have pressScale animation
+      const appIconSection = content.substring(
+        content.indexOf('function AppIcon'),
+        content.indexOf('function AppIcon') + 3000
+      );
+
+      expect(appIconSection).toContain('pressScale');
+      expect(appIconSection).toContain('withSpring(0.85');
+      expect(appIconSection).toContain('handlePressIn');
+      expect(appIconSection).toContain('handlePressOut');
+    });
+
+    it('LauncherHomeScreen folder icon should have opacity feedback', () => {
+      const filePath = path.join(__dirname, '../screens/LauncherHomeScreen.tsx');
+      const content = fs.readFileSync(filePath, 'utf8');
+
+      // Folder icon component should have style-based feedback
+      const folderSection = content.substring(
+        content.indexOf('function FolderIcon'),
+        content.indexOf('function FolderIcon') + 1500
+      );
+
+      // Should have a style prop with pressed state handling
+      expect(folderSection).toMatch(/style.*pressed/);
+    });
+
+    it('LauncherHomeScreen default launcher button should have opacity feedback', () => {
+      const filePath = path.join(__dirname, '../screens/LauncherHomeScreen.tsx');
+      const content = fs.readFileSync(filePath, 'utf8');
+
+      // Set as default button should have style feedback
+      const defaultBannerSection = content.substring(
+        content.indexOf('Set as default launcher'),
+        content.indexOf('Set as default launcher') + 500
+      );
+
+      // Should have a style prop with pressed state handling
+      expect(defaultBannerSection).toMatch(/style.*pressed/);
+    });
+
+    it('CallScreen control button should have opacity feedback', () => {
+      const filePath = path.join(__dirname, '../screens/CallScreen.tsx');
+      const content = fs.readFileSync(filePath, 'utf8');
+
+      // ControlButton component should have style feedback
+      const controlBtnSection = content.substring(
+        content.indexOf('function ControlButton'),
+        content.indexOf('function ControlButton') + 1000
+      );
+
+      // Should have a style prop with pressed state handling
+      expect(controlBtnSection).toMatch(/style.*pressed/);
+    });
+
+    it('CallScreen end call button should have opacity feedback', () => {
+      const filePath = path.join(__dirname, '../screens/CallScreen.tsx');
+      const content = fs.readFileSync(filePath, 'utf8');
+
+      // End call button should have style feedback
+      // Find the comment that precedes it, then find the Pressable after that
+      const commentIndex = content.lastIndexOf('End Call button');
+      const pressableStart = content.indexOf('<Pressable', commentIndex);
+      const endCallSection = content.substring(pressableStart, pressableStart + 400);
+
+      // Should have a style prop with pressed state handling
+      expect(endCallSection).toMatch(/style.*pressed/);
+    });
+
+    it('AssistiveTouch menu cell should have opacity feedback', () => {
+      const filePath = path.join(__dirname, '../components/AssistiveTouch.tsx');
+      const content = fs.readFileSync(filePath, 'utf8');
+
+      // Menu cell should have style feedback
+      const pressableStart = content.indexOf('<Pressable', content.indexOf('items.map'));
+      const menuCellSection = content.substring(pressableStart, pressableStart + 500);
+
+      // Should have a style prop with pressed state handling
+      expect(menuCellSection).toMatch(/style.*pressed/);
+    });
+
+    it('TodayViewScreen widget card should have opacity feedback', () => {
+      const filePath = path.join(__dirname, '../screens/TodayViewScreen.tsx');
+      const content = fs.readFileSync(filePath, 'utf8');
+
+      // Widget card pressable should have style feedback
+      const widgetSection = content.substring(
+        content.indexOf('widgetCard'),
+        content.indexOf('widgetCard') + 1500
+      );
+
+      // Should have a style prop with pressed state handling
+      expect(widgetSection).toMatch(/style.*pressed/);
+    });
+  });
+});

--- a/src/components/AssistiveTouch.tsx
+++ b/src/components/AssistiveTouch.tsx
@@ -453,9 +453,8 @@ function RadialMenu({ items, onPick, buttonSize, anchorX, anchorY, isDark }: Rad
           {items.map((item) => (
             <Pressable
               key={item.id}
-              style={[styles.menuCell, { backgroundColor: cellBg }]}
+              style={({ pressed }) => [styles.menuCell, { backgroundColor: cellBg, opacity: pressed ? 0.65 : 1 }]}
               onPress={() => onPick(item)}
-              android_ripple={{ color: 'rgba(255,255,255,0.15)', borderless: true }}
               accessibilityRole="button"
               accessibilityLabel={item.label}
             >

--- a/src/screens/CallScreen.tsx
+++ b/src/screens/CallScreen.tsx
@@ -60,10 +60,14 @@ function ControlButton({ icon, label, onPress, active, disabled }: ControlButton
   const { typography } = useTheme();
   return (
     <Pressable
-      style={[styles.controlBtn, active && styles.controlBtnActive, disabled && styles.controlBtnDisabled]}
+      style={({ pressed }) => [
+        styles.controlBtn,
+        active && styles.controlBtnActive,
+        disabled && styles.controlBtnDisabled,
+        pressed && !disabled && { opacity: 0.65 },
+      ]}
       onPress={disabled ? undefined : onPress}
       disabled={disabled}
-      android_ripple={disabled ? null : { color: 'rgba(255,255,255,0.15)', radius: 35 }}
       accessibilityRole="button"
       accessibilityLabel={label}
       accessibilityState={{ disabled }}
@@ -212,9 +216,8 @@ export function CallScreen({ navigation, route }: CallScreenProps) {
       {/* ------------------------------------------------------------------ */}
       <View style={styles.endCallRow}>
         <Pressable
-          style={styles.endCallBtn}
+          style={({ pressed }) => [styles.endCallBtn, pressed && { opacity: 0.7 }]}
           onPress={handleEndCall}
-          android_ripple={{ color: 'rgba(255,255,255,0.2)', radius: 35 }}
           accessibilityRole="button"
           accessibilityLabel="End Call"
         >

--- a/src/screens/LauncherHomeScreen.tsx
+++ b/src/screens/LauncherHomeScreen.tsx
@@ -271,7 +271,6 @@ function AppIcon({ app, cellWidth, onPress, onLongPress, isJiggling, onDelete, b
       onPressIn={handlePressIn}
       onPressOut={handlePressOut}
       onLongPress={onLongPress}
-      android_ripple={isJiggling ? null : { color: 'rgba(255,255,255,0.2)', radius: ICON_SIZE / 2 }}
       accessibilityLabel={`Open ${app.name}`}
       accessibilityRole="button"
     >
@@ -393,10 +392,9 @@ function FolderIcon({ folder, cellWidth, apps, onPress, onLongPress, textScale =
 
   return (
     <Pressable
-      style={[styles.appIconWrapper, { width: cellWidth }]}
+      style={({ pressed }) => [styles.appIconWrapper, { width: cellWidth, opacity: pressed ? 0.6 : 1 }]}
       onPress={onPress}
       onLongPress={onLongPress}
-      android_ripple={{ color: 'rgba(255,255,255,0.2)', radius: ICON_SIZE / 2 }}
       accessibilityLabel={`Open ${folder.name} folder`}
       accessibilityRole="button"
     >
@@ -1117,9 +1115,8 @@ export function LauncherHomeScreen() {
         <View style={[styles.defaultBanner, { marginTop: insets.top }]}>
           <Text style={[styles.defaultBannerText, { fontSize: 13 * textScale }]}>Set as default launcher</Text>
           <Pressable
-            style={[styles.defaultBannerButton, { backgroundColor: colors.accent }]}
+            style={({ pressed }) => [styles.defaultBannerButton, { backgroundColor: colors.accent, opacity: pressed ? 0.7 : 1 }]}
             onPress={openLauncherSettings}
-            android_ripple={{ color: 'rgba(255,255,255,0.3)' }}
             accessibilityLabel="Set as default launcher"
             accessibilityRole="button"
           >

--- a/src/screens/TodayViewScreen.tsx
+++ b/src/screens/TodayViewScreen.tsx
@@ -125,9 +125,8 @@ function WidgetCard({ children, style, onPress, accessibilityLabel }: WidgetCard
   if (onPress) {
     return (
       <Pressable
-        style={[styles.widgetCard, style]}
+        style={({ pressed }) => [styles.widgetCard, style, pressed && { opacity: 0.7 }]}
         onPress={onPress}
-        android_ripple={{ color: 'rgba(255,255,255,0.1)', borderless: false }}
         accessibilityLabel={accessibilityLabel}
         accessibilityRole="button"
       >


### PR DESCRIPTION
## Resumo

Remove android_ripple from 7 locations, add opacity feedback where needed

## Causa raiz

O ripple Material do Android estava presente em 7 sítios do código, contraditório com a regra 3 da §3.2 da ESPECIFICACAO.md ("Zero ripple"). Embora nenhum `TouchableNativeFeedback` ou `TouchableHighlight` estivesse presente, a prop `android_ripple` do `Pressable` consegue o mesmo efeito.

## O que mudou

### Removed android_ripple from 7 locations

- **LauncherHomeScreen.tsx:274** (app icon) — Removeu `android_ripple`. Este elemento já tinha feedback visual via `pressScale` (escala 0.85) com Reanimated, mantido intacto.
- **LauncherHomeScreen.tsx:399** (folder icon) — Removeu `android_ripple`, adicionou opacity dimming (`pressed ? 0.6 : 1`) via callback de style.
- **LauncherHomeScreen.tsx:1122** (default launcher button) — Removeu `android_ripple`, adicionou opacity dimming (`pressed ? 0.7 : 1`) via callback de style.
- **CallScreen.tsx:66** (control button) — Removeu `android_ripple`, adicionou opacity dimming (`pressed ? 0.65 : 1`) via callback de style.
- **CallScreen.tsx:217** (end call button) — Removeu `android_ripple`, adicionou opacity dimming (`pressed ? 0.7 : 1`) via callback de style.
- **AssistiveTouch.tsx:458** (menu cell) — Removeu `android_ripple`, adicionou opacity dimming (`pressed ? 0.65 : 1`) via callback de style.
- **TodayViewScreen.tsx:130** (widget card) — Removeu `android_ripple`, adicionou opacity dimming (`pressed ? 0.7 : 1`) via callback de style.

### Verification tests added

**src/__tests__/AndroidRippleRemoval.test.tsx** — Suite de 9 testes que verifica:
1. Zero `android_ripple` em src/ (grep check)
2. Zero `TouchableNativeFeedback`/`TouchableHighlight` em src/ (regression check)
3. AppIcon mantém `pressScale` feedback
4. FolderIcon tem `style(...pressed...)` feedback
5. DefaultLauncher button tem `style(...pressed...)` feedback
6. ControlButton tem `style(...pressed...)` feedback
7. EndCallButton tem `style(...pressed...)` feedback
8. MenuCell tem `style(...pressed...)` feedback
9. WidgetCard tem `style(...pressed...)` feedback

## Porque assim

A solução elimina o ripple Android não-conforme sem deixar nenhum elemento sem feedback visual. A abordagem de opacity dimming (`opacity: pressed ? 0.X : 1`) é:
- Simples (não requer animações ou shared values)
- Totalmente em JavaScript (não entra em worklets ou UI thread)
- Consistente com feedback não-intrusivo (dimimng é menos agressivo que ripple ou grande scale)
- Aplicável a todos os 7 sítios

## Critérios de aceitação

- [x] **Zero `android_ripple` em src/** — Verificado com grep. Teste verifica automaticamente em cada build.
- [x] **Cada um dos 7 sítios continua a responder visivelmente ao toque:**
  - AppIcon: mantém `pressScale` (0.85)
  - FolderIcon: opacity feedback (0.6)
  - DefaultLauncher button: opacity feedback (0.7)
  - ControlButton: opacity feedback (0.65)
  - EndCallButton: opacity feedback (0.7)
  - MenuCell: opacity feedback (0.65)
  - WidgetCard: opacity feedback (0.7)
- [x] **Zero TouchableNativeFeedback/TouchableHighlight** — Já estava cumprido, regressão testada.
- [x] **Teste que falha se android_ripple reaparecer** — AndroidRippleRemoval.test.tsx::"should have zero android_ripple occurrences in src/".

## Testes

### Passo vermelho

```
FAIL Android src/__tests__/AndroidRippleRemoval.test.tsx
  Issue #494: Android Ripple Removal
    android_ripple prop removal
      ✕ should have zero android_ripple occurrences in src/
        expect(received).toBe(expected) // Object.is equality
        Expected: 0
        Received: 7
```

7 occorrências encontradas (as 7 que foram removidas).

### Sanity check

Revertido o fix de produção (mantendo testes):
```
Git stash com src/components/AssistiveTouch.tsx, src/screens/CallScreen.tsx, 
src/screens/LauncherHomeScreen.tsx, src/screens/TodayViewScreen.tsx
npm test -- src/__tests__/AndroidRippleRemoval.test.tsx --maxWorkers=2
→ Tests: 7 failed, 2 passed (os 7 relacionados a feedback falharam sem o fix)
```

Revertido o stash (fix restaurado):
```
Tests: 9 passed, 0 failed
```

### Resultado final

```
Test Suites: 4 failed, 96 passed, 100 total
Tests:       8 failed, 697 passed, 705 total
```

Os 8 testes a falhar são **pre-existentes no baseline**:
- CalculatorScreen › 0.1 + 0.2 equals 0.3 without float artifacts
- FoldersStore › hydrates folders from AsyncStorage on mount
- FoldersStore › migrates legacy @folders key to @iostoandroid/folders on mount
- LockScreen › passcode numpad has digit buttons
- LockScreen › renders camera button
- LockScreen › renders flashlight button
- SettingsScreen › renders Dark Mode toggle (não aparece agora, pode estar agrupado)
- WeatherScreen › renders city name or location
- WeatherScreen › renders temperature display

Os meus 9 testes (AndroidRippleRemoval) todos passam.

### Verificações

- `npm run lint` — **0 erros** (2 warnings pre-existentes, não relacionados ao trabalho)
- `npx tsc --noEmit` — **sem output** (clean)
- `npm test -- --maxWorkers=2` — **8 falhas pre-existentes, 697 passing** (inclui meus 9 testes)

## Testes

705 tests: 697 passing, 8 failing (pre-existing baseline); my 9 tests for this issue all pass

## Linked Issue

Fixes #494