### PR TITLE
qa/issue-483: cache app icons to disk (versionCode-keyed) and paint the grid from a persisted index instead of re-extracting on every launch (#483)

### DIFF
--- a/modules/launcher-module/android/src/main/java/com/iostoandroid/launcher/IconCache.kt
+++ b/modules/launcher-module/android/src/main/java/com/iostoandroid/launcher/IconCache.kt
@@ -1,0 +1,25 @@
+package com.iostoandroid.launcher
+
+/**
+ * Pure-JVM logic for LauncherModule's on-disk icon cache. Kept free of
+ * android.* imports so it can be unit-tested without a device.
+ *
+ * Icons are cached as `<packageName>_<versionCode>.png` under
+ * `context.filesDir/icons/`. Folding versionCode into the key means an app
+ * update invalidates its icon for free — the old file simply stops matching
+ * any currently-installed package and [orphanedFiles] flags it for deletion.
+ */
+object IconCache {
+
+    /** The cache filename for [packageName] at [versionCode]. */
+    fun fileName(packageName: String, versionCode: Long): String = "${packageName}_$versionCode.png"
+
+    /**
+     * Names, from [existingFileNames], that no longer correspond to any name in
+     * [validFileNames] — i.e. the app was uninstalled, or was updated to a
+     * versionCode whose icon has already been (re-)cached under a new key.
+     * Callers should delete these from disk so `filesDir` doesn't grow forever.
+     */
+    fun orphanedFiles(existingFileNames: List<String>, validFileNames: Set<String>): List<String> =
+        existingFileNames.filterNot { validFileNames.contains(it) }
+}

--- a/modules/launcher-module/android/src/main/java/com/iostoandroid/launcher/LauncherModule.kt
+++ b/modules/launcher-module/android/src/main/java/com/iostoandroid/launcher/LauncherModule.kt
@@ -33,6 +33,8 @@ import android.util.Base64
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
 import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.FileOutputStream
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Date
@@ -82,12 +84,25 @@ class LauncherModule : Module() {
             val activities = pm.queryIntentActivities(mainIntent, 0)
                 .distinctBy { it.activityInfo.packageName }
 
-            activities.map { resolveInfo ->
+            // Icons are cached to disk as <packageName>_<versionCode>.png instead of
+            // being re-extracted and base64-encoded on every launch — see IconCache
+            // for the filename/orphan logic this AsyncFunction drives.
+            val iconsDir = File(context.filesDir, "icons").apply { mkdirs() }
+            val validIconFileNames = mutableSetOf<String>()
+
+            val apps = activities.map { resolveInfo ->
                 val appInfo = resolveInfo.activityInfo.applicationInfo
                 val label = resolveInfo.loadLabel(pm).toString()
                 val packageName = resolveInfo.activityInfo.packageName
                 val icon = try {
-                    drawableToBase64(resolveInfo.loadIcon(pm))
+                    val versionCode = getVersionCode(pm, packageName)
+                    val fileName = IconCache.fileName(packageName, versionCode)
+                    validIconFileNames.add(fileName)
+                    val iconFile = File(iconsDir, fileName)
+                    if (!iconFile.exists()) {
+                        writeIconToFile(resolveInfo.loadIcon(pm), iconFile)
+                    }
+                    "file://" + iconFile.absolutePath
                 } catch (e: Exception) { "" }
                 val isSystem = (appInfo.flags and ApplicationInfo.FLAG_SYSTEM) != 0
 
@@ -98,6 +113,16 @@ class LauncherModule : Module() {
                     "isSystem" to isSystem
                 )
             }.sortedBy { (it["name"] as String).lowercase() }
+
+            // Drop cached PNGs for apps that were uninstalled, or updated to a
+            // versionCode whose icon was just (re-)cached under a new key above —
+            // otherwise filesDir/icons grows without bound.
+            val existingIconFileNames = iconsDir.list()?.toList() ?: emptyList()
+            IconCache.orphanedFiles(existingIconFileNames, validIconFileNames).forEach { name ->
+                try { File(iconsDir, name).delete() } catch (e: Exception) { /* best effort */ }
+            }
+
+            apps
         }
 
         AsyncFunction("launchApp") { packageName: String ->
@@ -1097,6 +1122,28 @@ class LauncherModule : Module() {
 
     private fun intToIp(ip: Int): String {
         return "${ip and 0xFF}.${ip shr 8 and 0xFF}.${ip shr 16 and 0xFF}.${ip shr 24 and 0xFF}"
+    }
+
+    /** [PackageInfo.versionCode] is deprecated (32-bit, wraps); longVersionCode is its
+     * Android P+ replacement. Used as part of the icon cache key so an app update
+     * invalidates its cached PNG for free. */
+    private fun getVersionCode(pm: PackageManager, packageName: String): Long {
+        val info = pm.getPackageInfo(packageName, 0)
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            info.longVersionCode
+        } else {
+            @Suppress("DEPRECATION")
+            info.versionCode.toLong()
+        }
+    }
+
+    private fun writeIconToFile(drawable: Drawable, file: File) {
+        val bitmap = drawableToBitmap(drawable)
+        val scaledBitmap = Bitmap.createScaledBitmap(bitmap, 128, 128, true)
+        FileOutputStream(file).use { out ->
+            scaledBitmap.compress(Bitmap.CompressFormat.PNG, 90, out)
+        }
+        if (bitmap != scaledBitmap) scaledBitmap.recycle()
     }
 
     private fun drawableToBase64(drawable: Drawable): String {

--- a/modules/launcher-module/android/src/test/java/com/iostoandroid/launcher/IconCacheTest.kt
+++ b/modules/launcher-module/android/src/test/java/com/iostoandroid/launcher/IconCacheTest.kt
@@ -1,0 +1,64 @@
+package com.iostoandroid.launcher
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure-JVM unit tests for [IconCache] — the on-disk icon filename key and the
+ * orphan-detection logic used by LauncherModule.getInstalledApps. No android.*
+ * imports, so these run without a device or the Android SDK.
+ */
+class IconCacheTest {
+
+    @Test
+    fun `fileName encodes packageName and versionCode so an app update gets a new key`() {
+        assertEquals(
+            "com.android.settings_1.png",
+            IconCache.fileName("com.android.settings", 1L)
+        )
+        // Same package, new versionCode after an update — different key entirely,
+        // so the stale PNG is never mistaken for the new one.
+        assertEquals(
+            "com.android.settings_2.png",
+            IconCache.fileName("com.android.settings", 2L)
+        )
+    }
+
+    @Test
+    fun `fileName is stable for the same package and versionCode`() {
+        val first = IconCache.fileName("com.example.app", 42L)
+        val second = IconCache.fileName("com.example.app", 42L)
+        assertTrue(first == second)
+    }
+
+    @Test
+    fun `orphanedFiles is empty when every cached file matches a currently valid key`() {
+        val existing = listOf("com.a_1.png", "com.b_3.png")
+        val valid = setOf("com.a_1.png", "com.b_3.png")
+        assertTrue(IconCache.orphanedFiles(existing, valid).isEmpty())
+    }
+
+    @Test
+    fun `orphanedFiles flags an uninstalled app's icon for removal`() {
+        val existing = listOf("com.a_1.png", "com.uninstalled_5.png")
+        val valid = setOf("com.a_1.png") // com.uninstalled is no longer among installed apps
+        assertEquals(listOf("com.uninstalled_5.png"), IconCache.orphanedFiles(existing, valid))
+    }
+
+    @Test
+    fun `orphanedFiles flags the previous versionCode's icon after an app update`() {
+        // com.a updated from versionCode 1 to 2 — only the new key is valid now,
+        // the old file must not linger on disk forever.
+        val existing = listOf("com.a_1.png", "com.a_2.png")
+        val valid = setOf("com.a_2.png")
+        assertEquals(listOf("com.a_1.png"), IconCache.orphanedFiles(existing, valid))
+    }
+
+    @Test
+    fun `orphanedFiles never flags a file whose exact name is still valid`() {
+        val existing = listOf("com.a_1.png")
+        val valid = setOf("com.a_1.png")
+        assertTrue(IconCache.orphanedFiles(existing, valid).isEmpty())
+    }
+}

--- a/modules/launcher-module/src/index.ts
+++ b/modules/launcher-module/src/index.ts
@@ -5,10 +5,17 @@ export interface InstalledApp {
   name: string;
   packageName: string;
   /**
-   * A COMPLETE data URI — `data:image/png;base64,<payload>` — already prefixed by
-   * `LauncherModule.drawableToBase64` on the Kotlin side. Pass it straight to
+   * A COMPLETE URI, already prefixed on the Kotlin side — pass it straight to
    * `<Image source={{ uri: app.icon }} />`; prefixing it again yields a
    * double-prefixed URI that silently renders nothing.
+   *
+   * `getInstalledApps()` returns a `file://` URI pointing at a PNG cached
+   * under `context.filesDir/icons/<packageName>_<versionCode>.png`
+   * (LauncherModule.kt's `getInstalledApps` AsyncFunction + `IconCache`) — the
+   * icon is decoded from the launcher activity only once per app version, not
+   * on every app start. `getAppIcon(packageName)` still returns a one-off
+   * `data:image/png;base64,<payload>` (LauncherModule.kt's `drawableToBase64`),
+   * uncached, for on-demand single-icon lookups.
    * Empty string when the icon could not be loaded.
    */
   icon: string;

--- a/src/screens/__tests__/appIconDataUri.test.ts
+++ b/src/screens/__tests__/appIconDataUri.test.ts
@@ -48,6 +48,8 @@ describe('app icons from the native bridge', () => {
       'utf8'
     );
     // The comment is the only thing standing between the next reader and this bug.
-    expect(bridge).toMatch(/COMPLETE data URI/);
+    // getInstalledApps() moved to a cached file:// URI (issue #483) while getAppIcon()
+    // still returns a data: URI — both are covered by the same "COMPLETE URI" contract.
+    expect(bridge).toMatch(/COMPLETE URI/);
   });
 });

--- a/src/store/AppsStore.tsx
+++ b/src/store/AppsStore.tsx
@@ -6,6 +6,7 @@ import { logger } from '../utils/logger';
 import { migrateAsyncStorageKey } from './storage';
 
 const STORAGE_KEY = '@iostoandroid/apps_layout';
+const APPS_INDEX_KEY = '@iostoandroid/apps_index';
 const RECENTS_KEY = '@iostoandroid/recent_apps';
 const RECENTS_LEGACY_KEY = '@recent_apps';
 const MAX_RECENTS = 8;
@@ -25,6 +26,22 @@ export interface HomeApp {
 export interface RecentApp {
   packageName: string;
   launchedAt: number; // epoch ms
+}
+
+// Dynamic import to avoid crashing the module on non-Android. Falls back to a
+// synchronous require when dynamic import() is unavailable (e.g. Jest's VM
+// without --experimental-vm-modules) so moduleNameMapper mocks still apply in tests.
+async function getLauncherModule() {
+  try {
+    return (await import('../../modules/launcher-module/src')).default;
+  } catch {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports -- Metro supports require; fallback for environments without dynamic import
+      return require('../../modules/launcher-module/src').default;
+    } catch {
+      return null;
+    }
+  }
 }
 
 interface AppsState {
@@ -142,61 +159,91 @@ export function AppsProvider({ children }: { children: React.ReactNode }) {
     AsyncStorage.setItem(RECENTS_KEY, JSON.stringify([]));
   }, []);
 
+  // Resolves the final dock list: ensures our built-in apps are present (max 4),
+  // then drops any package that isn't installed (or a virtual built-in).
+  const resolveDock = useCallback((apps: InstalledApp[], savedDock: string[]) => {
+    let dockApps = savedDock;
+    for (const pkg of DEFAULT_DOCK) {
+      if (!dockApps.includes(pkg)) {
+        dockApps = [...dockApps.slice(0, 3), pkg]; // keep max 4, ensure built-in present
+      }
+    }
+    return dockApps.filter((pkg: string) =>
+      apps.some((app: InstalledApp) => app.packageName === pkg) || VIRTUAL_APPS_MAP[pkg]
+    ).slice(0, 4); // max 4 in dock
+  }, []);
+
   const loadApps = useCallback(async () => {
     if (Platform.OS !== 'android') {
       setState(prev => ({ ...prev, isLoading: false }));
       return;
     }
 
-    try {
-      // Dynamic import to avoid crash on non-Android
-      const LauncherModule = (await import('../../modules/launcher-module/src')).default;
+    const [savedLayout, cachedIndexRaw] = await Promise.all([
+      AsyncStorage.getItem(STORAGE_KEY),
+      AsyncStorage.getItem(APPS_INDEX_KEY),
+    ]);
 
-      const [apps, savedLayout, defaultStatus] = await Promise.all([
+    let dockApps = DEFAULT_DOCK;
+    let homeApps: HomeApp[] = [];
+    if (savedLayout) {
+      try {
+        const parsed = JSON.parse(savedLayout);
+        homeApps = parsed.homeApps || [];
+        // Only use saved dock if it contains our virtual apps (otherwise it's stale data)
+        const savedDock = parsed.dockApps || [];
+        const hasVirtualApps = DEFAULT_DOCK.some((pkg: string) => savedDock.includes(pkg));
+        dockApps = hasVirtualApps ? savedDock : DEFAULT_DOCK;
+      } catch { /* ignore */ }
+    }
+
+    // A cached index lets every arranque but the very first paint the grid
+    // immediately, without waiting on the native package scan below.
+    let cachedApps: InstalledApp[] | null = null;
+    if (cachedIndexRaw) {
+      try {
+        const parsed = JSON.parse(cachedIndexRaw);
+        if (Array.isArray(parsed)) cachedApps = parsed;
+      } catch (e) { logger.warn('AppsStore', 'failed to parse cached apps index', e); }
+    }
+
+    if (cachedApps) {
+      setState({
+        allApps: cachedApps,
+        homeApps,
+        dockApps: resolveDock(cachedApps, dockApps),
+        isLoading: false,
+      });
+    }
+
+    try {
+      const LauncherModule = await getLauncherModule();
+      if (!LauncherModule) throw new Error('LauncherModule unavailable');
+
+      const [apps, defaultStatus] = await Promise.all([
         LauncherModule.getInstalledApps(),
-        AsyncStorage.getItem(STORAGE_KEY),
         LauncherModule.isDefaultLauncher(),
       ]);
 
       setIsDefault(defaultStatus);
-
-      let dockApps = DEFAULT_DOCK;
-      let homeApps: HomeApp[] = [];
-
-      if (savedLayout) {
-        try {
-          const parsed = JSON.parse(savedLayout);
-          homeApps = parsed.homeApps || [];
-          // Only use saved dock if it contains our virtual apps (otherwise it's stale data)
-          const savedDock = parsed.dockApps || [];
-          const hasVirtualApps = DEFAULT_DOCK.some((pkg: string) => savedDock.includes(pkg));
-          dockApps = hasVirtualApps ? savedDock : DEFAULT_DOCK;
-        } catch { /* ignore */ }
-      }
-
-      // Ensure our built-in apps are always in the dock
-      for (const pkg of DEFAULT_DOCK) {
-        if (!dockApps.includes(pkg)) {
-          dockApps = [...dockApps.slice(0, 3), pkg]; // keep max 4, ensure built-in present
-        }
-      }
-
-      // Filter dock apps to only include installed or virtual ones
-      dockApps = dockApps.filter((pkg: string) =>
-        apps.some((app: InstalledApp) => app.packageName === pkg) || VIRTUAL_APPS_MAP[pkg]
-      ).slice(0, 4); // max 4 in dock
+      AsyncStorage.setItem(APPS_INDEX_KEY, JSON.stringify(apps));
 
       setState({
         allApps: apps,
         homeApps,
-        dockApps,
+        dockApps: resolveDock(apps, dockApps),
         isLoading: false,
       });
-    } catch {
-      alertRef.current('Error', 'Could not load apps. Please try again later.');
-      setState(prev => ({ ...prev, isLoading: false }));
+    } catch (e) {
+      logger.warn('AppsStore', 'background apps refresh failed', e);
+      // A cached index is already painted — keep it and refresh silently next time
+      // instead of surfacing an error for a scan the user isn't waiting on.
+      if (!cachedApps) {
+        alertRef.current('Error', 'Could not load apps. Please try again later.');
+        setState(prev => ({ ...prev, isLoading: false }));
+      }
     }
-  }, []);
+  }, [resolveDock]);
 
   useEffect(() => {
     loadApps();

--- a/src/store/__tests__/AppsStore.test.tsx
+++ b/src/store/__tests__/AppsStore.test.tsx
@@ -2,15 +2,21 @@ import React from 'react';
 import { renderHook, act } from '@testing-library/react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { AppsProvider, useApps } from '../AppsStore';
+// eslint-disable-next-line @typescript-eslint/no-require-imports -- default export of the jest-mocked module, needed to control getInstalledApps() resolution timing per test
+const LauncherModule = require('../../../modules/launcher-module/src').default;
 
 const wrapper = ({ children }: { children: React.ReactNode }) => (
   <AppsProvider>{children}</AppsProvider>
 );
 
+const APPS_INDEX_KEY = '@iostoandroid/apps_index';
+
 beforeEach(() => {
   jest.clearAllMocks();
   (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
   (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
+  (LauncherModule.getInstalledApps as jest.Mock).mockResolvedValue([]);
+  (LauncherModule.isDefaultLauncher as jest.Mock).mockResolvedValue(false);
 });
 
 describe('AppsStore — dock resolution of virtual built-in apps', () => {
@@ -35,5 +41,78 @@ describe('AppsStore — dock resolution of virtual built-in apps', () => {
     const dockEntry = result.current.dockApps.find((a) => a.packageName === packageName);
     expect(dockEntry).toBeDefined();
     expect(dockEntry?.name).toBe(name);
+  });
+});
+
+describe('AppsStore — paints from the cached apps index without waiting for the native scan', () => {
+  it('renders the grid from the cached index while getInstalledApps is still pending', async () => {
+    const cachedApps = [
+      { name: 'Cached App', packageName: 'com.example.cached', icon: 'file:///data/user/0/com.iostoandroid/files/icons/com.example.cached_1.png', isSystem: false },
+    ];
+    (AsyncStorage.getItem as jest.Mock).mockImplementation((key: string) =>
+      Promise.resolve(key === APPS_INDEX_KEY ? JSON.stringify(cachedApps) : null)
+    );
+    let resolveNative: (apps: unknown[]) => void = () => {};
+    (LauncherModule.getInstalledApps as jest.Mock).mockImplementation(
+      () => new Promise((resolve) => { resolveNative = resolve; })
+    );
+
+    const { result, unmount } = renderHook(() => useApps(), { wrapper });
+
+    // Flush the microtasks for the cache read only — getInstalledApps() is
+    // still unresolved at this point, on purpose.
+    await act(async () => {});
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.apps).toEqual(cachedApps);
+
+    // Let the still-pending native call settle so it doesn't leak into the next test.
+    await act(async () => { resolveNative([]); });
+    unmount();
+  });
+
+  it('falls back to the native scan when there is no cached index (first-ever launch)', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+    const nativeApps = [
+      { name: 'Native App', packageName: 'com.example.native', icon: 'file:///data/user/0/com.iostoandroid/files/icons/com.example.native_1.png', isSystem: false },
+    ];
+    (LauncherModule.getInstalledApps as jest.Mock).mockResolvedValue(nativeApps);
+
+    const { result } = renderHook(() => useApps(), { wrapper });
+    await act(async () => {});
+    await act(async () => {});
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.apps).toEqual(nativeApps);
+  });
+
+  it('persists the apps returned by getInstalledApps as the index for the next launch', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+    const nativeApps = [
+      { name: 'Native App', packageName: 'com.example.native', icon: 'file:///data/user/0/com.iostoandroid/files/icons/com.example.native_1.png', isSystem: false },
+    ];
+    (LauncherModule.getInstalledApps as jest.Mock).mockResolvedValue(nativeApps);
+
+    renderHook(() => useApps(), { wrapper });
+    await act(async () => {});
+    await act(async () => {});
+
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(APPS_INDEX_KEY, JSON.stringify(nativeApps));
+  });
+
+  it('keeps the painted cache and does not show an error alert when the background refresh fails', async () => {
+    const cachedApps = [
+      { name: 'Cached App', packageName: 'com.example.cached', icon: 'file:///data/user/0/com.iostoandroid/files/icons/com.example.cached_1.png', isSystem: false },
+    ];
+    (AsyncStorage.getItem as jest.Mock).mockImplementation((key: string) =>
+      Promise.resolve(key === APPS_INDEX_KEY ? JSON.stringify(cachedApps) : null)
+    );
+    (LauncherModule.getInstalledApps as jest.Mock).mockRejectedValue(new Error('native scan crashed'));
+
+    const { result } = renderHook(() => useApps(), { wrapper });
+    await act(async () => {});
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.apps).toEqual(cachedApps);
   });
 });


### PR DESCRIPTION
## Resumo

qa/issue-483: cache app icons to disk (versionCode-keyed) and paint the grid from a persisted index instead of re-extracting on every launch

## Causa raiz

Duas coisas, tal como o issue diagnosticou, confirmadas em `main` (`470a816`):

1. **Sem cache de ícones.** `getInstalledApps()` (`LauncherModule.kt:74-101` antes deste PR) chamava `resolveInfo.loadIcon(pm)` + `drawableToBase64` para todos os apps, todos os arranques — nada tocava disco.
2. **A grelha esperava por isso.** `AppsStore.tsx` (`loadApps`, antes deste PR `:145-199`) arrancava com `isLoading: true` e só o desligava depois de `Promise.all([getInstalledApps(), ...])` resolver. `LauncherHomeScreen.tsx` mostra `<CupertinoActivityIndicator>` enquanto `isLoading` é `true`.

## O que mudou

**`modules/launcher-module/android/src/main/java/com/iostoandroid/launcher/IconCache.kt`** (novo) — objecto Kotlin puro-JVM (sem `android.*`), com:
- `fileName(packageName, versionCode)` → `"<packageName>_<versionCode>.png"`.
- `orphanedFiles(existingFileNames, validFileNames)` → nomes em disco que já não correspondem a nenhuma chave válida (app desinstalada OU app actualizada para um `versionCode` novo).

**`modules/launcher-module/android/src/main/java/com/iostoandroid/launcher/LauncherModule.kt`** — `getInstalledApps`:
- Para cada app, obtém `versionCode` via `pm.getPackageInfo` (helper `getVersionCode`, com o `longVersionCode` do Android P+ e fallback ao `versionCode` de 32-bit antes disso).
- Calcula a chave via `IconCache.fileName`. Se `context.filesDir/icons/<chave>.png` já existe, reutiliza-o; senão extrai o ícone e grava-o (`writeIconToFile`, mesma escala 128×128 / qualidade 90 que já existia em `drawableToBase64`).
- Devolve `"file://" + iconFile.absolutePath` em vez de `data:image/png;base64,...`.
- No fim de cada scan, lista o conteúdo de `filesDir/icons`, calcula os órfãos via `IconCache.orphanedFiles` e apaga-os — cobre desinstalação e actualização de versão na mesma passagem.
- `getAppIcon(packageName)` (lookup individual, on-demand) fica **inalterado** — continua a devolver base64, sem cache; não faz parte do sintoma do issue (não é chamado em massa no arranque).

**`modules/launcher-module/android/src/test/java/com/iostoandroid/launcher/IconCacheTest.kt`** (novo) — 6 testes JUnit puro-JVM para `IconCache` (chave estável, chave muda com `versionCode`, órfãos por desinstalação, órfãos por actualização, nunca marca uma chave válida como órfã).

**`src/store/AppsStore.tsx`** — `loadApps`:
- Nova chave `@iostoandroid/apps_index` no AsyncStorage. No arranque, lê-a antes de tocar no módulo nativo; se existir, pinta a grelha de imediato (`isLoading: false`, `allApps` = índice em cache) **sem esperar** por `getInstalledApps()`.
- Só depois, em paralelo, chama `getInstalledApps()` + `isDefaultLauncher()` para refrescar; ao resolver, persiste o resultado como o novo índice e actualiza o estado.
- Se não há índice em cache (primeiro arranque de sempre), comportamento igual ao anterior: `isLoading` fica `true` até a chamada nativa resolver.
- Se o refresh em fundo falhar e já havia um índice em cache pintado, mantém-se o que está pintado e **não** mostra o alerta de erro (o utilizador já tem uma grelha funcional); só mostra o alerta quando falha sem cache nenhum, tal como antes.
- Extraído `getLauncherModule()`: `await import(...)` com fallback a `require(...)` — o mesmo padrão já usado em `LockScreen.tsx:38-51` — porque descobri, ao escrever os testes, que o `import()` dinâmico lança `ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING_FLAG` neste jest-expo (sem `--experimental-vm-modules`), e sem o fallback `getInstalledApps()` nunca corre em teste (fica sempre `[]`). Isto já acontecia em `main`, só nunca tinha sido exposto porque nenhum teste anterior verificava o conteúdo de `apps` vindo do nativo — só `launchApp` e `openLauncherSettings`, que não fazem parte deste issue, continuam com o `import()` sem fallback.

**`modules/launcher-module/src/index.ts`** — comentário de `InstalledApp.icon` actualizado: já não descreve só o `data:` URI; explica que `getInstalledApps()` devolve `file://` (cache em disco) e `getAppIcon()` continua a devolver `data:` (sem cache), mantendo o aviso sobre double-prefixing.

**`src/screens/__tests__/appIconDataUri.test.ts`** — regex do teste de regressão do double-prefix actualizada de `/COMPLETE data URI/` para `/COMPLETE URI/`, para acompanhar a redacção nova do comentário (o contrato "é sempre um URI completo, nunca re-prefixar" continua igual e continua coberto).

## Porque assim

- **Substituição total do array em vez de diff granular:** o issue sugeria "fazer diff contra o índice em vez de substituir o estado inteiro". Optei por substituição total porque é o que já existia (menor diff), é suficiente para corrigir o sintoma (a grelha já não espera pelo nativo), e a UI é uma FlatList/grid chaveada por `packageName` — o custo de reconciliação de uma lista de ~100-200 apps é desprezável comparado com o ganho de não bloquear no scan nativo. Registo aqui a troca por transparência, não é um requisito de aceitação explícito.
- **`getAppIcon` deixado sem cache:** fora do âmbito do issue (não corre em massa no arranque); tocar nele seria scope creep.
- **Auto-cura em vez de validação extra:** se `getVersionCode` falhar para um pacote (raríssimo — o pacote acabou de ser enumerado por `queryIntentActivities`), essa app não entra em `validIconFileNames` nessa passagem e o seu PNG antigo (se existir) é apagado como órfão; a extracção repete-se na passagem seguinte. Não tratei isto como erro bloqueante — é o mesmo espírito "best effort" que já existia no `catch (e: Exception) { false }` disperso pelo resto do módulo.

## Critérios de aceitação

- [x] Segundo arranque pinta a grelha sem chamar `getInstalledApps()` primeiro — `loadApps` pinta de `cachedApps` antes de sequer importar o módulo nativo (testado).
- [ ] **Tempo até à grelha visível, medido no 1º e no 2º arranque** — **não medido**. Este sandbox de implementação não tem emulador/dispositivo Android nem `expo run:android`; não há como obter um número real e não vou inventá-lo. A correcção elimina por construção a dependência da grelha do scan nativo no ≥2º arranque; a medição real fica para quem tiver um dispositivo/emulador à mão.
- [x] PNGs em `filesDir`, com chave que inclui `versionCode` — `IconCache.fileName` + `getInstalledApps` (Kotlin).
- [x] Actualizar uma app troca o ícone; desinstalar remove o PNG — ambos cobertos por `IconCache.orphanedFiles` + a limpeza no fim de `getInstalledApps` (testado em JUnit puro-JVM: `orphanedFiles flags an uninstalled app's icon for removal` e `... the previous versionCode's icon after an app update`).
- [x] Zero ícones duplicados (regressão de #435/#438) — `distinctBy { it.activityInfo.packageName }` em `getInstalledApps` não foi tocado; continua intacto.
- [x] `index.ts:8-12` reflecte o formato novo — reescrito para descrever `file://` (cache) vs `data:` (`getAppIcon`, sem cache).
- [x] Teste do índice: pinta do cache quando existe, cai no caminho nativo quando não existe — 2 dos 4 testes novos em `AppsStore.test.tsx` fazem exactamente isto.

**Limitação honesta:** os testes Kotlin (`IconCacheTest`) correram e passaram em JVM pura via `kotlinc` + JUnit (sem Gradle/Android SDK, indisponíveis neste sandbox) — ver output abaixo. O `LauncherModule.kt` em si (que depende de `android.*`) **não pôde ser compilado nem executado** neste ambiente; a revisão foi manual (balanço de chaves, tipos, imports). As verificações obrigatórias do pipeline (`npm run lint`, `npx tsc --noEmit`, `npm test`) não cobrem Kotlin — é consistente com o que o harness já exige.

## Testes

**Passo vermelho — `AppsStore.test.tsx` (JS), com o fix ainda não escrito:**
```
AppsStore — paints from the cached apps index without waiting for the native scan
  ✕ renders the grid from the cached index while getInstalledApps is still pending
  ✕ falls back to the native scan when there is no cached index (first-ever launch)
  ✕ persists the apps returned by getInstalledApps as the index for the next launch
  ✕ keeps the painted cache and does not show an error alert when the background refresh fails

  ● ... renders the grid from the cached index ...
    expect(received).toBe(expected) // Object.is equality
    Expected: false
    Received: true
      at Object.toBe (src/store/__tests__/AppsStore.test.tsx:65:33)   // expect(result.current.isLoading).toBe(false)

  ● ... falls back to the native scan when there is no cached index ...
    expect(received).toEqual(expected) // deep equality
    - Array [ Object { icon: 'file:///.../com.example.native_1.png', ... } ]
    + Array []
      at Object.toEqual (src/store/__tests__/AppsStore.test.tsx:85:33)  // expect(result.current.apps).toEqual(nativeApps)

  ● ... persists the apps returned by getInstalledApps ...
    expect(jest.fn()).toHaveBeenCalledWith(...expected)
    Number of calls: 0
      at Object.toHaveBeenCalledWith (src/store/__tests__/AppsStore.test.tsx:98:34)

Tests: 4 failed, 3 passed, 7 total
```

**Passo vermelho — `IconCacheTest.kt` (Kotlin), compilado com `kotlinc` antes de `IconCache.kt` existir:**
```
modules/launcher-module/android/src/test/java/com/iostoandroid/launcher/IconCacheTest.kt:18:13: error: unresolved reference: IconCache
modules/launcher-module/android/src/test/java/com/iostoandroid/launcher/IconCacheTest.kt:24:13: error: unresolved reference: IconCache
modules/launcher-module/android/src/test/java/com/iostoandroid/launcher/IconCacheTest.kt:39:20: error: unresolved reference: IconCache
... (7 erros, um por chamada a IconCache)
```

**Passo verde — depois do fix:**
- `AppsStore.test.tsx`: 7/7 passaram.
- `IconCacheTest.kt` via `kotlinc 1.9.24` + JUnit 4.13.2 (jars de sessões anteriores, fora do repo): `JUnit version 4.13.2 ...... OK (6 tests)`.

**Casos cobertos, além do caminho feliz:**
- Cache presente mas scan nativo ainda pendente (prova que a UI não espera).
- Sem cache nenhuma (primeiro arranque real) → cai no caminho nativo.
- Persistência do índice devolvido pelo nativo, para o arranque seguinte.
- Scan em fundo falha (rejeição) com cache já pintada → mantém a grelha, não mostra erro.
- Kotlin: chave estável para o mesmo (package, versionCode); chave diferente entre versões; órfão por desinstalação; órfão por actualização de versão; nunca marca uma chave ainda válida como órfã.

**Sanity-check:** `git stash push -u -m "issue-483-sanity-check-revert" -- src/store/AppsStore.tsx` (só a produção, teste ficou fora) → `npx jest src/store/__tests__/AppsStore.test.tsx` → 4 falharam pela razão certa (mesmo erro do passo vermelho) → `git stash apply <sha>` + `git stash drop <sha>` → 7/7 voltaram a passar.

**Resultado das verificações obrigatórias (JS):**
- `npm run lint`: 0 erros (2 warnings pré-existentes, não relacionados — `BridgeErrorReporting.test.tsx` e `ClockScreen.tsx`).
- `npx tsc --noEmit`: limpo.
- `npm test -- --maxWorkers=2`: **692 passaram, 8 falharam, 700 total, 99 suites (4 falhadas)**. As 8 falhas são um subconjunto exacto das 9 da LINHA DE BASE (`FoldersStore` ×2, `LockScreen` ×3, `SettingsScreen` ×1, `WeatherScreen` ×2) — nenhuma falha nova. `CalculatorScreen › 0.1 + 0.2 equals 0.3 without float artifacts` que está na baseline passou nesta corrida (não investigado — não é código tocado por este PR).

## Testes

692 passaram, 8 falharam, 700 total, 99 suites (4 falhadas) — subconjunto exacto da baseline de 9 falhas; IconCacheTest.kt: 6/6 via kotlinc+JUnit puro-JVM

## Linked Issue

Fixes #483