### PR TITLE
App Library: cascata de 3 niveis (ApplicationInfo.category > keywords > Other) expande 5 para 11 categorias de grelha (#514)

### DIFF
--- a/src/screens/AppLibraryScreen.tsx
+++ b/src/screens/AppLibraryScreen.tsx
@@ -34,23 +34,73 @@ const CATEGORY_KEYWORDS: { name: string; keywords: string[] }[] = [
   },
   {
     name: 'Entertainment',
-    keywords: ['youtube', 'netflix', 'spotify', 'disney', 'twitch', 'gaming', 'game', 'prime', 'hbo', 'hulu', 'music', 'podcast', 'radio', 'player'],
+    keywords: ['youtube', 'netflix', 'spotify', 'disney', 'twitch', 'prime', 'hbo', 'hulu', 'music', 'podcast', 'radio', 'player'],
   },
   {
-    name: 'Productivity',
-    keywords: ['gmail', 'drive', 'docs', 'sheets', 'calendar', 'slack', 'teams', 'office', 'word', 'excel', 'outlook', 'notion', 'trello', 'asana', 'zoom', 'meet'],
+    name: 'Games',
+    keywords: ['game', 'gaming', 'games', 'roblox', 'minecraft', 'fortnite', 'pubg', 'candy crush'],
+  },
+  {
+    name: 'Productivity & Finance',
+    keywords: ['gmail', 'drive', 'docs', 'sheets', 'calendar', 'slack', 'teams', 'office', 'word', 'excel', 'outlook', 'notion', 'trello', 'asana', 'zoom', 'meet', 'bank', 'banking', 'finance', 'wallet', 'paypal', 'venmo', 'crypto', 'invest', 'budget', 'tax'],
   },
   {
     name: 'Utilities',
-    keywords: ['calculator', 'clock', 'camera', 'files', 'settings', 'weather', 'maps', 'compass', 'flashlight', 'scanner', 'notes', 'reminder', 'translate', 'browser', 'chrome', 'firefox'],
+    keywords: ['calculator', 'clock', 'camera', 'files', 'settings', 'weather', 'compass', 'flashlight', 'scanner', 'notes', 'reminder', 'translate', 'browser', 'chrome', 'firefox'],
   },
   {
-    name: 'Shopping',
-    keywords: ['amazon', 'ebay', 'aliexpress', 'wish', 'shop', 'store', 'market', 'etsy', 'shein', 'zalando'],
+    name: 'Shopping & Food',
+    keywords: ['amazon', 'ebay', 'aliexpress', 'wish', 'shop', 'store', 'market', 'etsy', 'shein', 'zalando', 'food', 'restaurant', 'delivery', 'recipe', 'grocery', 'ubereats', 'doordash', 'foodpanda', 'wolt', 'glovo'],
+  },
+  {
+    name: 'Creativity',
+    keywords: ['photoshop', 'lightroom', 'canva', 'illustrator', 'procreate', 'sketch', 'draw', 'paint', 'capcut', 'premiere', 'figma'],
+  },
+  {
+    name: 'Information & Reading',
+    keywords: ['news', 'reader', 'kindle', 'book', 'magazine', 'rss', 'medium', 'wikipedia', 'flipboard'],
+  },
+  {
+    name: 'Travel',
+    keywords: ['uber', 'lyft', 'booking', 'airbnb', 'flight', 'trip', 'travel', 'transit', 'taxi', 'expedia', 'hotel', 'maps'],
+  },
+  {
+    name: 'Health & Fitness',
+    keywords: ['fitness', 'health', 'workout', 'gym', 'strava', 'fitbit', 'yoga', 'sleep', 'step', 'calorie', 'diet'],
+  },
+  {
+    name: 'Education',
+    keywords: ['education', 'learn', 'course', 'duolingo', 'khan', 'school', 'university', 'study', 'quiz', 'flashcard'],
   },
 ];
 
