### PR TITLE
Add AppStoreDetailScreen with Open/Get/Uninstall actions and navigate to it from Today cards (#246)

### DIFF
--- a/src/navigation/TabNavigator.tsx
+++ b/src/navigation/TabNavigator.tsx
@@ -50,6 +50,7 @@ import { BackupRestoreScreen } from '../screens/settings/BackupRestoreScreen';
 import { ComponentsGalleryScreen } from '../screens/ComponentsGalleryScreen';
 import { AppLibraryScreen } from '../screens/AppLibraryScreen';
 import { AppStoreScreen } from '../screens/AppStoreScreen';
+import { AppStoreDetailScreen } from '../screens/AppStoreDetailScreen';
 import { SpotlightSearchScreen } from '../screens/SpotlightSearchScreen';
 import { SiriScreen } from '../screens/SiriScreen';
 import { TodayViewScreen } from '../screens/TodayViewScreen';
@@ -142,6 +143,7 @@ export function TabNavigator() {
       {__DEV__ && <Stack.Screen name="ComponentsGallery" component={ComponentsGalleryScreen} options={{ animation: slideAnimation }} />}
       <Stack.Screen name="AppLibrary" component={AppLibraryScreen} />
       <Stack.Screen name="AppStore" component={AppStoreScreen} options={{ animation: slideAnimation }} />
+      <Stack.Screen name="AppStoreDetail" component={AppStoreDetailScreen} options={{ animation: slideAnimation }} />
       <Stack.Screen name="SpotlightSearch" component={SpotlightSearchScreen} options={{ animation: fadeAnimation, presentation: 'transparentModal' }} />
       <Stack.Screen name="Siri" component={SiriScreen} options={{ animation: fadeAnimation, presentation: 'transparentModal' }} />
       <Stack.Screen name="TodayView" component={TodayViewScreen} options={{ animation: settings.reduceMotion ? 'none' : 'slide_from_left' }} />

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -60,6 +60,7 @@ export type RootStackParamList = {
   ComponentsGallery: undefined;
   AppLibrary: undefined;
   AppStore: undefined;
+  AppStoreDetail: { packageName: string; name: string };
   SpotlightSearch: undefined;
   Siri: undefined;
   TodayView: undefined;

--- a/src/screens/AppStoreDetailScreen.tsx
+++ b/src/screens/AppStoreDetailScreen.tsx
@@ -1,0 +1,302 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  Pressable,
+  StatusBar,
+  Linking,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { CupertinoNavigationBar } from '../components';
+import { useTheme } from '../theme/ThemeContext';
+import { useApps } from '../store/AppsStore';
+import { CURATED_APPS } from '../data/curatedApps';
+import { playStoreUrl, playStoreWebUrl } from './AppStoreScreen';
+import type { AppNavigationProp, AppRouteProp } from '../navigation/types';
+import { logger } from '../utils/logger';
+
+/**
+ * Package-name prefix of this app's own virtual built-ins (Phone, Messages, …).
+ *
+ * Those packages are not real installed APKs — they are synthesised entries that
+ * route to internal screens (`BUILT_IN_APPS` in `LauncherHomeScreen.tsx`), so
+ * `PackageInstaller` has nothing to uninstall for them. The prefix is used
+ * instead of importing `BUILT_IN_APPS` to avoid pulling the whole launcher home
+ * screen (Reanimated worklets included) into this screen's module graph; every
+ * entry of that map lives under this namespace.
+ */
+const VIRTUAL_PACKAGE_PREFIX = 'com.iostoandroid.';
+
+export function isVirtualBuiltIn(packageName: string): boolean {
+  return packageName.startsWith(VIRTUAL_PACKAGE_PREFIX);
+}
+
+/**
+ * Same dynamic-import guard as `LauncherHomeScreen.tsx`, plus the `require`
+ * fallback that `AppsStore.tsx` already documents: Jest runs without
+ * `--experimental-vm-modules`, so `import()` throws
+ * ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING_FLAG there and the module would be
+ * silently unreachable under test. Metro supports `require`, so production
+ * behaviour is unchanged and the moduleNameMapper mock still applies.
+ */
+const getLauncher = async () => {
+  try {
+    return (await import('../../modules/launcher-module/src')).default;
+  } catch {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports -- Metro supports require; fallback for environments without dynamic import
+      return require('../../modules/launcher-module/src').default;
+    } catch {
+      return null; // Expected: module unavailable on non-Android
+    }
+  }
+};
+
+interface AppStoreDetailScreenProps {
+  navigation: AppNavigationProp;
+  route: AppRouteProp<'AppStoreDetail'>;
+}
+
+export function AppStoreDetailScreen({ navigation, route }: AppStoreDetailScreenProps) {
+  const { packageName, name } = route.params;
+  const { theme, isDark, typography, borderRadius } = useTheme();
+  const { colors } = theme;
+  const insets = useSafeAreaInsets();
+  const { apps, launchApp } = useApps();
+  const [uninstallRequested, setUninstallRequested] = useState(false);
+
+  const installed = useMemo(
+    () => apps.find((a) => a.packageName === packageName) ?? null,
+    [apps, packageName],
+  );
+
+  const curated = useMemo(
+    () => CURATED_APPS.find((a) => a.packageName === packageName) ?? null,
+    [packageName],
+  );
+
+  // Uninstall is only meaningful for a real, user-installed APK: system apps
+  // cannot be removed and virtual built-ins are not packages at all.
+  const canUninstall = !!installed && !installed.isSystem && !isVirtualBuiltIn(packageName);
+
+  const handleOpen = useCallback(() => {
+    launchApp(packageName);
+  }, [launchApp, packageName]);
+
+  // Same probe-then-fallback guard as AppStoreScreen's Get button: market://
+  // has no handler on de-Googled devices and on most emulators.
+  const handleGet = useCallback(async () => {
+    const marketUrl = playStoreUrl(packageName);
+    try {
+      if (await Linking.canOpenURL(marketUrl)) {
+        await Linking.openURL(marketUrl);
+        return;
+      }
+      const webUrl = playStoreWebUrl(packageName);
+      if (await Linking.canOpenURL(webUrl)) {
+        await Linking.openURL(webUrl);
+      }
+    } catch (err) {
+      logger.warn('AppStoreDetailScreen', 'could not open store listing', err);
+    }
+  }, [packageName]);
+
+  const handleUninstall = useCallback(async () => {
+    // Guard against the double tap: the system uninstall dialog is async, and a
+    // second press would queue a second PackageInstaller intent.
+    if (uninstallRequested) return;
+    setUninstallRequested(true);
+    try {
+      const mod = await getLauncher();
+      if (mod) await mod.uninstallApp(packageName);
+    } catch (err) {
+      logger.warn('AppStoreDetailScreen', 'uninstall failed', err);
+    }
+  }, [packageName, uninstallRequested]);
+
+  return (
+    <View style={styles.screenRoot}>
+      <StatusBar barStyle={isDark ? 'light-content' : 'dark-content'} />
+      <CupertinoNavigationBar
+        title={name}
+        largeTitle={false}
+        leftButton={
+          <Pressable
+            onPress={() => navigation.goBack()}
+            style={styles.backBtn}
+            accessibilityRole="button"
+            accessibilityLabel="Back"
+          >
+            <Ionicons name="chevron-back" size={22} color={colors.systemBlue} />
+            <Text style={[typography.body, styles.backLabel, { color: colors.systemBlue }]}>
+              Back
+            </Text>
+          </Pressable>
+        }
+      />
+
+      <ScrollView
+        style={[styles.root, { backgroundColor: colors.systemGroupedBackground }]}
+        contentContainerStyle={[styles.scrollContent, { paddingBottom: insets.bottom + 32 }]}
+        showsVerticalScrollIndicator={false}
+      >
+        <View style={styles.header}>
+          <View style={[styles.iconPlaceholder, { backgroundColor: colors.systemGray5 }]}>
+            <Ionicons name="cube-outline" size={34} color={colors.secondaryLabel} />
+          </View>
+          <View style={styles.headerText}>
+            <Text style={[typography.title3, styles.appName, { color: colors.label }]} numberOfLines={2}>
+              {name}
+            </Text>
+            <Text
+              style={[typography.footnote, { color: colors.secondaryLabel }]}
+              numberOfLines={2}
+              accessibilityLabel="App tagline"
+            >
+              {curated ? curated.tagline : 'Installed app'}
+            </Text>
+            <Text style={[typography.caption1, { color: colors.tertiaryLabel }]} numberOfLines={1}>
+              {curated ? curated.category : packageName}
+            </Text>
+          </View>
+        </View>
+
+        <View style={styles.actions}>
+          {installed ? (
+            <Pressable
+              onPress={handleOpen}
+              accessibilityRole="button"
+              accessibilityLabel={`Open ${name}`}
+              style={[styles.actionBtn, { backgroundColor: colors.systemGray5, borderRadius: borderRadius.medium }]}
+            >
+              <Text style={[typography.body, styles.actionLabel, { color: colors.systemBlue }]}>
+                Open
+              </Text>
+            </Pressable>
+          ) : (
+            <Pressable
+              onPress={handleGet}
+              accessibilityRole="button"
+              accessibilityLabel={`Get ${name}`}
+              style={[styles.actionBtn, { backgroundColor: colors.systemGray5, borderRadius: borderRadius.medium }]}
+            >
+              <Text style={[typography.body, styles.actionLabel, { color: colors.systemBlue }]}>
+                Get
+              </Text>
+            </Pressable>
+          )}
+
+          {canUninstall && (
+            <Pressable
+              onPress={handleUninstall}
+              accessibilityRole="button"
+              accessibilityLabel={`Uninstall ${name}`}
+              style={[styles.actionBtn, { backgroundColor: colors.systemGray5, borderRadius: borderRadius.medium }]}
+            >
+              <Text style={[typography.body, styles.actionLabel, { color: colors.systemRed }]}>
+                Uninstall
+              </Text>
+            </Pressable>
+          )}
+        </View>
+
+        <Text style={[typography.headline, styles.sectionTitle, { color: colors.label }]}>
+          Screenshots
+        </Text>
+        <View
+          style={[
+            styles.placeholderBlock,
+            { backgroundColor: colors.secondarySystemGroupedBackground, borderRadius: borderRadius.medium },
+          ]}
+          accessibilityLabel="Screenshots placeholder"
+        >
+          <Ionicons name="image-outline" size={28} color={colors.tertiaryLabel} />
+          <Text style={[typography.footnote, { color: colors.secondaryLabel }]}>
+            Screenshots not available
+          </Text>
+        </View>
+
+        <Text style={[typography.headline, styles.sectionTitle, { color: colors.label }]}>
+          Description
+        </Text>
+        <View
+          style={[
+            styles.placeholderBlock,
+            { backgroundColor: colors.secondarySystemGroupedBackground, borderRadius: borderRadius.medium },
+          ]}
+          accessibilityLabel="Description placeholder"
+        >
+          <Text style={[typography.footnote, { color: colors.secondaryLabel }]}>
+            Description not available
+          </Text>
+        </View>
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  screenRoot: {
+    flex: 1,
+  },
+  root: {
+    flex: 1,
+  },
+  scrollContent: {
+    paddingHorizontal: 16,
+    paddingTop: 12,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  iconPlaceholder: {
+    width: 72,
+    height: 72,
+    borderRadius: 16,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  headerText: {
+    flex: 1,
+    paddingHorizontal: 12,
+  },
+  appName: {
+    fontWeight: '700',
+  },
+  actions: {
+    flexDirection: 'row',
+    marginTop: 16,
+  },
+  actionBtn: {
+    paddingHorizontal: 20,
+    paddingVertical: 8,
+    marginRight: 10,
+  },
+  actionLabel: {
+    fontWeight: '600',
+  },
+  sectionTitle: {
+    marginTop: 24,
+    marginBottom: 8,
+    fontWeight: '700',
+  },
+  placeholderBlock: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 28,
+    gap: 8,
+  },
+  backBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    minWidth: 70,
+    paddingHorizontal: 4,
+  },
+  backLabel: {
+    fontWeight: '400',
+  },
+});

--- a/src/screens/AppStoreScreen.tsx
+++ b/src/screens/AppStoreScreen.tsx
@@ -104,17 +104,21 @@ function AppRow({
   installed,
   onOpen,
   onGet,
+  onPressCard,
 }: {
   app: CuratedApp;
   installed: boolean;
   onOpen: (packageName: string) => void;
   onGet: (packageName: string) => void;
+  onPressCard: (app: CuratedApp) => void;
 }) {
   const { theme, typography, borderRadius } = useTheme();
   const { colors } = theme;
 
   return (
-    <View
+    <Pressable
+      onPress={() => onPressCard(app)}
+      accessibilityRole="button"
       style={[
         styles.card,
         {
@@ -150,7 +154,7 @@ function AppRow({
           {installed ? 'Open' : 'Get'}
         </Text>
       </Pressable>
-    </View>
+    </Pressable>
   );
 }
 
@@ -159,6 +163,14 @@ function AppRow({
 // ---------------------------------------------------------------------------
 
 export function AppStoreScreen({ navigation }: { navigation: AppNavigationProp }) {
+  // O cartao abre o detalhe (#246). A rota so existe se estiver registada no
+  // TabNavigator E for navegada de algum sitio — este repo ja teve rotas
+  // registadas que ninguem alcancava.
+  const openDetail = React.useCallback(
+    (app: CuratedApp) =>
+      navigation.navigate('AppStoreDetail', { packageName: app.packageName, name: app.name }),
+    [navigation],
+  );
   const { theme, isDark, typography } = useTheme();
   const { colors } = theme;
   const insets = useSafeAreaInsets();
@@ -328,6 +340,7 @@ export function AppStoreScreen({ navigation }: { navigation: AppNavigationProp }
 
             {CURATED_APPS.map((app) => (
               <AppRow
+                onPressCard={openDetail}
                 key={app.packageName}
                 app={app}
                 installed={installedPackages.has(app.packageName)}
@@ -348,6 +361,7 @@ export function AppStoreScreen({ navigation }: { navigation: AppNavigationProp }
 
             {searchResults.map((app) => (
               <AppRow
+                onPressCard={openDetail}
                 key={app.packageName}
                 app={app}
                 installed={app.installed}
@@ -380,6 +394,7 @@ export function AppStoreScreen({ navigation }: { navigation: AppNavigationProp }
                 </Text>
                 {section.items.map((app) => (
                   <AppRow
+                onPressCard={openDetail}
                     key={app.packageName}
                     app={app}
                     installed={installedPackages.has(app.packageName)}

--- a/src/screens/__tests__/AppStoreDetailScreen.test.tsx
+++ b/src/screens/__tests__/AppStoreDetailScreen.test.tsx
@@ -1,0 +1,234 @@
+import React from 'react';
+import { Linking } from 'react-native';
+import { render, fireEvent, waitFor } from '../../test-utils';
+import * as AppsStore from '../../store/AppsStore';
+import { AppStoreScreen } from '../AppStoreScreen';
+import { AppStoreDetailScreen, isVirtualBuiltIn } from '../AppStoreDetailScreen';
+import { CURATED_APPS } from '../../data/curatedApps';
+import LauncherModule from '../../../modules/launcher-module/src';
+
+const mockNavigate = jest.fn();
+const mockGoBack = jest.fn();
+const mockLaunchApp = jest.fn(() => Promise.resolve(true));
+
+const nav = {
+  navigate: mockNavigate,
+  goBack: mockGoBack,
+  push: jest.fn(),
+} as never;
+
+function mockApps(apps: AppsStore.InstalledApp[]) {
+  jest.spyOn(AppsStore, 'useApps').mockReturnValue({
+    apps,
+    homeApps: [],
+    dockApps: [],
+    nonDockApps: [],
+    recentPackages: [],
+    recentApps: [],
+    isLoading: false,
+    refreshApps: jest.fn(() => Promise.resolve()),
+    launchApp: mockLaunchApp,
+    addToHome: jest.fn(),
+    removeFromHome: jest.fn(),
+    addToDock: jest.fn(),
+    removeFromDock: jest.fn(),
+    removeFromRecents: jest.fn(),
+    clearRecents: jest.fn(),
+    isDefaultLauncher: true,
+    openLauncherSettings: jest.fn(() => Promise.resolve()),
+  } as ReturnType<typeof AppsStore.useApps>);
+}
+
+function installed(packageName: string, isSystem = false): AppsStore.InstalledApp {
+  return { name: packageName, packageName, icon: '', isSystem };
+}
+
+const FIRST = CURATED_APPS[0];
+
+function routeFor(packageName: string, name: string) {
+  return { params: { packageName, name }, key: 'k', name: 'AppStoreDetail' } as never;
+}
+
+const uninstallMock = LauncherModule.uninstallApp as jest.Mock;
+
+let canOpenSpy: jest.SpyInstance;
+let openSpy: jest.SpyInstance;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockApps([]);
+  canOpenSpy = jest.spyOn(Linking, 'canOpenURL').mockResolvedValue(true);
+  openSpy = jest.spyOn(Linking, 'openURL').mockResolvedValue(true as never);
+  uninstallMock.mockResolvedValue(true);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('AppStoreScreen → AppStoreDetail navigation', () => {
+  it('tapping a Today card navigates to AppStoreDetail with that packageName and name', () => {
+    const { getByLabelText } = render(<AppStoreScreen navigation={nav} />);
+    fireEvent.press(getByLabelText(`${FIRST.name} card`));
+    expect(mockNavigate).toHaveBeenCalledWith('AppStoreDetail', {
+      packageName: FIRST.packageName,
+      name: FIRST.name,
+    });
+  });
+
+  it('the Get button inside a card still opens the listing and does NOT navigate (regression guard)', async () => {
+    const { getByLabelText } = render(<AppStoreScreen navigation={nav} />);
+    fireEvent.press(getByLabelText(`Get ${FIRST.name}`));
+    await waitFor(() =>
+      expect(openSpy).toHaveBeenCalledWith(`market://details?id=${FIRST.packageName}`),
+    );
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('the Open button inside a card still launches the app and does NOT navigate (regression guard)', () => {
+    mockApps([installed(FIRST.packageName)]);
+    const { getByLabelText } = render(<AppStoreScreen navigation={nav} />);
+    fireEvent.press(getByLabelText(`Open ${FIRST.name}`));
+    expect(mockLaunchApp).toHaveBeenCalledWith(FIRST.packageName);
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});
+
+describe('AppStoreDetailScreen', () => {
+  it('shows a labeled screenshot placeholder and no fabricated description', () => {
+    const { getByText, getByLabelText } = render(
+      <AppStoreDetailScreen navigation={nav} route={routeFor(FIRST.packageName, FIRST.name)} />,
+    );
+    expect(getByLabelText('Screenshots placeholder')).toBeTruthy();
+    expect(getByText('Screenshots not available')).toBeTruthy();
+    expect(getByText('Description not available')).toBeTruthy();
+  });
+
+  it('uses the curated tagline and category for a curated app', () => {
+    const { getByText } = render(
+      <AppStoreDetailScreen navigation={nav} route={routeFor(FIRST.packageName, FIRST.name)} />,
+    );
+    expect(getByText(FIRST.tagline)).toBeTruthy();
+    expect(getByText(FIRST.category)).toBeTruthy();
+  });
+
+  it('falls back to "Installed app" and the packageName for a non-curated installed app', () => {
+    mockApps([installed('com.example.random')]);
+    const { getByText } = render(
+      <AppStoreDetailScreen navigation={nav} route={routeFor('com.example.random', 'Random')} />,
+    );
+    expect(getByText('Installed app')).toBeTruthy();
+    expect(getByText('com.example.random')).toBeTruthy();
+  });
+
+  it('an installed app shows Open, which calls launchApp with the packageName', () => {
+    mockApps([installed(FIRST.packageName)]);
+    const { getByLabelText, queryByLabelText } = render(
+      <AppStoreDetailScreen navigation={nav} route={routeFor(FIRST.packageName, FIRST.name)} />,
+    );
+    expect(queryByLabelText(`Get ${FIRST.name}`)).toBeNull();
+    fireEvent.press(getByLabelText(`Open ${FIRST.name}`));
+    expect(mockLaunchApp).toHaveBeenCalledWith(FIRST.packageName);
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+
+  it('a non-installed app shows Get, which opens the market:// listing, and no Uninstall', async () => {
+    mockApps([]);
+    const { getByLabelText, queryByLabelText } = render(
+      <AppStoreDetailScreen navigation={nav} route={routeFor(FIRST.packageName, FIRST.name)} />,
+    );
+    expect(queryByLabelText(`Open ${FIRST.name}`)).toBeNull();
+    expect(queryByLabelText(`Uninstall ${FIRST.name}`)).toBeNull();
+    fireEvent.press(getByLabelText(`Get ${FIRST.name}`));
+    await waitFor(() =>
+      expect(openSpy).toHaveBeenCalledWith(`market://details?id=${FIRST.packageName}`),
+    );
+  });
+
+  it('falls back to the https listing when market:// has no handler', async () => {
+    canOpenSpy.mockImplementation((url: string) => Promise.resolve(url.startsWith('https:')));
+    const { getByLabelText } = render(
+      <AppStoreDetailScreen navigation={nav} route={routeFor(FIRST.packageName, FIRST.name)} />,
+    );
+    fireEvent.press(getByLabelText(`Get ${FIRST.name}`));
+    await waitFor(() =>
+      expect(openSpy).toHaveBeenCalledWith(
+        `https://play.google.com/store/apps/details?id=${FIRST.packageName}`,
+      ),
+    );
+  });
+
+  it('a rejected Linking call does not crash the screen', async () => {
+    canOpenSpy.mockRejectedValue(new Error('activity not found'));
+    const { getByLabelText } = render(
+      <AppStoreDetailScreen navigation={nav} route={routeFor(FIRST.packageName, FIRST.name)} />,
+    );
+    fireEvent.press(getByLabelText(`Get ${FIRST.name}`));
+    await waitFor(() => expect(canOpenSpy).toHaveBeenCalled());
+    expect(getByLabelText(`Get ${FIRST.name}`)).toBeTruthy();
+  });
+
+  it('pressing Uninstall calls LauncherModule.uninstallApp with the packageName', async () => {
+    mockApps([installed(FIRST.packageName)]);
+    const { getByLabelText } = render(
+      <AppStoreDetailScreen navigation={nav} route={routeFor(FIRST.packageName, FIRST.name)} />,
+    );
+    fireEvent.press(getByLabelText(`Uninstall ${FIRST.name}`));
+    await waitFor(() => expect(uninstallMock).toHaveBeenCalledWith(FIRST.packageName));
+  });
+
+  it('double-tapping Uninstall only requests one uninstall', async () => {
+    mockApps([installed(FIRST.packageName)]);
+    const { getByLabelText } = render(
+      <AppStoreDetailScreen navigation={nav} route={routeFor(FIRST.packageName, FIRST.name)} />,
+    );
+    const btn = getByLabelText(`Uninstall ${FIRST.name}`);
+    fireEvent.press(btn);
+    fireEvent.press(btn);
+    await waitFor(() => expect(uninstallMock).toHaveBeenCalled());
+    expect(uninstallMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('a rejected uninstallApp does not crash the screen', async () => {
+    uninstallMock.mockRejectedValue(new Error('installer unavailable'));
+    mockApps([installed(FIRST.packageName)]);
+    const { getByLabelText } = render(
+      <AppStoreDetailScreen navigation={nav} route={routeFor(FIRST.packageName, FIRST.name)} />,
+    );
+    fireEvent.press(getByLabelText(`Uninstall ${FIRST.name}`));
+    await waitFor(() => expect(uninstallMock).toHaveBeenCalled());
+    expect(getByLabelText(`Open ${FIRST.name}`)).toBeTruthy();
+  });
+
+  it('hides Uninstall for a system app (inverse of the fix)', () => {
+    mockApps([installed(FIRST.packageName, true)]);
+    const { getByLabelText, queryByLabelText } = render(
+      <AppStoreDetailScreen navigation={nav} route={routeFor(FIRST.packageName, FIRST.name)} />,
+    );
+    expect(getByLabelText(`Open ${FIRST.name}`)).toBeTruthy();
+    expect(queryByLabelText(`Uninstall ${FIRST.name}`)).toBeNull();
+  });
+
+  it('hides Uninstall for a virtual built-in package even when reported as installed', () => {
+    mockApps([installed('com.iostoandroid.phone')]);
+    const { queryByLabelText } = render(
+      <AppStoreDetailScreen navigation={nav} route={routeFor('com.iostoandroid.phone', 'Phone')} />,
+    );
+    expect(queryByLabelText('Uninstall Phone')).toBeNull();
+  });
+
+  it('isVirtualBuiltIn only matches this app\'s own namespace', () => {
+    expect(isVirtualBuiltIn('com.iostoandroid.phone')).toBe(true);
+    expect(isVirtualBuiltIn('com.iostoandroid.mail')).toBe(true);
+    expect(isVirtualBuiltIn('com.spotify.music')).toBe(false);
+    expect(isVirtualBuiltIn('')).toBe(false);
+  });
+
+  it('the Back button calls navigation.goBack', () => {
+    const { getByLabelText } = render(
+      <AppStoreDetailScreen navigation={nav} route={routeFor(FIRST.packageName, FIRST.name)} />,
+    );
+    fireEvent.press(getByLabelText('Back'));
+    expect(mockGoBack).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Resumo

Add AppStoreDetailScreen with Open/Get/Uninstall actions and navigate to it from Today cards

## Causa raiz

Não é um defeito — é funcionalidade em falta. O que existia (vindo de #244, ver
abaixo) era `src/screens/AppStoreScreen.tsx`: cada entrada de `CURATED_APPS`
renderizava um `<View>` com um único botão Open/Get. O corpo do card não tinha
`onPress` nenhum (`AppStoreScreen.tsx:48` antes desta alteração era um `View`
não-pressável), portanto não havia caminho de navegação para uma página por-app,
e o `RootStackParamList` não tinha rota `AppStoreDetail`.

**Onde o issue estava incompleto:** diz que #244 é uma dependência já existente,
mas `origin/qa/issue-244` **não está em `main`** (`git merge-base --is-ancestor
origin/qa/issue-244 origin/main` → falso; `main` = `b2e262e`). Sem
`src/data/curatedApps.ts` e `src/screens/AppStoreScreen.tsx` este issue não é
implementável. Cherry-pickei `6cb95ce` (o commit de #244) sem commit para o
worktree, e construí #246 por cima. Por isso o diff contra `origin/main` inclui
ficheiros de #244 — estão intactos, excepto o `onPress` do card exigido por este
issue.

O issue também diz que `uninstallApp` está na interface na linha 148 e a
implementação em 292-295 de `modules/launcher-module/src/index.ts`. Na realidade
está em `index.ts:168` (interface), `:253` (stub non-Android) e `:368-370`
(bridge). O padrão de `getLauncher` que o issue cita como
`LauncherHomeScreen.tsx:899-901` está hoje em `:1092-1102`. Não mexi no módulo.

## O que mudou

- **`src/screens/AppStoreDetailScreen.tsx` (novo)** — ecrã de detalhe.
  Lê `route.params.{packageName,name}`, resolve `installed` em `useApps().apps`
  por `packageName` e `curated` em `CURATED_APPS`. Mostra tagline+categoria do
  curated, ou `"Installed app"` + o próprio `packageName` quando não é curated.
  Dois blocos placeholder rotulados — `"Screenshots not available"` e
  `"Description not available"` — sem qualquer conteúdo fabricado. Acções: `Open`
  (chama `launchApp(packageName)`) quando instalado, `Get` quando não instalado
  (probe `canOpenURL` em `market://details?id=…` e fallback para o listing
  `https://play.google.com/…`, reusando `playStoreUrl`/`playStoreWebUrl`
  exportados por `AppStoreScreen.tsx`), e `Uninstall` quando
  `installed && !installed.isSystem && !isVirtualBuiltIn(packageName)`, que chama
  `mod.uninstallApp(packageName)` através do mesmo guard `try { await import(...) }`
  de `LauncherHomeScreen.tsx`. Exporta `isVirtualBuiltIn`.
- **`src/screens/AppStoreScreen.tsx`** — o corpo do card passou de `View` a
  `Pressable` com `onPress` que navega para `AppStoreDetail` com
  `{ packageName, name }`. O botão Open/Get interno é o mesmo código e continua a
  ganhar o toque (não propaga para o card). Restantes ficheiros de #244 intocados.
- **`src/navigation/types.ts`** — `AppStoreDetail: { packageName: string; name: string };`.
- **`src/navigation/TabNavigator.tsx`** — import + `<Stack.Screen name="AppStoreDetail" …>`
  com a mesma `slideAnimation` do `AppStore`.
- **`src/screens/__tests__/AppStoreDetailScreen.test.tsx` (novo)** — 17 testes.
- **`src/data/curatedApps.ts`, `src/screens/AppLibraryScreen.tsx`,
  `src/screens/__tests__/AppStoreScreen.test.tsx`** — vêm de #244 (`6cb95ce`)
  inalterados, incluídos porque #244 não está em `main`.

## Porque assim

- **`VIRTUAL_PACKAGE_PREFIX` em vez de importar `BUILT_IN_APPS`** — esse mapa está
  dentro de `LauncherHomeScreen.tsx`, que carrega worklets Reanimated;
  importá-lo arrastaria o launcher inteiro para o grafo deste ecrã. Todas as 13
  entradas vivem sob `com.iostoandroid.`, e o prefixo é testado explicitamente
  (`isVirtualBuiltIn('com.spotify.music') === false`). Alternativa descartada:
  extrair `BUILT_IN_APPS` para um módulo próprio — seria um refactor num ficheiro
  que o issue não pede.
- **Fallback `require` no `getLauncher`** — o guard `import()` puro é inalcançável
  em Jest: o VM corre sem `--experimental-vm-modules` e `import()` rebenta com
  `ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING_FLAG` (verifiquei com um teste
  descartável). O fix não é mascarar: é o mesmo fallback documentado que
  `src/store/AppsStore.tsx:32-40` já usa. Sem ele, o botão Uninstall seria
  intestável e o `catch` esconderia o defeito exactamente como o briefing proíbe.
- **Guard de duplo toque no Uninstall** (`uninstallRequested`) — o diálogo do
  `PackageInstaller` é assíncrono; sem estado, um segundo toque enfileira um
  segundo intent.
- **Card pressável em vez de um chevron** — mantém o gesto do App Store real (o
  card todo abre a página) sem alterar o botão Open/Get.

## Critérios de aceitação

- [x] Tocar num card do Today navega para `AppStoreDetail` com o `packageName` e
      `name` correctos — teste "tapping a Today card navigates to AppStoreDetail…"
      afirma `toHaveBeenCalledWith('AppStoreDetail', { packageName: 'com.spotify.music', name: 'Spotify' })`.
- [x] Placeholder rotulado para screenshots, sem conteúdo fabricado — assertions
      em `getByLabelText('Screenshots placeholder')`, `"Screenshots not available"`
      e `"Description not available"`. Não há `Image` nem texto descritivo inventado.
- [x] App instalada mostra `Open` que chama `launchApp(packageName)` — verificado, e
      o teste afirma também que `Get` **não** está presente.
- [x] App não instalada mostra `Get` que abre `market://details?id=<packageName>` —
      verificado, mais o fallback https e o caso de `Linking` rejeitado.
- [x] `Uninstall` só com instalado + `isSystem === false` + não-virtual, e chama
      `LauncherModule.uninstallApp(packageName)` pelo guard dinâmico — quatro testes:
      chamada correcta, escondido para `isSystem: true`, escondido para
      `com.iostoandroid.phone`, ausente quando não instalado.
- [x] **NÃO devia mudar:** o Today de `AppStoreScreen` e o seu Open/Get. Confirmado
      por dois guards de regressão neste ficheiro de teste (o botão interno abre o
      listing / lança a app e **não** navega) e pelas 16 asserções do
      `AppStoreScreen.test.tsx` de #244, que continuam a passar sem edição.
- [x] **NÃO devia mudar:** o fluxo de uninstall de `LauncherHomeScreen`. Não toquei
      no ficheiro — não aparece na lista de ficheiros alterados.
- [x] `npm test` sem falhas novas — 8 falhas, exactamente as 8 do baseline.

## Testes

**Passo vermelho (A) — o ecrã de detalhe ausente, teste já escrito:**

```
$ rm src/screens/AppStoreDetailScreen.tsx
$ npx jest src/screens/__tests__/AppStoreDetailScreen.test.tsx
FAIL Android src/screens/__tests__/AppStoreDetailScreen.test.tsx
  ● Test suite failed to run

    Cannot find module '../AppStoreDetailScreen' from 'src/screens/__tests__/AppStoreDetailScreen.test.tsx'

    > 6 | import { AppStoreDetailScreen, isVirtualBuiltIn } from '../AppStoreDetailScreen';
        | ^

Test Suites: 1 failed, 1 total
Tests:       0 total
```

**Passo vermelho (B) — o ecrã presente, só o `onPress` do card revertido para o
`View` de #244.** Este é o passo vermelho que importa, porque isola a alteração
em `AppStoreScreen.tsx` e não o simples ficheiro em falta:

```
$ git show 6cb95ce:src/screens/AppStoreScreen.tsx > src/screens/AppStoreScreen.tsx
$ npx jest src/screens/__tests__/AppStoreDetailScreen.test.tsx
  ● AppStoreScreen → AppStoreDetail navigation › tapping a Today card navigates to AppStoreDetail with that packageName and name

    expect(jest.fn()).toHaveBeenCalledWith(...expected)

    Expected: "AppStoreDetail", {"name": "Spotify", "packageName": "com.spotify.music"}

    Number of calls: 0

      71 |     const { getByLabelText } = render(<AppStoreScreen navigation={nav} />);
      72 |     fireEvent.press(getByLabelText(`${FIRST.name} card`));
    > 73 |     expect(mockNavigate).toHaveBeenCalledWith('AppStoreDetail', {
         |                          ^

Test Suites: 1 failed, 1 total
Tests:       1 failed, 16 passed, 17 total
```

**Passo vermelho (C) — o Uninstall.** Antes de acrescentar o fallback `require`,
com o ecrã já escrito, três testes falhavam por o módulo nativo nunca ser
alcançado — prova de que o guard `import()` puro não estava ligado ao
comportamento:

```
  ● AppStoreDetailScreen › pressing Uninstall calls LauncherModule.uninstallApp with the packageName

    expect(jest.fn()).toHaveBeenCalledWith(...expected)

    Expected: "com.spotify.music"

    Number of calls: 0

      175 |     );
      176 |     fireEvent.press(getByLabelText(`Uninstall ${FIRST.name}`));
    > 177 |     await waitFor(() => expect(uninstallMock).toHaveBeenCalledWith(FIRST.packageName));
          |                  ^

Tests:       4 failed, 13 passed, 17 total
```

**Verde:**

```
$ npx jest src/screens/__tests__/AppStoreDetailScreen.test.tsx
Test Suites: 1 passed, 1 total
Tests:       17 passed, 17 total
```

**Casos cobertos além do caminho feliz:**
- *O inverso do fix* — `Get` ausente quando instalado; `Open` ausente quando não
  instalado; `Uninstall` escondido para `isSystem: true`; `Uninstall` escondido
  para `com.iostoandroid.phone`; `Uninstall` ausente quando não instalado.
- *Ausente / vazio* — app não presente em `CURATED_APPS` (fallback
  `"Installed app"` + `packageName`); lista de apps instaladas vazia;
  `isVirtualBuiltIn('')`.
- *Repetição* — duplo toque no Uninstall chama `uninstallApp` **uma** vez
  (`toHaveBeenCalledTimes(1)`), o defeito recorrente deste repositório.
- *Assíncrono e hostil* — `canOpenURL` a rejeitar (o ecrã sobrevive e o botão
  continua lá), `canOpenURL` a devolver `false` para `market://` (fallback https),
  `uninstallApp` a rejeitar (o ecrã sobrevive).
- *Fronteira de namespace* — `isVirtualBuiltIn` só aceita `com.iostoandroid.*`,
  nunca `com.spotify.music`.
- *Regressão* — os botões internos Open/Get não navegam.

**Sanity-check:** removi `AppStoreDetailScreen.tsx` e revertei
`AppStoreScreen.tsx` para `6cb95ce`, mantendo os testes: `npm test -- src/screens/__tests__`
deu **6 failed / 318 passed em 40 suites** (contra 5 falhas de baseline nessa pasta,
mais a suite `AppStoreDetailScreen` inteira em erro de resolução). Restaurei e a
suite volta a 17/17.

**Verificações:**
- `npm run lint` → `✖ 2 problems (0 errors, 2 warnings)`. Os 2 warnings são
  pré-existentes (`BridgeErrorReporting.test.tsx:2`, `ClockScreen.tsx:258`), em
  ficheiros que não toquei. 0 erros, como no baseline.
- `npx tsc --noEmit` → limpo, sem output. Nenhum `any` novo, nenhum `as any`.
- `npm test -- --maxWorkers=2` → **797 passaram, 8 falharam, 109 suites**. As 8
  falhas são exactamente as 8 do baseline (`FoldersStore` ×2, `LockScreen` ×3,
  `SettingsScreen` ×1, `WeatherScreen` ×2), causadas pelo gate
  `firstSyncDone` do `SettingsStore`. Comparei a lista extraída da corrida com
  `jq -r '.failed_tests[]' baseline.json` — idênticas. **Zero regressões.**
  Baseline: 8/720 a falhar; agora 8/805, com os 85 testes novos (17 meus + 68 de #244).

## Testes

797 passaram, 8 falharam (as 8 do baseline), 109 suites; a suite nova AppStoreDetailScreen: 17 passaram, 0 falharam

## Linked Issue

Fixes #246