### PR TITLE
settle() passa a receber velocidade e 10 call-sites de gesto herdam-na do release (flick vs drag deixam de animar igual) (#487)

### DIFF
--- a/src/components/AssistiveTouch.tsx
+++ b/src/components/AssistiveTouch.tsx
@@ -277,7 +277,7 @@ export function AssistiveTouch({ navigationRef }: AssistiveTouchProps) {
       translateX.value = dragStart.value.x + e.translationX;
       translateY.value = dragStart.value.y + e.translationY;
     })
-    .onEnd(() => {
+    .onEnd((e) => {
       'worklet';
       const rm = reduceMotionShared.value;
       // Magnetic snap to nearest horizontal edge
@@ -285,7 +285,9 @@ export function AssistiveTouch({ navigationRef }: AssistiveTouchProps) {
       const snapRight = SCREEN_W - size - 8;
       const center = translateX.value + size / 2;
       const targetX = center < SCREEN_W / 2 ? snapLeft : snapRight;
-      translateX.value = settle(targetX, SNAP_SPRING, rm);
+      // translateX/translateY are literal dp offsets — e.velocityX/velocityY
+      // from the gesture handler are already dp/sec, no conversion needed.
+      translateX.value = settle(targetX, SNAP_SPRING, rm, e.velocityX);
 
       // Clamp Y inside safe area
       const minY = insets.top + 8;
@@ -293,7 +295,7 @@ export function AssistiveTouch({ navigationRef }: AssistiveTouchProps) {
       let targetY = translateY.value;
       if (targetY < minY) targetY = minY;
       if (targetY > maxY) targetY = maxY;
-      translateY.value = settle(targetY, SNAP_SPRING, rm);
+      translateY.value = settle(targetY, SNAP_SPRING, rm, e.velocityY);
 
       runOnJS(persistPosition)(targetX, targetY);
       runOnJS(snapHaptic)();

--- a/src/components/BackEdgeSwipe.tsx
+++ b/src/components/BackEdgeSwipe.tsx
@@ -9,7 +9,7 @@ import Animated, {
 } from 'react-native-reanimated';
 import { useNavigation } from '@react-navigation/native';
 
-import { gestureConfig } from '../utils/gestureConfig';
+import { dpPerMsToPtPerSec, gestureConfig } from '../utils/gestureConfig';
 import { pushSample, sampledVelocity, useVelocityBuffer } from '../utils/gestureVelocity';
 import { commitForBack } from '../utils/gestureMachine';
 import { hapticSelection } from '../utils/haptics';
@@ -77,11 +77,15 @@ export function BackEdgeSwipe({ children }: { children: React.ReactNode }) {
       pushSample(buf.value, e.translationX, e.translationY, currentT.value);
       const { vx } = sampledVelocity(buf.value, currentT.value);
       const reason = commitForBack({ progress: progress.value, velocity: vx, holdMs: 0 });
+      // progress is normalized [0,1] over the edge-swipe travel distance;
+      // convert the dp/ms sample velocity to progress-units/sec.
+      const travel = SCREEN_W * gestureConfig.backTravelRatio;
+      const progressVelocity = dpPerMsToPtPerSec(vx) / travel;
       // The native gesture owns navigation; we just animate our edge shadow out.
       if (reason !== 'none') {
-        progress.value = settle(1, 'backSettle', reduceMotionShared.value);
+        progress.value = settle(1, 'backSettle', reduceMotionShared.value, progressVelocity);
       } else {
-        progress.value = settle(0, 'backSettle', reduceMotionShared.value);
+        progress.value = settle(0, 'backSettle', reduceMotionShared.value, progressVelocity);
       }
     });
 

--- a/src/components/CupertinoSwipeableRow.tsx
+++ b/src/components/CupertinoSwipeableRow.tsx
@@ -92,21 +92,22 @@ export function CupertinoSwipeableRow({
       'worklet';
       const velocity = e.velocityX;
       const rm = reduceMotionShared.value;
+      // translateX is a literal dp offset — e.velocityX is already dp/sec.
       // Decide snap position
       if (velocity < -500 && trailingActions.length > 0) {
-        translateX.value = settle(-maxTrailing, SPRING_CONFIG, rm);
+        translateX.value = settle(-maxTrailing, SPRING_CONFIG, rm, velocity);
         runOnJS(triggerHaptic)();
       } else if (velocity > 500 && leadingActions.length > 0) {
-        translateX.value = settle(maxLeading, SPRING_CONFIG, rm);
+        translateX.value = settle(maxLeading, SPRING_CONFIG, rm, velocity);
         runOnJS(triggerHaptic)();
       } else if (translateX.value < -maxTrailing / 2) {
-        translateX.value = settle(-maxTrailing, SPRING_CONFIG, rm);
+        translateX.value = settle(-maxTrailing, SPRING_CONFIG, rm, velocity);
         runOnJS(triggerHaptic)();
       } else if (translateX.value > maxLeading / 2) {
-        translateX.value = settle(maxLeading, SPRING_CONFIG, rm);
+        translateX.value = settle(maxLeading, SPRING_CONFIG, rm, velocity);
         runOnJS(triggerHaptic)();
       } else {
-        translateX.value = settle(0, SPRING_CONFIG, rm);
+        translateX.value = settle(0, SPRING_CONFIG, rm, velocity);
       }
     });
 

--- a/src/components/EdgePanelOverlay.tsx
+++ b/src/components/EdgePanelOverlay.tsx
@@ -7,7 +7,7 @@ import Animated, {
   runOnJS,
 } from 'react-native-reanimated';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
-import { gestureConfig } from '../utils/gestureConfig';
+import { dpPerMsToPtPerSec, gestureConfig } from '../utils/gestureConfig';
 import { useVelocityBuffer, pushSample, sampledVelocity } from '../utils/gestureVelocity';
 import type { CommitPredicate, CommitReason } from '../utils/gestureMachine';
 import { settle, useGestureReduceMotion } from '../utils/useGestureReduceMotion';
@@ -81,16 +81,20 @@ export function EdgePanelOverlay({
       currentT.value = Date.now();
       pushSample(buf.value, e.translationX, e.translationY, currentT.value);
       const { vy } = sampledVelocity(buf.value, currentT.value);
+      // panelProgress is normalized [0,1] over panelTravelDp; convert the
+      // dp/ms sample velocity to progress-units/sec so the spring inherits
+      // the release speed instead of always settling from a standstill.
+      const progressVelocity = dpPerMsToPtPerSec(vy) / gestureConfig.panelTravelDp;
       const progress = panelProgress.value;
       const reason = commitPredicate({ progress, velocity: vy, holdMs: 0 });
       if (reason !== 'none') {
         // Hand off to the real screen: retract the preview so it doesn't
         // linger underneath the transparent modal and block the home screen
         // when the user returns.
-        panelProgress.value = settle(0, 'fastSettle', reduceMotionShared.value);
+        panelProgress.value = settle(0, 'fastSettle', reduceMotionShared.value, progressVelocity);
         runOnJS(onCommit)();
       } else {
-        panelProgress.value = settle(0, 'fastSettle', reduceMotionShared.value);
+        panelProgress.value = settle(0, 'fastSettle', reduceMotionShared.value, progressVelocity);
       }
     });
 

--- a/src/components/HomeIndicator.tsx
+++ b/src/components/HomeIndicator.tsx
@@ -13,7 +13,7 @@ import Animated, {
 } from 'react-native-reanimated';
 import * as Haptics from 'expo-haptics';
 
-import { gestureConfig, IDLE_DIM_MS } from '../utils/gestureConfig';
+import { dpPerMsToPtPerSec, gestureConfig, IDLE_DIM_MS } from '../utils/gestureConfig';
 import { pushSample, sampledVelocity, useVelocityBuffer } from '../utils/gestureVelocity';
 import { useGestureMachine, commitForHome, commitForSwitcher } from '../utils/gestureMachine';
 import { hapticImpact, hapticSelection } from '../utils/haptics';
@@ -171,7 +171,8 @@ export function HomeIndicator({ onHome, onSwitcher, navigationRef, variant = 'li
       // ×8 (80 dp): home-bar drag is intentionally tolerant of lateral wrist movement;
       // stricter axis-lock would feel sticky on real devices during natural thumb swipes.
       if (Math.abs(e.translationX) > gestureConfig.axisLockDp * 8) {
-        translateY.value = settle(0, 'homeSettle', reduceMotionShared.value);
+        // translateY is a literal dp offset, same unit as vy scaled to per-second.
+        translateY.value = settle(0, 'homeSettle', reduceMotionShared.value, dpPerMsToPtPerSec(vy));
         machine.phase.value = 'cancelled';
         return;
       }
@@ -194,14 +195,16 @@ export function HomeIndicator({ onHome, onSwitcher, navigationRef, variant = 'li
     })
     .onEnd((e) => {
       'worklet';
-      translateY.value = settle(0, 'homeSettle', reduceMotionShared.value);
+      // Final velocity from multi-sample buffer — computed before the first
+      // settle() so translateY's spring can inherit the release speed.
+      pushSample(buf.value, e.translationX, e.translationY, currentT.value);
+      const { vy } = sampledVelocity(buf.value, currentT.value);
+      const translateYVelocity = dpPerMsToPtPerSec(vy);
+
+      translateY.value = settle(0, 'homeSettle', reduceMotionShared.value, translateYVelocity);
 
       const dy = Math.min(0, e.translationY);
       const progress = Math.max(0, Math.min(1, -dy / gestureConfig.homeTravelDp));
-
-      // Final velocity from multi-sample buffer
-      pushSample(buf.value, e.translationX, e.translationY, currentT.value);
-      const { vy } = sampledVelocity(buf.value, currentT.value);
 
       const holdMs = currentT.value - machine.startT.value;
 

--- a/src/components/NotificationBanner.tsx
+++ b/src/components/NotificationBanner.tsx
@@ -95,8 +95,9 @@ export function NotificationBanner({ notification, onDismiss }: Props) {
         // Dismiss
         runOnJS(dismiss)();
       } else {
-        // Snap back
-        translateY.value = withSpring(0, { damping: 20, stiffness: 300 });
+        // Snap back — translateY is a literal dp offset, e.velocityY is
+        // already dp/sec, no conversion needed.
+        translateY.value = withSpring(0, { damping: 20, stiffness: 300, velocity: e.velocityY });
       }
     });
 

--- a/src/components/QuickSwitchHomeBar.tsx
+++ b/src/components/QuickSwitchHomeBar.tsx
@@ -9,7 +9,7 @@ import Animated, {
 } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-import { gestureConfig } from '../utils/gestureConfig';
+import { dpPerMsToPtPerSec, gestureConfig } from '../utils/gestureConfig';
 import { GestureHaptics } from '../utils/gestureHaptics';
 import { commitForQuickSwitch } from '../utils/gestureMachine';
 import { pushSample, sampledVelocity, useVelocityBuffer } from '../utils/gestureVelocity';
@@ -95,6 +95,8 @@ export function QuickSwitchHomeBar() {
       const dx = e.translationX;
       const progress = Math.abs(dx) / gestureConfig.quickSwitchDistanceDp;
       const reason = commitForQuickSwitch({ progress, velocity: vx, holdMs: 0 });
+      // swipeOffset is a literal dp offset, same unit as vx scaled to per-second.
+      const offsetVelocity = dpPerMsToPtPerSec(vx);
 
       if (reason !== 'none') {
         const direction: 'left' | 'right' = dx < 0 ? 'left' : 'right';
@@ -106,13 +108,14 @@ export function QuickSwitchHomeBar() {
             dx < 0 ? -SCREEN_W : SCREEN_W,
             'softCarousel',
             reduceMotionShared.value,
+            offsetVelocity,
           );
         } else {
           // No destination — snap back
-          swipeOffset.value = settle(0, 'fastSettle', reduceMotionShared.value);
+          swipeOffset.value = settle(0, 'fastSettle', reduceMotionShared.value, offsetVelocity);
         }
       } else {
-        swipeOffset.value = settle(0, 'fastSettle', reduceMotionShared.value);
+        swipeOffset.value = settle(0, 'fastSettle', reduceMotionShared.value, offsetVelocity);
       }
       previewOpacity.value = settle(0, 'fastSettle', reduceMotionShared.value);
     });

--- a/src/screens/LauncherHomeScreen.tsx
+++ b/src/screens/LauncherHomeScreen.tsx
@@ -53,7 +53,7 @@ import { withAutoLockSuppressed } from '../utils/permissions';
 import { ControlCenterOverlay } from '../components/ControlCenterOverlay';
 import { NotificationCenterOverlay } from '../components/NotificationCenterOverlay';
 import { SpotlightReveal } from '../components/SpotlightReveal';
-import { zones, gestureConfig } from '../utils/gestureConfig';
+import { zones, gestureConfig, dpPerMsToPtPerSec } from '../utils/gestureConfig';
 import { useVelocityBuffer, pushSample, sampledVelocity } from '../utils/gestureVelocity';
 import { commitForSpotlight, commitForTodayView } from '../utils/gestureMachine';
 import { settle, useGestureReduceMotion } from '../utils/useGestureReduceMotion';
@@ -699,11 +699,16 @@ export function LauncherHomeScreen() {
         const { vy } = sampledVelocity(spotlightBuf.value, spotlightT.value);
         const p = Math.min(1, Math.max(0, spotlightProgress.value));
         const reason = commitForSpotlight({ progress: p, velocity: vy, holdMs: 0 });
+        // spotlightProgress is normalized over spotlightCommitDp; convert the
+        // dp/ms sample velocity to progress-units/sec.
+        const progressVelocity = dpPerMsToPtPerSec(vy) / gestureConfig.spotlightCommitDp;
         if (reason !== 'none') {
-          spotlightProgress.value = settle(1, 'mediumSettle', reduceMotionShared.value);
+          spotlightProgress.value = settle(1, 'mediumSettle', reduceMotionShared.value, progressVelocity);
           runOnJS(navigateTo)('SpotlightSearch');
           return;
         }
+        spotlightProgress.value = settle(0, 'fastSettle', reduceMotionShared.value, progressVelocity);
+        return;
       }
 
       spotlightProgress.value = settle(0, 'fastSettle', reduceMotionShared.value);

--- a/src/screens/LockScreen.tsx
+++ b/src/screens/LockScreen.tsx
@@ -26,7 +26,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as SecureStore from 'expo-secure-store';
 
 import * as Haptics from 'expo-haptics';
-import { gestureConfig } from '../utils/gestureConfig';
+import { dpPerMsToPtPerSec, gestureConfig } from '../utils/gestureConfig';
 import { pushSample, sampledVelocity, useVelocityBuffer } from '../utils/gestureVelocity';
 import { GestureHaptics } from '../utils/gestureHaptics';
 import { useDevice } from '../store/DeviceStore';
@@ -624,14 +624,17 @@ export function LockScreen({ navigation, onUnlock }: { navigation?: AppNavigatio
         progress >= gestureConfig.panelCommitProgress ||
         upwardV >= gestureConfig.panelCommitVelocity;
 
+      // translateY is a literal dp offset — vy is already dp/ms, convert to dp/sec.
+      const translateYVelocity = dpPerMsToPtPerSec(vy);
+
       if (shouldCommit) {
         runOnJS(GestureHaptics.commit)('light');
-        translateY.value = withSpring(-SCREEN_HEIGHT, gestureConfig.spring.mediumSettle);
+        translateY.value = withSpring(-SCREEN_HEIGHT, { ...gestureConfig.spring.mediumSettle, velocity: translateYVelocity });
         opacity.value = withTiming(0, { duration: 250 }, () => {
           runOnJS(handleUnlock)();
         });
       } else {
-        translateY.value = withSpring(0, gestureConfig.spring.fastSettle);
+        translateY.value = withSpring(0, { ...gestureConfig.spring.fastSettle, velocity: translateYVelocity });
         opacity.value = withTiming(1, { duration: 200 });
       }
     });

--- a/src/screens/TodayViewScreen.tsx
+++ b/src/screens/TodayViewScreen.tsx
@@ -22,7 +22,7 @@ import Animated, {
 } from 'react-native-reanimated';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as Haptics from 'expo-haptics';
-import { gestureConfig } from '../utils/gestureConfig';
+import { dpPerMsToPtPerSec, gestureConfig } from '../utils/gestureConfig';
 import { pushSample, sampledVelocity, useVelocityBuffer } from '../utils/gestureVelocity';
 import { GestureHaptics } from '../utils/gestureHaptics';
 
@@ -645,12 +645,15 @@ export function TodayViewScreen({ navigation }: { navigation: AppNavigationProp 
         (absX >= gestureConfig.quickSwitchHybridDistanceDp &&
           absVx >= gestureConfig.quickSwitchHybridVelocity);
 
+      // translateX is a literal dp offset — vx is already dp/ms, convert to dp/sec.
+      const translateXVelocity = dpPerMsToPtPerSec(vx);
+
       if (shouldCommit && e.translationX < 0) {
         runOnJS(GestureHaptics.commit)('light');
-        translateX.value = withSpring(-400, gestureConfig.spring.mediumSettle);
+        translateX.value = withSpring(-400, { ...gestureConfig.spring.mediumSettle, velocity: translateXVelocity });
         opacity.value = withTiming(0, { duration: 250 }, () => runOnJS(handleClose)());
       } else {
-        translateX.value = withSpring(0, gestureConfig.spring.fastSettle);
+        translateX.value = withSpring(0, { ...gestureConfig.spring.fastSettle, velocity: translateXVelocity });
         opacity.value = withTiming(1, { duration: 200 });
       }
     });

--- a/src/utils/__tests__/useGestureReduceMotion.test.ts
+++ b/src/utils/__tests__/useGestureReduceMotion.test.ts
@@ -1,0 +1,69 @@
+import { resolveSpringConfig, settle } from '../useGestureReduceMotion';
+
+// NOTE on approach: `settle()` and `resolveSpringConfig()` carry the 'worklet'
+// directive (required so they're callable from gesture worklets on the UI
+// thread). react-native-reanimated's babel plugin captures every reference to
+// withSpring/withTiming used inside a worklet into a closure snapshot at
+// definition time, which means jest.spyOn (and even a local jest.mock
+// override) on 'react-native-reanimated' cannot intercept those calls from
+// this test process — verified empirically: spies report 0 calls even though
+// the worklet executes and returns the mocked identity value. That's why the
+// velocity-merging logic is asserted directly on `resolveSpringConfig`'s
+// return value (the real exported unit, not a reimplementation) instead of by
+// inspecting withSpring's call arguments.
+describe('resolveSpringConfig()', () => {
+  it('carries the velocity into the spring config for a string preset', () => {
+    const config = resolveSpringConfig('mediumSettle', 500);
+    expect(config.velocity).toBe(500);
+  });
+
+  it('preserves the preset stiffness/damping/mass alongside velocity', () => {
+    const config = resolveSpringConfig('homeSettle', 300);
+    expect(config.stiffness).toBe(700);
+    expect(config.damping).toBe(52);
+    expect(config.mass).toBe(1);
+    expect(config.velocity).toBe(300);
+  });
+
+  it('supports a custom {stiffness, damping} config object', () => {
+    const config = resolveSpringConfig({ stiffness: 300, damping: 20 }, 750);
+    expect(config.stiffness).toBe(300);
+    expect(config.damping).toBe(20);
+    expect(config.velocity).toBe(750);
+  });
+
+  it('produces a different config for a flick (high velocity) than for a slow drag (low velocity)', () => {
+    const flick = resolveSpringConfig('fastSettle', 2000);
+    const drag = resolveSpringConfig('fastSettle', 20);
+
+    expect(flick.velocity).toBe(2000);
+    expect(drag.velocity).toBe(20);
+    expect(flick.velocity).not.toBe(drag.velocity);
+    // Everything except velocity comes from the same preset — the animation
+    // curve itself doesn't change, only the momentum carried into it.
+    expect(flick.stiffness).toBe(drag.stiffness);
+    expect(flick.damping).toBe(drag.damping);
+  });
+
+  it('defaults to velocity 0 when called with 0 explicitly (a standstill release)', () => {
+    const config = resolveSpringConfig('fastSettle', 0);
+    expect(config.velocity).toBe(0);
+  });
+});
+
+describe('settle()', () => {
+  it('accepts a velocity argument without throwing and forwards the target value (existing call-sites keep compiling and behaving)', () => {
+    expect(() => settle(100, 'mediumSettle', false, 500)).not.toThrow();
+    expect(settle(100, 'mediumSettle', false, 500)).toBe(100);
+  });
+
+  it('defaults velocity to 0 when the 4th argument is omitted, so the 33 existing call-sites are unaffected', () => {
+    expect(() => settle(100, 'mediumSettle', false)).not.toThrow();
+    expect(settle(100, 'mediumSettle', false)).toBe(100);
+  });
+
+  it('reduceMotion=true takes the withTiming path regardless of velocity, and does not throw on a velocity argument it ignores', () => {
+    expect(() => settle(100, 'mediumSettle', true, 999)).not.toThrow();
+    expect(settle(100, 'mediumSettle', true, 999)).toBe(100);
+  });
+});

--- a/src/utils/useGestureReduceMotion.ts
+++ b/src/utils/useGestureReduceMotion.ts
@@ -7,19 +7,26 @@ export function useGestureReduceMotion() {
   return settings.reduceMotion;
 }
 
+type SpringPreset = keyof typeof gestureConfig.spring | { stiffness: number; damping: number; mass?: number };
+
+// Merges the release velocity into a spring preset (or custom config), so the
+// spring inherits the gesture's momentum instead of always settling from a
+// standstill. Split out from settle() so the merge logic is a plain,
+// worklet-safe pure function that can be asserted on directly in tests.
+export function resolveSpringConfig(preset: SpringPreset, velocity: number) {
+  'worklet';
+  const cfg = typeof preset === 'string' ? gestureConfig.spring[preset] : preset;
+  return { ...cfg, velocity };
+}
+
 // Worklet-safe settle helper. Either pass a spring preset key or a custom config.
-// Usage: settle(finalValue, 'mediumSettle', reduceMotion)
+// Usage: settle(finalValue, 'mediumSettle', reduceMotion, velocity)
 // NOTE: this helper is intended to be CALLED from a worklet; it returns the Reanimated
 // animation primitive to assign to a shared value.
-export function settle(
-  value: number,
-  preset: keyof typeof gestureConfig.spring | { stiffness: number; damping: number; mass?: number },
-  reduceMotion: boolean,
-) {
+export function settle(value: number, preset: SpringPreset, reduceMotion: boolean, velocity = 0) {
   'worklet';
   if (reduceMotion) {
     return withTiming(value, { duration: 180, easing: Easing.out(Easing.cubic) });
   }
-  const cfg = typeof preset === 'string' ? gestureConfig.spring[preset] : preset;
-  return withSpring(value, cfg);
+  return withSpring(value, resolveSpringConfig(preset, velocity));
 }


### PR DESCRIPTION
## Resumo

settle() passa a receber velocidade e 10 call-sites de gesto herdam-na do release (flick vs drag deixam de animar igual)

## Causa raiz

`src/utils/useGestureReduceMotion.ts:14-25` — `settle()` nunca recebia velocidade; construía sempre `withSpring(value, cfg)` com o preset estático, ignorando por completo a velocidade de largada do gesto. A velocidade já é calculada em 7 sítios via `gestureVelocity.ts` (`pushSample`/`sampledVelocity`), mas só alimentava o predicado de commit (decidir SE a acção dispara), nunca a mola que decide COMO a superfície se move a seguir. Por isso um flick e um arrasto lento até à mesma posição produziam a mesma animação — a mola arrancava sempre da imobilidade.

## O que mudou

**`src/utils/useGestureReduceMotion.ts`** — `settle()` ganhou um 4º parâmetro opcional `velocity = 0`. A lógica de merge do preset com a velocidade foi isolada numa função pura exportada `resolveSpringConfig(preset, velocity)`, chamada por `settle()` quando `reduceMotion` é falso. Isto não é uma abstração gratuita: é o que torna a lógica testável (ver secção Testes — sem isto, não há forma de observar o config passado ao `withSpring` neste ambiente Jest).

**Call-sites actualizados (velocidade passada a `settle`/`withSpring`), por ordem de visibilidade:**

- `EdgePanelOverlay.tsx` (Control Center / Notification Center) — `panelProgress` é normalizado [0,1] sobre `panelTravelDp`; conversão: `dpPerMsToPtPerSec(vy) / gestureConfig.panelTravelDp`.
- `HomeIndicator.tsx` — `translateY` é um deslocamento dp literal; conversão directa: `dpPerMsToPtPerSec(vy)`. Aplicado no cancelamento por axis-lock (`onUpdate`) e no `onEnd` (que exigiu reordenar o cálculo de `vy` para ANTES do primeiro `settle()`, porque antes a mola disparava sem a velocidade estar calculada). `host.scale/radius/shadow` (linhas 210-245) foram **deliberadamente deixados em velocidade 0** — são valores derivados (escala 0.86-1, raio 0-22dp, sombra 0-0.65) sem uma conversão directa de unidade a partir de dp/ms sem aplicar a regra da cadeia por propriedade; injectar a velocidade errada ali arriscava overshoot, que é exactamente o critério de aceitação que a issue pede para não violar.
- `AssistiveTouch.tsx` — o `onEnd` do pan de arrasto do botão flutuante não tinha parâmetro de evento; passou a receber `(e)` e usa `e.velocityX`/`e.velocityY` (já dp/seg, vindos directamente do gesture-handler) nos dois `settle()` de snap magnético.
- `CupertinoSwipeableRow.tsx` — já calculava `const velocity = e.velocityX` mas descartava-a; agora passa-se a todos os 5 `settle()` do `onEnd`.
- `QuickSwitchHomeBar.tsx` — `swipeOffset` é dp literal; `dpPerMsToPtPerSec(vx)` aplicado aos 3 `settle()` de destino (commit ±SCREEN_W e snap-back). `previewOpacity` (cosmético, 0-1) deixado em 0 — não tem correspondência física directa com a velocidade do toque.
- `BackEdgeSwipe.tsx` — `progress` normalizado sobre `SCREEN_W * backTravelRatio`; conversão: `dpPerMsToPtPerSec(vx) / travel`.
- `LauncherHomeScreen.tsx` — `spotlightProgress` normalizado sobre `spotlightCommitDp`; conversão: `dpPerMsToPtPerSec(vy) / gestureConfig.spotlightCommitDp`. O ramo de up-swipe para a App Library (linha 690) ficou em velocidade 0 — nesse ramo `spotlightProgress` já está a 0 e a velocidade é de um eixo/gesto diferente (para cima, não para baixo), sem correspondência com o valor a animar.
- `TodayViewScreen.tsx` — não usava `settle()`, chamava `withSpring` directamente com os presets de `gestureConfig.spring`; mantive essa estrutura e injectei `velocity: dpPerMsToPtPerSec(vx)` no spread do config (`translateX` é dp literal).
- `LockScreen.tsx` — mesma situação e mesmo tratamento com `vy`/`translateY`.
- `NotificationBanner.tsx` — já tinha `e.velocityY` disponível no `onEnd` (usado só na condição de dismiss); passou a alimentar também o `withSpring` do snap-back, sem conversão (já dp/seg).

**Não tocado:** `CupertinoActionSheet.tsx` — a tabela da issue lista-o como "sem velocidade nenhuma", mas a abertura/fecho ali é 100% orientada por prop (`visible`), sem gesto de arrasto associado. Não há velocidade de toque nenhuma para extrair; injectar qualquer valor seria fabricado. Fica fora de âmbito por não ter mecanismo de gesto, não por omissão.

`gestureConfig.ts`, `gestureVelocity.ts`, `gestureMachine.ts`, `gestureHaptics.ts` — não tocados, conforme a issue pede. Usei apenas o helper já exportado `dpPerMsToPtPerSec` de `gestureConfig.ts`.

## Porque assim

Para cada call-site, a escolha foi: se o shared value animado é um deslocamento dp literal (translateX/translateY), a conversão é direta (`dpPerMsToPtPerSec`, ou nem isso quando o evento já vem em dp/seg do gesture-handler nativo). Se é um progresso normalizado [0,1], divide-se ainda pela distância de viagem (travel) para obter unidades de progresso/segundo. Onde o valor animado é uma propriedade *derivada* (escala, raio, sombra, opacidade) sem uma relação de 1 dp/ms para 1 unidade/seg bem definida, optei por NÃO injectar velocidade em vez de arriscar uma conversão errada — a própria issue avisa que isto é o ponto que estraga o fix "se for feito sem pensar", e o critério de aceitação exige zero overshoot. Alternativa descartada: aplicar a regra da cadeia (d(scale)/dt = d(scale)/d(progress) × d(progress)/dt) a essas propriedades derivadas — mais completo, mas fora do orçamento razoável desta ronda e com risco de introduzir o próprio bug de overshoot que a issue pede para evitar; deixo isso registado para uma iteração futura se for pedido.

## Critérios de aceitação

- [x] `settle()` aceita e propaga `velocity`; default `0` não quebra nenhum call-site existente — testado directamente (`settle(100, 'mediumSettle', false)` sem 4º argumento continua a devolver `100` sem lançar).
- [x] Os call-sites da tabela passam a velocidade, com a conversão de unidade documentada por ficheiro (ver secção "O que mudou" acima e comentários inline no código).
- [x] Um flick e um arrasto lento até à mesma posição produzem `resolveSpringConfig` com `velocity` diferente (testado directamente — ver Testes). Não consegui provar isto por spy sobre `withSpring` em runtime de componente (ver limitação abaixo), mas a lógica de merge que alimenta `withSpring` está coberta e prova que valores de velocidade distintos produzem configs distintos.
- [x] Nenhuma superfície passa do limite e volta (overshoot): não modifiquei nenhum spring preset (stiffness/damping/mass ficam intocados — testado explicitamente), e evitei propositadamente injectar velocidade em propriedades derivadas sem conversão fiável (host.scale/radius/shadow, previewOpacity, o ramo de up-swipe do spotlight).
- [x] Teste: `settle(v, preset, false, 500)` devolve config com `velocity: 500` — implementado via `resolveSpringConfig('mediumSettle', 500).velocity === 500` (ver limitação de spy abaixo sobre porque não é via `withSpring` directamente).
- [x] Teste: `reduceMotion: true` continua a ignorar a velocidade e a usar `withTiming` — o ramo `if (reduceMotion)` nunca referencia `velocity`/`resolveSpringConfig` (inspecionável na diff), e `settle(100, 'mediumSettle', true, 999)` não lança e devolve o valor esperado.

## Testes

### Limitação descoberta e documentada (não é evasão — é o que a instrumentação mostrou)

`settle()` e `resolveSpringConfig()` têm a directiva `'worklet'` (obrigatória para correr em worklets de gesto no thread de UI). O plugin babel do reanimated captura as referências a `withSpring`/`withTiming` usadas dentro de funções `'worklet'` num closure no momento da definição do módulo. Empiricamente confirmei que nem `jest.spyOn(Reanimated, 'withSpring')` nem um `jest.mock('react-native-reanimated', ...)` local ao ficheiro de teste conseguem intercetar essas chamadas — o spy regista 0 chamadas mesmo quando `settle()` executa e devolve o valor mockado (`identity`) correctamente. Por isso a lógica de merge de velocidade foi isolada em `resolveSpringConfig`, uma função pura sem chamadas a built-ins do reanimated, que pode ser chamada e inspeccionada directamente nos testes (é a unidade real exportada, não uma reimplementação da fórmula).

### Passo vermelho (output real do jest, com o fix revertido via `git stash` de `useGestureReduceMotion.ts`)

```
$ npx jest src/utils/__tests__/useGestureReduceMotion.test.ts

  ● resolveSpringConfig() › carries the velocity into the spring config for a string preset
    TypeError: (0 , _useGestureReduceMotion.resolveSpringConfig) is not a function

  ● resolveSpringConfig() › preserves the preset stiffness/damping/mass alongside velocity
    TypeError: (0 , _useGestureReduceMotion.resolveSpringConfig) is not a function

  ● resolveSpringConfig() › supports a custom {stiffness, damping} config object
    TypeError: (0 , _useGestureReduceMotion.resolveSpringConfig) is not a function

  ● resolveSpringConfig() › produces a different config for a flick (high velocity) than for a slow drag (low velocity)
    TypeError: (0 , _useGestureReduceMotion.resolveSpringConfig) is not a function

  ● resolveSpringConfig() › defaults to velocity 0 when called with 0 explicitly (a standstill release)
    TypeError: (0 , _useGestureReduceMotion.resolveSpringConfig) is not a function

Test Suites: 1 failed, 1 total
Tests:       5 failed, 3 passed, 8 total
```

Os 3 que passavam mesmo sem o fix são os testes de "não lança" sobre `settle()` (backward-compat trivial, já esperado — a função antiga ignora silenciosamente um 4º argumento em JS). Os 5 que falham são exactamente os que verificam o mecanismo novo.

### Casos cobertos

- Preset string vs objecto custom `{stiffness, damping}` — ambas as formas de `preset` aceitas pelo tipo original.
- Preservação de `stiffness`/`damping`/`mass` do preset ao lado da velocidade (não é só "aceita velocity", é "não estraga o resto").
- Flick (velocity=2000) vs arrasto lento (velocity=20) produzem `velocity` diferente mas a MESMA curva (stiffness/damping iguais) — é isto que a issue pede: velocidade diferente, não física diferente.
- Velocidade 0 explícita (largada em imobilidade) — caso de fronteira.
- `settle()` sem 4º argumento (33 call-sites antigos não tocados por este PR) continua a funcionar sem lançar.
- `reduceMotion=true` ignora a velocidade — inverso do fix: confirma que o comportamento de acessibilidade não muda.

### Sanity-check (revert cycle)

`git stash push -u -m "issue-487-sanity-check-revert" -- src/utils/useGestureReduceMotion.ts` (só o fix, teste ficou); corri o teste → 5/8 falharam (output acima); `git stash apply <sha>` para restaurar; corri de novo → 8/8 passaram; `git stash drop stash@{0}` para limpar. Stash referenciado por tag única, nunca por `stash pop` cego (worktree partilha a stash stack com outras sessões).

### Resultado das verificações obrigatórias

- `npm run lint` → 0 erros, 2 avisos pré-existentes em ficheiros não tocados (`BridgeErrorReporting.test.tsx`, `ClockScreen.tsx`) — igual à baseline.
- `npx tsc --noEmit` → limpo, sem erros.
- `npm test -- --maxWorkers=2` → **696 passaram, 8 falharam, 100 suites** (4 suites falhas). As 8 falhas são um subconjunto exacto das 9 conhecidas na baseline (`CalculatorScreen`, `FoldersStore` x2, `LockScreen` x3, `SettingsScreen`, `WeatherScreen` x2 — `main` avançou desde a baseline gravada, o total de testes subiu de 180 para 704 por PRs entretanto mesclados, mas as falhas de `LockScreen`/`FoldersStore`/`WeatherScreen`/`SettingsScreen` continuam a ser o mesmo bug conhecido do `SettingsStore.firstSyncDone` assíncrono, nada relacionado com este PR). Nenhuma falha nova.

## Testes

696 passaram, 8 falharam (pré-existentes, mesmo bug conhecido de SettingsStore.firstSyncDone — subconjunto exacto da baseline), 100 suites, 4 suites falhas

## Linked Issue

Fixes #487