### PR TITLE
fix/500: COLS agora é sempre 4 (invariante) em qualquer largura; ícone encolhe para caber, não a grelha (#500)

### DIFF
--- a/src/utils/__tests__/launcherGridGeometry.test.ts
+++ b/src/utils/__tests__/launcherGridGeometry.test.ts
@@ -58,7 +58,9 @@ describe('computeLauncherGridGeometry', () => {
     (width) => {
       const g = computeLauncherGridGeometry(width);
       expect(g.cols).toBeGreaterThanOrEqual(1);
-      expect(g.iconSize).toBeGreaterThanOrEqual(1);
+      // Com cols=4 fixo, em larguras < 4 o ícone pode ser 0 para caber no ecrã.
+      // Isto é um edge case teórico (ecrãs reais >= 320dp).
+      expect(g.iconSize).toBeGreaterThanOrEqual(0);
       expect(g.horizontalPadding).toBeGreaterThanOrEqual(0);
       expect(g.iconSize * g.cols + g.horizontalPadding * 2).toBeLessThanOrEqual(
         Math.max(1, width),
@@ -75,6 +77,15 @@ describe('computeLauncherGridGeometry', () => {
 
   it('é puro: a mesma largura devolve sempre os mesmos valores', () => {
     expect(computeLauncherGridGeometry(411)).toEqual(computeLauncherGridGeometry(411));
+  });
+
+  it('mantém sempre 4 colunas (#500)', () => {
+    // A grelha deve ter sempre 4 colunas (como no iOS), em qualquer largura.
+    // O ícone é que encolhe para caber, não a contagem de colunas.
+    for (const width of [320, 360, 393, 411, 480]) {
+      const g = computeLauncherGridGeometry(width);
+      expect(g.cols).toBe(4);
+    }
   });
 });
 

--- a/src/utils/launcherGridGeometry.ts
+++ b/src/utils/launcherGridGeometry.ts
@@ -37,18 +37,23 @@ export type LauncherGridGeometry = {
  */
 export function computeLauncherGridGeometry(screenWidth: number): LauncherGridGeometry {
   const width = Math.max(1, screenWidth);
-  const cols = Math.max(1, Math.min(4, Math.floor(width / 90)));
+  const cols = 4;
 
-  const horizontalPadding = Math.min(
-    Math.round(width * GRID_PADDING_RATIO),
-    // Nunca deixar a área de conteúdo sem espaço, mesmo em larguras absurdas.
-    Math.floor((width - cols) / 2),
+  const horizontalPadding = Math.max(
+    0,
+    Math.min(
+      Math.round(width * GRID_PADDING_RATIO),
+      // Nunca deixar a área de conteúdo sem espaço, mesmo em larguras absurdas.
+      Math.floor((width - cols) / 2),
+    ),
   );
 
   const cellWidth = (width - horizontalPadding * 2) / cols;
   // O ícone tem de caber na célula: se o valor da especificação não couber
   // (larguras muito estreitas), fica limitado pela célula em vez de transbordar.
-  const iconSize = Math.max(1, Math.min(Math.round(width * ICON_SIZE_RATIO), Math.floor(cellWidth)));
+  // Em larguras absurdamente pequenas (< 4dp com cols=4), permite degradação
+  // a iconSize=0 em vez de quebrar o constraint de caber no ecrã.
+  const iconSize = Math.max(0, Math.min(Math.round(width * ICON_SIZE_RATIO), Math.floor(cellWidth)));
 
   return {
     cols,


### PR DESCRIPTION
## Resumo

fix/500: COLS agora é sempre 4 (invariante) em qualquer largura; ícone encolhe para caber, não a grelha

## Causa raiz

`src/utils/launcherGridGeometry.ts:40` calculava `cols = Math.min(4, Math.floor(width / 90))`, o que dava 3 colunas a 320dp em vez de 4. O comentário `// 24` na constante `APPS_PER_PAGE` era enganador: só era verdade se `SCREEN_WIDTH >= 360`.

A §2 da especificação fixa 4 colunas e deixa o ícone escalar com a largura, não o contrário.

## O que mudou

- **src/utils/launcherGridGeometry.ts** (linhas 40, 42-56):
  - Linha 40: `cols = 4` (fixo, não variável)
  - Linha 42-49: Adicionado `Math.max(0, ...)` em torno do cálculo de `horizontalPadding` para garantir que nunca fica negativa em larguras extremas
  - Linha 56: Alterado `iconSize` de `Math.max(1, ...)` para `Math.max(0, ...)` para permitir degradação a 0 em ecrãs impossíveis (< 4dp com cols=4)

- **src/utils/__tests__/launcherGridGeometry.test.ts**:
  - Adicionado teste "mantém sempre 4 colunas (#500)" para verificar que `cols === 4` em 320, 360, 393, 411, 480dp
  - Ajustado teste "degrada com segurança em larguras inválidas" para aceitar `iconSize >= 0` em vez de `>= 1`, pois com cols=4 fixo é geometricamente impossível em width < 4

## Porque assim

1. **Invariante de grelha**: a §2 fixa 4 colunas como a iOS. Isto é um contrato imutável — a aplicação inteira assume 24 ícones por página (COLS × ROWS = 4 × 6). Variações de largura resolvem-se pelo ícone encolher (proporcionalmente segundo ICON_SIZE_RATIO), não pela grelha mudar de forma.

2. **Robustez em casos extremos**: com cols=4 fixo, é impossível ter `iconSize >= 1` em width < 4. O teste original foi escrito assumindo cols variável. O novo comportamento aceita degradação a iconSize=0 em ecrãs impossíveis (< 4dp), que é um edge case teórico — ecrãs reais têm >= 320dp.

3. **Sem regressão**: os testes de launcherGridGeometry passam todos (16/16). A suite completa melhorou de 17 falhas no baseline para 8 (9 testes foram fixados). Nenhuma regressão nova introduzida.

## Critérios de aceitação

- [x] `COLS === 4` em qualquer largura (320, 360, 393, 411, 480dp verificados no teste)
- [x] `APPS_PER_PAGE === 24` em qualquer largura (derivado de COLS * ROWS = 4 * 6)
- [x] `computeLauncherGridGeometry(320).cols === 4` (antes era 3)
- [x] Teste que verifica a invariante em várias larguras simuladas ("mantém sempre 4 colunas (#500)")
- [x] Comportamento degradado gracefully em larguras extremas (< 4dp) sem quebrar constraint de caber no ecrã
- [x] Nenhuma regressão em LauncherHomeScreen (já consome a geometria, agora com cols invariante)
- [x] Lint: 0 erros (3 warnings pré-existentes em FindMyScreen)
- [x] TypeScript: limpo
- [x] Testes: 8 falhas vs. 17 no baseline (melhoria de 9)

## Testes

### Passo vermelho

Com o fix revertido, o teste novo "mantém sempre 4 colunas (#500)" falha:

```
expect(received).toBe(expected) // Object.is equality

Expected: 4
Received: 3

  83 |     for (const width of [320, 360, 393, 411, 480]) {
  84 |       const g = computeLauncherGridGeometry(width);
> 85 |       expect(g.cols).toBe(4);
```

Este é o passo vermelho obrigatório — prova que o teste está ligado ao comportamento.

### Cobertura

- **Invariante de colunas**: testa que cols=4 em 5 larguras diferentes (320, 360, 393, 411, 480)
- **Casos extremos**: testes pré-existentes cobrem width=0, -1, -1000 para degradação segura
- **Integridade da geometria**: teste "a soma das células cobre exactamente a área de conteúdo" continua a passar (verificado para 360, 393, 411, 480)
- **Proporcionalidade**: teste "mantém o raio proporcional ao lado do ícone" continua a passar em 320, 360, 393, 411, 480, 800

### Sanity-check

Revertido o fix, o teste falha. Restaurado o fix, o teste passa. Testes de geometria: 16/16 passam.

## Verificações

```
npm run lint: 0 errors (3 warnings pré-existentes)
npx tsc --noEmit: limpo
npm test: 1088 passed, 8 failed (vs. 1079 passed, 17 failed no baseline)
```

## Testes

1088 passaram, 8 falharam, 130 suites (vs. baseline: 1079 passaram, 17 falharam) — melhoria de 9 testes

## Linked Issue

Fixes #500