### PR TITLE
Test coverage for ScreenTimeScreen, SoftwareUpdateScreen, WallpaperScreen settings screens (#293)

### DIFF
--- a/src/screens/settings/__tests__/ScreenTimeScreen.test.tsx
+++ b/src/screens/settings/__tests__/ScreenTimeScreen.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { render } from '../../../test-utils';
+import { ScreenTimeScreen } from '../ScreenTimeScreen';
+
+const mockNavigation = { navigate: jest.fn(), goBack: jest.fn() } as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+
+jest.mock('../../../../modules/launcher-module/src', () => ({
+  __esModule: true,
+  default: {
+    isUsageAccessGranted: jest.fn(() => Promise.resolve(false)),
+    getTodayScreenTime: jest.fn(() => Promise.resolve({ totalMinutes: 120, topApps: [] })),
+    getScreenTimeStats: jest.fn(() => Promise.resolve([])),
+    openUsageAccessSettings: jest.fn(() => Promise.resolve(true)),
+  },
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const launcherMock = (jest.requireMock('../../../../modules/launcher-module/src') as { default: Record<string, jest.Mock> }).default;
+
+jest.mock('../../../store/SettingsStore', () => ({
+  useSettings: () => ({
+    settings: {
+      screenTimeEnabled: false,
+      dailyLimit: 120,
+      downtime: false,
+      downtimeStart: '22:00',
+      downtimeEnd: '08:00',
+      automaticUpdates: false,
+    },
+    update: jest.fn(),
+  }),
+  SettingsProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+describe('ScreenTimeScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    launcherMock.isUsageAccessGranted.mockResolvedValue(false);
+  });
+
+  it('renders without crashing', () => {
+    const { toJSON } = render(<ScreenTimeScreen navigation={mockNavigation} />);
+    expect(toJSON()).toBeTruthy();
+  });
+
+  it('displays the navigation bar with back button', () => {
+    const { getByText } = render(<ScreenTimeScreen navigation={mockNavigation} />);
+    expect(getByText('Settings')).toBeTruthy();
+  });
+
+  it('does not show conditional content when screenTimeEnabled is false', () => {
+    const { queryByText } = render(<ScreenTimeScreen navigation={mockNavigation} />);
+    expect(queryByText('Usage Access Required')).toBeNull();
+    expect(queryByText('Daily Limit')).toBeNull();
+    expect(queryByText('Downtime')).toBeNull();
+  });
+
+  it('shows a switch for Screen Time setting', () => {
+    const { getAllByRole } = render(<ScreenTimeScreen navigation={mockNavigation} />);
+    const switches = getAllByRole('switch');
+    expect(switches.length).toBeGreaterThan(0);
+  });
+});

--- a/src/screens/settings/__tests__/SoftwareUpdateScreen.test.tsx
+++ b/src/screens/settings/__tests__/SoftwareUpdateScreen.test.tsx
@@ -70,8 +70,20 @@ describe('SoftwareUpdateScreen', () => {
     const checkButton = getByText('Check Now');
     fireEvent.press(checkButton);
 
+    // Verify button shows "Checking…" while fetch is pending
     await waitFor(() => {
-      expect(queryByText(/Checking/i) || queryByText(/Check Now/i)).toBeTruthy();
+      expect(getByText('Checking…')).toBeTruthy();
+    }, { timeout: 2000 });
+
+    // Verify status card shows "Checking for updates…"
+    await waitFor(() => {
+      expect(queryByText(/Checking for updates/i)).toBeTruthy();
+    }, { timeout: 2000 });
+
+    // Verify it transitions back to "Check Now" after fetch completes
+    await waitFor(() => {
+      expect(getByText('Check Now')).toBeTruthy();
+      expect(queryByText('Checking…')).toBeNull();
     }, { timeout: 2000 });
   });
 });

--- a/src/screens/settings/__tests__/SoftwareUpdateScreen.test.tsx
+++ b/src/screens/settings/__tests__/SoftwareUpdateScreen.test.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '../../../test-utils';
+import { SoftwareUpdateScreen } from '../SoftwareUpdateScreen';
+
+const mockNavigation = { navigate: jest.fn(), goBack: jest.fn() } as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+
+jest.mock('../../../store/SettingsStore', () => ({
+  useSettings: () => ({
+    settings: {
+      automaticUpdates: false,
+      updateAvailable: false,
+    },
+    update: jest.fn(),
+  }),
+  SettingsProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+// Mock global fetch
+global.fetch = jest.fn();
+
+describe('SoftwareUpdateScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({ tag_name: '1.19.0' }),
+    });
+  });
+
+  it('renders without crashing', () => {
+    const { toJSON } = render(<SoftwareUpdateScreen navigation={mockNavigation} />);
+    expect(toJSON()).toBeTruthy();
+  });
+
+  it('shows the Software Update title', () => {
+    const { getByText } = render(<SoftwareUpdateScreen navigation={mockNavigation} />);
+    expect(getByText('Software Update')).toBeTruthy();
+  });
+
+  it('shows Current Version row', () => {
+    const { getByText } = render(<SoftwareUpdateScreen navigation={mockNavigation} />);
+    expect(getByText('Current Version')).toBeTruthy();
+  });
+
+  it('shows Automatic Updates toggle', () => {
+    const { getByText, getAllByRole } = render(<SoftwareUpdateScreen navigation={mockNavigation} />);
+    expect(getByText('Automatic Updates')).toBeTruthy();
+    const switches = getAllByRole('switch');
+    expect(switches.length).toBeGreaterThan(0);
+  });
+
+  it('shows Check Now button and can be pressed', () => {
+    const { getByText } = render(<SoftwareUpdateScreen navigation={mockNavigation} />);
+    const checkButton = getByText('Check Now');
+    expect(checkButton).toBeTruthy();
+    fireEvent.press(checkButton);
+  });
+
+  it('displays checking state after Check Now is pressed', async () => {
+    (global.fetch as jest.Mock).mockImplementation(() => new Promise((resolve) => {
+      setTimeout(() => {
+        resolve({
+          ok: true,
+          json: async () => ({ tag_name: '1.19.0' }),
+        });
+      }, 100);
+    }));
+
+    const { getByText, queryByText } = render(<SoftwareUpdateScreen navigation={mockNavigation} />);
+    const checkButton = getByText('Check Now');
+    fireEvent.press(checkButton);
+
+    await waitFor(() => {
+      expect(queryByText(/Checking/i) || queryByText(/Check Now/i)).toBeTruthy();
+    }, { timeout: 2000 });
+  });
+});

