### PR TITLE
Adiciona BrowserScreen (WebView + barra de endereço) com resolveUrl scheme/host/search, regista rota Browser e ícone compasso no ecrã principal (#247)

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -322,3 +322,23 @@ jest.mock('react-native/src/private/specs_DEPRECATED/modules/NativePermissionsAn
     requestMultiplePermissions: jest.fn(() => Promise.resolve({})),
   },
 }));
+
+// Mock react-native-webview: it calls TurboModuleRegistry.getEnforcing('RNCWebViewModule')
+// at import time, which throws in the JS-only test environment. The mock keeps the
+// component contract (source/testID props + an imperative reload()) so screens that
+// render a WebView can be asserted on.
+jest.mock('react-native-webview', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  const WebView = React.forwardRef((props, ref) => {
+    React.useImperativeHandle(ref, () => ({
+      reload: jest.fn(),
+      goBack: jest.fn(),
+      goForward: jest.fn(),
+      stopLoading: jest.fn(),
+    }));
+    return React.createElement(View, props);
+  });
+  WebView.displayName = 'WebView';
+  return { __esModule: true, WebView, default: WebView };
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "iostoandroid",
-  "version": "1.15.8",
+  "version": "1.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "iostoandroid",
-      "version": "1.15.8",
+      "version": "1.20.0",
       "dependencies": {
         "@expo/vector-icons": "15.0.3",
         "@react-native-async-storage/async-storage": "^3.0.2",
@@ -41,7 +41,8 @@
         "react-native-gesture-handler": "~2.28.0",
         "react-native-reanimated": "~4.1.1",
         "react-native-safe-area-context": "~5.6.0",
-        "react-native-screens": "~4.16.0"
+        "react-native-screens": "~4.16.0",
+        "react-native-webview": "^13.16.0"
       },
       "devDependencies": {
         "@testing-library/react-native": "^13.3.3",
@@ -12950,6 +12951,20 @@
         "react-freeze": "^1.0.0",
         "react-native-is-edge-to-edge": "^1.2.1",
         "warn-once": "^0.1.0"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-webview": {
+      "version": "13.16.0",
+      "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-13.16.0.tgz",
+      "integrity": "sha512-Nh13xKZWW35C0dbOskD7OX01nQQavOzHbCw9XoZmar4eXCo7AvrYJ0jlUfRVVIJzqINxHlpECYLdmAdFsl9xDA==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0",
+        "invariant": "2.2.4"
       },
       "peerDependencies": {
         "react": "*",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "react-native-gesture-handler": "~2.28.0",
     "react-native-reanimated": "~4.1.1",
     "react-native-safe-area-context": "~5.6.0",
-    "react-native-screens": "~4.16.0"
+    "react-native-screens": "~4.16.0",
+    "react-native-webview": "^13.16.0"
   },
   "devDependencies": {
     "@testing-library/react-native": "^13.3.3",

--- a/src/navigation/TabNavigator.tsx
+++ b/src/navigation/TabNavigator.tsx
@@ -62,6 +62,7 @@ import { NotesScreen } from '../screens/NotesScreen';
 import { MapsScreen } from '../screens/MapsScreen';
 import { RemindersScreen } from '../screens/RemindersScreen';
 import { MailScreen } from '../screens/MailScreen';
+import { BrowserScreen } from '../screens/BrowserScreen';
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
 
@@ -105,6 +106,7 @@ export function TabNavigator() {
       <Stack.Screen name="Maps" component={MapsScreen} options={{ animation }} />
       <Stack.Screen name="Reminders" component={RemindersScreen} options={{ animation }} />
       <Stack.Screen name="Mail" component={MailScreen} options={{ animation }} />
+      <Stack.Screen name="Browser" component={BrowserScreen} options={{ animation }} />
 
       {/* Settings app — zoom up on entry, push for sub-screens like iOS */}
       <Stack.Screen name="Settings" component={SettingsScreen} options={{ animation }} />

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -26,6 +26,7 @@ export type RootStackParamList = {
   Notes: undefined;
   Maps: undefined;
   Reminders: undefined;
+  Browser: undefined;
   Mail: { composeTo?: string; composeSubject?: string; composeBody?: string } | undefined;
 
   // Settings

--- a/src/screens/BrowserScreen.tsx
+++ b/src/screens/BrowserScreen.tsx
@@ -1,0 +1,182 @@
+import React, { useState, useRef, useCallback } from 'react';
+import {
+  View,
+  Text,
+  TextInput,
+  StyleSheet,
+  Pressable,
+  ActivityIndicator,
+} from 'react-native';
+import { WebView } from 'react-native-webview';
+import { Ionicons } from '@expo/vector-icons';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useTheme } from '../theme/ThemeContext';
+import type { CupertinoColors } from '../theme/CupertinoTheme';
+import { Typography } from '../theme/CupertinoTheme';
+import type { AppNavigationProp } from '../navigation/types';
+import { hapticImpact } from '../utils/haptics';
+
+// ─── Constants ──────────────────────────────────────────────────────────────
+
+export const BROWSER_HOME_URL = 'https://www.google.com';
+const SEARCH_PREFIX = 'https://www.google.com/search?q=';
+const BROWSER_ACCENT = '#007AFF';
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+/**
+ * Turn whatever the user typed in the address bar into a URL to load.
+ *
+ * - empty / whitespace-only → '' (caller must not navigate)
+ * - already has a scheme ('://') → used as-is
+ * - looks like a host (contains a '.' with non-empty labels on both sides and
+ *   no whitespace) → prefixed with 'https://'
+ * - anything else → a Google search for the literal text
+ *
+ * The host test deliberately requires a non-empty label each side of the dot:
+ * 'what.' or '.' are search terms, not hosts, and a term with a space
+ * ('node.js tutorial') is a search even though it contains a dot.
+ */
+export function resolveUrl(input: string): string {
+  const trimmed = input.trim();
+  if (!trimmed) return '';
+  if (trimmed.includes('://')) return trimmed;
+
+  const hostCandidate = trimmed.split(/[/?#]/, 1)[0];
+  const looksLikeHost =
+    !/\s/.test(trimmed) && /^[^\s.]+(\.[^\s.]+)+$/.test(hostCandidate);
+  if (looksLikeHost) return `https://${trimmed}`;
+
+  return `${SEARCH_PREFIX}${encodeURIComponent(trimmed)}`;
+}
+
+// ─── Screen ─────────────────────────────────────────────────────────────────
+
+export function BrowserScreen({ navigation }: { navigation: AppNavigationProp }) {
+  const { theme } = useTheme();
+  const { colors } = theme;
+  const insets = useSafeAreaInsets();
+  const styles = React.useMemo(() => createStyles(colors), [colors]);
+
+  const [inputUrl, setInputUrl] = useState(BROWSER_HOME_URL);
+  const [currentUrl, setCurrentUrl] = useState(BROWSER_HOME_URL);
+  const [loading, setLoading] = useState(false);
+  const [progress, setProgress] = useState(0);
+  const webviewRef = useRef<WebView>(null);
+
+  const handleSubmit = useCallback(() => {
+    const next = resolveUrl(inputUrl);
+    if (!next) return;
+    setCurrentUrl(next);
+  }, [inputUrl]);
+
+  const handleBack = useCallback(() => {
+    hapticImpact();
+    navigation.goBack();
+  }, [navigation]);
+
+  const handleReload = useCallback(() => {
+    webviewRef.current?.reload();
+  }, []);
+
+  return (
+    <View style={[styles.container, { paddingTop: insets.top }]}>
+      <View style={styles.topBar}>
+        <Pressable
+          onPress={handleBack}
+          hitSlop={8}
+          accessibilityLabel="Go back"
+          accessibilityRole="button"
+        >
+          <Ionicons name="chevron-back" size={28} color={BROWSER_ACCENT} />
+        </Pressable>
+        <TextInput
+          style={styles.addressBar}
+          value={inputUrl}
+          onChangeText={setInputUrl}
+          onSubmitEditing={handleSubmit}
+          placeholder="Search or enter website name"
+          placeholderTextColor={colors.secondaryLabel}
+          autoCapitalize="none"
+          autoCorrect={false}
+          keyboardType="url"
+          returnKeyType="go"
+          selectTextOnFocus
+          accessibilityLabel="Address bar"
+        />
+        <Pressable
+          onPress={handleSubmit}
+          hitSlop={8}
+          accessibilityLabel="Go"
+          accessibilityRole="button"
+        >
+          <Text style={styles.goText}>Go</Text>
+        </Pressable>
+        <Pressable
+          onPress={handleReload}
+          hitSlop={8}
+          accessibilityLabel="Reload page"
+          accessibilityRole="button"
+        >
+          <Ionicons name="refresh" size={22} color={BROWSER_ACCENT} />
+        </Pressable>
+      </View>
+
+      {loading ? (
+        <View style={styles.progressTrack}>
+          <View
+            testID="browser-progress"
+            style={[styles.progressBar, { width: `${Math.round(progress * 100)}%` }]}
+          />
+        </View>
+      ) : null}
+
+      <WebView
+        ref={webviewRef}
+        testID="browser-webview"
+        source={{ uri: currentUrl }}
+        style={styles.webview}
+        onLoadStart={() => {
+          setLoading(true);
+          setProgress(0);
+        }}
+        onLoadProgress={({ nativeEvent }) => setProgress(nativeEvent.progress)}
+        onLoadEnd={() => {
+          setLoading(false);
+          setProgress(1);
+        }}
+        startInLoadingState
+        renderLoading={() => <ActivityIndicator color={BROWSER_ACCENT} />}
+      />
+    </View>
+  );
+}
+
+// ─── Styles ─────────────────────────────────────────────────────────────────
+
+function createStyles(colors: CupertinoColors) {
+  return StyleSheet.create({
+    container: { flex: 1, backgroundColor: colors.systemBackground },
+    topBar: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 8,
+      paddingHorizontal: 12,
+      paddingVertical: 8,
+      backgroundColor: colors.secondarySystemBackground,
+    },
+    addressBar: {
+      flex: 1,
+      height: 36,
+      borderRadius: 10,
+      paddingHorizontal: 12,
+      backgroundColor: colors.tertiarySystemBackground,
+      color: colors.label,
+      ...Typography.body,
+    },
+    goText: { ...Typography.body, color: BROWSER_ACCENT, fontWeight: '600' },
+    progressTrack: { height: 2, backgroundColor: 'transparent' },
+    progressBar: { height: 2, backgroundColor: BROWSER_ACCENT },
+    webview: { flex: 1 },
+  });
+}

--- a/src/screens/LauncherHomeScreen.tsx
+++ b/src/screens/LauncherHomeScreen.tsx
@@ -102,7 +102,7 @@ export function computeWallpaperTranslateX(
 }
 
 // Built-in app routing: packageName → navigation screen name
-const BUILT_IN_APPS: Record<string, keyof RootStackParamList> = {
+export const BUILT_IN_APPS: Record<string, keyof RootStackParamList> = {
   'com.iostoandroid.phone': 'Phone',
   'com.iostoandroid.messages': 'Messages',
   'com.iostoandroid.contacts': 'Contacts',
@@ -116,6 +116,7 @@ const BUILT_IN_APPS: Record<string, keyof RootStackParamList> = {
   'com.iostoandroid.notes': 'Notes',
   'com.iostoandroid.reminders': 'Reminders',
   'com.iostoandroid.mail': 'Mail',
+  'com.iostoandroid.browser': 'Browser',
 };
 
 // Known Android packages that duplicate a built-in app (issue #438).
@@ -150,7 +151,7 @@ export const BUILT_IN_DUPLICATE_PACKAGES: ReadonlySet<string> = new Set(
 );
 
 // Icon config for virtual (built-in) apps rendered in dock/grid
-const VIRTUAL_ICON_CONFIG: Record<string, {
+export const VIRTUAL_ICON_CONFIG: Record<string, {
   icon: keyof typeof Ionicons.glyphMap;
   bg: string;
   gradient?: [string, string];
@@ -169,6 +170,7 @@ const VIRTUAL_ICON_CONFIG: Record<string, {
   'com.iostoandroid.notes': { icon: 'document-text', bg: '#FFCC00', gradient: ['#FFD60A', '#FFB300'], iconSize: 32 },
   'com.iostoandroid.reminders': { icon: 'checkmark-circle', bg: '#5E5CE6', gradient: ['#7D7AFF', '#5E5CE6'], iconSize: 32 },
   'com.iostoandroid.mail': { icon: 'mail', bg: '#0A84FF', gradient: ['#409CFF', '#0071E3'], iconSize: 30 },
+  'com.iostoandroid.browser': { icon: 'compass', bg: '#007AFF', gradient: ['#409CFF', '#0071E3'], iconSize: 34 },
 };
 
 // ---------------------------------------------------------------------------

--- a/src/screens/__tests__/BrowserScreen.test.tsx
+++ b/src/screens/__tests__/BrowserScreen.test.tsx
@@ -1,0 +1,142 @@
+import React from 'react';
+import { render, fireEvent } from '../../test-utils';
+import { BrowserScreen, resolveUrl, BROWSER_HOME_URL } from '../BrowserScreen';
+import { BUILT_IN_APPS, VIRTUAL_ICON_CONFIG } from '../LauncherHomeScreen';
+
+const nav = { navigate: jest.fn(), goBack: jest.fn() } as never;
+
+beforeEach(() => jest.clearAllMocks());
+
+function submitAddress(input: string) {
+  const utils = render(<BrowserScreen navigation={nav} />);
+  const bar = utils.getByPlaceholderText('Search or enter website name');
+  fireEvent.changeText(bar, input);
+  fireEvent(bar, 'submitEditing');
+  return utils;
+}
+
+function webviewUri(utils: ReturnType<typeof render>): string {
+  const webview = utils.getByTestId('browser-webview');
+  return (webview.props.source as { uri: string }).uri;
+}
+
+describe('BrowserScreen — address bar + WebView', () => {
+  it('renders an address bar and a WebView pointing at the home URL', () => {
+    const utils = render(<BrowserScreen navigation={nav} />);
+    expect(utils.getByPlaceholderText('Search or enter website name')).toBeTruthy();
+    expect(webviewUri(utils)).toBe(BROWSER_HOME_URL);
+  });
+
+  it('navigates to a Google search URL for a bare search term', () => {
+    const utils = submitAddress('cats');
+    expect(webviewUri(utils)).toBe('https://www.google.com/search?q=cats');
+  });
+
+  it('percent-encodes multi-word search terms', () => {
+    const utils = submitAddress('black cats');
+    expect(webviewUri(utils)).toBe('https://www.google.com/search?q=black%20cats');
+  });
+
+  it('prefixes https:// on a bare domain', () => {
+    const utils = submitAddress('example.com');
+    expect(webviewUri(utils)).toBe('https://example.com');
+  });
+
+  it('keeps an explicit scheme untouched', () => {
+    const utils = submitAddress('http://example.com/path?a=1');
+    expect(webviewUri(utils)).toBe('http://example.com/path?a=1');
+  });
+
+  it('goes back when the back button is pressed', () => {
+    const utils = render(<BrowserScreen navigation={nav} />);
+    fireEvent.press(utils.getByLabelText('Go back'));
+    expect((nav as unknown as { goBack: jest.Mock }).goBack).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('BrowserScreen — the Go button', () => {
+  it('navigates on Go press, same as submitEditing', () => {
+    const utils = render(<BrowserScreen navigation={nav} />);
+    fireEvent.changeText(utils.getByPlaceholderText('Search or enter website name'), 'example.org');
+    fireEvent.press(utils.getByLabelText('Go'));
+    expect(webviewUri(utils)).toBe('https://example.org');
+  });
+});
+
+describe('resolveUrl — boundaries, empties, hostile input', () => {
+  it('returns empty string for an empty or whitespace-only input', () => {
+    expect(resolveUrl('')).toBe('');
+    expect(resolveUrl('   ')).toBe('');
+  });
+
+  it('trims surrounding whitespace before deciding', () => {
+    expect(resolveUrl('  example.com  ')).toBe('https://example.com');
+  });
+
+  it('treats a term containing spaces as a search even when it has a dot', () => {
+    expect(resolveUrl('node.js tutorial')).toBe('https://www.google.com/search?q=node.js%20tutorial');
+  });
+
+  it('searches for a trailing-dot-only term rather than building a bogus host', () => {
+    expect(resolveUrl('what.')).toBe('https://www.google.com/search?q=what.');
+    expect(resolveUrl('.')).toBe('https://www.google.com/search?q=.');
+  });
+
+  it('encodes characters that would break the query string', () => {
+    expect(resolveUrl('a&b=c#d')).toBe('https://www.google.com/search?q=a%26b%3Dc%23d');
+  });
+
+  it('preserves an about:blank-style scheme rather than searching for it', () => {
+    expect(resolveUrl('https://sub.domain.co.uk:8443/x')).toBe('https://sub.domain.co.uk:8443/x');
+  });
+});
+
+describe('BrowserScreen — empty submit is inert (the inverse of the fix)', () => {
+  it('does not change the WebView URL when the address bar is emptied and submitted', () => {
+    const utils = submitAddress('   ');
+    expect(webviewUri(utils)).toBe(BROWSER_HOME_URL);
+  });
+
+  it('submitting the same term twice keeps the same URL (double tap)', () => {
+    const utils = render(<BrowserScreen navigation={nav} />);
+    const bar = utils.getByPlaceholderText('Search or enter website name');
+    fireEvent.changeText(bar, 'example.com');
+    fireEvent(bar, 'submitEditing');
+    fireEvent(bar, 'submitEditing');
+    expect(webviewUri(utils)).toBe('https://example.com');
+  });
+});
+
+describe('home-screen registration', () => {
+  it('registers the browser package in both maps', () => {
+    expect(BUILT_IN_APPS['com.iostoandroid.browser']).toBe('Browser');
+    expect(VIRTUAL_ICON_CONFIG['com.iostoandroid.browser']).toEqual({
+      icon: 'compass',
+      bg: '#007AFF',
+      gradient: ['#409CFF', '#0071E3'],
+      iconSize: 34,
+    });
+  });
+
+  it('leaves the pre-existing built-in app entries unchanged (regression guard)', () => {
+    const expected: Record<string, string> = {
+      'com.iostoandroid.phone': 'Phone',
+      'com.iostoandroid.messages': 'Messages',
+      'com.iostoandroid.contacts': 'Contacts',
+      'com.iostoandroid.settings': 'Settings',
+      'com.iostoandroid.weather': 'Weather',
+      'com.iostoandroid.clock': 'Clock',
+      'com.iostoandroid.camera': 'Camera',
+      'com.iostoandroid.photos': 'Photos',
+      'com.iostoandroid.calendar': 'Calendar',
+      'com.iostoandroid.calculator': 'Calculator',
+      'com.iostoandroid.notes': 'Notes',
+      'com.iostoandroid.reminders': 'Reminders',
+      'com.iostoandroid.mail': 'Mail',
+    };
+    for (const [pkg, route] of Object.entries(expected)) {
+      expect(BUILT_IN_APPS[pkg]).toBe(route);
+      expect(VIRTUAL_ICON_CONFIG[pkg]).toBeTruthy();
+    }
+  });
+});


### PR DESCRIPTION
## Resumo

Adiciona BrowserScreen (WebView + barra de endereço) com resolveUrl scheme/host/search, regista rota Browser e ícone compasso no ecrã principal

## Causa raiz

O repositório não tinha navegador in-app: `react-native-webview` não era dependência (ausente em `package.json`), não havia `Browser` em `RootStackParamList`, e `BUILT_IN_APPS`/`VIRTUAL_ICON_CONFIG` em `LauncherHomeScreen.tsx` não incluíam a app. O sintoma do issue (sem forma de abrir um browser a partir do ecrã principal) decorre destas três ausências, não de um defeito num componente existente.

A lógica de resolução de URL — o núcleo comportamental testado — é implementada numa função pura `resolveUrl(input): string` em `src/screens/BrowserScreen.tsx:40`. O mecanismo: (1) trim; (2) vazio → `''` (o submit torna-se inerte); (3) contém `://` → usado como está; (4) parece host (`/^[^\s.]+(\.[^\s.]+)+$/` no rótulo antes de `/?#`, sem espaços) → prefixo `https://`; (5) caso contrário → `https://www.google.com/search?q=<encodeURIComponent>`. A barra de endereço liga-se a isto via `handleSubmit` (`BrowserScreen.tsx:67`), que só faz `setCurrentUrl` se `resolveUrl` devolver não-vazio.

## O que mudou

- `package.json` / `package-lock.json`: `react-native-webview@^13.16.0` adicionado a `dependencies` (instalação verificada — `node_modules/react-native-webview` presente).
- `src/screens/BrowserScreen.tsx` (novo, 182 linhas): componente `BrowserScreen` com `TextInput` (barra de endereço) + `WebView` (fill-rest), botão Go, botão back (`navigation.goBack`), reload, e indicador de progresso (`onLoadStart/Progress/End`). Exporta `resolveUrl` e `BROWSER_HOME_URL` para testabilidade.
- `src/screens/__tests__/BrowserScreen.test.tsx` (novo, 17 testes): monta o componente REAL e lê `props.source.uri` do WebView renderizado para afirmar o URL, e chama `resolveUrl` exportado para os casos de fronteira. NÃO reimplementa a fórmula no ficheiro de teste.
- `src/navigation/types.ts`: `Browser: undefined;` adicionado a `RootStackParamList`.
- `src/navigation/TabNavigator.tsx`: importa `BrowserScreen` e regista `<Stack.Screen name="Browser" component={BrowserScreen} options={{ animation }} />`.
- `src/screens/LauncherHomeScreen.tsx`: adiciona `com.iostoandroid.browser → 'Browser'` a `BUILT_IN_APPS` e a entrada `compass`/`#007AFF`/`['#409CFF','#0071E3']`/`iconSize:34` a `VIRTUAL_ICON_CONFIG`.
- `jest.setup.js`: mock de `react-native-webview` (o módulo nativo chama `TurboModuleRegistry.getEnforcing` em import-time e rebenta no ambiente JS-only de teste). O mock preserva o contrato (props `source`/`testID` + `reload()` imperativo).

## Porque assim

- **Função pura `resolveUrl` em vez de lógica inline**: testável sem montar o componente e coberta por fronteiras hostis. Decisão mantida da implementação prévia.
- **Tratamento de host**: exige rótulo não-vazio de cada lado do ponto; `what.` e `.` são pesquisas, `node.js tutorial` (com espaço) é pesquisa apesar do ponto. Evita prefixar `https://` a lixo.
- **Submit vazio inerte**: `resolveUrl('') === ''` → `handleSubmit` devolve cedo; o URL do WebView não muda. Protege contra navegação para string vazia.
- **Não usei `CupertinoNavigationBar`**: o issue avisa que é para large-title scroll header, não barra editável — criei top bar própria, por coerência com a recomendação.
- **Alternativa descartada**: prefixar `https://` a qualquer input com `.` — rejeitada porque quebraria pesquisas multi-palavra com ponto e termos com ponto final.

## Critérios de aceitação

- [x] `react-native-webview` em `package.json` dependencies e `npm install` ok — verificado (`node_modules/react-native-webview/package.json` existe).
- [x] `BrowserScreen` renderiza `TextInput` e `WebView` — teste `renders an address bar and a WebView pointing at the home URL` passa.
- [x] Termo nu → pesquisa Google — `navigates to a Google search URL for a bare search term` (`https://www.google.com/search?q=cats`) passa.
- [x] Domínio sem scheme → `https://` — `prefixes https:// on a bare domain` (`https://example.com`) passa.
- [x] `Browser` válido em `RootStackParamList` e registado no `TabNavigator.tsx` — ambos presentes; teste de registo no ecrã principal passa.
- [x] Ícone Browser no grid via `BUILT_IN_APPS`+`VIRTUAL_ICON_CONFIG` e navega para `Browser` — teste `registers the browser package in both maps` passa (compass/`#007AFF`/gradiente/`iconSize:34`).
- [x] Entradas existentes (Phone, Messages, Contacts, Settings, Weather, Clock, Camera, Photos, Calendar, Calculator, Notes, Reminders, Mail) inalteradas — teste `leaves the pre-existing built-in app entries unchanged (regression guard)` passa; diff confirma que só a linha `browser` foi adicionada a cada mapa.
- [x] Testes novos cobrem: barra renderiza, search term → URL esperada, domínio nu → `https://`. Ver abaixo.
- [x] O que NÃO devia mudar: nenhuma outra rota, nenhum outro ícone, e os 8 testes que já falhavam em `main` (baseline) continuam a falhar pelas mesmas razões — não introduzi falhas novas. Confirmado abaixo.

## Testes

**Passo vermelho (output real do jest com a implementação de `resolveUrl` revertida, mantendo o componente e o teste intactos):**

```
  ● resolveUrl — boundaries, empties, hostile input › trims surrounding whitespace before deciding

    Expected: "https://example.com"
    Received: "https://www.google.com/search?q=example.com"

      73 |     expect(resolveUrl('  example.com  ')).toBe('https://example.com');

  ● resolveUrl — boundaries, empties, hostile input › preserves an about:blank-style scheme rather than searching for it

    Expected: "https://sub.domain.co.uk:8443/x"
    Received: "https://www.google.com/search?q=https%3A%2F%2Fsub.domain.co.uk%3A8443%2Fx"

      90 |     expect(resolveUrl('https://sub.domain.co.uk:8443/x')).toBe('https://sub.domain.co.uk:8443/x');

  ● BrowserScreen — empty submit is inert (the inverse of the fix) › submitting the same term twice keeps the same URL (double tap)

    Expected: "https://example.com"
    Received: "https://www.google.com/search?q=example.com"

      106 |     expect(webviewUri(utils)).toBe('https://example.com');

  Test Suites: 1 failed, 1 total
  Tests:       6 failed, 11 passed, 17 total
```

Nota de procedimento: o fix já estava **commitado** em `8c1426a` (não no working tree), por isso `git stash push -- <ficheiros>` devolvia `"No local changes to save"` e os testes ficavam verdes — estave falsamente "verde". Para um passo vermelho genuíno reverteu-se temporariamente o corpo de `resolveUrl` (removendo a deteção de scheme/host) mantendo componente+teste, correu-se o jest (6 falhas acima), e restaurou-se `git checkout -- src/screens/BrowserScreen.tsx` antes de concluir. Prova de que os testes exercitam o comportamento real, não uma cópia.

**Casos cobertos (além do caminho feliz):** fronteiras/espaços em branco (`''`, `'   '`, trim); host com espaço é pesquisa (`node.js tutorial`); ponto final só (`what.`, `.`) → pesquisa; encoding hostil (`a&b=c#d`, scheme preservado); scheme explícito intacto; submit vazio inerte (o inverso do fix); duplo-tap mantém URL; Go button igual a submitEditing; botão back chama `goBack`; registo em ambos os maps + guarda de regressão das entradas existentes. Cada teste pode falhar por razão diferente (host vs scheme vs vazio vs duplo-tap).

**Sanity-check:** revertido o corpo de `resolveUrl` (fix retirado) → suite falha 6 testes; restaurado → 17/17 passam. Feito antes de escrever o veredicto.

**Verificações (no worktree, contra a baseline de `main` = 8 falhas/4 suites):**
- `npm run lint`: 0 erros, 2 warnings pré-existentes (irrelevantes: `requireNativeModule` em BridgeErrorReporting, `tzTick` em ClockScreen).
- `npx tsc --noEmit`: limpo (exit 0).
- `npm test -- --maxWorkers=2`: **782 passaram, 8 falharam de 790** (108 suites). As 8 falhas são **exatamente** as do baseline (`FoldersStore › hydrates folders…`, `FoldersStore › migrates legacy…`, `LockScreen › renders flashlight/camera/passcode numpad`, `SettingsScreen › renders Dark Mode`, `WeatherScreen › renders city name/temperature`) — **0 falhas novas** em ficheiros tocados por este issue.

## Testes

BrowserScreen: 17 passaram, 0 falharam. Suite completa: 782 passaram, 8 falharam de 790 (8 = baseline já existente em main; 0 novas)

## Linked Issue

Fixes #247