### PR TITLE
BackEdgeSwipe: reservar a faixa da margem esquerda contra o gesto de sistema Android via View nativa (setSystemGestureExclusionRects) (#511)

### DIFF
--- a/modules/launcher-module/android/src/main/java/com/iostoandroid/launcher/GestureExclusionRects.kt
+++ b/modules/launcher-module/android/src/main/java/com/iostoandroid/launcher/GestureExclusionRects.kt
@@ -1,0 +1,34 @@
+package com.iostoandroid.launcher
+
+/**
+ * Pure-JVM geometry for the system-gesture exclusion rect requested by
+ * [SystemGestureExclusionView]. Kept free of android.* imports so it can be
+ * unit-tested without a device (same pattern as [PhoneNumberValidator]).
+ *
+ * Android only honours ~200dp of exclusion height per edge and silently ignores
+ * the excess (documented behaviour of `View.setSystemGestureExclusionRects`), so
+ * there is no point asking for more than that: the returned rect is clamped to
+ * [MAX_EXCLUSION_HEIGHT_DP] * density pixels, anchored at the TOP of the view.
+ * Consequence, accepted per ESPECIFICACAO.md §6.4: on tall screens the lower
+ * part of the left margin stays claimable by the system gesture.
+ */
+object GestureExclusionRects {
+    /** Height, in dp, that Android is willing to exclude per edge. */
+    const val MAX_EXCLUSION_HEIGHT_DP = 200
+
+    /** A rect in view-local pixels: [left, top, right, bottom]. */
+    data class Rect(val left: Int, val top: Int, val right: Int, val bottom: Int)
+
+    /**
+     * The rect to exclude for a view of [width] x [height] pixels at [density]
+     * (pixels per dp). Returns `null` when there is nothing to exclude — a
+     * zero/negative sized view, which happens during the first layout pass.
+     */
+    fun forView(width: Int, height: Int, density: Float): Rect? {
+        if (width <= 0 || height <= 0) return null
+        val safeDensity = if (density > 0f) density else 1f
+        val maxPx = (MAX_EXCLUSION_HEIGHT_DP * safeDensity).toInt().coerceAtLeast(1)
+        val bottom = if (height < maxPx) height else maxPx
+        return Rect(0, 0, width, bottom)
+    }
+}

--- a/modules/launcher-module/android/src/main/java/com/iostoandroid/launcher/LauncherModule.kt
+++ b/modules/launcher-module/android/src/main/java/com/iostoandroid/launcher/LauncherModule.kt
@@ -67,6 +67,11 @@ class LauncherModule : Module() {
 
         Events("onNotificationPosted", "onNotificationRemoved", "onHomePressed")
 
+        // Native view that reserves its own bounds against the Android system
+        // gesture (see SystemGestureExclusionView). Used by BackEdgeSwipe's
+        // left-edge catcher; no props, geometry comes from layout.
+        View(SystemGestureExclusionView::class) {}
+
         // Register this module instance so NotificationService can route events through it.
         instance = this@LauncherModule
 

--- a/modules/launcher-module/android/src/main/java/com/iostoandroid/launcher/SystemGestureExclusionView.kt
+++ b/modules/launcher-module/android/src/main/java/com/iostoandroid/launcher/SystemGestureExclusionView.kt
@@ -1,0 +1,44 @@
+package com.iostoandroid.launcher
+
+import android.content.Context
+import android.graphics.Rect
+import android.os.Build
+import expo.modules.kotlin.AppContext
+import expo.modules.kotlin.views.ExpoView
+
+/**
+ * A zero-painting View whose only job is to tell Android "do not steal touches
+ * here" via `setSystemGestureExclusionRects`, so the app's left-edge swipe-back
+ * (src/components/BackEdgeSwipe.tsx) is not intercepted by the system back
+ * gesture before it ever reaches the app.
+ *
+ * `systemGestureExclusionRects` does NOT exist as a React Native `View` prop in
+ * react-native 0.81.5 (verified by grep over react-native,
+ * react-native-gesture-handler and react-native-screens) — a native view is the
+ * only supported route, and with Fabric enabled (app.json `newArchEnabled`)
+ * reaching the native View by hand through UIManager is not viable either.
+ *
+ * Known and accepted limitation (ESPECIFICACAO.md §6.4): Android honours only
+ * ~200dp of exclusion height per edge and ignores the excess, so the lower part
+ * of the left margin remains claimable by the system gesture. The rect is
+ * clamped accordingly by [GestureExclusionRects.forView] — asking for more is
+ * silently dropped, not additive.
+ *
+ * API < 29 (Android 10) has no such API: the call is skipped, no crash.
+ */
+class SystemGestureExclusionView(context: Context, appContext: AppContext) :
+    ExpoView(context, appContext) {
+
+    override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
+        super.onSizeChanged(w, h, oldw, oldh)
+        applyExclusion(w, h)
+    }
+
+    private fun applyExclusion(w: Int, h: Int) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) return
+        val rect = GestureExclusionRects.forView(w, h, resources.displayMetrics.density)
+        systemGestureExclusionRects =
+            if (rect == null) emptyList()
+            else listOf(Rect(rect.left, rect.top, rect.right, rect.bottom))
+    }
+}

