### PR TITLE
qa/issue-559: merge missing Back/Forward WebView toolbar (qa/issue-248) into BrowserScreen, which already had WebView/address-bar/Share on main (#559)

### DIFF
--- a/src/screens/BrowserScreen.tsx
+++ b/src/screens/BrowserScreen.tsx
@@ -65,6 +65,8 @@ export function BrowserScreen({ navigation }: { navigation: AppNavigationProp })
   const [loading, setLoading] = useState(false);
   const [progress, setProgress] = useState(0);
   const [showShareSheet, setShowShareSheet] = useState(false);
+  const [canGoBack, setCanGoBack] = useState(false);
+  const [canGoForward, setCanGoForward] = useState(false);
   const webviewRef = useRef<WebView>(null);
 
   const handleSubmit = useCallback(() => {
@@ -89,7 +91,20 @@ export function BrowserScreen({ navigation }: { navigation: AppNavigationProp })
 
   const handleNavigationStateChange = useCallback((navState: WebViewNavigation) => {
     setPageTitle(navState.title);
+    setCanGoBack(navState.canGoBack);
+    setCanGoForward(navState.canGoForward);
+    setInputUrl(navState.url);
   }, []);
+
+  const handleGoBackInHistory = useCallback(() => {
+    if (!canGoBack) return;
+    webviewRef.current?.goBack();
+  }, [canGoBack]);
+
+  const handleGoForwardInHistory = useCallback(() => {
+    if (!canGoForward) return;
+    webviewRef.current?.goForward();
+  }, [canGoForward]);
 
   return (
     <View style={[styles.container, { paddingTop: insets.top }]}>
@@ -176,6 +191,44 @@ export function BrowserScreen({ navigation }: { navigation: AppNavigationProp })
         title={pageTitle}
         url={currentUrl}
       />
+
+      <View
+        style={[
+          styles.bottomToolbar,
+          { paddingBottom: insets.bottom + 8, borderTopColor: colors.separator },
+        ]}
+      >
+        <Pressable
+          onPress={handleGoBackInHistory}
+          disabled={!canGoBack}
+          hitSlop={8}
+          accessibilityLabel="Go back in history"
+          accessibilityRole="button"
+          accessibilityState={{ disabled: !canGoBack }}
+        >
+          <Ionicons
+            name="chevron-back"
+            size={26}
+            color={BROWSER_ACCENT}
+            style={{ opacity: canGoBack ? 1 : 0.3 }}
+          />
+        </Pressable>
+        <Pressable
+          onPress={handleGoForwardInHistory}
+          disabled={!canGoForward}
+          hitSlop={8}
+          accessibilityLabel="Go forward in history"
+          accessibilityRole="button"
+          accessibilityState={{ disabled: !canGoForward }}
+        >
+          <Ionicons
+            name="chevron-forward"
+            size={26}
+            color={BROWSER_ACCENT}
+            style={{ opacity: canGoForward ? 1 : 0.3 }}
+          />
+        </Pressable>
+      </View>
     </View>
   );
 }
@@ -206,5 +259,17 @@ function createStyles(colors: CupertinoColors) {
     progressTrack: { height: 2, backgroundColor: 'transparent' },
     progressBar: { height: 2, backgroundColor: BROWSER_ACCENT },
     webview: { flex: 1 },
+    bottomToolbar: {
+      position: 'absolute',
+      left: 0,
+      right: 0,
+      bottom: 0,
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      paddingHorizontal: 24,
+      paddingTop: 10,
+      borderTopWidth: StyleSheet.hairlineWidth,
+      backgroundColor: colors.secondarySystemBackground,
+    },
   });
 }

--- a/src/screens/__tests__/BrowserScreen.test.tsx
+++ b/src/screens/__tests__/BrowserScreen.test.tsx
@@ -3,6 +3,31 @@ import { render, fireEvent } from '../../test-utils';
 import { BrowserScreen, resolveUrl, BROWSER_HOME_URL } from '../BrowserScreen';
 import { BUILT_IN_APPS, VIRTUAL_ICON_CONFIG } from '../LauncherHomeScreen';
 
+// The global mock in jest.setup.js hands out a fresh jest.fn() per render
+// (useImperativeHandle has no deps array), so a reference captured before a
+// state-driven re-render would not be the one BrowserScreen actually calls.
+// Override it here with module-scoped mocks so the same fn identity survives
+// every re-render within this file, and BrowserScreen.test.tsx can assert on it.
+const mockGoBack = jest.fn();
+const mockGoForward = jest.fn();
+jest.mock('react-native-webview', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const ReactActual = require('react');
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { View } = require('react-native');
+  const WebView = ReactActual.forwardRef((props: object, ref: React.Ref<unknown>) => {
+    ReactActual.useImperativeHandle(ref, () => ({
+      reload: jest.fn(),
+      goBack: mockGoBack,
+      goForward: mockGoForward,
+      stopLoading: jest.fn(),
+    }));
+    return ReactActual.createElement(View, props);
+  });
+  WebView.displayName = 'WebView';
+  return { __esModule: true, WebView, default: WebView };
+});
+
 const nav = { navigate: jest.fn(), goBack: jest.fn() } as never;
 
 beforeEach(() => jest.clearAllMocks());
