### PR TITLE
fix/253: browser tabs button gets a count badge and closing the last tab no longer leaves zero tabs open (#253)

### DIFF
--- a/src/screens/BrowserScreen.tsx
+++ b/src/screens/BrowserScreen.tsx
@@ -150,11 +150,14 @@ export function BrowserScreen({ navigation }: { navigation: AppNavigationProp })
   const handleCloseTab = useCallback(
     (id: string) => {
       setTabs((prev) => {
-        const next = prev.filter((t) => t.id !== id);
-        if (id === activeTabId) {
+        const remaining = prev.filter((t) => t.id !== id);
+        // Invariant: the browser never has zero tabs open. Closing the last one
+        // replaces it with a fresh home tab rather than leaving an empty state.
+        const next = remaining.length > 0 ? remaining : [createTab(BROWSER_HOME_URL)];
+        if (id === activeTabId || remaining.length === 0) {
           const fallback = next[0];
-          setActiveTabId(fallback?.id ?? '');
-          setInputUrl(fallback?.url ?? BROWSER_HOME_URL);
+          setActiveTabId(fallback.id);
+          setInputUrl(fallback.url);
         }
         return next;
       });
@@ -235,8 +238,14 @@ export function BrowserScreen({ navigation }: { navigation: AppNavigationProp })
           hitSlop={8}
           accessibilityLabel="Tabs"
           accessibilityRole="button"
+          style={styles.tabsButton}
         >
           <Ionicons name="albums-outline" size={22} color={BROWSER_ACCENT} />
+          <View style={styles.tabsBadge}>
+            <Text testID="browser-tabs-badge" style={styles.tabsBadgeText}>
+              {String(tabs.length)}
+            </Text>
+          </View>
         </Pressable>
         <Pressable
           onPress={handleShare}
@@ -351,6 +360,22 @@ function createStyles(colors: CupertinoColors) {
     progressTrack: { height: 2, backgroundColor: 'transparent' },
     progressBar: { height: 2, backgroundColor: BROWSER_ACCENT },
     webview: { flex: 1 },
+    tabsButton: { justifyContent: 'center', alignItems: 'center' },
+    tabsBadge: {
+      minWidth: 16,
+      paddingHorizontal: 3,
+      borderRadius: 8,
+      backgroundColor: BROWSER_ACCENT,
+      alignItems: 'center',
+      justifyContent: 'center',
+      marginTop: 1,
+    },
+    tabsBadgeText: {
+      ...Typography.caption2,
+      color: '#FFFFFF',
+      fontWeight: '700',
+      textAlign: 'center',
+    },
     tabGridHeader: {
       flexDirection: 'row',
       alignItems: 'center',

--- a/src/screens/__tests__/BrowserScreen.test.tsx
+++ b/src/screens/__tests__/BrowserScreen.test.tsx
@@ -224,14 +224,44 @@ describe('BrowserScreen — multi-tab (BrowserTabGrid)', () => {
     expect(webviewUri(utils)).toBe('https://example.com');
   });
 
-  it('closing the only tab leaves activeTabId pointing at no tab (grid shown, no WebView, no crash)', () => {
+  it('the Tabs button shows a badge with the current tab count', () => {
+    const utils = render(<BrowserScreen navigation={nav} />);
+    expect(utils.getByTestId('browser-tabs-badge').props.children).toBe('1');
+
+    fireEvent.press(utils.getByLabelText('Tabs'));
+    fireEvent.press(utils.getByLabelText('New Tab'));
+    expect(utils.getByTestId('browser-tabs-badge').props.children).toBe('2');
+
+    fireEvent.press(utils.getByLabelText('Tabs'));
+    fireEvent.press(utils.getByLabelText('New Tab'));
+    expect(utils.getByTestId('browser-tabs-badge').props.children).toBe('3');
+  });
+
+  it('closing the only (active) tab never leaves zero tabs: a fresh home tab takes over', () => {
+    const utils = submitAddress('example.com');
+    expect(webviewUri(utils)).toBe('https://example.com');
+
+    fireEvent.press(utils.getByLabelText('Tabs'));
+    fireEvent.press(utils.getByLabelText('Close tab: https://example.com'));
+
+    // Never zero tabs: exactly one remains, at the home URL.
+    expect(utils.getByLabelText(`Tab: ${BROWSER_HOME_URL}`)).toBeTruthy();
+    expect(utils.queryByLabelText('Tab: https://example.com')).toBeNull();
+    fireEvent.press(utils.getByLabelText('Done'));
+    expect(utils.getByTestId('browser-tabs-badge').props.children).toBe('1');
+    expect(webviewUri(utils)).toBe(BROWSER_HOME_URL);
+  });
+
+  it('closing tabs repeatedly (double-tap on the last close affordance) still leaves exactly one tab', () => {
     const utils = render(<BrowserScreen navigation={nav} />);
     fireEvent.press(utils.getByLabelText('Tabs'));
-    fireEvent.press(utils.getByLabelText(`Close tab: ${BROWSER_HOME_URL}`));
+    const label = `Close tab: ${BROWSER_HOME_URL}`;
+    fireEvent.press(utils.getByLabelText(label));
+    fireEvent.press(utils.getByLabelText(label));
 
-    expect(utils.queryByTestId('browser-webview')).toBeNull();
-    expect(utils.getByLabelText('New Tab')).toBeTruthy();
-    expect(utils.queryByLabelText(/^Tab: /)).toBeNull();
+    fireEvent.press(utils.getByLabelText('Done'));
+    expect(utils.getByTestId('browser-tabs-badge').props.children).toBe('1');
+    expect(utils.getByTestId('browser-webview')).toBeTruthy();
   });
 
   it('closing the active tab (when others remain) activates another existing tab', () => {


### PR DESCRIPTION
## Resumo

fix/253: browser tabs button gets a count badge and closing the last tab no longer leaves zero tabs open

## Causa raiz

O issue foi escrito quando `BrowserScreen` não existia no branch base, e um `blocked` anterior concluiu que "a epic #120 não existe". Ambos estão hoje desactualizados: `main` já integrou o multi-tab do browser no commit `303bde2` ("fix/560: add multi-tab support to BrowserScreen"). `src/screens/BrowserScreen.tsx`, `src/components/BrowserTabGrid.tsx` e os dois testes já existem no worktree, com `tabs`/`activeTabId`, `WebView` com `key={activeTabId}`, botão Tabs, e grid com card por tab + "New Tab".

Ficaram, no entanto, **dois critérios de aceitação do issue não cumpridos** nesse código já integrado, e são defeitos reais:

1. **Sem badge de contagem.** `src/screens/BrowserScreen.tsx:233-240` (antes da alteração) renderizava o botão Tabs apenas com o ícone `albums-outline`. Nada no ecrã mostrava `tabs.length`. O AC "Tabs button shows a badge with the current tab count" nunca foi implementado.

2. **A invariante "nunca zero tabs" estava invertida.** `handleCloseTab` em `src/screens/BrowserScreen.tsx:150-163` fazia `const next = prev.filter(...)` e, quando a tab fechada era a activa, `setActiveTabId(fallback?.id ?? '')` — ou seja, com uma única tab aberta o array ficava **vazio** e `activeTabId` ficava `''`. O mecanismo: com `tabs = []`, o guard `if (showTabGrid || !activeTab)` (linha 165) passa a ser sempre verdadeiro, o `WebView` deixa de estar montado e o ecrã fica preso num grid vazio sem forma de sair (o header com "Done" está atrás de `tabs.length > 0`, logo desaparece também). O `?? ''` e o `?.` tapavam exactamente o caso que devia ser tratado. Havia até um teste (`closing the only tab leaves activeTabId pointing at no tab`) que **consagrava** esse estado como esperado, contradizendo o AC do issue "closing the active tab falls back to another remaining tab (never leaves zero tabs open)".

## O que mudou

**`src/screens/BrowserScreen.tsx`**
- `handleCloseTab`: se a filtragem deixar zero tabs, o estado passa a ser `[createTab(BROWSER_HOME_URL)]` — uma tab nova na home — e `activeTabId`/`inputUrl` passam a apontar para ela. A condição de reactivação passou a `id === activeTabId || remaining.length === 0`. Removidos o `?? ''` e o `?.` no fallback: `next[0]` está garantido não-vazio por construção.
- Botão Tabs: passa a renderizar, sob o ícone, um `<Text testID="browser-tabs-badge">` com `String(tabs.length)`.
- Estilos novos `tabsButton`, `tabsBadge`, `tabsBadgeText` (pílula com `BROWSER_ACCENT`, `Typography.caption2`).

**`src/screens/__tests__/BrowserScreen.test.tsx`**
- Removido o teste `closing the only tab leaves activeTabId pointing at no tab (grid shown, no WebView, no crash)`, que afirmava o comportamento contrário ao AC do issue (zero tabs, sem WebView). Não é um teste alheio que se apaga para ficar verde: é a asserção do defeito, substituída por três testes que asseveram a invariante correcta.
- Três testes novos: badge de contagem (1 → 2 → 3), fechar a única tab activa (fica exactamente 1 tab na home, WebView remontado nela), e duplo toque no close da última tab (repetição — continua exactamente 1 tab e o WebView montado).

## Porque assim

- **Substituir a última tab em vez de proibir o close:** o issue exige "never leaves zero tabs open" mas também exige que o close esteja disponível por card. Desactivar o × na última tab seria a alternativa; escolhi substituí-la por uma tab nova na home porque é o comportamento do Safari em iOS (fechar a última página deixa uma página em branco, não bloqueia o botão) e porque mantém o grid e o botão × com semântica uniforme, sem estado condicional na UI.
- **Badge com `testID` em vez de só texto:** o URL da home é `https://www.google.com` e a contagem é um dígito curto; um `getByText('1')` colidiria trivialmente com outro texto do ecrã. O `testID` liga o teste ao nó real do badge.
- **Não toquei em Forward/Share nem na address bar** — já existem em `main` e estão fora do que faltava.
- Nada de `any` novo; ao contrário, o fix **remove** dois operadores defensivos (`?.`, `?? ''`) que escondiam o caso em vez de o tratar.

## Critérios de aceitação

- [x] **Badge com a contagem de tabs abre o grid ao ser premido** — `browser-tabs-badge` mostra `String(tabs.length)`; teste `the Tabs button shows a badge with the current tab count` verifica 1 → 2 → 3 ao criar tabs.
- [x] **Fechar a tab activa nunca deixa zero tabs** — teste `closing the only (active) tab never leaves zero tabs: a fresh home tab takes over`: fecha a única tab (em example.com) e confirma que fica exactamente 1 tab, na `BROWSER_HOME_URL`, com o WebView remontado nela e o badge a "1".
- [x] **Repetição (duplo toque)** — teste `closing tabs repeatedly (double-tap on the last close affordance) still leaves exactly one tab`: dois presses seguidos no × da última tab; continua 1 tab e o WebView montado.
- [x] **O grid, a selecção de tab, o "+ New Tab" e o fecho de tab não-activa continuam a funcionar** — os testes pré-existentes desse comportamento (`opens the tab grid`, `"+ New Tab" creates a tab...`, `switching tabs in the grid re-mounts the WebView...`, `closing a background (non-active) tab does not change the active WebView url`, `closing the active tab (when others remain) activates another existing tab`, `"Done" returns to the active tab`) passam sem qualquer alteração.
- [x] **NÃO devia mudar: address bar, Back, Reload, Share, Back/Forward de histórico** — não foram tocados; as suites `BrowserScreen — address bar + WebView`, `— Back/Forward toolbar` e os testes de share sheet passam inalterados (46/46 nas duas suites de browser). `BrowserTabGrid.tsx` não foi alterado.
- [x] **Nada de `any` novo; nada de erros de lint/tsc** — `npx tsc --noEmit` limpo, `npm run lint` 0 erros.

## Testes

**Passo vermelho** (`git stash push -- src/screens/BrowserScreen.tsx`, testes mantidos):

```
● BrowserScreen — multi-tab (BrowserTabGrid) › the Tabs button shows a badge with the current tab count

    Unable to find an element with testID: browser-tabs-badge

      at Object.getByTestId (src/screens/__tests__/BrowserScreen.test.tsx:228:24)

● BrowserScreen — multi-tab (BrowserTabGrid) › closing the only (active) tab never leaves zero tabs: a fresh home tab takes over

    Unable to find an element with accessibility label: Tab: https://www.google.com

      248 |     expect(utils.getByLabelText(`Tab: ${BROWSER_HOME_URL}`)).toBeTruthy();
      at Object.getByLabelText (src/screens/__tests__/BrowserScreen.test.tsx:248:18)

● BrowserScreen — multi-tab (BrowserTabGrid) › closing tabs repeatedly (double-tap on the last close affordance) still leaves exactly one tab

    Unable to find an element with accessibility label: Close tab: https://www.google.com

    <View>
      <View testID="browser-tab-grid">
        <View>
          <View accessibilityLabel="New Tab" accessibilityRole="button" ...>

      258 |     const label = `Close tab: ${BROWSER_HOME_URL}`;
      259 |     fireEvent.press(utils.getByLabelText(label));
    > 260 |     fireEvent.press(utils.getByLabelText(label));
      at Object.getByLabelText (src/screens/__tests__/BrowserScreen.test.tsx:260:27)

Test Suites: 1 failed, 1 total
Tests:       3 failed, 35 passed, 38 total
```

Nota: o output do terceiro teste mostra literalmente o defeito — depois de um único close, a árvore do grid tem **zero** cards de tab, só o "New Tab".

Com o fix aplicado:

```
Test Suites: 2 passed, 2 total
Tests:       46 passed, 46 total
```
(`BrowserScreen.test.tsx` + `BrowserTabGrid.test.tsx`)

**Casos cobertos além do caminho feliz:** fronteira do tamanho da lista (fechar quando `tabs.length === 1`, o limite exacto da invariante), repetição (duplo toque no mesmo × — defeito recorrente neste repo), e o inverso do fix (fechar uma tab **não** activa continua a não mudar o URL do WebView — teste pré-existente que se mantém verde, garantindo que a substituição só dispara no caso limite). O badge é verificado em três valores distintos, não só no inicial.

**Sanity-check:** confirmado acima — `git stash push -- src/screens/BrowserScreen.tsx` fez a suite falhar (3 falhados), `git stash pop` restaurou e ficou 46/46. Cada um dos três testes novos falha por uma razão diferente (badge ausente, tab de fallback ausente, × ausente na segunda passagem).

**Verificações obrigatórias:**
- `npm run lint`: 0 erros, 3 avisos pré-existentes (`BridgeErrorReporting.test.tsx`, `ClockScreen.tsx:258`, `FindMyScreen.tsx:1`) — nenhum em ficheiros que toquei.
- `npx tsc --noEmit`: limpo.
- `npm test -- --maxWorkers=2`: **1183 passaram, 8 falharam, 138 suites (4 falhadas)**. As 8 falhas são exclusivamente de baseline (`LockScreen` ×3, `SettingsScreen` ×1, `WeatherScreen` ×2, `FoldersStore` ×2), todas do gate `firstSyncDone`/AsyncStorage descrito na LINHA DE BASE. Nenhuma é nova e nenhuma é de browser — **abaixo** dos 17 falhados da baseline documentada.

## Testes

1183 passaram, 8 falharam (todas de baseline, nenhuma em browser), 138 suites; suites de browser 46/46

## Linked Issue

Fixes #253