--- a/modules/launcher-module/android/src/test/java/com/iostoandroid/launcher/GestureExclusionRectsTest.kt
+++ b/modules/launcher-module/android/src/test/java/com/iostoandroid/launcher/GestureExclusionRectsTest.kt
@@ -1,0 +1,53 @@
+package com.iostoandroid.launcher
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Pure-JVM unit tests for [GestureExclusionRects] — no android.* imports, runs
+ * without a device or the Android SDK (same pattern as [PhoneNumberValidatorTest]).
+ */
+class GestureExclusionRectsTest {
+
+    @Test
+    fun `covers the whole view when shorter than the android limit`() {
+        val rect = GestureExclusionRects.forView(width = 40, height = 300, density = 2f)!!
+        assertEquals(0, rect.left)
+        assertEquals(0, rect.top)
+        assertEquals(40, rect.right)
+        assertEquals(300, rect.bottom)
+    }
+
+    @Test
+    fun `clamps to ~200dp of height because android ignores the excess`() {
+        // density 2 → 200dp == 400px; a 2000px tall strip must not ask for more.
+        val rect = GestureExclusionRects.forView(width = 40, height = 2000, density = 2f)!!
+        assertEquals(400, rect.bottom)
+        assertEquals(0, rect.top)
+    }
+
+    @Test
+    fun `limit is exactly the boundary, and boundary plus one clamps`() {
+        assertEquals(400, GestureExclusionRects.forView(40, 400, 2f)!!.bottom)
+        assertEquals(400, GestureExclusionRects.forView(40, 401, 2f)!!.bottom)
+        assertEquals(399, GestureExclusionRects.forView(40, 399, 2f)!!.bottom)
+    }
+
+    @Test
+    fun `no rect for a view that has not been laid out yet`() {
+        assertNull(GestureExclusionRects.forView(0, 0, 2f))
+        assertNull(GestureExclusionRects.forView(40, 0, 2f))
+        assertNull(GestureExclusionRects.forView(0, 300, 2f))
+        assertNull(GestureExclusionRects.forView(-40, -300, 2f))
+    }
+
+    @Test
+    fun `absurd density values do not produce an empty or negative rect`() {
+        // density 0 is nonsense → treated as 1, i.e. 200dp == 200px.
+        assertEquals(200, GestureExclusionRects.forView(40, 900, 0f)!!.bottom)
+        assertEquals(200, GestureExclusionRects.forView(40, 900, -3f)!!.bottom)
+        // density 100 → limit far beyond the view, so the whole view is used.
+        assertEquals(900, GestureExclusionRects.forView(40, 900, 100f)!!.bottom)
+    }
+}

--- a/src/components/BackEdgeSwipe.tsx
+++ b/src/components/BackEdgeSwipe.tsx
@@ -14,6 +14,7 @@ import { pushSample, sampledVelocity, useVelocityBuffer } from '../utils/gesture
 import { commitForBack } from '../utils/gestureMachine';
 import { hapticSelection } from '../utils/haptics';
 import { settle, useGestureReduceMotion } from '../utils/useGestureReduceMotion';
+import { GestureExclusionView } from './GestureExclusionView';
 
 const { width: SCREEN_W } = Dimensions.get('window');
 
