### PR TITLE
qa/issue-504: remove BlurView do .map() de notificações — cartões passam a superfícies sólidas com borda de material (#504)

### DIFF
--- a/src/screens/NotificationCenterScreen.tsx
+++ b/src/screens/NotificationCenterScreen.tsx
@@ -18,6 +18,7 @@ import * as Haptics from 'expo-haptics';
 
 import { useApps } from '../store/AppsStore';
 import { useTheme } from '../theme/ThemeContext';
+import { Glass } from '../theme/CupertinoTheme';
 import { CupertinoSwipeableRow } from '../components/CupertinoSwipeableRow';
 import { useAlert } from '../components';
 import { hapticImpact, hapticNotification } from '../utils/haptics';
@@ -26,7 +27,14 @@ const getLauncher = async () => {
   try {
     return (await import('../../modules/launcher-module/src')).default;
   } catch {
-    return null;
+    // Dynamic import is unavailable in some environments (e.g. Jest's VM);
+    // fall back to a synchronous require so the module stays reachable there.
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports -- Metro supports require; fallback for environments without dynamic import
+      return require('../../modules/launcher-module/src').default;
+    } catch {
+      return null; // Expected: module unavailable on non-Android
+    }
   }
 };
 
@@ -324,7 +332,7 @@ export function NotificationCenterScreen() {
                             accessibilityLabel={`${notif.title || group.appName} notification from ${group.appName}`}
                             accessibilityRole="button"
                           >
-                            <BlurView intensity={50} tint="dark" experimentalBlurMethod="dimezisBlurView" style={styles.notifCard}>
+                            <View style={styles.notifCard}>
                               <View style={styles.notifCardHeader}>
                                 <View style={styles.notifTitleRow}>
                                   {!isRead && <View style={styles.unreadDot} />}
@@ -421,7 +429,7 @@ export function NotificationCenterScreen() {
                                   </View>
                                 </View>
                               )}
-                            </BlurView>
+                            </View>
                           </Pressable>
                         </CupertinoSwipeableRow>
                       );
@@ -521,6 +529,8 @@ export const styles = StyleSheet.create({
     padding: 12,
     overflow: 'hidden',
     backgroundColor: 'rgba(32,32,36,0.92)',
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: Glass.dark.hairline,
   },
   notifCardHeader: {
     flexDirection: 'row',

--- a/src/screens/__tests__/NotificationCenterScreen.test.tsx
+++ b/src/screens/__tests__/NotificationCenterScreen.test.tsx
@@ -1,6 +1,29 @@
 import React from 'react';
-import { render } from '../../test-utils';
+import { render, waitFor } from '../../test-utils';
 import { NotificationCenterScreen, styles } from '../NotificationCenterScreen';
+import launcherModule from '../../../modules/launcher-module/src';
+
+interface MockNotif {
+  id: string;
+  key: string;
+  packageName: string;
+  title: string;
+  text: string;
+  time: number;
+  isOngoing: boolean;
+}
+
+function makeNotifs(count: number): MockNotif[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `n${i}`,
+    key: `n${i}`,
+    packageName: `com.app${i}`,
+    title: `Title ${i}`,
+    text: `Body ${i}`,
+    time: Date.now(),
+    isOngoing: false,
+  }));
+}
 
 // -- Contrast helpers (WCAG 2.1) applied to the screen's REAL style values --
 function parseColor(color: string) {
@@ -133,5 +156,47 @@ describe('NotificationCenterScreen', () => {
         }
       },
     );