-function categorizeApp(app: InstalledApp): string {
+// ApplicationInfo.category (exposed as InstalledApp.category by LauncherModule,
+// see modules/launcher-module/src/index.ts) mapped to our category names.
+// Not 1:1 — decisions documented in the PR body:
+//   - AUDIO and VIDEO both collapse into Entertainment (no separate Music bucket).
+//   - IMAGE maps to Creativity (image editors/viewers read closer to creative
+//     tools than to any other iOS bucket).
+//   - ACCESSIBILITY maps to Utilities (assistive tools are utility-like; iOS's
+//     14 categories have no dedicated accessibility bucket).
+//   - Health & Fitness and Education have no native ApplicationInfo constant —
+//     they're only reachable via keywords below.
+const NATIVE_CATEGORY_MAP: Record<string, string> = {
+  game: 'Games',
+  social: 'Social',
+  news: 'Information & Reading',
+  maps: 'Travel',
+  productivity: 'Productivity & Finance',
+  audio: 'Entertainment',
+  video: 'Entertainment',
+  image: 'Creativity',
+  accessibility: 'Utilities',
+};
+
+export function categorizeApp(app: InstalledApp): string {
+  const native = app.category;
+  if (native && native !== 'undefined' && NATIVE_CATEGORY_MAP[native]) {
+    return NATIVE_CATEGORY_MAP[native];
+  }
   const nameLower = app.name.toLowerCase();
   const pkgLower = app.packageName.toLowerCase();
   for (const cat of CATEGORY_KEYWORDS) {

--- a/src/screens/__tests__/categorizeApp.test.ts
+++ b/src/screens/__tests__/categorizeApp.test.ts
@@ -1,0 +1,69 @@
+import { categorizeApp } from '../AppLibraryScreen';
+import type { InstalledApp } from '../../store/AppsStore';
+
+function app(overrides: Partial<InstalledApp>): InstalledApp {
+  return {
+    name: 'Some App',
+    packageName: 'com.example.someapp',
+    icon: '',
+    isSystem: false,
+    ...overrides,
+  };
+}
+
+describe('categorizeApp — cascata de 3 niveis (nativo > keywords > Other)', () => {
+  // --- Nivel 1: ApplicationInfo.category nativo tem precedencia ---
+  it('usa a categoria nativa "game" mesmo quando o nome bate com keyword de outra categoria', () => {
+    // "Facebook" bateria com a keyword de Social — a categoria nativa deve ganhar
+    const result = categorizeApp(app({ name: 'Facebook Gaming', category: 'game' }));
+    expect(result).toBe('Games');
+  });
+
+  it.each([
+    ['social', 'Social'],
+    ['news', 'Information & Reading'],
+    ['maps', 'Travel'],
+    ['productivity', 'Productivity & Finance'],
+    ['audio', 'Entertainment'],
+    ['video', 'Entertainment'],
+    ['image', 'Creativity'],
+    ['accessibility', 'Utilities'],
+    ['game', 'Games'],
+  ])('mapeia a categoria nativa "%s" para "%s"', (native, expected) => {
+    const result = categorizeApp(app({ name: 'App Generico', category: native }));
+    expect(result).toBe(expected);
+  });
+
+  // --- Nivel 2: fallback por keywords quando a categoria nativa nao existe ---
+  it('cai para keywords quando category e a string literal "undefined" (API 24/25 ou modulo antigo)', () => {
+    const result = categorizeApp(app({ name: 'Spotify', category: 'undefined' }));
+    expect(result).toBe('Entertainment');
+  });
+
+  it('cai para keywords quando category esta totalmente ausente (cache antigo, app virtual)', () => {
+    const result = categorizeApp(app({ name: 'Spotify', category: undefined }));
+    expect(result).toBe('Entertainment');
+  });
+
+  it('Games e categoria propria via keyword — nao cai em Entertainment', () => {
+    const result = categorizeApp(app({ name: 'Candy Crush Saga', packageName: 'com.king.candycrush' }));
+    expect(result).toBe('Games');
+  });
+
+  it.each([
+    ['Strava', 'com.strava.app', 'Health & Fitness'],
+    ['Duolingo', 'com.duolingo.app', 'Education'],
+    ['Canva', 'com.canva.editor', 'Creativity'],
+    ['Kindle', 'com.example.kindlereader', 'Information & Reading'],
+    ['Uber', 'com.ubercab', 'Travel'],
+  ])('categoriza "%s" como "%s" via keyword quando nao ha categoria nativa util', (name, pkg, expected) => {
+    const result = categorizeApp(app({ name, packageName: pkg, category: 'undefined' }));
+    expect(result).toBe(expected);
+  });
+
+  // --- Nivel 3: Other quando nada bate ---
+  it('devolve "Other" quando nem a categoria nativa nem nenhuma keyword batem', () => {
+    const result = categorizeApp(app({ name: 'Xyzzy Foo Bar', packageName: 'com.unknown.xyzzy', category: 'undefined' }));
+    expect(result).toBe('Other');
+  });
+});

--- a/src/store/AppsStore.tsx
+++ b/src/store/AppsStore.tsx
@@ -16,6 +16,12 @@ export interface InstalledApp {
   packageName: string;
   icon: string;
   isSystem: boolean;
+  /**
+   * ApplicationInfo.category exposed by LauncherModule (see modules/launcher-module).
+   * Optional: absent on cached indexes written before this field existed, and
+   * on the virtual built-in apps in VIRTUAL_APPS_MAP below.
+   */
+  category?: string;
 }
 
 export interface HomeApp {


### PR DESCRIPTION
## Resumo

App Library: cascata de 3 niveis (ApplicationInfo.category > keywords > Other) expande 5 para 11 categorias de grelha

## Causa raiz

`src/screens/AppLibraryScreen.tsx:53-64` (antes do fix) so tinha 5 categorias (`Social`, `Entertainment`, `Productivity`, `Utilities`, `Shopping`) e categorizava exclusivamente por substring do nome/packageName contra uma lista fixa de keywords (`CATEGORY_KEYWORDS`). Qualquer app fora dessas keywords caia em `Other`. `Games` estava fundido em `Entertainment` via `'game'`/`'gaming'`. Faltavam Games, Creativity, Information & Reading, Travel, Health & Fitness e Education (6 das 14 categorias do epic #472/§8).

O bloqueador #513 expos `ApplicationInfo.category` como `InstalledApp.category: string` em `modules/launcher-module/src/index.ts:29`, mas esse campo nao estava sequer declarado na interface `InstalledApp` usada pelo resto da app (`src/store/AppsStore.tsx:14-19`) nem era consultado por `categorizeApp`.

## O que mudou

- **`src/store/AppsStore.tsx`**: acrescentado `category?: string;` a `InstalledApp` (opcional — apps virtuais em `VIRTUAL_APPS_MAP` e indices em cache gravados antes desta feature nao tem o campo).
- **`src/screens/AppLibraryScreen.tsx`**:
  - `CATEGORY_KEYWORDS` expandido de 5 para 11 categorias: `Social`, `Entertainment`, `Games` (agora propria, nao fundida), `Productivity & Finance`, `Utilities`, `Shopping & Food`, `Creativity`, `Information & Reading`, `Travel`, `Health & Fitness`, `Education`. Keywords novas por categoria (finance/food/games/creativity/reading/travel/fitness/education); `'maps'` migrado de Utilities para Travel para nao competir com o mapeamento nativo `MAPS`.
  - Nova constante `NATIVE_CATEGORY_MAP` mapeando os valores nativos de `ApplicationInfo.category` para as categorias acima.
  - `categorizeApp` (agora exportada) implementa a cascata de 3 niveis: 1) categoria nativa quando presente e reconhecida, 2) keywords como fallback, 3) `Other`.
- **`src/screens/__tests__/categorizeApp.test.ts`** (novo): 19 testes cobrindo os 3 niveis da cascata.

## Tabela de mapeamento nativo -> categoria (decisoes documentadas em `AppLibraryScreen.tsx`, junto de `NATIVE_CATEGORY_MAP`)

| `ApplicationInfo.category` nativo | Categoria da App Library | Nota |
|---|---|---|
| `GAME` | Games | 1:1, sem ambiguidade |
| `SOCIAL` | Social | 1:1 |
| `NEWS` | Information & Reading | 1:1 |
| `MAPS` | Travel | 1:1 |
| `PRODUCTIVITY` | Productivity & Finance | sem constante nativa dedicada a Finance |
| `AUDIO` | Entertainment | colapsado — nao ha bucket Music separado no epic |
| `VIDEO` | Entertainment | idem |
| `IMAGE` | Creativity | decisao: editores/visualizadores de imagem leem-se melhor como Creativity do que como qualquer outra das 14 |
| `ACCESSIBILITY` (valor 8, API 31+) | Utilities | nao esta na tabela do issue; decisao: ferramentas assistivas sao utilitarias, e as 14 categorias do iOS nao tem bucket de acessibilidade |
| `UNDEFINED` / campo ausente | (cai para keywords) | API 24/25 ou modulo antigo devolvem sempre `'undefined'` |

`Health & Fitness` e `Education` **nao tem constante nativa** — so alcancaveis via keywords, como o issue ja antecipava.

## Porque assim

- Cascata em vez de substituir a heuristica: preserva a categorizacao de apps sem `ApplicationInfo.category` declarada (API 24/25, ou apps que nao declararam a categoria no manifesto), que segundo #513 e uma fracao real dos dispositivos.
- `category` opcional em vez de obrigatorio em `InstalledApp`: evitar quebrar `VIRTUAL_APPS_MAP` (13 apps virtuais sem equivalente nativo) e indices `AsyncStorage` em cache gravados por versoes anteriores da app — sao lidos de volta como `InstalledApp[]` sem o campo.
- `'maps'` keyword movida de Utilities para Travel: o mapeamento nativo ja manda MAPS para Travel; manter a keyword em Utilities criaria uma inconsistencia entre o caminho nativo e o caminho por keyword para o mesmo tipo de app.

## Criterios de aceitacao

- [x] As 14 categorias da secao existem — 11 categorias de grelha (`categorizeApp`) + `Other` + as 2 strips ja existentes (`Recently Added`, `Suggestions`, inalteradas) = 14.
- [x] `ApplicationInfo.category` tem precedencia sobre keywords; keywords mantidas como fallback — testado em `categorizeApp.test.ts` ("usa a categoria nativa game mesmo quando o nome bate com keyword de outra categoria").
- [x] Games e categoria propria, nao fundida em Entertainment — keyword `'game'`/`'gaming'` removida de Entertainment, categoria `Games` dedicada; testado.
- [x] Tabela de mapeamento nativo->iOS documentada no PR — ver secao acima e comentario em `AppLibraryScreen.tsx` junto de `NATIVE_CATEGORY_MAP`.
- [ ] Contagem antes/depois de apps em Other num dispositivo real — **nao medido**. Este ambiente e um worktree sem device/emulador Android acoplado; nao existe forma de correr `getInstalledApps()` real aqui. Fica registado como falta a medir por quem fizer QA num dispositivo fisico.
- [x] Categorias vazias nao renderizam cartao — inalterado por este PR: `AppLibraryContent`'s `categories` (`AppLibraryScreen.tsx:382-396`) so cria uma entrada no `map` quando ha pelo menos uma app nessa categoria; nunca existiu logica que gerasse cartoes vazios. Confirmado por leitura de codigo, nao por teste novo (nao e comportamento alterado por este issue).
- [x] Pesquisa continua a funcionar (#173) — `filteredApps`/`SearchResults` (`AppLibraryScreen.tsx:422-428`) nao foram tocados; nao dependem de `categorizeApp`.
- [x] Testes de `categorizeApp` cobrindo os 3 niveis da cascata — `src/screens/__tests__/categorizeApp.test.ts`, 19 testes.

## Testes

**Passo vermelho** (com o fix revertido via `git stash`, mantendo so os testes novos):

```
 TypeError: (0 , _AppLibraryScreen.categorizeApp) is not a function

   64 |   // --- Nivel 3: Other quando nada bate ---
   65 |   it('devolve "Other" quando nem a categoria nativa nem nenhuma keyword batem', () => {
 > 66 |     const result = categorizeApp(app({ name: 'Xyzzy Foo Bar', packageName: 'com.unknown.xyzzy', category: 'undefined' }));
      |                                 ^
   67 |     expect(result).toBe('Other');
   68 |   });
   69 | });

 Test Suites: 1 failed, 1 total
 Tests:       19 failed, 19 total
```

Com o fix restaurado: `Test Suites: 1 passed, 1 total` / `Tests: 19 passed, 19 total`.

**Casos cobertos** (`categorizeApp.test.ts`):
- Precedencia: categoria nativa `game` vence mesmo quando o nome bate com keyword de `Social` (`Facebook Gaming`).
- Os 9 valores nativos mapeados (`social`, `news`, `maps`, `productivity`, `audio`, `video`, `image`, `accessibility`, `game`).
- Fallback quando `category` e a string literal `'undefined'` (API 24/25 / modulo antigo).
- Fallback quando `category` esta totalmente ausente (cache antigo, apps virtuais) — o oposto do caminho feliz de precedencia nativa.
- `Games` alcancavel so por keyword, sem cair em `Entertainment`.
- 5 categorias novas alcancaveis so por keyword (`Health & Fitness`, `Education`, `Creativity`, `Information & Reading`, `Travel`) — as que nao tem constante nativa dedicada ou que dependem do fallback.
- `Other` quando nada bate.

**Sanity-check**: fix revertido via `git stash push -u -- src/screens/AppLibraryScreen.tsx src/store/AppsStore.tsx` (mantendo o teste), suite falhou (19/19), `git stash apply` + `git stash drop` para restaurar. Confirmado acima.

**Resultados**:
- `npm run lint`: 0 erros, 2 warnings pre-existentes e nao relacionados (`BridgeErrorReporting.test.tsx`, `ClockScreen.tsx`).
- `npx tsc --noEmit`: limpo, sem output.
- `npm test`: 878 passaram, 8 falharam, 115 suites (111 passaram, 4 falharam). As 8 falhas e as 4 suites sao **exactamente** as da linha de base (`FoldersStore` x2, `LockScreen` x3, `SettingsScreen` x1, `WeatherScreen` x2 — causa raiz conhecida: `SettingsStore.tsx`'s `if (!firstSyncDone) return null`). Sem regressao. O total de testes subiu de 720 (baseline, sha `51c1509`) para 886 porque o branch parte de `ecc3eb6`, varios commits a frente da baseline — nao e efeito deste PR.

## Testes

878 passaram, 8 falharam (identicos a baseline), 115 suites (111 passaram, 4 falharam)

## Linked Issue

Fixes #514