### PR TITLE
feat(siri): add SiriScreen with text-input command routing and wire the AssistiveTouch siri action to it (#250)

### DIFF
--- a/src/assistant/__tests__/commandParser.test.ts
+++ b/src/assistant/__tests__/commandParser.test.ts
@@ -1,0 +1,228 @@
+import { parseCommand } from '../commandParser';
+import type { AssistantCommand } from '../commandParser';
+
+describe('parseCommand', () => {
+  describe('OPEN_APP', () => {
+    it('parses "Open Notes" into an OPEN_APP command', () => {
+      const cmd: AssistantCommand = parseCommand('Open Notes');
+      expect(cmd).toEqual({ type: 'OPEN_APP', appName: 'Notes' });
+    });
+
+    it('is case-insensitive for the verb and preserves app-name case', () => {
+      expect(parseCommand('open PHOTOS')).toEqual({
+        type: 'OPEN_APP',
+        appName: 'PHOTOS',
+      });
+      expect(parseCommand('OPEN reminders')).toEqual({
+        type: 'OPEN_APP',
+        appName: 'reminders',
+      });
+    });
+
+    it('tolerates trailing punctuation on the app name', () => {
+      expect(parseCommand('Open Calculator.')).toEqual({
+        type: 'OPEN_APP',
+        appName: 'Calculator',
+      });
+    });
+
+    it('returns UNRECOGNIZED when "Open" has no argument', () => {
+      expect(parseCommand('Open')).toEqual({ type: 'UNRECOGNIZED', raw: 'Open' });
+      expect(parseCommand('Open ')).toEqual({ type: 'UNRECOGNIZED', raw: 'Open ' });
+    });
+  });
+
+  describe('CALL_CONTACT', () => {
+    it('parses "Call Alice" into a CALL_CONTACT command', () => {
+      expect(parseCommand('Call Alice')).toEqual({
+        type: 'CALL_CONTACT',
+        contactName: 'Alice',
+      });
+    });
+
+    it('preserves multi-word contact names and tolerates trailing punctuation', () => {
+      expect(parseCommand('Call Bob Smith!')).toEqual({
+        type: 'CALL_CONTACT',
+        contactName: 'Bob Smith',
+      });
+    });
+
+    it('is case-insensitive', () => {
+      expect(parseCommand('call alice')).toEqual({
+        type: 'CALL_CONTACT',
+        contactName: 'alice',
+      });
+    });
+  });
+
+  describe('SEND_MESSAGE', () => {
+    it('parses "Send message to Alice" into a SEND_MESSAGE command', () => {
+      expect(parseCommand('Send message to Alice')).toEqual({
+        type: 'SEND_MESSAGE',
+        contactName: 'Alice',
+      });
+    });
+
+    it('also accepts the natural "send a message to" alias', () => {
+      expect(parseCommand('send a message to Bob')).toEqual({
+        type: 'SEND_MESSAGE',
+        contactName: 'Bob',
+      });
+    });
+
+    it('tolerates trailing punctuation and preserves contact name case', () => {
+      expect(parseCommand('Send message to Carol.')).toEqual({
+        type: 'SEND_MESSAGE',
+        contactName: 'Carol',
+      });
+    });
+  });
+
+  describe('WHAT_TIME', () => {
+    it('parses "What time is it" into a WHAT_TIME command', () => {
+      expect(parseCommand('What time is it')).toEqual({ type: 'WHAT_TIME' });
+    });
+
+    it('is case-insensitive and tolerates trailing punctuation', () => {
+      expect(parseCommand('what time is it?')).toEqual({ type: 'WHAT_TIME' });
+      expect(parseCommand('WHAT TIME IS IT')).toEqual({ type: 'WHAT_TIME' });
+    });
+  });
+
+  describe('SET_ALARM', () => {
+    it('parses a 24-hour time without am/pm', () => {
+      expect(parseCommand('Set alarm for 19:30')).toEqual({
+        type: 'SET_ALARM',
+        hour: 19,
+        minute: 30,
+      });
+    });
+
+    it('parses a 12-hour "pm" time with no minutes', () => {
+      expect(parseCommand('Set alarm for 7pm')).toEqual({
+        type: 'SET_ALARM',
+        hour: 19,
+        minute: 0,
+      });
+    });
+
+    it('parses a 12-hour "pm" time with minutes and spaced meridian', () => {
+      expect(parseCommand('Set alarm for 7:30 pm')).toEqual({
+        type: 'SET_ALARM',
+        hour: 19,
+        minute: 30,
+      });
+    });
+
+    it('parses a 12-hour "am" time', () => {
+      expect(parseCommand('Set alarm for 9:15 am')).toEqual({
+        type: 'SET_ALARM',
+        hour: 9,
+        minute: 15,
+      });
+    });
+
+    it('treats 12 pm as noon and 12 am as midnight', () => {
+      expect(parseCommand('Set alarm for 12 pm')).toEqual({
+        type: 'SET_ALARM',
+        hour: 12,
+        minute: 0,
+      });
+      expect(parseCommand('Set alarm for 12 am')).toEqual({
+        type: 'SET_ALARM',
+        hour: 0,
+        minute: 0,
+      });
+    });
+
+    it('accepts "Set alarm" without the "for" connector', () => {
+      expect(parseCommand('Set alarm 6:45 am')).toEqual({
+        type: 'SET_ALARM',
+        hour: 6,
+        minute: 45,
+      });
+    });
+
+    it('is case-insensitive on the verb and meridian', () => {
+      expect(parseCommand('SET ALARM FOR 7 PM')).toEqual({
+        type: 'SET_ALARM',
+        hour: 19,
+        minute: 0,
+      });
+    });
+
+    it('returns UNRECOGNIZED for an hour out of range (>= 24)', () => {
+      expect(parseCommand('Set alarm for 25:00')).toEqual({
+        type: 'UNRECOGNIZED',
+        raw: 'Set alarm for 25:00',
+      });
+    });
+
+    it('returns UNRECOGNIZED for a minute out of range (>= 60)', () => {
+      expect(parseCommand('Set alarm for 7:70 pm')).toEqual({
+        type: 'UNRECOGNIZED',
+        raw: 'Set alarm for 7:70 pm',
+      });
+    });
+
+    it('returns UNRECOGNIZED when no time is supplied', () => {
+      expect(parseCommand('Set alarm')).toEqual({
+        type: 'UNRECOGNIZED',
+        raw: 'Set alarm',
+      });
+    });
+  });
+
+  describe('wake-phrase stripping', () => {
+    it('strips a leading "Hey Siri" wake phrase', () => {
+      expect(parseCommand('Hey Siri open Maps')).toEqual({
+        type: 'OPEN_APP',
+        appName: 'Maps',
+      });
+      expect(parseCommand('Hey Siri call Dave')).toEqual({
+        type: 'CALL_CONTACT',
+        contactName: 'Dave',
+      });
+    });
+
+    it('strips a bare "Siri" wake phrase', () => {
+      expect(parseCommand('Siri what time is it')).toEqual({ type: 'WHAT_TIME' });
+      expect(parseCommand('siri set alarm for 8 am')).toEqual({
+        type: 'SET_ALARM',
+        hour: 8,
+        minute: 0,
+      });
+    });
+
+    it('strips the wake phrase case-insensitively with trailing separator', () => {
+      expect(parseCommand('HEY SIRI, call Eve')).toEqual({
+        type: 'CALL_CONTACT',
+        contactName: 'Eve',
+      });
+    });
+  });
+
+  describe('UNRECOGNIZED', () => {
+    it('returns UNRECOGNIZED for an empty string', () => {
+      expect(parseCommand('')).toEqual({ type: 'UNRECOGNIZED', raw: '' });
+    });
+
+    it('returns UNRECOGNIZED for whitespace-only input', () => {
+      expect(parseCommand('   ')).toEqual({ type: 'UNRECOGNIZED', raw: '   ' });
+    });
+
+    it('returns UNRECOGNIZED for gibberish', () => {
+      expect(parseCommand('flibber wobber')).toEqual({
+        type: 'UNRECOGNIZED',
+        raw: 'flibber wobber',
+      });
+    });
+
+    it('returns UNRECOGNIZED for an unsupported intent', () => {
+      expect(parseCommand('Play music')).toEqual({
+        type: 'UNRECOGNIZED',
+        raw: 'Play music',
+      });
+    });
+  });
+});

--- a/src/assistant/commandParser.ts
+++ b/src/assistant/commandParser.ts
@@ -1,0 +1,143 @@
+/**
+ * Pure voice/text command parser for the Siri voice assistant.
+ *
+ * Turns a free-text command string (e.g. "Call Alice") into a structured,
+ * typed intent. No React, no React Native, no native module, no store imports —
+ * deterministic and unit-testable in isolation. This is the first building block
+ * toward replacing the `AssistiveTouch` "siri" placeholder (see #122).
+ */
+
+export type AssistantCommand =
+  | { type: 'OPEN_APP'; appName: string }
+  | { type: 'CALL_CONTACT'; contactName: string }
+  | { type: 'SEND_MESSAGE'; contactName: string }
+  | { type: 'WHAT_TIME' }
+  | { type: 'SET_ALARM'; hour: number; minute: number }
+  | { type: 'UNRECOGNIZED'; raw: string };
+
+/** Parse a raw voice/text command into a structured intent. */
+export function parseCommand(input: string): AssistantCommand {
+  const raw = input;
+  const trimmed = input.trim();
+
+  // Whitespace-only or empty input is unrecognized (raw keeps the original text).
+  if (trimmed.length === 0) {
+    return { type: 'UNRECOGNIZED', raw };
+  }
+
+  let text = trimmed;
+
+  // Strip a leading "Hey Siri" / "Siri" wake phrase and any following separator.
+  const wake = /^(?:hey\s+siri|siri)[\s,:.!?]*/i.exec(text);
+  if (wake) {
+    text = text.slice(wake[0].length).trim();
+  }
+  if (text.length === 0) {
+    return { type: 'UNRECOGNIZED', raw };
+  }
+
+  // Drop trailing sentence punctuation (but never a meaningful colon).
+  text = text.replace(/[.!?]+$/, '');
+
+  const lower = text.toLowerCase();
+
+  // "Open [app]"
+  const open = /^open\s+(.+)$/i.exec(text);
+  if (open) {
+    const appName = open[1].trim();
+    if (appName.length > 0) {
+      return { type: 'OPEN_APP', appName };
+    }
+  }
+
+  // "Call [contact]"
+  const call = /^call\s+(.+)$/i.exec(text);
+  if (call) {
+    const contactName = call[1].trim();
+    if (contactName.length > 0) {
+      return { type: 'CALL_CONTACT', contactName };
+    }
+  }
+
+  // "Send [a] message to [contact]"
+  const send = /^send\s+(?:a\s+)?message\s+to\s+(.+)$/i.exec(text);
+  if (send) {
+    const contactName = send[1].trim();
+    if (contactName.length > 0) {
+      return { type: 'SEND_MESSAGE', contactName };
+    }
+  }
+
+  // "What time is it"
+  if (/^what\s+time\s+is\s+it$/.test(lower)) {
+    return { type: 'WHAT_TIME' };
+  }
+
+  // "Set alarm [for] [time]" — 12-hour (7pm / 7:30 pm) or 24-hour (19:30)
+  const alarm = /^set\s+alarm\s+(?:for\s+)?(.+)$/i.exec(text);
+  if (alarm) {
+    const timeStr = alarm[1].trim();
+    const parsed = parseTime(timeStr);
+    if (parsed) {
+      return { type: 'SET_ALARM', hour: parsed.hour, minute: parsed.minute };
+    }
+  }
+
+  return { type: 'UNRECOGNIZED', raw };
+}
+
+/**
+ * Parse a time expression into a 0–23 hour / 0–59 minute integer pair.
+ * Accepts 24-hour ("19:30") and 12-hour ("7pm", "7:30 pm", "12 am") forms.
+ * Returns null when no valid time is present or a value is out of range,
+ * so the caller can fall back to UNRECOGNIZED.
+ */
+function parseTime(value: string): { hour: number; minute: number } | null {
+  const time = value.trim();
+  if (time.length === 0) {
+    return null;
+  }
+
+  let match = /^(\d{1,2}):(\d{2})\s*(am|pm)?$/i.exec(time);
+  let hourStr: string;
+  let minuteStr: string | undefined;
+  let meridian: string | undefined;
+
+  if (match) {
+    hourStr = match[1];
+    minuteStr = match[2];
+    meridian = match[3]?.toLowerCase();
+  } else {
+    match = /^(\d{1,2})\s*(am|pm)$/i.exec(time);
+    if (!match) {
+      return null;
+    }
+    hourStr = match[1];
+    minuteStr = undefined;
+    meridian = match[2].toLowerCase();
+  }
+
+  const hour = Number(hourStr);
+  const minute = minuteStr !== undefined ? Number(minuteStr) : 0;
+
+  if (!Number.isInteger(hour) || !Number.isInteger(minute)) {
+    return null;
+  }
+
+  let normalizedHour = hour;
+  if (meridian === 'pm') {
+    if (normalizedHour < 12) {
+      normalizedHour += 12;
+    }
+  } else if (meridian === 'am') {
+    if (normalizedHour === 12) {
+      normalizedHour = 0;
+    }
+  }
+
+  if (normalizedHour < 0 || normalizedHour > 23 || minute < 0 || minute > 59) {
+    return null;
+  }
+
+  return { hour: normalizedHour, minute };
+}

--- a/src/components/AssistiveTouch.tsx
+++ b/src/components/AssistiveTouch.tsx
@@ -229,7 +229,7 @@ export function AssistiveTouch({ navigationRef }: AssistiveTouchProps) {
         case 'controlCenter':    navigate('ControlCenter'); break;
         case 'spotlight':        navigate('SpotlightSearch'); break;
         case 'settings':         navigate('Settings'); break;
-        case 'siri':             navigate('SpotlightSearch'); break; // best-available analogue
+        case 'siri':             navigate('Siri'); break;
         case 'screenshot':
           // No reliable programmatic screenshot API; briefly flash the screen
           // and let the user capture via power+volume. Treat as placeholder.

--- a/src/components/__tests__/AssistiveTouch.test.tsx
+++ b/src/components/__tests__/AssistiveTouch.test.tsx
@@ -71,6 +71,15 @@ function EnableAssistiveTouch() {
   return null;
 }
 
+/** Enables AssistiveTouch AND puts `siri` in the menu (it is not there by default). */
+function EnableWithSiri() {
+  const { update } = useAssistiveTouch();
+  useEffect(() => {
+    update({ enabled: true, menuItems: ['siri', 'spotlight'] });
+  }, [update]);
+  return null;
+}
+
 function makeNavigationRef() {
   return {
     isReady: () => true,
@@ -245,5 +254,48 @@ describe('AssistiveTouch menu backdrop', () => {
 
     advance(150); // o timer da abertura original dispararia nesta janela
     expect(queryByLabelText(BACKDROP_LABEL)).toBeNull();
+  });
+});
+
+describe('AssistiveTouch acção siri', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockTapRecords.length = 0;
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  function renderWithSiri(navigationRef = makeNavigationRef()) {
+    return {
+      navigationRef,
+      ...render(
+        <AssistiveTouchProvider>
+          <EnableWithSiri />
+          <AssistiveTouch navigationRef={navigationRef} />
+        </AssistiveTouchProvider>
+      ),
+    };
+  }
+
+  it('tocar em Siri navega para Siri, não para SpotlightSearch', () => {
+    const { navigationRef, getByLabelText } = renderWithSiri();
+    openMenu();
+    advance(150);
+
+    fireEvent.press(getByLabelText('Siri'));
+    expect(navigationRef.navigate).toHaveBeenCalledWith('Siri');
+    expect(navigationRef.navigate).not.toHaveBeenCalledWith('SpotlightSearch');
+  });
+
+  it('a acção Spotlight continua a navegar para SpotlightSearch', () => {
+    const { navigationRef, getByLabelText } = renderWithSiri();
+    openMenu();
+    advance(150);
+
+    fireEvent.press(getByLabelText('Spotlight'));
+    expect(navigationRef.navigate).toHaveBeenCalledWith('SpotlightSearch');
+    expect(navigationRef.navigate).not.toHaveBeenCalledWith('Siri');
   });
 });

--- a/src/navigation/TabNavigator.tsx
+++ b/src/navigation/TabNavigator.tsx
@@ -50,6 +50,7 @@ import { BackupRestoreScreen } from '../screens/settings/BackupRestoreScreen';
 import { ComponentsGalleryScreen } from '../screens/ComponentsGalleryScreen';
 import { AppLibraryScreen } from '../screens/AppLibraryScreen';
 import { SpotlightSearchScreen } from '../screens/SpotlightSearchScreen';
+import { SiriScreen } from '../screens/SiriScreen';
 import { TodayViewScreen } from '../screens/TodayViewScreen';
 import { NotificationCenterScreen } from '../screens/NotificationCenterScreen';
 import { LauncherSettingsScreen } from '../screens/LauncherSettingsScreen';
@@ -136,6 +137,7 @@ export function TabNavigator() {
       {__DEV__ && <Stack.Screen name="ComponentsGallery" component={ComponentsGalleryScreen} options={{ animation: slideAnimation }} />}
       <Stack.Screen name="AppLibrary" component={AppLibraryScreen} />
       <Stack.Screen name="SpotlightSearch" component={SpotlightSearchScreen} options={{ animation: fadeAnimation, presentation: 'transparentModal' }} />
+      <Stack.Screen name="Siri" component={SiriScreen} options={{ animation: fadeAnimation, presentation: 'transparentModal' }} />
       <Stack.Screen name="TodayView" component={TodayViewScreen} options={{ animation: settings.reduceMotion ? 'none' : 'slide_from_left' }} />
       <Stack.Screen name="LauncherSettings" component={LauncherSettingsScreen} options={{ animation: slideAnimation }} />
     </Stack.Navigator>

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -58,6 +58,7 @@ export type RootStackParamList = {
   ComponentsGallery: undefined;
   AppLibrary: undefined;
   SpotlightSearch: undefined;
+  Siri: undefined;
   TodayView: undefined;
   LauncherSettings: undefined;
 };

--- a/src/screens/SiriScreen.tsx
+++ b/src/screens/SiriScreen.tsx
@@ -1,0 +1,208 @@
+import React, { useCallback, useMemo, useRef, useState } from 'react';
+import {
+  View,
+  Text,
+  TextInput,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Ionicons } from '@expo/vector-icons';
+
+import { useApps } from '../store/AppsStore';
+import { useContacts, Contact } from '../store/ContactsStore';
+import { useTheme } from '../theme/ThemeContext';
+import { parseCommand } from '../assistant/commandParser';
+import type { AppNavigationProp } from '../navigation/types';
+import { logger } from '../utils/logger';
+
+const GREETING = 'What can I help you with?';
+const NOT_SUPPORTED = "That's not supported yet.";
+
+/** Format a Date the way the assistant speaks a clock time ("2:05 PM"). */
+export function formatAssistantTime(date: Date): string {
+  return date.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
+}
+
+function fullName(c: Contact): string {
+  return `${c.firstName} ${c.lastName}`.trim();
+}
+
+/**
+ * Match a spoken contact name against first name, last name or the full name.
+ * Case-insensitive substring so "call anderson" and "call alice a" both land.
+ */
+function findContact(contacts: Contact[], query: string): Contact | undefined {
+  const q = query.trim().toLowerCase();
+  if (q.length === 0) return undefined;
+  return contacts.find((c) => {
+    const first = c.firstName.toLowerCase();
+    const last = c.lastName.toLowerCase();
+    const full = fullName(c).toLowerCase();
+    return first === q || last === q || full === q ||
+      first.includes(q) || last.includes(q) || full.includes(q);
+  });
+}
+
+interface SiriScreenProps {
+  navigation: AppNavigationProp;
+}
+
+export function SiriScreen({ navigation }: SiriScreenProps) {
+  const { theme, typography } = useTheme();
+  const { colors } = theme;
+  const insets = useSafeAreaInsets();
+  const { apps, launchApp } = useApps();
+  const { contacts } = useContacts();
+
+  const [text, setText] = useState('');
+  const [response, setResponse] = useState<string | null>(null);
+  const inputRef = useRef<TextInput>(null);
+
+  const findApp = useCallback(
+    (name: string) => {
+      const q = name.trim().toLowerCase();
+      if (q.length === 0) return undefined;
+      return apps.find((a) => a.name.toLowerCase() === q)
+        ?? apps.find((a) => a.name.toLowerCase().includes(q));
+    },
+    [apps],
+  );
+
+  const handleSubmit = useCallback(() => {
+    const input = text;
+    if (input.trim().length === 0) return;
+    setText('');
+
+    const command = parseCommand(input);
+
+    switch (command.type) {
+      case 'OPEN_APP': {
+        const app = findApp(command.appName);
+        if (!app) {
+          setResponse(`Couldn't find an app called "${command.appName}".`);
+          return;
+        }
+        setResponse(`Opening ${app.name}.`);
+        // launchApp is a no-op off Android and can reject if the package
+        // vanished between the scan and the tap; surface it instead of
+        // letting an unhandled rejection escape the handler.
+        launchApp(app.packageName).catch((e) => {
+          logger.warn('SiriScreen', 'launchApp failed', e);
+          setResponse(`Couldn't open ${app.name}.`);
+        });
+        return;
+      }
+      case 'CALL_CONTACT': {
+        const contact = findContact(contacts, command.contactName);
+        if (!contact) {
+          setResponse(`Couldn't find a contact called "${command.contactName}".`);
+          return;
+        }
+        setResponse(`Calling ${fullName(contact) || contact.phone}.`);
+        navigation.navigate('CallScreen', { name: fullName(contact), number: contact.phone });
+        return;
+      }
+      case 'SEND_MESSAGE': {
+        const contact = findContact(contacts, command.contactName);
+        if (!contact) {
+          setResponse(`Couldn't find a contact called "${command.contactName}".`);
+          return;
+        }
+        setResponse(`Messaging ${fullName(contact) || contact.phone}.`);
+        navigation.navigate('Conversation', { address: contact.phone });
+        return;
+      }
+      case 'WHAT_TIME':
+        setResponse(`It's ${formatAssistantTime(new Date())}`);
+        return;
+      case 'SET_ALARM':
+        setResponse(`Setting alarms ${NOT_SUPPORTED.replace("That's ", '')}`);
+        return;
+      case 'UNRECOGNIZED':
+      default:
+        setResponse(NOT_SUPPORTED);
+        return;
+    }
+  }, [text, findApp, contacts, launchApp, navigation]);
+
+  const styles = useMemo(() => createStyles(), []);
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.systemBackground }]}>
+      <View style={[styles.header, { paddingTop: insets.top + 8 }]}>
+        <Pressable
+          onPress={() => navigation.goBack()}
+          accessibilityRole="button"
+          accessibilityLabel="Back"
+          hitSlop={12}
+          style={styles.backButton}
+        >
+          <Ionicons name="chevron-back" size={26} color={colors.systemBlue} />
+          <Text style={[typography.body, { color: colors.systemBlue }]}>Back</Text>
+        </Pressable>
+      </View>
+
+      <ScrollView
+        style={styles.responseArea}
+        contentContainerStyle={styles.responseContent}
+        keyboardShouldPersistTaps="handled"
+      >
+        <Text
+          style={[typography.title3, styles.responseText, { color: colors.label }]}
+          accessibilityLabel="Siri response"
+        >
+          {response ?? GREETING}
+        </Text>
+      </ScrollView>
+
+      <View
+        style={[
+          styles.inputRow,
+          {
+            borderTopColor: colors.separator,
+            backgroundColor: colors.secondarySystemBackground,
+            paddingBottom: insets.bottom + 8,
+          },
+        ]}
+      >
+        <TextInput
+          ref={inputRef}
+          style={[typography.body, styles.input, { color: colors.label, backgroundColor: colors.systemBackground }]}
+          placeholder="Type a request"
+          placeholderTextColor={colors.systemGray}
+          value={text}
+          onChangeText={setText}
+          onSubmitEditing={handleSubmit}
+          returnKeyType="send"
+          accessibilityLabel="Ask Siri"
+          autoFocus
+          blurOnSubmit={false}
+        />
+      </View>
+    </View>
+  );
+}
+
+function createStyles() {
+  return StyleSheet.create({
+    container: { flex: 1 },
+    header: { paddingHorizontal: 8, paddingBottom: 8 },
+    backButton: { flexDirection: 'row', alignItems: 'center' },
+    responseArea: { flex: 1 },
+    responseContent: { padding: 24, flexGrow: 1, justifyContent: 'center' },
+    responseText: { textAlign: 'center' },
+    inputRow: {
+      paddingHorizontal: 12,
+      paddingTop: 8,
+      borderTopWidth: StyleSheet.hairlineWidth,
+    },
+    input: {
+      minHeight: 40,
+      borderRadius: 20,
+      paddingHorizontal: 16,
+      paddingVertical: 8,
+    },
+  });
+}