+  });
+
+  // Issue #504: one real BlurView per notification card, mounted inside the
+  // .map() of visibleNotifs, blew past the §5 ceiling of 2 real blur surfaces
+  // (~13 with 10 notifications). Cards must render as solid glass surfaces;
+  // only the screen backdrop / dock are allowed a real blur.
+  describe('blur surface budget (issue #504)', () => {
+    afterEach(() => {
+      // Restore launcher-module defaults so unrelated tests in this file keep
+      // the denied-access default (hasAccess=false, empty notification list).
+      (launcherModule.isNotificationAccessGranted as jest.Mock).mockResolvedValue(false);
+      (launcherModule.getNotifications as jest.Mock).mockResolvedValue([]);
+    });
+
+    it('mounts zero real BlurView surfaces for notification cards, even with 12 notifications', async () => {
+      (launcherModule.isNotificationAccessGranted as jest.Mock).mockResolvedValue(true);
+      (launcherModule.getNotifications as jest.Mock).mockResolvedValue(makeNotifs(12));
+
+      const { getByText, UNSAFE_queryAllByType } = render(<NotificationCenterScreen />);
+      await waitFor(() => expect(getByText('Title 0')).toBeTruthy());
+      // Sanity: all 12 cards actually mounted (otherwise a 0-count would be vacuous).
+      expect(getByText('Title 11')).toBeTruthy();
+
+      expect(UNSAFE_queryAllByType('BlurView' as never)).toHaveLength(0);
+    });
+
+    it('keeps a single notification card solid (no BlurView) when there is exactly one', async () => {
+      (launcherModule.isNotificationAccessGranted as jest.Mock).mockResolvedValue(true);
+      (launcherModule.getNotifications as jest.Mock).mockResolvedValue(makeNotifs(1));
+
+      const { getByText, UNSAFE_queryAllByType } = render(<NotificationCenterScreen />);
+      await waitFor(() => expect(getByText('Title 0')).toBeTruthy());
+
+      expect(UNSAFE_queryAllByType('BlurView' as never)).toHaveLength(0);
+    });
+
+    it('gives the notification card a material top hairline border in place of the removed blur', () => {
+      expect(styles.notifCard.borderTopWidth).toBeGreaterThan(0);
+      expect(styles.notifCard.borderTopColor).toBeTruthy();
+      // Border must not be the same as the fill — otherwise it's invisible, defeating the point.
+      expect(styles.notifCard.borderTopColor).not.toBe(styles.notifCard.backgroundColor);
+    });
   });
 });


### PR DESCRIPTION
## Resumo

qa/issue-504: remove BlurView do .map() de notificações — cartões passam a superfícies sólidas com borda de material

## Causa raiz

`src/screens/NotificationCenterScreen.tsx:334` (antes da correção, `:327`) monta um `BlurView` com `experimentalBlurMethod="dimezisBlurView"` — o caminho de blur real no Android — dentro do `.map()` de `visibleNotifs`. Cada notificação visível instancia a sua própria superfície de blur real. Com 10 notificações visíveis simultaneamente (mais o dock, sempre montado por `NotificationCenter` ser `presentation: 'transparentModal'`, e o `AssistiveTouch`, se activo) o número de superfícies reais cresce linearmente e viola o tecto de 2 imposto pela §5.

**Correcção ao enunciado do issue:** o issue descreve o fix como "o blur fica só no backdrop do ecrã", implicando que o backdrop (`styles.root`) já tinha um `BlurView` real. Não tinha — `root` sempre foi um scrim sólido (`backgroundColor: 'rgba(0,0,0,0.82)'`, ver `NotificationCenterScreen.tsx:465`), sem `BlurView` nenhum. Confirmado por grep (`BlurView` só aparecia em `:246` e `:327`) e pelo histórico do fix do #436, que resolveu a transparência do backdrop trocando para um scrim sólido, não para um blur. Não adicionei um `BlurView` novo ao backdrop: sem os cartões, o total de superfícies reais no ecrã já cai para 1 (dock) ou 2 (dock + AssistiveTouch se activo) — dentro do tecto da §5 sem precisar de mais nenhuma superfície de blur. Adicionar uma seria regredir a própria motivação de performance do issue.

## O que mudou

