### PR TITLE
qa/issue-251: add Share button (CupertinoShareSheet) to BrowserScreen's top bar, wired to currentUrl/pageTitle (#251)

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -322,3 +322,23 @@ jest.mock('react-native/src/private/specs_DEPRECATED/modules/NativePermissionsAn
     requestMultiplePermissions: jest.fn(() => Promise.resolve({})),
   },
 }));
+
+// Mock react-native-webview: it calls TurboModuleRegistry.getEnforcing('RNCWebViewModule')
+// at import time, which throws in the JS-only test environment. The mock keeps the
+// component contract (source/testID props + an imperative reload()) so screens that
+// render a WebView can be asserted on.
+jest.mock('react-native-webview', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  const WebView = React.forwardRef((props, ref) => {
+    React.useImperativeHandle(ref, () => ({
+      reload: jest.fn(),
+      goBack: jest.fn(),
+      goForward: jest.fn(),
+      stopLoading: jest.fn(),
+    }));
+    return React.createElement(View, props);
+  });
+  WebView.displayName = 'WebView';
+  return { __esModule: true, WebView, default: WebView };
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "iostoandroid",
-  "version": "1.20.0",
+  "version": "1.22.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "iostoandroid",
-      "version": "1.20.0",
+      "version": "1.22.1",
       "dependencies": {
         "@expo/vector-icons": "15.0.3",
         "@react-native-async-storage/async-storage": "^3.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "iostoandroid",
-  "version": "1.15.8",
+  "version": "1.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "iostoandroid",
-      "version": "1.15.8",
+      "version": "1.20.0",
       "dependencies": {
         "@expo/vector-icons": "15.0.3",
         "@react-native-async-storage/async-storage": "^3.0.2",
@@ -41,7 +41,8 @@
         "react-native-gesture-handler": "~2.28.0",
         "react-native-reanimated": "~4.1.1",
         "react-native-safe-area-context": "~5.6.0",
-        "react-native-screens": "~4.16.0"
+        "react-native-screens": "~4.16.0",
+        "react-native-webview": "^13.16.0"
       },
       "devDependencies": {
         "@testing-library/react-native": "^13.3.3",
@@ -12950,6 +12951,20 @@
         "react-freeze": "^1.0.0",
         "react-native-is-edge-to-edge": "^1.2.1",
         "warn-once": "^0.1.0"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-webview": {
+      "version": "13.16.0",
+      "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-13.16.0.tgz",
+      "integrity": "sha512-Nh13xKZWW35C0dbOskD7OX01nQQavOzHbCw9XoZmar4eXCo7AvrYJ0jlUfRVVIJzqINxHlpECYLdmAdFsl9xDA==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0",
+        "invariant": "2.2.4"
       },
       "peerDependencies": {
         "react": "*",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "react-native-gesture-handler": "~2.28.0",
     "react-native-reanimated": "~4.1.1",
     "react-native-safe-area-context": "~5.6.0",
-    "react-native-screens": "~4.16.0"
+    "react-native-screens": "~4.16.0",
+    "react-native-webview": "^13.16.0"
   },
   "devDependencies": {
     "@testing-library/react-native": "^13.3.3",

--- a/src/navigation/TabNavigator.tsx
+++ b/src/navigation/TabNavigator.tsx
@@ -63,6 +63,7 @@ import { NotesScreen } from '../screens/NotesScreen';
 import { MapsScreen } from '../screens/MapsScreen';
 import { RemindersScreen } from '../screens/RemindersScreen';
 import { MailScreen } from '../screens/MailScreen';
+import { BrowserScreen } from '../screens/BrowserScreen';
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
 
@@ -106,6 +107,7 @@ export function TabNavigator() {
       <Stack.Screen name="Maps" component={MapsScreen} options={{ animation }} />
       <Stack.Screen name="Reminders" component={RemindersScreen} options={{ animation }} />
       <Stack.Screen name="Mail" component={MailScreen} options={{ animation }} />
+      <Stack.Screen name="Browser" component={BrowserScreen} options={{ animation }} />
 
       {/* Settings app — zoom up on entry, push for sub-screens like iOS */}
       <Stack.Screen name="Settings" component={SettingsScreen} options={{ animation }} />

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -26,6 +26,7 @@ export type RootStackParamList = {
   Notes: undefined;
   Maps: undefined;
   Reminders: undefined;
+  Browser: undefined;
   Mail: { composeTo?: string; composeSubject?: string; composeBody?: string } | undefined;
 
   // Settings

--- a/src/screens/BrowserScreen.tsx
+++ b/src/screens/BrowserScreen.tsx
@@ -1,0 +1,182 @@
+import React, { useState, useRef, useCallback } from 'react';
+import {
+  View,
+  Text,
+  TextInput,
+  StyleSheet,
+  Pressable,
+  ActivityIndicator,
+} from 'react-native';
+import { WebView } from 'react-native-webview';
+import { Ionicons } from '@expo/vector-icons';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useTheme } from '../theme/ThemeContext';
+import type { CupertinoColors } from '../theme/CupertinoTheme';
+import { Typography } from '../theme/CupertinoTheme';
+import type { AppNavigationProp } from '../navigation/types';
+import { hapticImpact } from '../utils/haptics';
+
+// ─── Constants ──────────────────────────────────────────────────────────────
+
+export const BROWSER_HOME_URL = 'https://www.google.com';
+const SEARCH_PREFIX = 'https://www.google.com/search?q=';
+const BROWSER_ACCENT = '#007AFF';
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+/**
+ * Turn whatever the user typed in the address bar into a URL to load.
+ *
+ * - empty / whitespace-only → '' (caller must not navigate)
+ * - already has a scheme ('://') → used as-is
+ * - looks like a host (contains a '.' with non-empty labels on both sides and
+ *   no whitespace) → prefixed with 'https://'
+ * - anything else → a Google search for the literal text
+ *
+ * The host test deliberately requires a non-empty label each side of the dot:
+ * 'what.' or '.' are search terms, not hosts, and a term with a space
+ * ('node.js tutorial') is a search even though it contains a dot.
+ */
+export function resolveUrl(input: string): string {
+  const trimmed = input.trim();
+  if (!trimmed) return '';
+  if (trimmed.includes('://')) return trimmed;
+
+  const hostCandidate = trimmed.split(/[/?#]/, 1)[0];
+  const looksLikeHost =
+    !/\s/.test(trimmed) && /^[^\s.]+(\.[^\s.]+)+$/.test(hostCandidate);
+  if (looksLikeHost) return `https://${trimmed}`;
+
+  return `${SEARCH_PREFIX}${encodeURIComponent(trimmed)}`;
+}
+
+// ─── Screen ─────────────────────────────────────────────────────────────────
+
+export function BrowserScreen({ navigation }: { navigation: AppNavigationProp }) {
+  const { theme } = useTheme();
+  const { colors } = theme;
+  const insets = useSafeAreaInsets();
+  const styles = React.useMemo(() => createStyles(colors), [colors]);
+
+  const [inputUrl, setInputUrl] = useState(BROWSER_HOME_URL);
+  const [currentUrl, setCurrentUrl] = useState(BROWSER_HOME_URL);
+  const [loading, setLoading] = useState(false);
+  const [progress, setProgress] = useState(0);
+  const webviewRef = useRef<WebView>(null);
+
+  const handleSubmit = useCallback(() => {
+    const next = resolveUrl(inputUrl);
+    if (!next) return;
+    setCurrentUrl(next);
+  }, [inputUrl]);
+
+  const handleBack = useCallback(() => {
+    hapticImpact();
+    navigation.goBack();
+  }, [navigation]);
+
+  const handleReload = useCallback(() => {
+    webviewRef.current?.reload();
+  }, []);
+
+  return (
+    <View style={[styles.container, { paddingTop: insets.top }]}>
+      <View style={styles.topBar}>
+        <Pressable
+          onPress={handleBack}
+          hitSlop={8}
+          accessibilityLabel="Go back"
+          accessibilityRole="button"
+        >
+          <Ionicons name="chevron-back" size={28} color={BROWSER_ACCENT} />
+        </Pressable>
+        <TextInput
+          style={styles.addressBar}
+          value={inputUrl}
+          onChangeText={setInputUrl}
+          onSubmitEditing={handleSubmit}
+          placeholder="Search or enter website name"
+          placeholderTextColor={colors.secondaryLabel}
+          autoCapitalize="none"
+          autoCorrect={false}
+          keyboardType="url"
+          returnKeyType="go"
+          selectTextOnFocus
+          accessibilityLabel="Address bar"
+        />
+        <Pressable
+          onPress={handleSubmit}
+          hitSlop={8}
+          accessibilityLabel="Go"
+          accessibilityRole="button"
+        >
+          <Text style={styles.goText}>Go</Text>
+        </Pressable>
+        <Pressable
+          onPress={handleReload}
+          hitSlop={8}
+          accessibilityLabel="Reload page"
+          accessibilityRole="button"
+        >
+          <Ionicons name="refresh" size={22} color={BROWSER_ACCENT} />
+        </Pressable>
+      </View>
+
+      {loading ? (
+        <View style={styles.progressTrack}>
+          <View
+            testID="browser-progress"
+            style={[styles.progressBar, { width: `${Math.round(progress * 100)}%` }]}
+          />
+        </View>
+      ) : null}
+
+      <WebView
+        ref={webviewRef}
+        testID="browser-webview"
+        source={{ uri: currentUrl }}
+        style={styles.webview}
+        onLoadStart={() => {
+          setLoading(true);
+          setProgress(0);
+        }}
+        onLoadProgress={({ nativeEvent }) => setProgress(nativeEvent.progress)}
+        onLoadEnd={() => {
+          setLoading(false);
+          setProgress(1);
+        }}
+        startInLoadingState
+        renderLoading={() => <ActivityIndicator color={BROWSER_ACCENT} />}
+      />
+    </View>
+  );
+}
+
+// ─── Styles ─────────────────────────────────────────────────────────────────
+
+function createStyles(colors: CupertinoColors) {
+  return StyleSheet.create({
+    container: { flex: 1, backgroundColor: colors.systemBackground },
+    topBar: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 8,
+      paddingHorizontal: 12,
+      paddingVertical: 8,
+      backgroundColor: colors.secondarySystemBackground,
+    },
+    addressBar: {
+      flex: 1,
+      height: 36,
+      borderRadius: 10,
+      paddingHorizontal: 12,
+      backgroundColor: colors.tertiarySystemBackground,
+      color: colors.label,
+      ...Typography.body,
+    },
+    goText: { ...Typography.body, color: BROWSER_ACCENT, fontWeight: '600' },
+    progressTrack: { height: 2, backgroundColor: 'transparent' },
+    progressBar: { height: 2, backgroundColor: BROWSER_ACCENT },
+    webview: { flex: 1 },
+  });
+}

--- a/src/screens/BrowserScreen.tsx
+++ b/src/screens/BrowserScreen.tsx
@@ -7,7 +7,7 @@ import {
   Pressable,
   ActivityIndicator,
 } from 'react-native';
-import { WebView } from 'react-native-webview';
+import { WebView, WebViewNavigation } from 'react-native-webview';
 import { Ionicons } from '@expo/vector-icons';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTheme } from '../theme/ThemeContext';
@@ -15,6 +15,7 @@ import type { CupertinoColors } from '../theme/CupertinoTheme';
 import { Typography } from '../theme/CupertinoTheme';
 import type { AppNavigationProp } from '../navigation/types';
 import { hapticImpact } from '../utils/haptics';
+import { CupertinoShareSheet } from '../components/CupertinoShareSheet';
 
 // ─── Constants ──────────────────────────────────────────────────────────────
 
@@ -60,8 +61,10 @@ export function BrowserScreen({ navigation }: { navigation: AppNavigationProp })
 
   const [inputUrl, setInputUrl] = useState(BROWSER_HOME_URL);
   const [currentUrl, setCurrentUrl] = useState(BROWSER_HOME_URL);
+  const [pageTitle, setPageTitle] = useState('');
   const [loading, setLoading] = useState(false);
   const [progress, setProgress] = useState(0);
+  const [showShareSheet, setShowShareSheet] = useState(false);
   const webviewRef = useRef<WebView>(null);
 
   const handleSubmit = useCallback(() => {
@@ -77,6 +80,15 @@ export function BrowserScreen({ navigation }: { navigation: AppNavigationProp })
 
   const handleReload = useCallback(() => {
     webviewRef.current?.reload();
+  }, []);
+
+  const handleShare = useCallback(() => {
+    hapticImpact();
+    setShowShareSheet(true);
+  }, []);
+
+  const handleNavigationStateChange = useCallback((navState: WebViewNavigation) => {
+    setPageTitle(navState.title);
   }, []);
 
   return (
@@ -120,6 +132,14 @@ export function BrowserScreen({ navigation }: { navigation: AppNavigationProp })
         >
           <Ionicons name="refresh" size={22} color={BROWSER_ACCENT} />
         </Pressable>
+        <Pressable
+          onPress={handleShare}
+          hitSlop={8}
+          accessibilityLabel="Share"
+          accessibilityRole="button"
+        >
+          <Ionicons name="share-outline" size={22} color={BROWSER_ACCENT} />
+        </Pressable>
       </View>
 
       {loading ? (
@@ -145,8 +165,16 @@ export function BrowserScreen({ navigation }: { navigation: AppNavigationProp })
           setLoading(false);
           setProgress(1);
         }}
+        onNavigationStateChange={handleNavigationStateChange}
         startInLoadingState
         renderLoading={() => <ActivityIndicator color={BROWSER_ACCENT} />}
+      />
+
+      <CupertinoShareSheet
+        visible={showShareSheet}
+        onClose={() => setShowShareSheet(false)}
+        title={pageTitle}
+        url={currentUrl}
       />
     </View>
   );

--- a/src/screens/LauncherHomeScreen.tsx
+++ b/src/screens/LauncherHomeScreen.tsx
@@ -102,7 +102,7 @@ export function computeWallpaperTranslateX(
 }
 
 // Built-in app routing: packageName → navigation screen name
-const BUILT_IN_APPS: Record<string, keyof RootStackParamList> = {
+export const BUILT_IN_APPS: Record<string, keyof RootStackParamList> = {
   'com.iostoandroid.phone': 'Phone',
   'com.iostoandroid.messages': 'Messages',
   'com.iostoandroid.contacts': 'Contacts',
@@ -116,6 +116,7 @@ const BUILT_IN_APPS: Record<string, keyof RootStackParamList> = {
   'com.iostoandroid.notes': 'Notes',
   'com.iostoandroid.reminders': 'Reminders',
   'com.iostoandroid.mail': 'Mail',
+  'com.iostoandroid.browser': 'Browser',
 };
 
 // Known Android packages that duplicate a built-in app (issue #438).
@@ -150,7 +151,7 @@ export const BUILT_IN_DUPLICATE_PACKAGES: ReadonlySet<string> = new Set(
 );
 
 // Icon config for virtual (built-in) apps rendered in dock/grid
-const VIRTUAL_ICON_CONFIG: Record<string, {
+export const VIRTUAL_ICON_CONFIG: Record<string, {
   icon: keyof typeof Ionicons.glyphMap;
   bg: string;
   gradient?: [string, string];
@@ -169,6 +170,7 @@ const VIRTUAL_ICON_CONFIG: Record<string, {
   'com.iostoandroid.notes': { icon: 'document-text', bg: '#FFCC00', gradient: ['#FFD60A', '#FFB300'], iconSize: 32 },
   'com.iostoandroid.reminders': { icon: 'checkmark-circle', bg: '#5E5CE6', gradient: ['#7D7AFF', '#5E5CE6'], iconSize: 32 },
   'com.iostoandroid.mail': { icon: 'mail', bg: '#0A84FF', gradient: ['#409CFF', '#0071E3'], iconSize: 30 },
+  'com.iostoandroid.browser': { icon: 'compass', bg: '#007AFF', gradient: ['#409CFF', '#0071E3'], iconSize: 34 },
 };
 
 // ---------------------------------------------------------------------------

--- a/src/screens/__tests__/BrowserScreen.test.tsx
+++ b/src/screens/__tests__/BrowserScreen.test.tsx
@@ -1,0 +1,142 @@
+import React from 'react';
+import { render, fireEvent } from '../../test-utils';
+import { BrowserScreen, resolveUrl, BROWSER_HOME_URL } from '../BrowserScreen';
+import { BUILT_IN_APPS, VIRTUAL_ICON_CONFIG } from '../LauncherHomeScreen';
+
+const nav = { navigate: jest.fn(), goBack: jest.fn() } as never;
+
+beforeEach(() => jest.clearAllMocks());
+
+function submitAddress(input: string) {
+  const utils = render(<BrowserScreen navigation={nav} />);
+  const bar = utils.getByPlaceholderText('Search or enter website name');
+  fireEvent.changeText(bar, input);
+  fireEvent(bar, 'submitEditing');
+  return utils;
+}
+
+function webviewUri(utils: ReturnType<typeof render>): string {
+  const webview = utils.getByTestId('browser-webview');
+  return (webview.props.source as { uri: string }).uri;
+}
+
+describe('BrowserScreen — address bar + WebView', () => {
+  it('renders an address bar and a WebView pointing at the home URL', () => {
+    const utils = render(<BrowserScreen navigation={nav} />);
+    expect(utils.getByPlaceholderText('Search or enter website name')).toBeTruthy();
+    expect(webviewUri(utils)).toBe(BROWSER_HOME_URL);
+  });
+
+  it('navigates to a Google search URL for a bare search term', () => {
+    const utils = submitAddress('cats');
+    expect(webviewUri(utils)).toBe('https://www.google.com/search?q=cats');
+  });
+
+  it('percent-encodes multi-word search terms', () => {
+    const utils = submitAddress('black cats');
+    expect(webviewUri(utils)).toBe('https://www.google.com/search?q=black%20cats');
+  });
+
+  it('prefixes https:// on a bare domain', () => {
+    const utils = submitAddress('example.com');
+    expect(webviewUri(utils)).toBe('https://example.com');
+  });
+
+  it('keeps an explicit scheme untouched', () => {
+    const utils = submitAddress('http://example.com/path?a=1');
+    expect(webviewUri(utils)).toBe('http://example.com/path?a=1');
+  });
+
+  it('goes back when the back button is pressed', () => {
+    const utils = render(<BrowserScreen navigation={nav} />);
+    fireEvent.press(utils.getByLabelText('Go back'));
+    expect((nav as unknown as { goBack: jest.Mock }).goBack).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('BrowserScreen — the Go button', () => {
+  it('navigates on Go press, same as submitEditing', () => {
+    const utils = render(<BrowserScreen navigation={nav} />);
+    fireEvent.changeText(utils.getByPlaceholderText('Search or enter website name'), 'example.org');
+    fireEvent.press(utils.getByLabelText('Go'));
+    expect(webviewUri(utils)).toBe('https://example.org');
+  });
+});
+
+describe('resolveUrl — boundaries, empties, hostile input', () => {
+  it('returns empty string for an empty or whitespace-only input', () => {
+    expect(resolveUrl('')).toBe('');
+    expect(resolveUrl('   ')).toBe('');
+  });
+
+  it('trims surrounding whitespace before deciding', () => {
+    expect(resolveUrl('  example.com  ')).toBe('https://example.com');
+  });
+
+  it('treats a term containing spaces as a search even when it has a dot', () => {
+    expect(resolveUrl('node.js tutorial')).toBe('https://www.google.com/search?q=node.js%20tutorial');
+  });
+
+  it('searches for a trailing-dot-only term rather than building a bogus host', () => {
+    expect(resolveUrl('what.')).toBe('https://www.google.com/search?q=what.');
+    expect(resolveUrl('.')).toBe('https://www.google.com/search?q=.');
+  });
+
+  it('encodes characters that would break the query string', () => {
+    expect(resolveUrl('a&b=c#d')).toBe('https://www.google.com/search?q=a%26b%3Dc%23d');
+  });
+
+  it('preserves an about:blank-style scheme rather than searching for it', () => {
+    expect(resolveUrl('https://sub.domain.co.uk:8443/x')).toBe('https://sub.domain.co.uk:8443/x');
+  });
+});
+
+describe('BrowserScreen — empty submit is inert (the inverse of the fix)', () => {
+  it('does not change the WebView URL when the address bar is emptied and submitted', () => {
+    const utils = submitAddress('   ');
+    expect(webviewUri(utils)).toBe(BROWSER_HOME_URL);
+  });
+
+  it('submitting the same term twice keeps the same URL (double tap)', () => {
+    const utils = render(<BrowserScreen navigation={nav} />);
+    const bar = utils.getByPlaceholderText('Search or enter website name');
+    fireEvent.changeText(bar, 'example.com');
+    fireEvent(bar, 'submitEditing');
+    fireEvent(bar, 'submitEditing');
+    expect(webviewUri(utils)).toBe('https://example.com');
+  });
+});
+
+describe('home-screen registration', () => {
+  it('registers the browser package in both maps', () => {
+    expect(BUILT_IN_APPS['com.iostoandroid.browser']).toBe('Browser');
+    expect(VIRTUAL_ICON_CONFIG['com.iostoandroid.browser']).toEqual({
+      icon: 'compass',
+      bg: '#007AFF',
+      gradient: ['#409CFF', '#0071E3'],
+      iconSize: 34,
+    });
+  });
+
+  it('leaves the pre-existing built-in app entries unchanged (regression guard)', () => {
+    const expected: Record<string, string> = {
+      'com.iostoandroid.phone': 'Phone',
+      'com.iostoandroid.messages': 'Messages',
+      'com.iostoandroid.contacts': 'Contacts',
+      'com.iostoandroid.settings': 'Settings',
+      'com.iostoandroid.weather': 'Weather',
+      'com.iostoandroid.clock': 'Clock',
+      'com.iostoandroid.camera': 'Camera',
+      'com.iostoandroid.photos': 'Photos',
+      'com.iostoandroid.calendar': 'Calendar',
+      'com.iostoandroid.calculator': 'Calculator',
+      'com.iostoandroid.notes': 'Notes',
+      'com.iostoandroid.reminders': 'Reminders',
+      'com.iostoandroid.mail': 'Mail',
+    };
+    for (const [pkg, route] of Object.entries(expected)) {
+      expect(BUILT_IN_APPS[pkg]).toBe(route);
+      expect(VIRTUAL_ICON_CONFIG[pkg]).toBeTruthy();
+    }
+  });
+});

--- a/src/screens/__tests__/BrowserScreen.test.tsx
+++ b/src/screens/__tests__/BrowserScreen.test.tsx
@@ -107,6 +107,47 @@ describe('BrowserScreen — empty submit is inert (the inverse of the fix)', () 
   });
 });
 
+describe('BrowserScreen — Share', () => {
+  it('does not show the share sheet before the Share button is pressed', () => {
+    const utils = render(<BrowserScreen navigation={nav} />);
+    expect(utils.queryByLabelText('Copy')).toBeNull();
+  });
+
+  it('pressing Share opens the CupertinoShareSheet', () => {
+    const utils = render(<BrowserScreen navigation={nav} />);
+    fireEvent.press(utils.getByLabelText('Share'));
+    expect(utils.getByLabelText('Copy')).toBeTruthy();
+  });
+
+  it('the share sheet receives the current URL and page title as props', () => {
+    const utils = render(<BrowserScreen navigation={nav} />);
+    const webview = utils.getByTestId('browser-webview');
+    fireEvent(webview, 'navigationStateChange', { title: 'Example Domain', url: BROWSER_HOME_URL });
+    fireEvent.press(utils.getByLabelText('Share'));
+    expect(utils.getByText('Example Domain')).toBeTruthy();
+    expect(utils.getByText(BROWSER_HOME_URL)).toBeTruthy();
+  });
+
+  it('reflects a navigated URL and title in the share sheet, not the stale home ones', () => {
+    const utils = submitAddress('example.com');
+    const webview = utils.getByTestId('browser-webview');
+    fireEvent(webview, 'navigationStateChange', { title: 'Example', url: 'https://example.com' });
+    fireEvent.press(utils.getByLabelText('Share'));
+    expect(utils.getByText('Example')).toBeTruthy();
+    expect(utils.getByText('https://example.com')).toBeTruthy();
+    expect(utils.queryByText(BROWSER_HOME_URL)).toBeNull();
+  });
+
+  it('closing the share sheet dismisses it without changing the WebView URL', () => {
+    const utils = render(<BrowserScreen navigation={nav} />);
+    fireEvent.press(utils.getByLabelText('Share'));
+    expect(utils.getByLabelText('Cancel')).toBeTruthy();
+    fireEvent.press(utils.getByLabelText('Cancel'));
+    expect(utils.queryByLabelText('Copy')).toBeNull();
+    expect(webviewUri(utils)).toBe(BROWSER_HOME_URL);
+  });
+});
+
 describe('home-screen registration', () => {
   it('registers the browser package in both maps', () => {
     expect(BUILT_IN_APPS['com.iostoandroid.browser']).toBe('Browser');


### PR DESCRIPTION
## Resumo

qa/issue-251: add Share button (CupertinoShareSheet) to BrowserScreen's top bar, wired to currentUrl/pageTitle

## Causa raiz

O issue #251 pressupunha uma `BrowserScreen.tsx` com bottom toolbar de Back/Forward e um `onNavigationStateChange` já ligado a um estado de título — nenhum dos dois existia em `main` (confirmado por uma corrida anterior, `blocked`, que fez a investigação de base: `find`/`grep` por Browser/WebView em `src/` sem resultados). O curator localizou o trabalho real: `BrowserScreen.tsx` (issue #247) estava implementada e testada na branch `qa/issue-247` (commit `8c1426a`, PR #551), aberta e `MERGEABLE`, mas nunca integrada em `main`; a issue #248 (bottom toolbar / `onNavigationStateChange`) nunca foi implementada (branch vazia, sem PR — e `qa/issue-248` já não existe no remoto).

Esta corrida seguiu a orientação do curator: trouxe `8c1426a` por `git cherry-pick` (sem reescrever o ecrã, evitando duplicar o que a PR #551 já tem) e acrescentou apenas o mínimo pedido por #251 — botão Share e captura de título — no `topBar` já existente de `BrowserScreen.tsx`, sem construir a bottom toolbar de #248 (fora de scope).

## O que mudou

- `src/screens/BrowserScreen.tsx` (linhas alteradas nesta corrida, por cima do cherry-pick de `8c1426a`):
  - Importa `CupertinoShareSheet` e o tipo `WebViewNavigation`.
  - Novo estado `pageTitle` (inicial `''`) e `showShareSheet` (inicial `false`).
  - Novo handler `handleShare` (haptic + `setShowShareSheet(true)`) e `handleNavigationStateChange` (`setPageTitle(navState.title)`).
  - Novo botão Share (`Ionicons` `share-outline`, `accessibilityLabel="Share"`) no `topBar`, ao lado do botão de reload.
  - `onNavigationStateChange={handleNavigationStateChange}` adicionado à `WebView` existente — não tocado `canGoBack`/`canGoForward`/nenhuma lógica de navegação-na-página.
  - `<CupertinoShareSheet visible={showShareSheet} onClose={() => setShowShareSheet(false)} title={pageTitle} url={currentUrl} />` montado no fim do ecrã, seguindo o padrão de `MapsScreen.tsx`.
- `src/screens/__tests__/BrowserScreen.test.tsx`: novo `describe('BrowserScreen — Share')` com 5 testes (ver secção Testes). Os 17 testes herdados de #247 (`resolveUrl`, address bar, WebView, registo no launcher) não foram alterados.
- `jest.setup.js`, `package.json`, `package-lock.json`, `src/navigation/TabNavigator.tsx`, `src/navigation/types.ts`, `src/screens/LauncherHomeScreen.tsx`: trazidos inalterados pelo cherry-pick de `8c1426a` (issue #247 — criação da `BrowserScreen`, registo da rota `Browser`, ícone no launcher, dependência `react-native-webview`, mock de `WebView` em `jest.setup.js`). Não fazem parte do scope de #251, mas têm de estar no diff porque #247 ainda não está em `main` — confirmado pelo curator e pela skill `ios-android-implement-with-unmerged-dependency` ("não filtrar o prerequisito do diff").

## Porque assim

- Botão Share no `topBar` (não numa bottom toolbar): a bottom toolbar de Back/Forward pertence à issue #248, que nunca foi implementada. Construí-la aqui duplicaria esse scope e entraria em conflito quando #248 for feito.
- `onNavigationStateChange` mínimo, só para `title`: não implementei `canGoBack`/`canGoForward`/navegação-na-página — isso é #248, explicitamente fora de scope segundo a análise do curator.
- `pageTitle` inicia em `''`: `CupertinoShareSheet` já trata título vazio (`{title && (...)}`), por isso a preview do share sheet mostra só o URL até a página carregar e disparar `onNavigationStateChange` — sem placeholder inventado.
- `cherry-pick` do commit `8c1426a` em vez de `merge`: traz só o commit de implementação de #247, sem o merge de `main` que esse branch já tinha feito (`0766a1e`), evitando histórico redundante. Sem conflitos (confirmado — `Auto-merging` em 3 ficheiros, sem marcadores de conflito).

## Critérios de aceitação

- [x] `BrowserScreen.tsx` e a rota `Browser` existem no branch — trazidas por cherry-pick de `8c1426a` (`qa/issue-247`), sem reescrever o ecrã.
- [x] Um botão Share (`Ionicons` `share-outline`, `accessibilityLabel="Share"`) está presente no `topBar` de `BrowserScreen` — `src/screens/BrowserScreen.tsx`, ao lado do botão reload.
- [x] Existe um estado `pageTitle`, populado via `onNavigationStateChange` novo na `WebView`, sem `canGoBack`/`canGoForward`/botões de navegação-na-página (confirmado: nenhum desses símbolos foi adicionado).
- [x] Pressionar Share abre `CupertinoShareSheet` com `url=currentUrl` e `title=pageTitle` — testado em "the share sheet receives the current URL and page title as props" e "reflects a navigated URL and title... not the stale home ones".
- [x] Fechar o share sheet não navega a `WebView` para outro URL nem altera `currentUrl` — testado em "closing the share sheet dismisses it without changing the WebView URL" (afirma `webviewUri(utils)` inalterado após abrir e fechar).
- [x] Os 17 testes existentes de `BrowserScreen.test.tsx` (herdados de #247) continuam a passar inalterados — confirmado, suite completa 22/22 a passar (17 herdados + 5 novos).
- [x] Nenhuma bottom toolbar, Back/Forward de navegação, ou lógica `canGoBack`/`canGoForward` foi adicionada — confirmado por leitura do diff final: só `pageTitle`, `showShareSheet`, `handleShare`, `handleNavigationStateChange` e o botão/sheet.

## Testes

**Passo vermelho** (testes de Share escritos, fix de produção ainda não aplicado — stash de `src/screens/BrowserScreen.tsx` sobre o cherry-pick de #247, mantendo os testes):

```
$ npx jest src/screens/__tests__/BrowserScreen.test.tsx -t "Share"
...
  141 |   it('closing the share sheet dismisses it without changing the WebView URL', () => {
  142 |     const utils = render(<BrowserScreen navigation={nav} />);
> 143 |     fireEvent.press(utils.getByLabelText('Share'));
      |                           ^
  144 |     expect(utils.getByLabelText('Cancel')).toBeTruthy();

      at Object.getByLabelText (src/screens/__tests__/BrowserScreen.test.tsx:143:27)

Test Suites: 1 failed, 1 total
Tests:       4 failed, 17 skipped, 1 passed, 22 total
```

4 dos 5 testes de Share falharam por "Unable to find an element with accessibility label: Share" (o botão não existia ainda) — a razão certa. O 5º ('does not show the share sheet before Share is pressed') passa nos dois estados porque é a asserção do caso inverso, por definição verdadeira antes do fix.

**Depois do fix** (mesmo comando): `Tests: 22 passed, 22 total`.

**Casos cobertos** (além do caminho feliz):
- Estado inicial: sheet não visível antes do 1º press (`does not show the share sheet before the Share button is pressed`).
- Título/URL correntes propagados no momento do press, não valores antigos (`the share sheet receives the current URL and page title as props`, e o caso que navega primeiro para `example.com` e confirma que o valor antigo `BROWSER_HOME_URL` já não aparece — `reflects a navigated URL and title..., not the stale home ones`).
- Inverso do fix: fechar o sheet (`Cancel`) não altera `currentUrl`/`source.uri` da WebView — protege contra fecho que dispare navegação.

**Sanity-check** (revert-e-restaura): `git stash push -u -m "qa-issue-251-sanity-check" -- src/screens/BrowserScreen.tsx` (por cima do cherry-pick de #247, mantendo os testes) → `npx jest ... -t Share` → 4 falharam, 1 passou pela razão certa (ver acima) → `git stash apply <sha>` (confirmado pela SHA exacta antes de aplicar) → suite completa novamente 22/22 → `git stash drop <mesma SHA>`.

**Verificações obrigatórias:**
- `npm run lint` → `0 errors, 2 warnings` (os 2 warnings são pré-existentes, em `modules/launcher-module/.../BridgeErrorReporting.test.tsx` e `src/screens/ClockScreen.tsx` — nenhum ficheiro tocado nesta corrida).
- `npx tsc --noEmit` → limpo, exit 0.
- `npm test -- --maxWorkers=2` → `Test Suites: 4 failed, 111 passed, 115 total` / `Tests: 8 failed, 878 passed, 886 total`. As 4 suites e os 8 testes a falhar são exactamente os do baseline (`LockScreen`, `WeatherScreen`, `FoldersStore`, `SettingsScreen` — defeito conhecido do `firstSyncDone`/`AsyncStorage` assíncrono em `SettingsStore.tsx`), confirmado por comparação linha-a-linha com `iostoandroid-verdicts/state/baseline.json`. `BrowserScreen.test.tsx` passa por inteiro (22/22). Nenhuma falha nova.

## Testes

886 total, 878 passaram, 8 falharam (4 suites — idênticas ao baseline pré-existente: LockScreen, WeatherScreen, FoldersStore, SettingsScreen); BrowserScreen.test.tsx: 22 passaram, 0 falharam (17 herdados de #247 + 5 novos de Share)

## Linked Issue

Fixes #251