### PR TITLE
feat(#489): rubber band no overscroll das bordas do pager do ecrã inicial via Gesture.Pan aditivo ao Gesture.Race (#489)

### DIFF
--- a/src/screens/LauncherHomeScreen.tsx
+++ b/src/screens/LauncherHomeScreen.tsx
@@ -66,6 +66,7 @@ import type { AppNavigationProp } from '../navigation/types';
 import type { SettingsState } from '../store/SettingsStore';
 import { hapticImpact, hapticSelection } from '../utils/haptics';
 import { computeLauncherGridGeometry } from '../utils/launcherGridGeometry';
+import { clampWithRubberBand } from '../theme/motion';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -107,6 +108,26 @@ export function computeWallpaperTranslateX(
   'worklet';
   const progress = Math.min(1, Math.max(0, scrollX / Math.max(1, maxScrollX)));
   return overhang * (1 - 2 * progress);
+}
+
+// Rubber-band overscroll da paginação (#489, §3.3).
+//
+// A `ScrollView` do Android não reporta um offset proporcional ao arrasto para
+// além do limite (`View.overScrollBy` limita o desvio a
+// `ViewConfiguration.getScaledOverscrollDistance()`, uma constante pequena), por
+// isso a resistência elástica não pode vir de `onScroll`. Vem da distância real
+// do dedo (`translationX` de um `Gesture.Pan`) convertida pela fórmula pura de
+// `src/theme/motion.ts` (#488).
+//
+// `dimension` é a largura da página (cada página mede exactamente SCREEN_WIDTH),
+// o que dá o mesmo limite assimptótico (`dimension / RUBBER_C`) do UIScrollView.
+export function computePagerRubberBandOffset(
+  translationX: number,
+  dimension: number,
+): number {
+  // Corre dentro de `.onUpdate` / `useAnimatedStyle`, ou seja na thread de UI.
+  'worklet';
+  return clampWithRubberBand(translationX, 0, 0, dimension);
 }
 
 // Built-in app routing: packageName → navigation screen name
@@ -783,6 +804,20 @@ export function LauncherHomeScreen() {
   // worklets can gate the gesture without touching JS state.
   const canSpotlightShared = useSharedValue(true);
 
+  // Rubber-band overscroll das bordas do pager (#489). Dois SharedValues, um por
+  // borda: o conteúdo da página activa desloca-se pela curva da §3.3 enquanto o
+  // dedo arrasta para fora dos limites, e volta a 0 com mola ao soltar.
+  const firstPageOverscrollX = useSharedValue(0);
+  const lastPageOverscrollX = useSharedValue(0);
+
+  const firstPageOverscrollStyle = useAnimatedStyle(() => ({
+    transform: [{ translateX: firstPageOverscrollX.value }],
+  }));
+  const lastPageOverscrollStyle = useAnimatedStyle(() => ({
+    transform: [{ translateX: lastPageOverscrollX.value }],
+  }));
+
+
   const panGesture = Gesture.Pan()
     .activeOffsetY([-20, 20])
     .onUpdate((e) => {
@@ -1223,6 +1258,22 @@ export function LauncherHomeScreen() {
     return options;
   })();
 
+  // Borda da última página (App Library) — #489. Direcção/página que nenhum
+  // outro gesto reclama: `activeOffsetX([-20, Infinity])` activa só para
+  // arrastos para a ESQUERDA, e só na última página, por isso a paginação
+  // normal do `ScrollView` fica intacta em todas as outras páginas.
+  const lastPageRubberBandGesture = Gesture.Pan()
+    .enabled(currentPage === totalPages - 1)
+    .activeOffsetX([-20, Infinity])
+    .onUpdate((event) => {
+      'worklet';
+      lastPageOverscrollX.value = computePagerRubberBandOffset(event.translationX, SCREEN_WIDTH);
+    })
+    .onFinalize(() => {
+      'worklet';
+      lastPageOverscrollX.value = settle(0, 'fastSettle', reduceMotionShared.value);
+    });
+
   // Right-swipe on the first home page → Today View (#455).
   //
   // TodayViewScreen was registered in RootStackParamList and given a
@@ -1237,16 +1288,28 @@ export function LauncherHomeScreen() {
   const todayViewGesture = Gesture.Pan()
     .enabled(canSpotlight && currentPage === 0)
     .activeOffsetX([-Infinity, 20])
+    .onUpdate((event) => {
+      'worklet';
+      // Resistência elástica na borda esquerda (#489). O gesto não tinha
+      // `.onUpdate`: arrastar para a direita na página 0 não dava feedback
+      // nenhum durante o arrasto. O deslocamento é sub-linear desde o primeiro
+      // pixel e satura em `SCREEN_WIDTH / RUBBER_C`.
+      firstPageOverscrollX.value = computePagerRubberBandOffset(event.translationX, SCREEN_WIDTH);
+    })
     .onEnd((event) => {
       'worklet';
       const progress = Math.max(0, event.translationX) / gestureConfig.todayViewCommitDp;
       if (commitForTodayView({ progress, velocity: 0, holdMs: 0 }) !== 'none') {
         runOnJS(navigateTo)('TodayView');
       }
+    })
+    .onFinalize(() => {
+      'worklet';
+      firstPageOverscrollX.value = settle(0, 'fastSettle', reduceMotionShared.value);
     });
 
   return (
-    <GestureDetector gesture={Gesture.Race(panGesture, todayViewGesture)}>
+    <GestureDetector gesture={Gesture.Race(panGesture, todayViewGesture, lastPageRubberBandGesture)}>
       <Animated.View style={[styles.root, { overflow: 'hidden' }]}>
         {/* Parallax wallpaper — absolute layer, slightly oversized to allow horizontal shift */}
         <Animated.View
@@ -1369,7 +1432,10 @@ export function LauncherHomeScreen() {
         scrollEnabled={!isJiggling}
       >
         {pages.map((pageItems, pageIndex) => (
-          <View key={pageIndex} style={styles.page}>
+          <Animated.View
+            key={pageIndex}
+            style={[styles.page, pageIndex === 0 ? firstPageOverscrollStyle : null]}
+          >
             <View
               testID={`launcher-page-grid-${pageIndex}`}
               style={styles.pageGrid}
@@ -1414,15 +1480,18 @@ export function LauncherHomeScreen() {
                 );
               })}
             </View>
-          </View>
+          </Animated.View>
         ))}
 
         {/* App Library page — the App Library IS the last swipeable page
             (#434), rendered inline via the shared AppLibraryContent instead
             of a tap-through placeholder. */}
-        <View key="app-library" style={[styles.page, styles.appLibraryPage]}>
+        <Animated.View
+          key="app-library"
+          style={[styles.page, styles.appLibraryPage, lastPageOverscrollStyle]}
+        >
           <AppLibraryContent />
-        </View>
+        </Animated.View>
       </ScrollView>
 
       {/* ---------------------------------------------------------------- */}

--- a/src/screens/__tests__/LauncherHomeScreen.pagerRubberBand.test.tsx
+++ b/src/screens/__tests__/LauncherHomeScreen.pagerRubberBand.test.tsx
@@ -1,0 +1,246 @@
+import React from 'react';
+import { Dimensions } from 'react-native';
+import { render, fireEvent } from '../../test-utils';
+import * as AppsStore from '../../store/AppsStore';
+import * as Reanimated from 'react-native-reanimated';
+import { rubberBand, RUBBER_C } from '../../theme/motion';
+
+// #489: rubber-band overscroll nas bordas do pager do ecrã inicial.
+//
+// Este ficheiro exercita os gestos REAIS ligados ao LauncherHomeScreen (os
+// `Gesture.Pan` construídos em cada render e passados ao `Gesture.Race`), não
+// uma reimplementação da fórmula: captura os gestos pelo re-mock local de
+// react-native-gesture-handler (mesma técnica de
+// LauncherHomeScreen.todayViewGesture.test.tsx e AssistiveTouch.test.tsx) e
+// dispara `onUpdate`/`onFinalize` directamente, observando os SharedValues
+// criados pelo ecrã.
+
+const mockNavigate = jest.fn();
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({
+    navigate: mockNavigate,
+    goBack: jest.fn(),
+    canGoBack: jest.fn(() => false),
+    getParent: () => ({ navigate: jest.fn() }),
+  }),
+  useRoute: () => ({ params: {} }),
+  NavigationContainer: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+type PanRecord = {
+  axis?: 'x' | 'y';
+  offsets?: number[];
+  enabled?: unknown;
+  onUpdate?: (e: { translationX: number; translationY: number }) => void;
+  onEnd?: (e: { translationX: number; translationY: number }) => void;
+  onFinalize?: () => void;
+};
+
+const mockPanRecords: PanRecord[] = [];
+
+jest.mock('react-native-gesture-handler', () => {
+  const chain = (record: Record<string, unknown>) => {
+    const g: Record<string, unknown> = {};
+    [
+      'onBegin', 'minDistance', 'simultaneousWithExternalGesture', 'withRef', 'onChange',
+      'onStart', 'onTouchesBegan', 'onTouchesMove', 'onTouchesUp', 'onTouchesCancelled',
+      'hitSlop', 'maxPointers', 'minPointers', 'averageTouches', 'failOffsetX', 'failOffsetY',
+    ].forEach((m) => { g[m] = () => g; });
+    g.activeOffsetX = (v: number[]) => { record.axis = 'x'; record.offsets = v; return g; };
+    g.activeOffsetY = (v: number[]) => { record.axis = 'y'; record.offsets = v; return g; };
+    g.enabled = (v: unknown) => { record.enabled = v; return g; };
+    g.onUpdate = (fn: unknown) => { record.onUpdate = fn; return g; };
+    g.onEnd = (fn: unknown) => { record.onEnd = fn; return g; };
+    g.onFinalize = (fn: unknown) => { record.onFinalize = fn; return g; };
+    return g;
+  };
+  return {
+    GestureHandlerRootView: 'View',
+    GestureDetector: 'View',
+    Gesture: {
+      Pan: () => {
+        const record: Record<string, unknown> = { enabled: true };
+        mockPanRecords.push(record as never);
+        return chain(record);
+      },
+      Tap: () => chain({}),
+      LongPress: () => chain({}),
+      Fling: () => chain({}),
+      Exclusive: (...gs: unknown[]) => gs[0],
+      Simultaneous: (...gs: unknown[]) => gs[0],
+      Race: (...gs: unknown[]) => gs[0],
+    },
+    Swipeable: 'View',
+    DrawerLayout: 'View',
+    State: {},
+    PanGestureHandler: 'View',
+    TapGestureHandler: 'View',
+    FlatList: 'FlatList',
+    ScrollView: 'ScrollView',
+  };
+});
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { LauncherHomeScreen, computePagerRubberBandOffset } = require('../LauncherHomeScreen');
+
+const SCREEN_WIDTH = Dimensions.get('window').width;
+
+// Todos os SharedValues criados durante o render, para poder observar o valor
+// escrito pelos worklets dos gestos.
+let sharedValues: Array<{ value: unknown }> = [];
+
+function sharedNumbers() {
+  return sharedValues.map((s) => s.value).filter((v) => typeof v === 'number') as number[];
+}
+
+/** O gesto horizontal que só activa para arrastos para a ESQUERDA (última página). */
+function lastPagePan(): PanRecord {
+  for (let i = mockPanRecords.length - 1; i >= 0; i--) {
+    const r = mockPanRecords[i];
+    if (r.axis === 'x' && r.offsets && r.offsets[1] === Infinity) return r;
+  }
+  throw new Error('no leftward (activeOffsetX [-20, Infinity]) pan gesture captured');
+}
+
+/** O gesto horizontal da primeira página (Today View, arrasto para a direita). */
+function firstPagePan(): PanRecord {
+  for (let i = mockPanRecords.length - 1; i >= 0; i--) {
+    const r = mockPanRecords[i];
+    if (r.axis === 'x' && r.offsets && r.offsets[0] === -Infinity) return r;
+  }
+  throw new Error('no rightward (activeOffsetX [-Infinity, 20]) pan gesture captured');
+}
+
+function mockLoadedApps() {
+  jest.spyOn(AppsStore, 'useApps').mockReturnValue({
+    apps: [],
+    homeApps: [],
+    dockApps: [],
+    nonDockApps: [],
+    recentPackages: [],
+    recentApps: [],
+    isLoading: false,
+    refreshApps: jest.fn(() => Promise.resolve()),
+    launchApp: jest.fn(() => Promise.resolve(true)),
+    addToHome: jest.fn(),
+    removeFromHome: jest.fn(),
+    addToDock: jest.fn(),
+    removeFromDock: jest.fn(),
+    removeFromRecents: jest.fn(),
+    clearRecents: jest.fn(),
+    isDefaultLauncher: true,
+    openLauncherSettings: jest.fn(() => Promise.resolve()),
+  } as ReturnType<typeof AppsStore.useApps>);
+}
+
+beforeEach(() => {
+  mockNavigate.mockClear();
+  mockPanRecords.length = 0;
+  sharedValues = [];
+  mockLoadedApps();
+  const real = Reanimated.useSharedValue;
+  jest.spyOn(Reanimated, 'useSharedValue').mockImplementation(((init: unknown) => {
+    const sv = (real as (i: unknown) => { value: unknown })(init);
+    sharedValues.push(sv);
+    return sv;
+  }) as typeof Reanimated.useSharedValue);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('computePagerRubberBandOffset (#489, §3.3)', () => {
+  it('é sub-linear e coincide com a fórmula pura de motion.ts', () => {
+    for (const d of [40, 120, 400]) {
+      expect(computePagerRubberBandOffset(d, SCREEN_WIDTH)).toBeCloseTo(rubberBand(d, SCREEN_WIDTH), 5);
+      expect(computePagerRubberBandOffset(d, SCREEN_WIDTH)).toBeLessThan(d);
+    }
+    expect(computePagerRubberBandOffset(-40, SCREEN_WIDTH)).toBeCloseTo(-rubberBand(40, SCREEN_WIDTH), 5);
+  });
+
+  it('satura abaixo do limite assimptótico dimension / RUBBER_C', () => {
+    const limit = SCREEN_WIDTH / RUBBER_C;
+    expect(computePagerRubberBandOffset(1e6, SCREEN_WIDTH)).toBeLessThan(limit);
+    expect(computePagerRubberBandOffset(-1e6, SCREEN_WIDTH)).toBeGreaterThan(-limit);
+  });
+
+  it('devolve 0 para 0 e para dimensão inválida', () => {
+    expect(computePagerRubberBandOffset(0, SCREEN_WIDTH)).toBe(0);
+    expect(computePagerRubberBandOffset(100, 0)).toBe(0);
+  });
+});
+
+describe('LauncherHomeScreen — rubber band nas bordas do pager (#489)', () => {
+  it('a borda da última página existe como gesto para a esquerda e desloca o conteúdo pela curva', () => {
+    render(<LauncherHomeScreen />);
+    const pan = lastPagePan();
+    expect(pan.onUpdate).toBeTruthy();
+
+    const drag = -150;
+    pan.onUpdate!({ translationX: drag, translationY: 0 });
+    const expected = computePagerRubberBandOffset(drag, SCREEN_WIDTH);
+    expect(sharedNumbers()).toContain(expected);
+    // Não é o arrasto cru: tem de haver resistência.
+    expect(Math.abs(expected)).toBeLessThan(Math.abs(drag));
+  });
+
+  it('volta a 0 ao soltar (onFinalize)', () => {
+    render(<LauncherHomeScreen />);
+    const pan = lastPagePan();
+    pan.onUpdate!({ translationX: -150, translationY: 0 });
+    expect(sharedNumbers()).toContain(computePagerRubberBandOffset(-150, SCREEN_WIDTH));
+    pan.onFinalize!();
+    expect(sharedNumbers()).not.toContain(computePagerRubberBandOffset(-150, SCREEN_WIDTH));
+  });
+
+  it('a borda da última página está desactivada numa página que não é a última', () => {
+    render(<LauncherHomeScreen />);
+    // Sem apps: 1 página de grelha + App Library ⇒ currentPage 0 não é a última.
+    expect(lastPagePan().enabled).toBe(false);
+  });
+
+  it('fica activa quando o pager chega à última página', () => {
+    const { UNSAFE_getAllByType } = render(<LauncherHomeScreen />);
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { ScrollView } = require('react-native');
+    const pager = UNSAFE_getAllByType(ScrollView).find(
+      (n: { props: { pagingEnabled?: boolean } }) => n.props.pagingEnabled,
+    );
+    expect(pager).toBeTruthy();
+    fireEvent(pager, 'momentumScrollEnd', {
+      nativeEvent: {
+        contentOffset: { x: SCREEN_WIDTH },
+        contentSize: { width: SCREEN_WIDTH * 2 },
+        layoutMeasurement: { width: SCREEN_WIDTH },
+      },
+    });
+    expect(lastPagePan().enabled).toBe(true);
+  });
+
+  it('a primeira página passa a dar feedback elástico durante o arrasto, sem navegar antes do commit', () => {
+    render(<LauncherHomeScreen />);
+    const pan = firstPagePan();
+    expect(pan.onUpdate).toBeTruthy();
+    const drag = 30; // abaixo de todayViewCommitDp (64)
+    pan.onUpdate!({ translationX: drag, translationY: 0 });
+    expect(sharedNumbers()).toContain(computePagerRubberBandOffset(drag, SCREEN_WIDTH));
+    expect(mockNavigate).not.toHaveBeenCalledWith('TodayView');
+  });
+
+  it('o arrasto repetido na mesma borda não fica preso (sem latch)', () => {
+    render(<LauncherHomeScreen />);
+    const pan = lastPagePan();
+    pan.onUpdate!({ translationX: -80, translationY: 0 });
+    pan.onFinalize!();
+    pan.onUpdate!({ translationX: -200, translationY: 0 });
+    expect(sharedNumbers()).toContain(computePagerRubberBandOffset(-200, SCREEN_WIDTH));
+  });
+
+  it('o inverso do fix: sem arrasto o deslocamento é 0', () => {
+    render(<LauncherHomeScreen />);
+    const pan = lastPagePan();
+    pan.onUpdate!({ translationX: 0, translationY: 0 });
+    expect(sharedNumbers()).not.toContain(computePagerRubberBandOffset(-150, SCREEN_WIDTH));
+  });
+});


### PR DESCRIPTION
## Resumo

feat(#489): rubber band no overscroll das bordas do pager do ecrã inicial via Gesture.Pan aditivo ao Gesture.Race

## Causa raiz

O pager do ecrã inicial (`src/screens/LauncherHomeScreen.tsx`, `ScrollView` horizontal `pagingEnabled`) não oferece resistência elástica nas bordas porque:

1. `bounces` é iOS-only e o Android não tem equivalente.
2. A opção (b) do issue — ler `onScroll`/`contentOffset.x` e alimentar a curva — é **inviável por mecanismo de plataforma**: `View.overScrollBy` limita o desvio para fora de `[0, scrollRange]` a `ViewConfiguration.getScaledOverscrollDistance()`, uma constante pequena e fixa, não escalada pela distância do dedo; o "glow" nativo corre por `EdgeEffect.onPull()`, um canal desligado da posição de scroll. O offset em JS é ruído perto de zero.

O issue estava **mal formulado** ao apresentar (a) e (b) como as únicas alternativas. Não é preciso reescrever o pager: o ecrã já tem `<GestureDetector gesture={Gesture.Race(panGesture, todayViewGesture)}>` a envolver a árvore inteira, incluindo o próprio `ScrollView`, e já mistura em produção um `Gesture.Pan` horizontal (`todayViewGesture`, #455) com o scroll horizontal real — a técnica é `activeOffsetX/Y` a restringir cada `Pan` a uma direcção/página, deixando as outras direcções para o gesto nativo. A rubber band é uma extensão **aditiva** desse `Gesture.Race`.

## O que mudou

**`src/screens/LauncherHomeScreen.tsx`**

- Importa `clampWithRubberBand` de `src/theme/motion.ts` (#488) — a fórmula não é reimplementada.
- Nova função pura exportada `computePagerRubberBandOffset(translationX, dimension)` com `'worklet'`, ao estilo de `computeWallpaperTranslateX`: aplica a curva da §3.3 a um deslocamento em qualquer das duas direcções (limites `[0, 0]`, logo qualquer arrasto é overscroll).
- Dois `SharedValue` novos, `firstPageOverscrollX` e `lastPageOverscrollX`, e os respectivos `useAnimatedStyle` (declarados no topo do corpo do componente, junto dos shared values, para não violar `react-hooks/rules-of-hooks`).
- `todayViewGesture` (primeira página, arrasto para a direita) ganha `.onUpdate` — que antes não tinha, logo o arrasto não dava feedback nenhum — a escrever `firstPageOverscrollX` pela função nova, e `.onFinalize` a devolver a 0 com `settle(0, 'fastSettle', reduceMotionShared.value)`. O `.onEnd` de commit/navegação fica **byte-a-byte igual**.
- Novo `lastPageRubberBandGesture = Gesture.Pan().enabled(currentPage === totalPages - 1).activeOffsetX([-20, Infinity])` — só arrastos para a ESQUERDA, só na última página (App Library), combinação que nenhum outro gesto reclama — com `.onUpdate`/`.onFinalize` equivalentes sobre `lastPageOverscrollX`.
- `Gesture.Race(panGesture, todayViewGesture, lastPageRubberBandGesture)`.
- As páginas de grelha passam de `View` para `Animated.View` (aplicando `firstPageOverscrollStyle` só a `pageIndex === 0`) e a página da App Library também, com `lastPageOverscrollStyle`. O `translateX` é aplicado ao **conteúdo da página**, nunca ao offset do `ScrollView`.

**`src/screens/__tests__/LauncherHomeScreen.pagerRubberBand.test.tsx`** (novo) — 10 testes contra os gestos reais do ecrã, com re-mock local de `react-native-gesture-handler` (técnica de `LauncherHomeScreen.todayViewGesture.test.tsx`) que captura cada `Gesture.Pan` e um spy em `useSharedValue` para observar os valores escritos pelos worklets.

## Porque assim

- **(b) descartada por evidência de plataforma** (acima), não por palpite.
- **(a) pura descartada**: reescrever o pager exigia, pelo próprio issue, aprovação humana prévia — impossível numa corrida headless — e arriscava as 3 regressões históricas (#433 parallax, #434 App Library, #437/#446 back).
- **Escolhido: extensão aditiva do `Gesture.Race` existente.** Preserva 100% do comportamento fora das duas bordas: `ScrollView`, `handleScroll`/`handlePageScroll`, `scrollX`/`maxScrollX` e `computeWallpaperTranslateX` ficam intactos.
- `Gesture.Native()` **não** foi usado e `jest.setup.js` **não** foi alterado — nenhum dos dois era necessário.
- `useAnimatedStyle` movido para junto dos shared values porque declarado depois de ramos de `return` antecipados o ESLint apanha-o como hook condicional (erro real observado e corrigido).

## Critérios de aceitação

- [x] Arrastar além da primeira/última página dá resistência sublinear e volta com mola — `computePagerRubberBandOffset` + `settle(0, 'fastSettle', ...)` em `.onFinalize`; testado disparando `onUpdate`/`onFinalize` no `Pan` capturado.
- [x] `computePagerRubberBandOffset` testada como função pura: coincidência com `rubberBand` (`toBeCloseTo`), sub-linearidade, saturação abaixo de `dimension / RUBBER_C`, simetria negativa, `0` e `dimension` inválida.
- [x] O `ScrollView` de paginação não é substituído; `onScroll`/`onMomentumScrollEnd` não são tocados — confirmado no diff (só os elementos `View`→`Animated.View` das páginas mudaram dentro dele).
- [x] Parallax #433 intacto: `computeWallpaperTranslateX`, `scrollX`, `maxScrollX` não alterados; `LauncherHomeScreen.test.tsx` passa **sem edição** (33/33).
- [x] App Library como última página #434 continua a renderizar e alcançável — `AppLibraryContent` no mesmo lugar; teste verifica que o gesto da borda só activa depois do pager chegar à última página (via `momentumScrollEnd` real).
- [x] #455 intacto: `LauncherHomeScreen.todayViewGesture.test.tsx` passa **sem edição** (6/6). Nota: ordem de declaração importa — com `lastPageRubberBandGesture` declarado *depois* de `todayViewGesture`, o helper `lastHorizontalPan()` desse ficheiro apanhava o gesto errado e as 6 falhavam; o gesto novo foi declarado **antes** para preservar a ordem observável.
- [x] Nenhum ficheiro de navegação/back modificado (#437/#446) — `files_changed` tem 2 ficheiros.
- [x] `reduceMotion` via `settle(...)`/`reduceMotionShared` já existente — nenhuma segunda forma de o verificar.
- [x] `jest.setup.js` não alterado.
- [x] Decisão (a) vs (b) escrita acima com razão e evidência.
- [ ] 60fps medido em dispositivo — **fora do âmbito desta corrida** (`adb devices` vazio, pipeline headless), mesmo tratamento de #488. Prova estática em vez disso: todo o cálculo por frame corre em `.onUpdate`/`useAnimatedStyle` com `'worklet'`, nunca via `setState`; nenhum `runOnJS` foi acrescentado dentro de `.onUpdate` (os `runOnJS` do ficheiro continuam só nos `.onEnd` pré-existentes).

## Testes

**Passo vermelho** — `git stash push -- src/screens/LauncherHomeScreen.tsx` (fix fora, teste dentro):

```
  ● LauncherHomeScreen — rubber band nas bordas do pager (#489) › o arrasto repetido na mesma borda não fica preso (sem latch)

    no leftward (activeOffsetX [-20, Infinity]) pan gesture captured

      100 |     if (r.axis === 'x' && r.offsets && r.offsets[1] === Infinity) return r;
      101 |   }
    > 102 |   throw new Error('no leftward (activeOffsetX [-20, Infinity]) pan gesture captured');
          |         ^
      at lastPagePan (src/screens/__tests__/LauncherHomeScreen.pagerRubberBand.test.tsx:102:9)
      at Object.lastPagePan (src/screens/__tests__/LauncherHomeScreen.pagerRubberBand.test.tsx:233:17)

Test Suites: 1 failed, 1 total
Tests:       10 failed, 10 total
```

Com o fix: `Tests: 10 passed, 10 total`.

**Casos cobertos além do caminho feliz:** valor 0 e `dimension` 0 (vazio/inválido); `1e6` (valor absurdamente grande → saturação); negativo simétrico; arrasto repetido na mesma borda (duplo toque, defeito recorrente do repo); `.enabled()` explícito na página errada (borda não activa no meio) **e** na página certa depois de `momentumScrollEnd` real; o inverso do fix (sem arrasto, deslocamento 0); arrasto curto na primeira página não navega prematuramente.

**Sanity-check:** `git stash push -- src/screens/LauncherHomeScreen.tsx` → suite do ficheiro novo `10 failed, 10 total` → `git stash pop`. Confirmado.

**Verificações:**
- `npm run lint`: `✖ 3 problems (0 errors, 3 warnings)` — 0 erros, igual à baseline.
- `npx tsc --noEmit`: limpo.
- `npm test -- --maxWorkers=2`: `1191 passed, 8 failed, 1199 total` (4 de 139 suites). As 8 falhas — FoldersStore (2), LockScreen (3), SettingsScreen (1), WeatherScreen (2) — estão **todas** confirmadas em `baseline.json` (`grep -Fc` = 1 para cada). Nenhuma falha nova; nenhuma em ficheiro tocado. A baseline media 17 falhas.

## Testes

1191 passaram, 8 falharam (todas de baseline), 139 suites; ficheiro novo: 10/10 a passar

## Linked Issue

Fixes #489