### PR TITLE
AppStoreScreen: add honest 'Updates' tab (4th segmented segment) — lists real installed apps, deep-links to Play Store, no fabricated update state (#254)

### DIFF
--- a/src/screens/AppStoreScreen.tsx
+++ b/src/screens/AppStoreScreen.tsx
@@ -12,7 +12,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { CupertinoNavigationBar, CupertinoSegmentedControl, CupertinoSearchBar } from '../components';
 import { useTheme } from '../theme/ThemeContext';
-import { useApps } from '../store/AppsStore';
+import { useApps, VIRTUAL_APP_PACKAGE_NAMES } from '../store/AppsStore';
 import { CURATED_APPS, type CuratedApp } from '../data/curatedApps';
 import type { AppNavigationProp } from '../navigation/types';
 import { logger } from '../utils/logger';
@@ -20,7 +20,7 @@ import type { InstalledApp } from '../store/AppsStore';
 
 // Segment labels live in one place — inserting/reordering a tab means
 // changing this array only, not the render branches below.
-const APP_STORE_SEGMENTS = ['Today', 'Search', 'Categories'] as const;
+const APP_STORE_SEGMENTS = ['Today', 'Search', 'Categories', 'Updates'] as const;
 
 // ---------------------------------------------------------------------------
 // Categories tab — keyword-based grouping, scoped to this file
@@ -159,6 +159,67 @@ function AppRow({
 }
 
 // ---------------------------------------------------------------------------
+// Updates tab — honest manual-update check (no fabrication of update state)
+// ---------------------------------------------------------------------------
+
+// Android offers no public, key-free way for a third-party app to know whether
+// an installed app has an update pending — that needs the Play Developer API,
+// which this app neither has nor can obtain. So the Updates tab does NOT claim
+// to detect updates. It lists every real, user-installed app (system apps and
+// this app's own virtual built-ins excluded) and offers a deep link to that
+// app's Play Store page so the user can check/update manually. No fabricated
+// "N updates available" badge, no fake version comparison, ever.
+function UpdatesTab({ apps, onCheck }: { apps: InstalledApp[]; onCheck: (packageName: string) => void }) {
+  const { theme, typography } = useTheme();
+  const { colors } = theme;
+
+  return (
+    <>
+      <Text
+        testID="updates-notice"
+        style={[typography.footnote, styles.updatesNotice, { color: colors.secondaryLabel }]}
+      >
+        Android cannot check for app updates automatically. Tap an app to open its Play Store page.
+      </Text>
+
+      {apps.length === 0 ? (
+        <Text style={[typography.footnote, styles.updatesEmpty, { color: colors.tertiaryLabel }]}>
+          No installed apps to check.
+        </Text>
+      ) : (
+        apps.map((app) => (
+          <Pressable
+            key={app.packageName}
+            onPress={() => onCheck(app.packageName)}
+            accessibilityRole="button"
+            accessibilityLabel={`Check ${app.name} on Play Store`}
+            style={[
+              styles.updateRow,
+              { backgroundColor: colors.secondarySystemGroupedBackground },
+            ]}
+          >
+            <View style={[styles.iconPlaceholder, { backgroundColor: colors.systemGray5 }]}>
+              <Ionicons name="cube-outline" size={26} color={colors.secondaryLabel} />
+            </View>
+            <View style={styles.cardText}>
+              <Text style={[typography.headline, { color: colors.label }]} numberOfLines={1}>
+                {app.name}
+              </Text>
+              <Text style={[typography.caption1, { color: colors.tertiaryLabel }]} numberOfLines={1}>
+                {app.packageName}
+              </Text>
+            </View>
+            <Text style={[typography.footnote, styles.updateActionLabel, { color: colors.systemBlue }]}>
+              Check
+            </Text>
+          </Pressable>
+        ))
+      )}
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Screen
 // ---------------------------------------------------------------------------
 
@@ -182,6 +243,18 @@ export function AppStoreScreen({ navigation }: { navigation: AppNavigationProp }
   // display name, so a user-renamed app still resolves as installed.
   const installedPackages = useMemo(
     () => new Set(apps.map((a) => a.packageName)),
+    [apps],
+  );
+
+  // Updates tab candidates: real, user-installed apps only. System apps are
+  // excluded via isSystem; this app's own virtual built-ins (Phone, Messages,
+  // Settings, …) are excluded by package name because every entry in
+  // VIRTUAL_APPS_MAP has isSystem:false and would otherwise slip through.
+  const updatableCandidates = useMemo(
+    () =>
+      apps.filter(
+        (a) => !a.isSystem && !VIRTUAL_APP_PACKAGE_NAMES.has(a.packageName),
+      ),
     [apps],
   );
 
@@ -224,6 +297,26 @@ export function AppStoreScreen({ navigation }: { navigation: AppNavigationProp }
       }
     } catch (err) {
       logger.warn('AppStoreScreen', 'could not open Play Store search', err);
+    }
+  }, []);
+
+  // Manual update check: Android can't tell us whether an installed app has a
+  // pending update, so we deep-link to its Play Store listing and let the user
+  // check there. Same canOpenURL→openURL→https-fallback guard as the Today
+  // "Get" action — honest about the limitation, not faking detection.
+  const handleCheckUpdate = useCallback(async (packageName: string) => {
+    const marketUrl = playStoreUrl(packageName);
+    try {
+      if (await Linking.canOpenURL(marketUrl)) {
+        await Linking.openURL(marketUrl);
+        return;
+      }
+      const webUrl = playStoreWebUrl(packageName);
+      if (await Linking.canOpenURL(webUrl)) {
+        await Linking.openURL(webUrl);
+      }
+    } catch (err) {
+      logger.warn('AppStoreScreen', 'could not open store listing', err);
     }
   }, []);
 
@@ -385,7 +478,7 @@ export function AppStoreScreen({ navigation }: { navigation: AppNavigationProp }
               </Text>
             </Pressable>
           </>
-        ) : (
+        ) : tabIndex === 2 ? (
           <>
             {categorySections.map((section) => (
               <View key={section.name} style={styles.categorySection}>
@@ -405,6 +498,8 @@ export function AppStoreScreen({ navigation }: { navigation: AppNavigationProp }
               </View>
             ))}
           </>
+        ) : (
+          <UpdatesTab apps={updatableCandidates} onCheck={handleCheckUpdate} />
         )}
       </ScrollView>
     </View>
@@ -483,5 +578,23 @@ const styles = StyleSheet.create({
   },
   backLabel: {
     fontWeight: '400',
+  },
+  updatesNotice: {
+    marginTop: 2,
+    marginBottom: 12,
+    lineHeight: 19,
+  },
+  updatesEmpty: {
+    marginTop: 4,
+  },
+  updateRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: 12,
+    marginBottom: 10,
+    borderRadius: 12,
+  },
+  updateActionLabel: {
+    fontWeight: '700',
   },
 });