--- a/src/screens/__tests__/SiriScreen.test.tsx
+++ b/src/screens/__tests__/SiriScreen.test.tsx
@@ -1,0 +1,183 @@
+import React from 'react';
+import { render, fireEvent } from '../../test-utils';
+import { SiriScreen } from '../SiriScreen';
+import type { AppNavigationProp } from '../../navigation/types';
+import type { InstalledApp } from '../../store/AppsStore';
+
+const mockLaunchApp = jest.fn<Promise<void>, [string]>(() => Promise.resolve());
+const mockApps: InstalledApp[] = [
+  { name: 'Calculator', packageName: 'com.iostoandroid.calculator', icon: '', isSystem: false },
+  { name: 'Weather', packageName: 'com.iostoandroid.weather', icon: '', isSystem: false },
+];
+
+// Only `useApps` is stubbed: `AppsProvider` (used by test-utils) stays real, and
+// the real provider yields an empty app list under jest because the native
+// launcher module is unavailable, so app-matching could never be exercised.
+jest.mock('../../store/AppsStore', () => {
+  const actual = jest.requireActual('../../store/AppsStore');
+  return {
+    ...actual,
+    useApps: () => ({ apps: mockApps, launchApp: mockLaunchApp }),
+  };
+});
+
+function makeNav() {
+  return { navigate: jest.fn(), goBack: jest.fn(), push: jest.fn() } as unknown as AppNavigationProp;
+}
+
+function submit(input: string, nav: AppNavigationProp = makeNav()) {
+  const utils = render(<SiriScreen navigation={nav} />);
+  const field = utils.getByLabelText('Ask Siri');
+  fireEvent.changeText(field, input);
+  fireEvent(field, 'submitEditing');
+  return { ...utils, nav, field };
+}
+
+beforeEach(() => {
+  mockLaunchApp.mockClear();
+});
+
+describe('SiriScreen', () => {
+  it('renders without crashing and shows the text input', () => {
+    const { getByLabelText, toJSON } = render(<SiriScreen navigation={makeNav()} />);
+    expect(toJSON()).toBeTruthy();
+    expect(getByLabelText('Ask Siri')).toBeTruthy();
+  });
+
+  // ── OPEN_APP ─────────────────────────────────────────────────────────────
+  it('routes "Open Calculator" to launchApp with the Calculator package name', () => {
+    const { nav } = submit('Open Calculator');
+    expect(mockLaunchApp).toHaveBeenCalledWith('com.iostoandroid.calculator');
+    expect(nav.navigate).not.toHaveBeenCalled();
+  });
+
+  it('matches the app name case-insensitively and by substring', () => {
+    submit('Open calcul');
+    expect(mockLaunchApp).toHaveBeenCalledWith('com.iostoandroid.calculator');
+  });
+
+  it('shows a "Couldn\'t find" response and does not launch when no app matches', () => {
+    const { getByText, nav } = submit('Open Photoshop');
+    expect(getByText(/Couldn't find/i)).toBeTruthy();
+    expect(getByText(/Photoshop/)).toBeTruthy();
+    expect(mockLaunchApp).not.toHaveBeenCalled();
+    expect(nav.navigate).not.toHaveBeenCalled();
+  });
+
+  // ── CALL_CONTACT ─────────────────────────────────────────────────────────
+  it('routes "Call Alice" to CallScreen with Alice\'s number', () => {
+    const { nav } = submit('Call Alice');
+    expect(nav.navigate).toHaveBeenCalledWith('CallScreen', {
+      name: 'Alice Anderson',
+      number: '+1 (555) 100-0001',
+    });
+  });
+
+  it('matches a contact by last name too', () => {
+    const { nav } = submit('Call anderson');
+    expect(nav.navigate).toHaveBeenCalledWith('CallScreen', {
+      name: 'Alice Anderson',
+      number: '+1 (555) 100-0001',
+    });
+  });
+
+  it('shows a "Couldn\'t find" response and does not navigate for an unknown contact', () => {
+    const { getByText, nav } = submit('Call Zebediah');
+    expect(getByText(/Couldn't find/i)).toBeTruthy();
+    expect(nav.navigate).not.toHaveBeenCalled();
+  });
+
+  // ── SEND_MESSAGE ─────────────────────────────────────────────────────────
+  it('routes "Send message to Alice" to Conversation with her phone as address', () => {
+    const { nav } = submit('Send message to Alice');
+    expect(nav.navigate).toHaveBeenCalledWith('Conversation', { address: '+1 (555) 100-0001' });
+  });
+
+  it('does not navigate to Conversation for an unknown message recipient', () => {
+    const { getByText, nav } = submit('Send a message to Nobody');
+    expect(getByText(/Couldn't find/i)).toBeTruthy();
+    expect(nav.navigate).not.toHaveBeenCalled();
+  });
+
+  // ── WHAT_TIME ────────────────────────────────────────────────────────────
+  it('answers "What time is it" with the current time and navigates nowhere', () => {
+    jest.useFakeTimers().setSystemTime(new Date(2026, 0, 2, 14, 5, 0));
+    try {
+      const { getByText, nav } = submit('What time is it');
+      const expected = new Date(2026, 0, 2, 14, 5, 0).toLocaleTimeString(undefined, {
+        hour: 'numeric',
+        minute: '2-digit',
+      });
+      expect(getByText(`It's ${expected}`)).toBeTruthy();
+      expect(nav.navigate).not.toHaveBeenCalled();
+      expect(mockLaunchApp).not.toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  // ── SET_ALARM / UNRECOGNIZED ─────────────────────────────────────────────
+  it('tells the user alarms are not supported yet, without navigating', () => {
+    const { getByText, nav } = submit('Set alarm for 7:30 am');
+    expect(getByText(/not supported yet/i)).toBeTruthy();
+    expect(nav.navigate).not.toHaveBeenCalled();
+  });
+
+  it('responds to an unrecognized command without throwing or navigating', () => {
+    const { getByText, nav } = submit('Make me a sandwich');
+    expect(getByText(/not supported yet|didn't catch/i)).toBeTruthy();
+    expect(nav.navigate).not.toHaveBeenCalled();
+    expect(mockLaunchApp).not.toHaveBeenCalled();
+  });
+
+  // ── Empty / boundary input ───────────────────────────────────────────────
+  it('ignores an empty submit: no navigation, no launch, no response text change', () => {
+    const nav = makeNav();
+    const { getByLabelText, queryByText } = render(<SiriScreen navigation={nav} />);
+    fireEvent(getByLabelText('Ask Siri'), 'submitEditing');
+    expect(nav.navigate).not.toHaveBeenCalled();
+    expect(mockLaunchApp).not.toHaveBeenCalled();
+    expect(queryByText(/Couldn't find/i)).toBeNull();
+  });
+
+  it('ignores a whitespace-only submit', () => {
+    const nav = makeNav();
+    const { getByLabelText, queryByText } = render(<SiriScreen navigation={nav} />);
+    fireEvent.changeText(getByLabelText('Ask Siri'), '   ');
+    fireEvent(getByLabelText('Ask Siri'), 'submitEditing');
+    expect(nav.navigate).not.toHaveBeenCalled();
+    expect(mockLaunchApp).not.toHaveBeenCalled();
+    expect(queryByText(/Couldn't find/i)).toBeNull();
+  });
+
+  // ── Repetition / order ───────────────────────────────────────────────────
+  it('launches twice when the same command is submitted twice (no stale-state swallow)', () => {
+    const nav = makeNav();
+    const { getByLabelText } = render(<SiriScreen navigation={nav} />);
+    const field = getByLabelText('Ask Siri');
+    fireEvent.changeText(field, 'Open Calculator');
+    fireEvent(field, 'submitEditing');
+    fireEvent.changeText(field, 'Open Calculator');
+    fireEvent(field, 'submitEditing');
+    expect(mockLaunchApp).toHaveBeenCalledTimes(2);
+  });
+
+  it('clears the previous "couldn\'t find" answer once a later command succeeds', () => {
+    const nav = makeNav();
+    const { getByLabelText, queryByText } = render(<SiriScreen navigation={nav} />);
+    const field = getByLabelText('Ask Siri');
+    fireEvent.changeText(field, 'Open Photoshop');
+    fireEvent(field, 'submitEditing');
+    expect(queryByText(/Couldn't find/i)).toBeTruthy();
+    fireEvent.changeText(field, 'Open Calculator');
+    fireEvent(field, 'submitEditing');
+    expect(queryByText(/Couldn't find/i)).toBeNull();
+  });
+
+  // ── Async ────────────────────────────────────────────────────────────────
+  it('does not throw when launchApp rejects', () => {
+    mockLaunchApp.mockRejectedValueOnce(new Error('launch failed'));
+    expect(() => submit('Open Calculator')).not.toThrow();
+    expect(mockLaunchApp).toHaveBeenCalledWith('com.iostoandroid.calculator');
+  });
+});


### PR DESCRIPTION
## Resumo

feat(siri): add SiriScreen with text-input command routing and wire the AssistiveTouch siri action to it

## Causa raiz

Não é um bug de regressão — é uma funcionalidade ausente, e o issue descreve-a corretamente. Dois mecanismos concretos:

1. `src/components/AssistiveTouch.tsx:232` fazia `case 'siri': navigate('SpotlightSearch'); break; // best-available analogue`. O item de menu `siri` existe no catálogo (`src/components/AssistiveTouch.tsx:47`, ícone `mic`), portanto o utilizador podia tocar em "Siri" e aterrava na busca Spotlight — um placeholder assumido em comentário.
2. Não existia qualquer superfície de assistente nem qualquer código que traduzisse um comando em ação. `RootStackParamList` (`src/navigation/types.ts`) não tinha rota `Siri` e o `Stack.Navigator` (`src/navigation/TabNavigator.tsx`) não registava nenhum ecrã correspondente.

**Desvio face ao issue (importante):** o issue diz que depende de #245, que exporta `parseCommand` em `src/assistant/commandParser.ts`. Esse ficheiro **não existe em `origin/main`** — confirmado com `git cat-file -e origin/main:src/assistant/commandParser.ts` → `does not exist`. O trabalho de #245 vive apenas no commit `7ba64e7` (branch não fundida). Sem o parser este slice não compila, por isso trouxe o parser e os seus testes desse commit para este branch (`src/assistant/commandParser.ts` + `src/assistant/__tests__/commandParser.test.ts`, cópias byte-a-byte de `7ba64e7`, sem modificações). Se #245 for fundida primeiro, estes dois ficheiros serão idênticos e o merge é trivial.

## O que mudou

- **`src/screens/SiriScreen.tsx`** (novo): ecrã `SiriScreen` (export nomeado) com botão Back, área de resposta centrada e um `TextInput` no fundo (`accessibilityLabel="Ask Siri"`, `returnKeyType="send"`). No `onSubmitEditing` chama `parseCommand(text)` e routeia: `OPEN_APP` → procura em `useApps().apps` (nome exato primeiro, depois substring case-insensitive) e chama `launchApp(packageName)`; `CALL_CONTACT` → `navigate('CallScreen', { name, number })`; `SEND_MESSAGE` → `navigate('Conversation', { address: phone })`; `WHAT_TIME` → resposta `It's <hora>`, sem navegação; `SET_ALARM`/`UNRECOGNIZED` → resposta "not supported yet", sem navegação. Sem match, escreve `Couldn't find ...` em vez de lançar. Exporta também `formatAssistantTime(date)`. Um `launchApp` rejeitado é apanhado, registado via `logger.warn` e convertido em resposta visível — não é engolido em silêncio.
- **`src/screens/__tests__/SiriScreen.test.tsx`** (novo): 17 testes (ver abaixo).
- **`src/navigation/types.ts`**: acrescenta `Siri: undefined;` a `RootStackParamList`, imediatamente depois de `SpotlightSearch`.
- **`src/navigation/TabNavigator.tsx`**: importa `SiriScreen` e registra `<Stack.Screen name="Siri" component={SiriScreen} options={{ animation: fadeAnimation, presentation: 'transparentModal' }} />` (mesmas opções que o Spotlight, para o assistente entrar por cima do ecrã atual como no iOS). A linha do `SpotlightSearch` fica intacta.
- **`src/components/AssistiveTouch.tsx`**: `case 'siri'` passa a `navigate('Siri')`; o comentário "best-available analogue" desaparece porque já não é verdade. O `case 'spotlight'` não é tocado.
- **`src/components/__tests__/AssistiveTouch.test.tsx`**: novo helper `EnableWithSiri` (o `siri` não está no `menuItems` por omissão — `src/store/AssistiveTouchStore.tsx:69`) e um bloco `describe('AssistiveTouch acção siri')` com dois testes: `siri` → `'Siri'`, e `spotlight` continua → `'SpotlightSearch'`.
- **`src/assistant/commandParser.ts`** e **`src/assistant/__tests__/commandParser.test.ts`** (novos): cópias exatas de `7ba64e7` (dependência #245 ausente de `main`, ver acima).

## Porque assim

- **Match de contacto** por `firstName`/`lastName`/nome completo, com igualdade exata antes de substring, para que "Call Alice" não seja capturado por um contacto cujo apelido contenha "alice". Descartei fuzzy matching à `SpotlightSearchScreen` (`fuzzyMatch`, score 0.5 para caracteres em ordem): num assistente que **liga** a alguém, um falso positivo é destrutivo — chama a pessoa errada.
- **Match de app** igual em espírito: exato → substring, conforme o issue pede.
- **`presentation: 'transparentModal'` + `fadeAnimation`**: consistente com o `SpotlightSearch`, ambos overlays de sistema. Alternativa descartada: `slideAnimation`, que faria o assistente parecer um ecrã de settings.
- **Sem microfone**: fora do âmbito deste slice, como o issue explicita.
- **`SET_ALARM` não abre o Clock**: o issue diz explicitamente que fica para uma issue posterior; abrir o ClockScreen seria inventar âmbito.
- **Nada de `any`, nada de `?? 0`**: o único `catch` é o do `launchApp`, e escreve o erro no `logger` **e** no ecrã.

## Critérios de aceitação

- [x] "Open Calculator" chama `launchApp('com.iostoandroid.calculator')` — teste `routes "Open Calculator" to launchApp with the Calculator package name`.
- [x] "Call Alice" navega para `CallScreen` com `{ name: 'Alice Anderson', number: '+1 (555) 100-0001' }` (número real do seed em `ContactsStore.tsx:21`).
- [x] "Send message to Alice" navega para `Conversation` com `{ address: '+1 (555) 100-0001' }`.
- [x] "What time is it" mostra `It's <hora>` e **não** navega nem lança app — verificado com `jest.useFakeTimers().setSystemTime(...)` para a hora ser determinística.
- [x] Nome de app/contacto sem match mostra `Couldn't find ...` e não lança nem navega (3 testes: app, contacto de chamada, contacto de mensagem).
- [x] `AssistiveTouch` `siri` → `'Siri'`, provado com passo vermelho abaixo.
- [x] **NÃO devia mudar:** `SpotlightSearchScreen.tsx` não foi tocado (não aparece em `git status`), a rota `SpotlightSearch` continua registada no `TabNavigator`, o `case 'spotlight'` continua a navegar para lá — coberto pelo teste `a acção Spotlight continua a navegar para SpotlightSearch`, e os 5 testes existentes de `SpotlightSearchScreen.test.tsx` continuam a passar.
- [x] **NÃO devia mudar:** os 9 testes preexistentes de `AssistiveTouch.test.tsx` passam sem alteração (só acrescentei um helper e um `describe`).
- [x] Sem regressões: 8 falhas antes, 8 falhas depois, exatamente as mesmas (ver Testes).

## Testes

**Passo vermelho 1 — `SiriScreen` (com o ecrã substituído por um stub que renderiza a superfície mas não routeia nada, i.e. o estado do issue):**

```
  ● SiriScreen › launches twice when the same command is submitted twice (no stale-state swallow)

    expect(jest.fn()).toHaveBeenCalledTimes(expected)

    Expected number of calls: 2
    Received number of calls: 0

      160 |     fireEvent.changeText(field, 'Open Calculator');
      161 |     fireEvent(field, 'submitEditing');
    > 162 |     expect(mockLaunchApp).toHaveBeenCalledTimes(2);
          |                           ^
      163 |   });

  ● SiriScreen › clears the previous "couldn't find" answer once a later command succeeds

    expect(received).toBeTruthy()

    Received: null

      169 |     fireEvent.changeText(field, 'Open Photoshop');
      170 |     fireEvent(field, 'submitEditing');
    > 171 |     expect(queryByText(/Couldn't find/i)).toBeTruthy();
          |                                           ^

  ● SiriScreen › does not throw when launchApp rejects

    expect(jest.fn()).toHaveBeenCalledWith(...expected)

    Expected: "com.iostoandroid.calculator"

    Number of calls: 0

      179 |     mockLaunchApp.mockRejectedValueOnce(new Error('launch failed'));
      180 |     expect(() => submit('Open Calculator')).not.toThrow();
    > 181 |     expect(mockLaunchApp).toHaveBeenCalledWith('com.iostoandroid.calculator');
          |                           ^

Test Suites: 1 failed, 1 total
Tests:       14 failed, 3 passed, 17 total
```

Usei um stub em vez de apagar o ficheiro de propósito: apagá-lo dá `Cannot find module '../SiriScreen'`, que é falha de resolução e **não** prova nada sobre comportamento. Com o stub (superfície presente, routing ausente) falham 14 dos 17 — exatamente os testes de routing — e passam só os 3 que apenas exigem a superfície (render, submit vazio, submit em branco). Isso liga cada teste de routing à unidade real.

**Passo vermelho 2 — `AssistiveTouch`, com `git stash push -- src/components/AssistiveTouch.tsx`:**

```
  AssistiveTouch acção siri
    ✕ tocar em Siri navega para Siri, não para SpotlightSearch (1068 ms)
    ✓ a acção Spotlight continua a navegar para SpotlightSearch (489 ms)

  ● AssistiveTouch acção siri › tocar em Siri navega para Siri, não para SpotlightSearch

    expect(jest.fn()).toHaveBeenCalledWith(...expected)

    Expected: "Siri"
    Received: "SpotlightSearch"

    Number of calls: 1

      286 |
      287 |     fireEvent.press(getByLabelText('Siri'));
    > 288 |     expect(navigationRef.navigate).toHaveBeenCalledWith('Siri');
          |                                    ^
      289 |     expect(navigationRef.navigate).not.toHaveBeenCalledWith('SpotlightSearch');

Test Suites: 1 failed, 1 total
Tests:       1 failed, 9 skipped, 1 passed, 11 total
```

Nota: o teste falha com `Received: "SpotlightSearch"` — o comportamento antigo, não um guard preexistente. Confirmei também que a rota `Siri` não existia em `main` (`RootStackParamList` sem ela) e que o comentário `// best-available analogue` estava lá.

**Casos cobertos além do caminho felizo (17 testes em `SiriScreen.test.tsx`):**
- *Vazio/fronteira:* submit com string vazia e submit só com espaços — nenhum dos dois navega, lança app ou escreve resposta (o parser devolveria `UNRECOGNIZED` para "   ", pelo que o guard tem de estar no ecrã, não no parser).
- *Não encontrado:* app inexistente, contacto inexistente para chamada, contacto inexistente para mensagem — três testes distintos porque são três ramos distintos do `switch`.
- *Matching:* app por substring minúscula (`"Open calcul"`), contacto por apelido (`"Call anderson"`).
- *Repetição:* o mesmo comando duas vezes seguidas lança **duas** vezes — o duplo-submit é o defeito recorrente deste repositório, e um `setText('')` mal colocado engoliria o segundo.
- *Inverso do fix:* `Couldn't find` desaparece quando um comando posterior tem êxito (a resposta não fica presa no ecrã).
- *Assíncrono:* `launchApp` que rejeita não faz o handler explodir.
- *WHAT_TIME:* hora fixada com `setSystemTime`, e asserção explícita de que não houve navegação nem launch.

**Sanity-check:** removi `src/screens/SiriScreen.tsx` e fiz `git stash` de `src/components/AssistiveTouch.tsx`, mantendo os testes. Resultado: `Test Suites: 2 failed, 2 total` / `Tests: 1 failed, 10 passed, 11 total` (a suite do SiriScreen nem corre — `Cannot find module`; a do AssistiveTouch falha no teste do `siri`). Restaurei ambos e reconfirmei: `Test Suites: 3 passed, 3 total` / `Tests: 57 passed, 57 total` (SiriScreen 17 + AssistiveTouch 11 + commandParser 29).

**Verificações:**
- `npm run lint`: **0 erros**, 2 warnings — os mesmos 2 preexistentes (`BridgeErrorReporting.test.tsx` e `ClockScreen.tsx:258`), nenhum em ficheiros que toquei. Baseline: 0 erros. **Não piorou.**
- `npx tsc --noEmit`: **limpo**, sem output. Baseline: limpo.
- `npm test -- --maxWorkers=2`: `Test Suites: 4 failed, 105 passed, 109 total` / `Tests: 8 failed, 813 passed, 821 total`. A baseline tem **8 falhas em 4 suites** e as 8 são exatamente as mesmas: `FoldersStore` (2), `LockScreen` (3), `SettingsScreen` (1), `WeatherScreen` (2) — todas o defeito conhecido do gate do `SettingsStore`. **Zero falhas novas.** (Uma primeira corrida deu 9/5 com uma falha de timing intermitente no `WeatherScreen`; a re-corrida deu 8/4, alinhado com a baseline, e nenhuma das falhas está em ficheiros que toquei.) Total de testes subiu de 720 para 821 — +101, dos quais 17 do SiriScreen, 2 do AssistiveTouch e 29 do parser importado.

## Testes

821 testes: 813 passaram, 8 falharam (as mesmas 8 da baseline, defeito do gate do SettingsStore), 109 suites. Novos: 17 em SiriScreen.test.tsx + 2 em AssistiveTouch.test.tsx, todos a passar.

## Linked Issue

Fixes #250