@@ -101,7 +102,7 @@ export function BackEdgeSwipe({ children }: { children: React.ReactNode }) {
   return (
     <View style={{ flex: 1 }}>
       <GestureDetector gesture={pan}>
-        <View
+        <GestureExclusionView
           style={styles.edgeCatch}
           collapsable={false}
           accessible={false}

--- a/src/components/GestureExclusionView.tsx
+++ b/src/components/GestureExclusionView.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Platform, View, type ViewProps } from 'react-native';
+import { requireNativeView } from 'expo';
+
+/**
+ * Left-edge touch catcher that also reserves its own bounds against the Android
+ * system gesture, so the app's swipe-back is not swallowed by the system back
+ * gesture before the touch is ever dispatched to the app.
+ *
+ * Why a native view: `systemGestureExclusionRects` is NOT a React Native `View`
+ * prop in react-native 0.81.5 (verified by grep over react-native,
+ * react-native-gesture-handler and react-native-screens), so the exclusion can
+ * only be requested from a native View — see
+ * modules/launcher-module/android/.../SystemGestureExclusionView.kt, which calls
+ * `setSystemGestureExclusionRects` on every layout (rotation, split-screen).
+ *
+ * Known and accepted limitation (ESPECIFICACAO.md §6.4): Android honours only
+ * ~200dp of exclusion height per edge and ignores the excess, so the lower part
+ * of the left margin stays claimable by the system gesture. Also a no-op below
+ * API 29, where the platform API does not exist.
+ *
+ * On any non-Android platform there is nothing to exclude, so this degrades to a
+ * plain `View` with the same props.
+ */
+const NativeGestureExclusionView =
+  Platform.OS === 'android'
+    ? requireNativeView<ViewProps>('LauncherModule', 'SystemGestureExclusionView')
+    : null;
+
+export function GestureExclusionView(props: ViewProps) {
+  if (NativeGestureExclusionView) {
+    return <NativeGestureExclusionView {...props} />;
+  }
+  return <View {...props} />;
+}

--- a/src/components/__tests__/BackEdgeSwipe.test.tsx
+++ b/src/components/__tests__/BackEdgeSwipe.test.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { Text } from 'react-native';
+import { render } from '../../test-utils';
+
+const mockCanGoBack = jest.fn(() => true);
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ canGoBack: mockCanGoBack, goBack: jest.fn(), navigate: jest.fn() }),
+}));
+
+// The real component resolves a native view manager that only exists on a
+// device; here it is replaced by a marker so we can assert BackEdgeSwipe mounts
+// IT for the edge catcher, and not a plain <View>.
+jest.mock('../GestureExclusionView', () => {
+  const ReactActual = jest.requireActual('react');
+  const RN = jest.requireActual('react-native');
+  return {
+    GestureExclusionView: (props: Record<string, unknown>) =>
+      ReactActual.createElement(RN.View, { testID: 'gesture-exclusion', ...props }),
+  };
+});
+
+import { BackEdgeSwipe } from '../BackEdgeSwipe';
+import { gestureConfig } from '../../utils/gestureConfig';
+
+// The edge catcher is deliberately hidden from accessibility
+// (importantForAccessibility="no-hide-descendants"), so queries must opt in.
+const HIDDEN = { includeHiddenElements: true } as const;
+
+describe('BackEdgeSwipe system gesture exclusion', () => {
+  beforeEach(() => {
+    mockCanGoBack.mockReturnValue(true);
+  });
+
+  it('renders the edge catcher as the gesture-exclusion view when it can go back', () => {
+    const { getByTestId } = render(
+      <BackEdgeSwipe>
+        <Text>child</Text>
+      </BackEdgeSwipe>,
+    );
+    expect(getByTestId('gesture-exclusion', HIDDEN)).toBeTruthy();
+  });
+
+  it('gives the exclusion view the full-height left edge strip', () => {
+    const { getByTestId } = render(
+      <BackEdgeSwipe>
+        <Text>child</Text>
+      </BackEdgeSwipe>,
+    );
+    const style = getByTestId('gesture-exclusion', HIDDEN).props.style;
+    const flat = Array.isArray(style) ? Object.assign({}, ...style) : style;
+    expect(flat).toMatchObject({
+      position: 'absolute',
+      left: 0,
+      top: 0,
+      bottom: 0,
+      width: gestureConfig.leftEdgeWidthDp,
+    });
+  });
+
+  // Inverse of the fix: nothing may be excluded on screens with no back target,
+  // otherwise we would steal the system gesture on root screens for nothing.
+  it('renders no exclusion view when there is nothing to go back to', () => {
+    mockCanGoBack.mockReturnValue(false);
+    const { queryByTestId, getByText } = render(
+      <BackEdgeSwipe>
+        <Text>child</Text>
+      </BackEdgeSwipe>,
+    );
+    expect(queryByTestId('gesture-exclusion', HIDDEN)).toBeNull();
+    expect(getByText('child')).toBeTruthy();
+  });
+
+  // Repetition: mounting twice (screen pushed, popped, pushed again) must keep
+  // producing exactly one exclusion strip, never zero and never a duplicate.
+  it('mounts exactly one exclusion view per render, twice in a row', () => {
+    const first = render(
+      <BackEdgeSwipe>
+        <Text>child</Text>
+      </BackEdgeSwipe>,
+    );
+    expect(first.getAllByTestId('gesture-exclusion', HIDDEN)).toHaveLength(1);
+    first.unmount();
+    const second = render(
+      <BackEdgeSwipe>
+        <Text>child</Text>
+      </BackEdgeSwipe>,
+    );
+    expect(second.getAllByTestId('gesture-exclusion', HIDDEN)).toHaveLength(1);
+  });
+
+  it('keeps rendering children alongside the exclusion view', () => {
+    const { getByText } = render(
+      <BackEdgeSwipe>
+        <Text>child</Text>
+      </BackEdgeSwipe>,
+    );
+    expect(getByText('child')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Resumo

BackEdgeSwipe: reservar a faixa da margem esquerda contra o gesto de sistema Android via View nativa (setSystemGestureExclusionRects)

## Causa raiz

Em modo de navegação por gestos, o Android intercepta os toques na faixa de borda ao nível do dispatch de input do `Window`, **antes** de qualquer `View` da app os receber — excepto nas zonas que a app declarou nesse frame via `View.setSystemGestureExclusionRects()`.

`src/components/BackEdgeSwipe.tsx:52-55` monta um `Gesture.Pan()` com `hitSlop({ left: 0, width: gestureConfig.leftEdgeWidthDp })` (20dp, `src/utils/gestureConfig.ts:7`), activo sempre que `navigation.canGoBack()` (`:29`, `:53`), mas a View apanha-toques (`BackEdgeSwipe.tsx:100-105`) era uma `View` genérica do React Native, que **não declara nenhuma exclusion rect**. A app nunca ganha a corrida por design; a "intermitência" descrita no issue é variação da largura da faixa por fabricante e da posição vertical do toque, não uma disputa aleatória.

O issue estava errado em dois pontos e o código ganhou:

1. Descrevia `systemGestureExclusionRects` como "a prop que o RN expõe na View em Android". **Não existe** — `grep -ril "GestureExclusion" node_modules/react-native/ node_modules/react-native-gesture-handler/ node_modules/react-native-screens/` dá zero na versão instalada (RN 0.81.5). O caminho (a), dado como "Pequeno", exige uma View nativa via Expo Modules.
2. Exigia, como gate antes de escrever código, medir a taxa de captura num dispositivo Android físico. Esse gate é estruturalmente impossível neste pipeline (sem `adb`, sem `emulator`, sem AVD; a captura é comportamento de dispatch do SO, não reproduzível em `jest-expo`/Node) e manteria o issue bloqueado em qualquer corrida futura. Seguindo a análise do curator, implementei directamente o caminho (a) — aditivo e reversível — e documentei o limite dos ~200dp em vez de o medir. Caminhos (b)/(c) descartados: desfariam a decisão deliberada de #231/GEST-06 e exigem aprovação de produto que este issue não tem.

Além disso, `app.json:9` tem `newArchEnabled: true` (Fabric), o que exclui aceder à View nativa por `UIManager.resolveView`/reflection.

## O que mudou

- **`modules/launcher-module/android/src/main/java/com/iostoandroid/launcher/GestureExclusionRects.kt`** (novo): objecto puro-JVM, sem imports `android.*`, que calcula o rect a excluir a partir de `width`/`height`/`density`. Devolve `null` para dimensões <= 0 (primeiro passe de layout) e **limita a altura a `MAX_EXCLUSION_HEIGHT_DP = 200` dp**, ancorada no topo, porque o Android ignora o excedente. Densidade <= 0 cai para 1f; o clamp nunca desce abaixo de 1px.
- **`modules/launcher-module/android/src/main/java/com/iostoandroid/launcher/SystemGestureExclusionView.kt`** (novo): `ExpoView` que não pinta nada e, em `onSizeChanged` (portanto reaplicado em rotação e split-screen, sem assumir altura fixa de ecrã), chama `setSystemGestureExclusionRects` com o rect calculado. Guardado por `Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q` (API 29) — abaixo disso é no-op silencioso, não crash.
- **`modules/launcher-module/android/src/main/java/com/iostoandroid/launcher/LauncherModule.kt`**: registo `View(SystemGestureExclusionView::class) {}` na definição do módulo (5 linhas adicionadas, nada removido nem alterado).
- **`modules/launcher-module/android/src/test/java/com/iostoandroid/launcher/GestureExclusionRectsTest.kt`** (novo): teste JVM puro do cálculo do rect, no padrão de `PhoneNumberValidatorTest.kt`.
- **`src/components/GestureExclusionView.tsx`** (novo): wrapper JS que resolve a View nativa com `requireNativeView('LauncherModule', 'SystemGestureExclusionView')` apenas quando `Platform.OS === 'android'`, e degrada para `<View {...props} />` em qualquer outra plataforma. Comentário no ficheiro documenta a inexistência da prop RN e o limite dos ~200dp.
- **`src/components/BackEdgeSwipe.tsx`**: duas linhas — o import, e a View apanha-toques passa de `<View>` para `<GestureExclusionView>`, mantendo `styles.edgeCatch`, `collapsable={false}`, `accessible={false}` e o resto das props. O `GestureDetector`, o `Gesture.Pan()`, `enabled(canGo)` e o early-return `if (!canGo)` ficam intactos.
- **`src/components/__tests__/BackEdgeSwipe.test.tsx`** (novo): 5 testes.

## Porque assim

View nativa via Expo Modules API é a única via suportada: a prop JS não existe, e com Fabric activo o acesso por `UIManager` não é fiável. Reutilizei o `launcher-module` já existente em vez de criar um módulo novo — menos superfície de configuração de build, e o módulo já é carregado pela app.

O clamp aos 200dp vive num objecto puro sem `android.*` precisamente para ser testável sem dispositivo nem Gradle instrumentation; a chamada real ao SO fica isolada na View, que é a única parte não testável em JVM.

Alternativas descartadas: prop `systemGestureExclusionRects` em `<View>` (não existe); reflection/`UIManager` (Fabric); reduzir ou remover o `BackEdgeSwipe` (decisão de produto, fora do âmbito).

## Critérios de aceitação

- [x] Exclusão aplicada via View nativa Kotlin/Expo Modules, não prop JS — `SystemGestureExclusionView.kt`, registada em `LauncherModule.kt`.
- [x] O rect cobre a faixa da margem esquerda com a largura de `gestureConfig.leftEdgeWidthDp` (a View herda `styles.edgeCatch`: `left:0, top:0, bottom:0, width: leftEdgeWidthDp`) e a altura visível **limitada aos 200dp** que o Android honra; teste `gives the exclusion view the full-height left edge strip` verifica o estilo propagado.
- [x] Chamada protegida por `Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q` (29); abaixo disso não faz nada e não rebenta — `SystemGestureExclusionView.applyExclusion`.
- [x] Limite dos ~200dp documentado em comentário no código (`GestureExclusionRects.kt`, `SystemGestureExclusionView.kt`, `GestureExclusionView.tsx`) e neste PR: acima dessa altura o Android ignora o excedente, logo **a parte inferior da margem esquerda continua a poder ser roubada pelo gesto de sistema**. Limitação aceite pela §6.4, não bug desta corrida.
- [x] `Gesture.Pan()`, `src/utils/gestureConfig.ts`, `src/utils/gestureMachine.ts` e `app.json` inalterados — nenhum aparece no `git diff --name-only origin/main...HEAD`; `predictiveBackGestureEnabled` intocado.
- [x] Back físico / 3 botões sem regressão: nada no caminho do `BackHandler` foi tocado, e a exclusion rect só afecta o dispatch do gesto de borda em modo de gestos. Em modo de 3 botões o Android não reclama faixa de borda, logo a rect é inócua. Suite completa nos mesmos 8 falhados do baseline (nenhum em #437/#446).
- [x] Nenhum código de `BackEdgeSwipe` removido: `enabled(canGo)` e `if (!canGo)` mantêm-se; o diff do ficheiro são +2/-1 linhas.

## Testes

**Passo vermelho** (teste escrito, fix de produção revertido com `git checkout origin/main -- src/components/BackEdgeSwipe.tsx`, mantendo `GestureExclusionView.tsx` para o `jest.mock` resolver):

```
    Unable to find an element with testID: gesture-exclusion

    <View>
      <View>
        <View
          accessible={false}
          importantForAccessibility="no-hide-descendants"
        />
      </View>
      <View>
        <Text>
          child
        </Text>
      </View>
      ...
    </View>

      79 |       </BackEdgeSwipe>,
      80 |     );
    > 81 |     expect(first.getAllByTestId('gesture-exclusion', HIDDEN)).toHaveLength(1);
         |                  ^

      at Object.getAllByTestId (src/components/__tests__/BackEdgeSwipe.test.tsx:81:18)

Test Suites: 1 failed, 1 total
Tests:       3 failed, 2 passed, 5 total
```

Falhavam `renders the edge catcher as the gesture-exclusion view when it can go back`, `gives the exclusion view the full-height left edge strip` e `mounts exactly one exclusion view per render, twice in a row` — exactamente pela razão certa: a árvore renderizada mostra a `View` genérica sem exclusão. (Numa primeira tentativa removi também `GestureExclusionView.tsx` e a suite falhou por `Cannot find module` — módulo em falta, não o defeito; repeti sem remover o ficheiro para obter o vermelho legítimo acima.)

Com o fix reposto:

```
Test Suites: 1 passed, 1 total
Tests:       5 passed, 5 total
```

**Casos cobertos** além do caminho feliz:
- **O inverso do fix** — `renders no exclusion view when there is nothing to go back to`: com `canGoBack() === false` não pode existir nenhuma faixa de exclusão, senão roubávamos o gesto de sistema em ecrãs de raiz sem ganho nenhum.
- **Repetição** — `mounts exactly one exclusion view per render, twice in a row`: montar, desmontar e montar outra vez (push/pop/push de ecrã) tem de dar sempre exactamente uma faixa, nunca zero nem duplicada.
- **Não-regressão de conteúdo** — `keeps rendering children alongside the exclusion view`.
- **Fronteiras e vazios do rect** (Kotlin, `GestureExclusionRectsTest.kt`): `width`/`height` a 0 e negativos devolvem `null` (primeiro passe de layout); altura menor que o máximo devolve a altura inteira; altura maior é cortada nos 200dp; densidade 0/negativa não produz rect degenerado.
- **API < 29** — coberto pelo guard `Build.VERSION.SDK_INT`; a lógica de geometria é testada em JVM e a chamada ao SO fica atrás do guard.
- Limitação honesta: `GestureExclusionRectsTest.kt` é um teste JVM puro no padrão de `PhoneNumberValidatorTest.kt` e **não foi executado nesta corrida** — não há Gradle/JDK configurado no worktree headless. Não afirmo que passou. A suite Jest é a prova que corri.
- Não existe (nem é possível aqui) teste automático que meça a taxa de captura pelo SO.

**Sanity-check:** revertido `src/components/BackEdgeSwipe.tsx` para `origin/main` mantendo os testes → 3 testes falharam (output acima); `git checkout HEAD -- src/components/BackEdgeSwipe.tsx` restaurou e os 5 passam. Sem o fix, os testes falham.

**Verificações** (baseline em `main` `51c1509`: 0 erros de lint, tsc limpo, 8/720 testes a falhar em 4 suites):
- `npm run lint` → `✖ 2 problems (0 errors, 2 warnings)` — 0 erros, warnings pré-existentes em `BridgeErrorReporting.test.tsx` e `ClockScreen.tsx`, ficheiros que não toquei.
- `npx tsc --noEmit` → limpo, sem output. Nenhum `any` novo.
- `npm test -- --maxWorkers=2` → `Test Suites: 4 failed, 104 passed, 108 total` / `Tests: 8 failed, 770 passed, 778 total`. **Exactamente as mesmas 8 falhas do baseline, nas mesmas 4 suites** (causa conhecida: `SettingsStore.tsx` `if (!firstSyncDone) return null`). Zero falhas novas; os 5 testes desta corrida passam.

## Testes

770 passaram, 8 falharam (as mesmas 8 do baseline), 108 suites; os 5 testes novos de BackEdgeSwipe passam

## Linked Issue

Fixes #511