--- a/src/screens/__tests__/AppStoreScreen.test.tsx
+++ b/src/screens/__tests__/AppStoreScreen.test.tsx
@@ -358,6 +358,137 @@ describe('AppStoreScreen — Categories tab', () => {
   });
 });
 
+describe('AppStoreScreen — Updates tab', () => {
+  const UPDATES_NOTICE =
+    "Android cannot check for app updates automatically. Tap an app to open its Play Store page.";
+
+  it('the segmented control now offers Today, Search, Categories and Updates', () => {
+    const { getAllByText, getByText } = render(<AppStoreScreen navigation={nav} />);
+    expect(getAllByText('Today').length).toBeGreaterThan(0);
+    expect(getByText('Search')).toBeTruthy();
+    expect(getByText('Categories')).toBeTruthy();
+    expect(getByText('Updates')).toBeTruthy();
+  });
+
+  it('selecting Updates shows the honesty notice that automatic detection is unavailable', () => {
+    const { getByText, getByTestId } = render(<AppStoreScreen navigation={nav} />);
+    fireEvent.press(getByText('Updates'));
+    // Exact copy states the limitation plainly — no "live check" implication.
+    expect(getByText(UPDATES_NOTICE)).toBeTruthy();
+    expect(getByTestId('updates-notice')).toBeTruthy();
+  });
+
+  it('shows a non-system installed app as a row with a Check-on-Play-Store action', () => {
+    const regular: AppsStore.InstalledApp = {
+      name: 'Acme Notes',
+      packageName: 'com.acme.notes',
+      icon: '',
+      isSystem: false,
+    };
+    mockApps([regular]);
+    const { getByText, getByLabelText } = render(<AppStoreScreen navigation={nav} />);
+    fireEvent.press(getByText('Updates'));
+    expect(getByLabelText('Check Acme Notes on Play Store')).toBeTruthy();
+  });
+
+  it('excludes system apps from the Updates list', () => {
+    const systemApp: AppsStore.InstalledApp = {
+      name: 'Android System',
+      packageName: 'com.android.system',
+      icon: '',
+      isSystem: true,
+    };
+    mockApps([systemApp]);
+    const { getByText, queryByLabelText } = render(<AppStoreScreen navigation={nav} />);
+    fireEvent.press(getByText('Updates'));
+    expect(queryByLabelText('Check Android System on Play Store')).toBeNull();
+  });
+
+  it('excludes this app’s own virtual built-ins from the Updates list', () => {
+    const virtualApp: AppsStore.InstalledApp = {
+      name: 'Phone',
+      packageName: 'com.iostoandroid.phone',
+      icon: '',
+      isSystem: false,
+    };
+    mockApps([virtualApp]);
+    const { getByText, queryByLabelText } = render(<AppStoreScreen navigation={nav} />);
+    fireEvent.press(getByText('Updates'));
+    // VIRTUAL_APPS_MAP entries are isSystem:false, so isSystem alone wouldn't
+    // exclude them — the exclusion must be by package name.
+    expect(queryByLabelText('Check Phone on Play Store')).toBeNull();
+  });
+
+  it('tapping a row’s action calls Linking.openURL with the market:// deep link for that package', async () => {
+    const regular: AppsStore.InstalledApp = {
+      name: 'Acme Notes',
+      packageName: 'com.acme.notes',
+      icon: '',
+      isSystem: false,
+    };
+    mockApps([regular]);
+    const { getByText, getByLabelText } = render(<AppStoreScreen navigation={nav} />);
+    fireEvent.press(getByText('Updates'));
+    fireEvent.press(getByLabelText('Check Acme Notes on Play Store'));
+    await waitFor(() =>
+      expect(openSpy).toHaveBeenCalledWith('market://details?id=com.acme.notes'),
+    );
+    expect(canOpenSpy).toHaveBeenCalledWith('market://details?id=com.acme.notes');
+    expect(mockLaunchApp).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the https listing when market:// cannot be opened (same guard as Today)', async () => {
+    canOpenSpy.mockImplementation((url: string) => Promise.resolve(url.startsWith('https:')));
+    const regular: AppsStore.InstalledApp = {
+      name: 'Acme Notes',
+      packageName: 'com.acme.notes',
+      icon: '',
+      isSystem: false,
+    };
+    mockApps([regular]);
+    const { getByText, getByLabelText } = render(<AppStoreScreen navigation={nav} />);
+    fireEvent.press(getByText('Updates'));
+    fireEvent.press(getByLabelText('Check Acme Notes on Play Store'));
+    await waitFor(() =>
+      expect(openSpy).toHaveBeenCalledWith(
+        'https://play.google.com/store/apps/details?id=com.acme.notes',
+      ),
+    );
+    expect(openSpy).not.toHaveBeenCalledWith('market://details?id=com.acme.notes');
+  });
+
+  it('shows no fabricated "update available" badge or version number', () => {
+    mockApps([
+      { name: 'Acme Notes', packageName: 'com.acme.notes', icon: '', isSystem: false },
+    ]);
+    const { getByText, queryByText } = render(<AppStoreScreen navigation={nav} />);
+    fireEvent.press(getByText('Updates'));
+    // No fabricated update state of any kind.
+    expect(queryByText(/update(s)? available/i)).toBeNull();
+    expect(getByText(UPDATES_NOTICE)).toBeTruthy();
+  });
+
+  it('shows an empty state (notice only, no rows) when there are no non-system, non-virtual apps', () => {
+    mockApps([]);
+    const { getByText, queryAllByLabelText } = render(<AppStoreScreen navigation={nav} />);
+    fireEvent.press(getByText('Updates'));
+    expect(queryAllByLabelText(/^Check .* on Play Store$/)).toHaveLength(0);
+    expect(getByText(UPDATES_NOTICE)).toBeTruthy();
+  });
+
+  it('switching Today → Updates → Today keeps the Today cards unchanged (regression guard)', () => {
+    mockApps([]);
+    const { getByText, getAllByLabelText, queryAllByLabelText } = render(
+      <AppStoreScreen navigation={nav} />,
+    );
+    expect(getAllByLabelText(/card$/)).toHaveLength(CURATED_APPS.length);
+    fireEvent.press(getByText('Updates'));
+    expect(queryAllByLabelText(/card$/)).toHaveLength(0);
+    fireEvent.press(getByText('Today'));
+    expect(getAllByLabelText(/card$/)).toHaveLength(CURATED_APPS.length);
+  });
+});
+
 describe('AppLibraryScreen entry point to the App Store', () => {
   it('renders an App Store button that navigates to the AppStore route', () => {
     const { getByLabelText } = render(<AppLibraryScreen navigation={nav} />);

--- a/src/store/AppsStore.tsx
+++ b/src/store/AppsStore.tsx
@@ -118,6 +118,14 @@ const VIRTUAL_APPS_MAP: Record<string, InstalledApp> = {
   'com.iostoandroid.mail': { name: 'Mail', packageName: 'com.iostoandroid.mail', icon: '', isSystem: false },
 };
 
+// Single source of truth for this app's own virtual built-ins. Every entry in
+// VIRTUAL_APPS_MAP has isSystem:false, so screens must exclude them by package
+// name, never by isSystem — otherwise the App Store's Updates list (and any
+// other "real installed apps" view) would surface our own fake packages.
+export const VIRTUAL_APP_PACKAGE_NAMES: ReadonlySet<string> = new Set(
+  Object.keys(VIRTUAL_APPS_MAP),
+);
+
 // Default dock apps — our built-in screens
 const DEFAULT_DOCK = [
   'com.iostoandroid.phone',


### PR DESCRIPTION
## Resumo

AppStoreScreen: add honest 'Updates' tab (4th segmented segment) — lists real installed apps, deep-links to Play Store, no fabricated update state

## Causa raiz

O issue #254 pedia um separador "Updates" na `AppStoreScreen`. A premissa do issue original — de que a fundação (`CupertinoSegmentedControl` com `['Today','Search','Categories']`, `playStoreUrl()`, `useApps()`) **não existia** em `main` — já não era verdade no worktree desta corrida: `HEAD` (`56ad126`) já contém `src/screens/AppStoreScreen.tsx` com o segmented control a 3 valores, os helpers `playStoreUrl()`/`playStoreWebUrl()` e `useApps()`. (As análises do curator anexadas ao issue eram estaleiradas — assumiam que a fundação continuava ausente e propunham `['Today','Updates']`; o código real já tinha 3 separadores, por isso segui o **issue original**, que pede `['Today','Search','Categories','Updates']`.)

O mecanismo real que o issue identificou continua válido e foi o que implementei: Android não expõe, sem a Play Developer API, forma pública e sem chave de saber se uma app instalada tem update pendente. Por isso o separador **não deteta** updates — lista as apps reais instaladas e oferece um deep-link `market://details?id=<packageName>` para o utilizador verificar manualmente. Ponto crítico confirmado por inspecção de `src/store/AppsStore.tsx:105-119`: todas as entradas de `VIRTUAL_APPS_MAP` têm `isSystem: false`, logo filtrar só por `!a.isSystem` **não** excluiria os apps virtuais próprios (`com.iostoandroid.phone`, etc.) — a exclusão tem de ser **por package name**.

## O que mudou

- `src/screens/AppStoreScreen.tsx`:
  - `APP_STORE_SEGMENTS` passa a `['Today', 'Search', 'Categories', 'Updates']` (linha 23).
  - Novo `UpdatesTab` (componente) que renderiza o aviso de honestidade (`testID="updates-notice"`) e, para cada app elegível, uma linha com acção "Check" que abre o listing da Play Store. Sem badge "N updates", sem número de versão, sem estado fabricado.
  - `updatableCandidates` (`useMemo`): `apps.filter(a => !a.isSystem && !VIRTUAL_APP_PACKAGE_NAMES.has(a.packageName))` — exclui sistema **e** virtuais por package name.
  - `handleCheckUpdate` (reutiliza `playStoreUrl()`/`playStoreWebUrl()` com o mesmo guard `canOpenURL → openURL → fallback https` da acção "Get" do Today).
  - Render branch `tabIndex === 3` → `<UpdatesTab .../>`.
  - Estilos `updatesNotice`, `updatesEmpty`, `updateRow`, `updateActionLabel`.
- `src/store/AppsStore.tsx`:
  - Exporta `VIRTUAL_APP_PACKAGE_NAMES: ReadonlySet<string>` a partir de `Object.keys(VIRTUAL_APPS_MAP)` — fonte única de verdade para a exclusão de apps virtuais (em vez de hardcodar a lista na screen).
- `src/screens/__tests__/AppStoreScreen.test.tsx`:
  - Novo `describe('AppStoreScreen — Updates tab')` com 10 testes (ver abaixo).

## Porque assim

- **4º segmento, não 2º**: o curator sugeriu `['Today','Updates']`, mas o worktree já tinha Today/Search/Categories a funcionar; inserir "Updates" como 4º mantém os separadores anteriores intactos e não antecipa/duplica trabalho de #249/#252.
- **Exclusão por package name**: já justificado acima — `isSystem` sozinho deixa passar os apps virtuais.
- **Sem nova constante `BUILT_IN_VIRTUAL_PACKAGES`** (do snippet do issue, que não existe em lado nenhum): usei a fonte real `VIRTUAL_APPS_MAP` exportando `VIRTUAL_APP_PACKAGE_NAMES`.
- **Reuso de `playStoreUrl`/`playStoreWebUrl`** em vez de escrever um novo helper de deep-link — consistência com o Today tab.

## Critérios de aceitação

- [x] Segmented control mostra `['Today', 'Search', 'Categories', 'Updates']` — testado em `the segmented control now offers Today, Search, Categories and Updates`.
- [x] Updates mostra copy visível a dizer que a detecção automática não está disponível — `selecting Updates shows the honesty notice...` (texto: "Android cannot check for app updates automatically. Tap an app to open its Play Store page.").
- [x] Nenhuma app com estado/update fabricado — `shows no fabricated "update available" badge or version number`.
- [x] Sistema excluídos — `excludes system apps from the Updates list`.
- [x] Apps virtuais próprias excluídas (mesmo com `isSystem:false`) — `excludes this app's own virtual built-ins from the Updates list`.
- [x] Today/Search/Categories intactos — `switching Today → Updates → Today keeps the Today cards unchanged` + suite completa do ficheiro passa (42/42).
- [x] Tapping a acção chama `Linking.openURL` com `market://details?id=<pkg>` — `tapping a row's action calls Linking.openURL...` (e fallback https testado).
- [x] `npm test` sem novas falhas (ver abaixo).

## Testes

- **Passo vermelho** (fix revertido via `git stash`, só os ficheiros de produção): os 10 testes do Updates falharam todos com `Unable to find an element with text: Updates`, ex.:
  ```
  ● AppStoreScreen — Updates tab › the segmented control now offers Today, Search, Categories and Updates
      Unable to find an element with text: Updates
        at Object.getByText (src/screens/__tests__/AppStoreScreen.test.tsx:485:21)
  ```
  (Output real de `npx jest src/screens/__tests__/AppStoreScreen.test.tsx -t "Updates"` com o fix stashed: `Tests: 10 failed, 32 skipped, 42 total`, todos `Unable to find an element with text: Updates`.)
- **Casos cobertos além do caminho feliz**: (1) sistema excluído; (2) virtual com `isSystem:false` excluído por package name; (3) fallback https quando `canOpenURL` devolve false (mesmo padrão do Today); (4) lista vazia → estado vazio sem placeholder fabricado (`No installed apps to check.`); (5) ausência de badge/versão fabricados (`queryByText(/update(s)? available/i)` é null); (6) inverso do fix — `Today → Updates → Today` restaura os cards.
- **Sanity-check**: reverti os ficheiros de produção (`git stash push -- src/screens/AppStoreScreen.tsx src/store/AppsStore.tsx`), corri os testes Updates → 10 falharam (`Unable to find an element with text: Updates`), e restaurei (`git stash pop`). Confirma que os testes testam o comportamento real.
- **Resultado das verificações obrigatórias**:
  - `npm run lint`: 0 erros (3 warnings pré-existentes em ficheiros que não toquei: `ClockScreen`, `FindMyScreen`, `BridgeErrorReporting`).
  - `npx tsc --noEmit`: limpo.
  - `npm test -- --maxWorkers=2`: `Tests: 8 failed, 1191 passed, 1199 total` em 138 suites. Confirmado por comparação normalizada contra `baseline.json`: as 8 falhas actuais são **exatamente** 8 das 17 falhas conhecidas da baseline (LockScreen×3, WeatherScreen×2, FoldersStore×2, SettingsScreen×1) — **0 novas falhas**. Nenhuma delas toca em `AppStoreScreen` ou `AppsStore`. O ficheiro `AppStoreScreen.test.tsx` passa 42/42 (os 10 novos inclusivos).

Nota: `git diff --name-only origin/main...HEAD` está vazio porque `HEAD` ainda é `56ad126` (= origin/main); as alterações estão por commitar. A lista `files_changed` é a de `git status --porcelain`.

## Testes

AppStoreScreen.test.tsx: 42 passaram, 0 falharam (10 novos testes do Updates). Full suite: 1191 passaram, 8 falharam (todas baseline, 0 novas), 138 suites

## Linked Issue

Fixes #254