**`src/screens/NotificationCenterScreen.tsx`**
- O cartão de cada notificação (dentro do `.map()` de `visibleNotifs`) deixou de ser um `BlurView` e passou a ser um `View` simples com `styles.notifCard` — sem blur real, `backgroundColor` inalterado (`rgba(32,32,36,0.92)`).
- `styles.notifCard` ganhou `borderTopWidth: StyleSheet.hairlineWidth` e `borderTopColor: Glass.dark.hairline` (token importado de `../theme/CupertinoTheme`, landed no PR #522) — a borda superior de material que faz o cartão sólido ler como vidro.
- `getLauncher()` ganhou o fallback `require()` já usado em `LockScreen.tsx` (dynamic `import()` falha na VM do Jest sem `--experimental-vm-modules`; o `require()` passa pelo `moduleNameMapper` e resolve para o mock). Sem isto, `hasAccess` nunca fica `true` em teste e é impossível montar o cartão real para provar o defeito ou a correcção — o próprio teste pré-existente do ficheiro já documentava esta limitação ("notifCard can't be reached via a synchronous mount in this jest-expo setup"). Esta mudança elimina essa limitação.

**`src/screens/__tests__/NotificationCenterScreen.test.tsx`**
- Novo `describe('blur surface budget (issue #504)')` com 3 testes que montam o ecrã real com `hasAccess=true` e notificações mockadas via `launcherModule`.

## Porque assim

- **Não toquei em `accessCard` (`:254`)**: não está dentro de um `.map()` (renderiza no máximo 1 vez, e nunca ao mesmo tempo que a lista de notificações — é `!hasAccess`, mutuamente exclusivo com `hasAccess && <lista>`). Fora do âmbito literal do issue e da AC1.
- **Não mudei o `backgroundColor` de `notifCard`**: haveria uma escolha óbvia de consumir `Glass.dark.regular` (`rgba(28,28,30,0.78)`, o valor literal que o próprio issue sugere) em vez do literal actual `rgba(32,32,36,0.92)`. Descartei-a porque o teste pré-existente `'notifCard and accessCard share the exact same fallback background'` (linha 140) e o teste WCAG (linha 143) fixam esse literal como parte do fix do #436 — mudá-lo exigiria também mudar `accessCard`, que está fora do âmbito deste issue. Manter o literal cumpre a AC de não regredir #436 sem tocar em código não pedido.
- **Não adicionei `BlurView` novo ao backdrop**: ver secção "Causa raiz" acima — o tecto de 2 já é cumprido sem isso, e adicionar seria contrariar o objectivo de performance do issue.
- **`require()` fallback em vez de mock manual no teste**: é o padrão já estabelecido em `LockScreen.tsx` (mesmo bloco de código, mesmo comentário) — não inventei um mecanismo novo, reutilizei o existente.

## Critérios de aceitação

- [x] Zero `BlurView` dentro de um `.map()` em `src/` — grep repo-wide (`grep -rn "BlurView" src --include=*.tsx`) confirma que o único caso antes da correcção era `NotificationCenterScreen.tsx:327` (agora removido). O outro candidato encontrado, `LauncherHomeScreen.tsx:453`, está dentro do componente `FolderOverlay`, montado uma única vez por modal aberto (não dentro de uma lista `.map()` de itens repetidos) — fora do padrão do defeito e fora do âmbito deste issue.
- [x] No máximo 2 superfícies de blur real com o Notification Center aberto e 10+ notificações — com o fix, 0 dos cartões usam `BlurView`; testado com 12 notificações (`'mounts zero real BlurView surfaces...'`). As únicas superfícies reais que sobram no ecrã são o dock (sempre montado) e o `AssistiveTouch` (se activo) = no máximo 2.
- [x] Cartões com borda superior de material — `styles.notifCard.borderTopWidth = StyleSheet.hairlineWidth`, `borderTopColor = Glass.dark.hairline` (`rgba(255,255,255,0.12)`), testado.
- [x] Conteúdo legível sobre wallpaper claro e escuro (regressão #436) — não toquei no `backgroundColor` do cartão (`rgba(32,32,36,0.92)`, alpha 0.92 ≥ 0.85, o mínimo que o teste do #436 já impõe); os 10 testes WCAG AA pré-existentes (`styles.notifTitle`, `styles.notifBody`, etc., linha 143) continuam a passar inalterados. Não tenho capturas de ecrã (ambiente sem emulador Android disponível nesta corrida) — deixo registado que a prova aqui é por contraste calculado (WCAG), não visual.
- [ ] Scroll da lista a 60fps com 20 notificações, medido antes/depois — não medido nesta corrida (sem device/profiler disponível no ambiente da corrida). Dado que o fix remove 1 superfície de blur real (a operação mais cara de GPU) por notificação e o issue documenta esse blur como a causa directa do custo, a expectativa é uma melhoria substancial, mas não tenho medição empírica para marcar isto como cumprido.
- [x] Teste que falhe se um `BlurView` reaparecer dentro de uma lista — `'mounts zero real BlurView surfaces for notification cards, even with 12 notifications'` e `'keeps a single notification card solid...'`, ambos com prova de passo vermelho abaixo.

## Testes

**Passo vermelho** (revertido apenas o hunk do cartão — `BlurView` de volta, borda removida — mantendo o fallback `require()` que é infra-estrutura de teste, não o fix):

```
 FAIL Android src/screens/__tests__/NotificationCenterScreen.test.tsx (filtro: "blur surface budget")
  ● blur surface budget (issue #504) › mounts zero real BlurView surfaces for notification cards, even with 12 notifications
    expect(received).toHaveLength(expected)
    Expected length: 0
    Received length: 12
      182 |       expect(UNSAFE_queryAllByType('BlurView' as never)).toHaveLength(0);

  ● blur surface budget (issue #504) › keeps a single notification card solid (no BlurView) when there is exactly one
    Expected length: 0
    Received length: 1
      192 |       expect(UNSAFE_queryAllByType('BlurView' as never)).toHaveLength(0);

  ● blur surface budget (issue #504) › gives the notification card a material top hairline border in place of the removed blur
    Matcher error: received value must be a number or bigint
    Received has value: undefined
      196 |       expect(styles.notifCard.borderTopWidth).toBeGreaterThan(0);

Tests: 3 failed, 20 skipped, 23 total
```

Os 3 testes falham exactamente pela razão certa: os `BlurView` reais aparecem (12 e 1) em vez de 0, e a borda não existe. Com o fix restaurado, os 3 passam.

**Casos cobertos:**
- Caminho feliz com múltiplas notificações (12, distribuídas por 12 pacotes distintos para evitar o `COLLAPSED_LIMIT=3` por grupo esconder cartões e falsear a contagem).
- Caso de fronteira: exactamente 1 notificação (garante que a remoção do `BlurView` não depende de haver múltiplas).
- Verificação estrutural do estilo (`borderTopWidth`/`borderTopColor` definidos e distintos do `backgroundColor`, para a borda não ser invisível).
- `afterEach` restaura os mocks de `launcherModule` para o estado por omissão (`hasAccess=false`, lista vazia) para não contaminar os testes pré-existentes do mesmo ficheiro que assumem acesso negado.

**Sanity-check:** fix revertido (só o hunk do cartão) → suite falhou nos 3 testes novos (acima) → fix restaurado → suite completa do ficheiro voltou a passar (23/23).

**Resultado das verificações obrigatórias:**
- `npm run lint`: 0 erros (2 warnings pré-existentes e não relacionadas: `BridgeErrorReporting.test.tsx`, `ClockScreen.tsx`).
- `npx tsc --noEmit`: limpo, sem output.
- `npm test -- --maxWorkers=2`: 691 passaram, 8 falharam, 99 suites (95 passaram, 4 falharam). As 8 falhas são um subconjunto exacto das 9 já documentadas na linha de base (`CalculatorScreen`, `FoldersStore` ×2, `LockScreen` ×3, `SettingsScreen`, `WeatherScreen` ×2) — nenhuma falha nova. `NotificationCenterScreen.test.tsx`: 23/23 a passar.

## Testes

691 passaram, 8 falharam, 99 suites (95 passaram, 4 falharam) — 0 falhas novas vs linha de base (9); NotificationCenterScreen.test.tsx: 23/23

## Linked Issue

Fixes #504