@@ -145,6 +170,93 @@ describe('BrowserScreen — Share', () => {
     fireEvent.press(utils.getByLabelText('Cancel'));
     expect(utils.queryByLabelText('Copy')).toBeNull();
     expect(webviewUri(utils)).toBe(BROWSER_HOME_URL);
+  });
+});
+
+function fireNavigationStateChange(
+  utils: ReturnType<typeof render>,
+  nav: { canGoBack: boolean; canGoForward: boolean; url: string; loading?: boolean },
+) {
+  fireEvent(utils.getByTestId('browser-webview'), 'navigationStateChange', {
+    canGoBack: nav.canGoBack,
+    canGoForward: nav.canGoForward,
+    url: nav.url,
+    loading: nav.loading ?? false,
+    title: '',
+    lockIdentifier: 0,
+    navigationType: 'click',
+  });
+}
+
+describe('BrowserScreen — Back/Forward toolbar', () => {
+  it('renders Back and Forward buttons dimmed and inert when history is empty in both directions', () => {
+    const utils = render(<BrowserScreen navigation={nav} />);
+    fireNavigationStateChange(utils, { canGoBack: false, canGoForward: false, url: BROWSER_HOME_URL });
+
+    const back = utils.getByLabelText('Go back in history');
+    const forward = utils.getByLabelText('Go forward in history');
+    expect(back.props.accessibilityState?.disabled).toBe(true);
+    expect(forward.props.accessibilityState?.disabled).toBe(true);
+
+    fireEvent.press(back);
+    fireEvent.press(forward);
+    expect(mockGoBack).not.toHaveBeenCalled();
+    expect(mockGoForward).not.toHaveBeenCalled();
+  });
+
+  it('enables Back and calls only WebView.goBack when canGoBack is true (not Forward)', () => {
+    const utils = render(<BrowserScreen navigation={nav} />);
+    fireNavigationStateChange(utils, { canGoBack: true, canGoForward: false, url: 'https://example.com/page2' });
+
+    const back = utils.getByLabelText('Go back in history');
+    expect(back.props.accessibilityState?.disabled).toBe(false);
+    fireEvent.press(back);
+
+    expect(mockGoBack).toHaveBeenCalledTimes(1);
+    expect(mockGoForward).not.toHaveBeenCalled();
+  });
+
+  it('enables Forward and calls only WebView.goForward when canGoForward is true (not Back)', () => {
+    const utils = render(<BrowserScreen navigation={nav} />);
+    fireNavigationStateChange(utils, { canGoBack: false, canGoForward: true, url: 'https://example.com/page1' });
+
+    const forward = utils.getByLabelText('Go forward in history');
+    expect(forward.props.accessibilityState?.disabled).toBe(false);
+    fireEvent.press(forward);
+
+    expect(mockGoForward).toHaveBeenCalledTimes(1);
+    expect(mockGoBack).not.toHaveBeenCalled();
+  });
+
+  it('re-enables both buttons when a later navigation reports history in both directions', () => {
+    const utils = render(<BrowserScreen navigation={nav} />);
+    fireNavigationStateChange(utils, { canGoBack: false, canGoForward: false, url: BROWSER_HOME_URL });
+    fireNavigationStateChange(utils, { canGoBack: true, canGoForward: true, url: 'https://example.com/page3' });
+
+    fireEvent.press(utils.getByLabelText('Go back in history'));
+    fireEvent.press(utils.getByLabelText('Go forward in history'));
+    expect(mockGoBack).toHaveBeenCalledTimes(1);
+    expect(mockGoForward).toHaveBeenCalledTimes(1);
+  });
+
+  it('reflects the WebView current URL in the address bar after navigating within the page', () => {
+    const utils = render(<BrowserScreen navigation={nav} />);
+    fireNavigationStateChange(utils, {
+      canGoBack: true,
+      canGoForward: false,
+      url: 'https://example.com/deep/link',
+    });
+    expect(utils.getByPlaceholderText('Search or enter website name').props.value).toBe(
+      'https://example.com/deep/link',
+    );
+  });
+
+  it('does not touch the top-bar "Go back" (navigation.goBack) button or label — regression guard', () => {
+    const utils = render(<BrowserScreen navigation={nav} />);
+    fireNavigationStateChange(utils, { canGoBack: true, canGoForward: true, url: 'https://example.com' });
+    fireEvent.press(utils.getByLabelText('Go back'));
+    expect((nav as unknown as { goBack: jest.Mock }).goBack).toHaveBeenCalledTimes(1);
+    expect(mockGoBack).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Resumo

qa/issue-559: merge missing Back/Forward WebView toolbar (qa/issue-248) into BrowserScreen, which already had WebView/address-bar/Share on main

## Causa raiz

O issue descrevia um estado que já não é o actual: `git ls-tree -r origin/main --name-only | grep -i browser` **já devolve** `src/screens/BrowserScreen.tsx` e `src/screens/__tests__/BrowserScreen.test.tsx` — os commits de `qa/issue-247` (WebView + address bar) e `qa/issue-251` (Share) já foram mesclados em `main` através da PR #556 (`e970a27`, `git log origin/main` confirma). O que o issue pedia para os passos 1 e 3 já não é accionável: não há nada para cherry-pick, já está lá.

O que **continua em falta** é o passo 2: `qa/issue-248` (`f5ae23a`, "add Back/Forward toolbar to BrowserScreen with WebView history tracking") nunca foi mesclado em `main` — confirmado com `git log --graph --oneline --all`, que mostra o branch `qa/issue-248` isolado, sem merge para `main`. `main:src/screens/BrowserScreen.tsx` tem `handleNavigationStateChange` a só actualizar `pageTitle` (herdado do commit de Share), sem `canGoBack`/`canGoForward`/toolbar inferior — o mecanismo real do WebView back/forward simplesmente não existe no ecrã actual.

## O que mudou

- `src/screens/BrowserScreen.tsx`: cherry-pick de `f5ae23a` (`qa/issue-248`) sobre o estado actual (que já tinha Share de `qa/issue-251`), com o conflito resolvido a juntar os dois blocos em vez de escolher um:
  - Estado: `canGoBack`/`canGoForward` (de 248) juntam-se a `showShareSheet` (de 251) — os três coexistem.
  - `handleNavigationStateChange` agora actualiza **as quatro coisas**: `pageTitle` (Share), `canGoBack`, `canGoForward` e `inputUrl` (Back/Forward) — nenhuma das duas versões do conflito sozinha bastava.
  - `handleGoBackInHistory`/`handleGoForwardInHistory` chamam `webviewRef.current.goBack()/.goForward()`, guardados por `canGoBack`/`canGoForward`.
  - Nova barra inferior (`bottomToolbar`) com os botões "Go back in history"/"Go forward in history", esmaecidos (`opacity 0.3`) e `accessibilityState.disabled` quando não há histórico nessa direcção — coexiste com o `CupertinoShareSheet` (modal) e com o botão "Go back" do topo (que continua a ser `navigation.goBack()`, inalterado).
- `src/screens/__tests__/BrowserScreen.test.tsx`: mesmo merge para os testes — mantém os 5 testes de `describe('BrowserScreen — Share', ...)` e acrescenta os 6 testes de `describe('BrowserScreen — Back/Forward toolbar', ...)` de `f5ae23a`, incluindo o `fireNavigationStateChange` helper e o teste de regressão que confirma que o botão "Go back" do topo continua a chamar `navigation.goBack()` e não `webview.goBack()`.

## Porque assim

O issue previa exactamente este conflito ("conflita com o passo 2 em `BrowserScreen.tsx` (3 hunks) ... resolver juntando os dois blocos"), mas a topologia real do repositório já tinha avançado — 247 e 251 estavam em `main`, só 248 estava órfão. Em vez de cherry-pick sequencial dos 3 commits (que teria re-aplicado 247/251 e gerado conflitos espúrios com o que já existe em `main`), fiz cherry-pick apenas de `f5ae23a` (o único commit realmente em falta) directamente sobre o `HEAD` actual, que já contém 247+251. Resultado idêntico ao pedido, sem reintroduzir trabalho já integrado.

Alternativa descartada: reescrever o Back/Forward de raiz. Rejeitada — o commit `f5ae23a` já tem a lógica correcta e testada; reimplementar seria trabalho duplicado e um desvio das regras ("não desenvolvimento, é integração").

## Critérios de aceitação

- [x] `src/screens/BrowserScreen.tsx` existe com WebView, address bar, toolbar Back/Forward e botão Share, todos funcionais em simultâneo — confirmado por leitura do ficheiro final e pelos 28 testes a passar juntos na mesma suite.
- [x] `react-native-webview` está em `dependencies` de `package.json` e em `node_modules` — já estava (herdado de 247/main), confirmado com `grep react-native-webview package.json` → `"^13.16.0"`.
- [x] Rota `Browser` registada e acessível pelo ícone do launcher — já estava em `main` (`src/navigation/types.ts:30`, `TabNavigator.tsx:68,113`), inalterado por este trabalho.
- [x] Nenhuma funcionalidade nova além dos 3 commits originais — só copiei o diff de `f5ae23a`, sem adições.
- [x] Testes existentes passam sem alterações de comportamento — 28/28 na suite de `BrowserScreen.test.tsx`, incluindo os 5 testes de Share que já estavam a passar em `main` antes desta alteração.

## Testes

**Passo vermelho** (fix revertido, testes mesclados mantidos — `BrowserScreen.tsx` reposto na versão de `main`/`HEAD`, sem o Back/Forward):

```
FAIL Android src/screens/__tests__/BrowserScreen.test.tsx
  ● BrowserScreen — Back/Forward toolbar › renders Back and Forward buttons dimmed and inert when history is empty in both directions
  ● BrowserScreen — Back/Forward toolbar › enables Back and calls only WebView.goBack when canGoBack is true (not Forward)
  ● BrowserScreen — Back/Forward toolbar › enables Forward and calls only WebView.goForward when canGoForward is true (not Back)
  ● BrowserScreen — Back/Forward toolbar › re-enables both buttons when a later navigation reports history in both directions

    > 236 |     fireEvent.press(utils.getByLabelText('Go back in history'));
           |                           ^

  ● BrowserScreen — Back/Forward toolbar › reflects the WebView current URL in the address bar after navigating within the page

    expect(received).toBe(expected) // Object.is equality
    Expected: "https://example.com/deep/link"
    Received: "https://www.google.com"

      247 |       url: 'https://example.com/deep/link',
      248 |     });
    > 249 |     expect(utils.getByPlaceholderText('Search or enter website name').props.value).toBe(
           |                                                                                    ^
      250 |       'https://example.com/deep/link',
      251 |     );

Test Suites: 1 failed, 1 total
Tests:       5 failed, 23 passed, 28 total
```

Com o fix reposto: `Test Suites: 1 passed, 1 total / Tests: 28 passed, 28 total`.

**Casos cobertos** (herdados de `f5ae23a`, verificados por leitura + execução):
- Fronteira: histórico vazio nas duas direcções → botões esmaecidos e inertes, `webview.goBack/goForward` NÃO chamados mesmo com toque.
- Só uma direcção disponível de cada vez (`canGoBack` sem `canGoForward` e vice-versa) → só o botão certo dispara a chamada certa.
- Transição: navegação inicial sem histórico, depois com histórico nas duas direcções → botões reactivam correctamente.
- Efeito lateral: `inputUrl` (endereço) reflecte a URL do WebView após navegação interna (deep link), não fica preso ao valor digitado.
- Regressão/inverso do fix: o botão "Go back" do topo (`navigation.goBack()`, ecrã anterior da app) continua a NÃO chamar `webview.goBack()` — são dois mecanismos distintos e não podem colidir.
- Suite de Share (herdada, 5 testes) corre sem alteração de comportamento na mesma execução — confirma que os dois blocos do conflito coexistem sem um pisar o outro.

**Sanity-check:** reverti `BrowserScreen.tsx` para a versão de `HEAD` (sem o Back/Forward, com Share), mantendo os testes mesclados; a suite falhou 5/28 (acima, output real). Restaurei o ficheiro com o fix; a suite voltou a 28/28. Confirmado também por `git stash` que as 8 falhas da suite completa (`LockScreen`, `WeatherScreen`, `FoldersStore`, `SettingsScreen`) são idênticas com e sem as minhas alterações — pré-existentes, nada tocado por mim nesses ficheiros.

**`npm run lint`:** 0 erros, 3 warnings pré-existentes em ficheiros não tocados (`BridgeErrorReporting.test.tsx`, `ClockScreen.tsx`, `FindMyScreen.tsx`).
**`npx tsc --noEmit`:** limpo, sem output.
**`npm test -- --maxWorkers=2`:** `Test Suites: 4 failed, 117 passed, 121 total` / `Tests: 8 failed, 960 passed, 968 total` — as 8 falhas são as mesmas 4 suites pré-existentes e não relacionadas com Browser (confirmadas idênticas via `git stash` antes/depois desta alteração); nenhuma falha nova.

## Testes

28 passaram, 0 falharam na suite BrowserScreen.test.tsx (suite completa: 960 passaram, 8 falharam pré-existentes não relacionados, 968 total)

## Linked Issue

Fixes #559