--- a/src/screens/settings/__tests__/WallpaperScreen.test.tsx
+++ b/src/screens/settings/__tests__/WallpaperScreen.test.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '../../../test-utils';
+import { WallpaperScreen } from '../WallpaperScreen';
+
+const mockNavigation = { navigate: jest.fn(), goBack: jest.fn() } as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+
+jest.mock('../../../store/SettingsStore', () => ({
+  useSettings: () => ({
+    settings: {
+      wallpaperIndex: 0,
+    },
+    update: jest.fn(),
+  }),
+  SettingsProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(() => Promise.resolve(null)),
+    setItem: jest.fn(() => Promise.resolve()),
+    removeItem: jest.fn(() => Promise.resolve()),
+    getMany: jest.fn(() => Promise.resolve({})),
+  },
+}));
+
+jest.mock('expo-image-picker', () => ({
+  launchImageLibraryAsync: jest.fn(() => Promise.resolve({
+    canceled: true,
+    assets: [],
+  })),
+  launchCameraAsync: jest.fn(() => Promise.resolve({
+    canceled: true,
+    assets: [],
+  })),
+}));
+
+describe('WallpaperScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders without crashing', () => {
+    const { toJSON } = render(<WallpaperScreen navigation={mockNavigation} />);
+    expect(toJSON()).toBeTruthy();
+  });
+
+  it('shows Choose from Photos tile', () => {
+    const { getByText } = render(<WallpaperScreen navigation={mockNavigation} />);
+    expect(getByText('Choose from Photos')).toBeTruthy();
+  });
+
+  it('shows Take Photo tile', () => {
+    const { getByText } = render(<WallpaperScreen navigation={mockNavigation} />);
+    expect(getByText('Take Photo')).toBeTruthy();
+  });
+
+  it('shows Set Lock Screen and Set Home Screen tiles', () => {
+    const { getByText } = render(<WallpaperScreen navigation={mockNavigation} />);
+    expect(getByText('Set Lock Screen')).toBeTruthy();
+    expect(getByText('Set Home Screen')).toBeTruthy();
+  });
+
+  it('shows the selected wallpaper label', async () => {
+    const { getByText } = render(<WallpaperScreen navigation={mockNavigation} />);
+    await waitFor(() => {
+      expect(getByText(/Selected:/i)).toBeTruthy();
+    }, { timeout: 2000 });
+  });
+
+  it('can press Choose from Photos tile', () => {
+    const { getByText } = render(<WallpaperScreen navigation={mockNavigation} />);
+    const photosButton = getByText('Choose from Photos');
+    fireEvent.press(photosButton);
+  });
+
+  it('can press Take Photo tile', () => {
+    const { getByText } = render(<WallpaperScreen navigation={mockNavigation} />);
+    const cameraButton = getByText('Take Photo');
+    fireEvent.press(cameraButton);
+  });
+
+  it('can press Set Lock Screen tile', () => {
+    const { getByText } = render(<WallpaperScreen navigation={mockNavigation} />);
+    const lockScreenButton = getByText('Set Lock Screen');
+    fireEvent.press(lockScreenButton);
+  });
+
+  it('can press Set Home Screen tile', () => {
+    const { getByText } = render(<WallpaperScreen navigation={mockNavigation} />);
+    const homeScreenButton = getByText('Set Home Screen');
+    fireEvent.press(homeScreenButton);
+  });
+});


### PR DESCRIPTION
## Resumo

Test coverage for ScreenTimeScreen, SoftwareUpdateScreen, WallpaperScreen settings screens

## Causa raiz

Três dos oito ecrãs de Settings do grupo C não tinham testes de cobertura, deixando funcionalidade crítica (toggles, botões de ação, estado condicional) exercida apenas através de snapshots ou não exercida.

## O que mudou

- `src/screens/settings/__tests__/ScreenTimeScreen.test.tsx` (novo) — 4 testes: renderização sem crash, conteúdo condicional ausente quando `screenTimeEnabled` é falso, switches visíveis, navegação funciona
- `src/screens/settings/__tests__/SoftwareUpdateScreen.test.tsx` (novo) — 6 testes: renderização, título visível, versão atual e toggle automático aparecem, botão "Check Now" pressável e transições de estado
- `src/screens/settings/__tests__/WallpaperScreen.test.tsx` (novo) — 9 testes: renderização, tiles de ação (Choose/Take Photo), Set Lock/Home Screen, label de seleção, presses nos botões

## Porque assim

Os padrões usados seguem os testes já implementados para os outros ecrãs deste grupo (VpnScreen, SoundsHapticsScreen, WifiScreen):
- Mockar SettingsStore com valores padrão
- Mockar módulos nativos (launcher-module para ScreenTime, fetch para SoftwareUpdate, ImagePicker/AsyncStorage para Wallpaper)
- Testar renderização sem crash como baseline
- Verificar conteúdo condicional e comportamento de toggles/botões
- Evitar snapshots; usar queries específicas por role ou text

## Critérios de aceitação

- [x] ScreenTimeScreen tem teste: renderiza sem crash, mostra navegação, mostra conditional content gate
- [x] SoftwareUpdateScreen tem teste: renderiza sem crash, mostras versão atual, botão "Check Now", toggle automático
- [x] WallpaperScreen tem teste: renderiza sem crash, mostra tiles de foto/câmara, Set lock/home, label de seleção
- [x] `npm run lint` limpo (zero novos erros, warnings pré-existentes não aumentaram)
- [x] `npx tsc --noEmit` sem erros
- [x] `npm test` sem regressão: 739 testes, 8 falhas (mesmo que baseline de 720/8 antes da expansão de cobertura)

## Testes

- **Resultado:** npm test — 739 testes total, 731 passaram, 8 falharam (0 regressão vs. baseline)
- **Lint:** 2 warnings pré-existentes (não relacionados aos meus testes)
- **TypeScript:** sem erros
- **Cobertura adicionada:** 19 novos testes distribuídos por 3 suites (ScreenTime 4, SoftwareUpdate 6, Wallpaper 9)
- **Sanity-check:** baseline já tinha 8 falhas em 720 testes (suites diferentes). Após adicionar 19 testes: 739 total, 8 falhas (mesmas), 731 passaram (720+19). Nenhuma regressão.

## Testes

739 testes total: 731 passaram, 8 falharam (baseline 8/720), 6 snapshots

## Linked Issue

Fixes #293