### PR TITLE
feat/482: expõe a forma dos ícones (squircle/circle/rounded/original) e o expoente nas definições, com a forma na chave da cache de ícones (#482)

### DIFF
--- a/modules/launcher-module/android/src/main/java/com/iostoandroid/launcher/IconCache.kt
+++ b/modules/launcher-module/android/src/main/java/com/iostoandroid/launcher/IconCache.kt
@@ -4,15 +4,37 @@ package com.iostoandroid.launcher
  * Pure-JVM logic for LauncherModule's on-disk icon cache. Kept free of
  * android.* imports so it can be unit-tested without a device.
  *
- * Icons are cached as `<packageName>_<versionCode>.png` under
+ * Icons are cached as `<packageName>_<versionCode>_<shapeKey>.png` under
  * `context.filesDir/icons/`. Folding versionCode into the key means an app
  * update invalidates its icon for free — the old file simply stops matching
  * any currently-installed package and [orphanedFiles] flags it for deletion.
+ * Folding the shape key in does the same for the icon-shape setting (#482):
+ * change the shape or the squircle exponent and the previously masked PNGs stop
+ * matching, so the grid re-renders instead of serving the old shape.
  */
 object IconCache {
 
-    /** The cache filename for [packageName] at [versionCode]. */
-    fun fileName(packageName: String, versionCode: Long): String = "${packageName}_$versionCode.png"
+    /** Shape key used when the caller did not specify one (default squircle, n=4.7). */
+    const val DEFAULT_SHAPE_KEY = "squircle4.7"
+
+    /**
+     * The cache filename for [packageName] at [versionCode], masked with
+     * [shapeKey]. Characters that are not filename-safe are stripped from the
+     * shape key so a malformed value from JS cannot escape the icons directory.
+     */
+    fun fileName(
+        packageName: String,
+        versionCode: Long,
+        shapeKey: String = DEFAULT_SHAPE_KEY
+    ): String = "${packageName}_${versionCode}_${sanitizeShapeKey(shapeKey)}.png"
+
+    /** Keeps letters, digits, dots and dashes; everything else becomes '-'. */
+    fun sanitizeShapeKey(shapeKey: String): String {
+        val cleaned = shapeKey.map { c ->
+            if (c.isLetterOrDigit() || c == '.' || c == '-') c else '-'
+        }.joinToString("")
+        return if (cleaned.isEmpty()) DEFAULT_SHAPE_KEY else cleaned
+    }
 
     /**
      * Names, from [existingFileNames], that no longer correspond to any name in

--- a/modules/launcher-module/android/src/main/java/com/iostoandroid/launcher/IconMaskSpec.kt
+++ b/modules/launcher-module/android/src/main/java/com/iostoandroid/launcher/IconMaskSpec.kt
@@ -1,0 +1,58 @@
+package com.iostoandroid.launcher
+
+/**
+ * Pure-JVM parsing of the icon-mask argument JS passes to `getInstalledApps`,
+ * `getAppInfo` and `getAppIcon` (#482). Kept free of android.* imports so it can
+ * be unit-tested without a device.
+ *
+ * JS decides the shape (src/utils/iconShape.ts); the native side only applies
+ * it. `exponent == null` means "no mask at all" — the `'original'` shape, where
+ * the system drawable is returned untouched.
+ */
+data class IconMaskSpec(
+    /** Superellipse exponent, or null for no mask ('original'). */
+    val exponent: Double?,
+    /** Segment folded into the on-disk cache filename. */
+    val cacheKey: String
+) {
+    val hasMask: Boolean get() = exponent != null
+
+    companion object {
+        /** Default when JS sends nothing (older bundle against a newer binary). */
+        val DEFAULT = IconMaskSpec(AdaptiveIconCompositor.DEFAULT_SQUIRCLE_EXPONENT, IconCache.DEFAULT_SHAPE_KEY)
+
+        /** Useful range for the exponent; matches ICON_SHAPE_EXPONENT_MIN/MAX in JS. */
+        const val MIN_EXPONENT = 2.0
+        const val MAX_EXPONENT = 8.0
+
+        /**
+         * Builds a spec from the loosely-typed map the bridge delivers. A null or
+         * malformed map falls back to [DEFAULT] rather than producing an
+         * undefined mask; an out-of-range exponent is clamped, not rejected,
+         * because an unmasked icon would be a bigger visual regression than a
+         * slightly-off silhouette.
+         *
+         * Only `shape == "original"` yields a null exponent. A missing exponent
+         * on any other shape is the default, never null — otherwise a partially
+         * populated payload would silently disable masking everywhere.
+         */
+        fun from(raw: Map<String, Any?>?): IconMaskSpec {
+            if (raw == null) return DEFAULT
+            val shape = raw["shape"] as? String
+            val cacheKey = (raw["cacheKey"] as? String)?.takeIf { it.isNotBlank() }
+                ?: shape?.takeIf { it.isNotBlank() }
+                ?: IconCache.DEFAULT_SHAPE_KEY
+            if (shape == "original") return IconMaskSpec(null, cacheKey)
+            val exponent = when (val e = raw["exponent"]) {
+                is Number -> e.toDouble()
+                else -> null
+            }
+            val safe = if (exponent == null || exponent.isNaN() || exponent.isInfinite()) {
+                AdaptiveIconCompositor.DEFAULT_SQUIRCLE_EXPONENT
+            } else {
+                exponent.coerceIn(MIN_EXPONENT, MAX_EXPONENT)
+            }
+            return IconMaskSpec(safe, cacheKey)
+        }
+    }
+}

--- a/modules/launcher-module/android/src/main/java/com/iostoandroid/launcher/LauncherModule.kt
+++ b/modules/launcher-module/android/src/main/java/com/iostoandroid/launcher/LauncherModule.kt
@@ -91,7 +91,10 @@ class LauncherModule : Module() {
 
         // ── Apps ─────────────────────────────────────────────────────────
 
-        AsyncFunction("getInstalledApps") {
+        AsyncFunction("getInstalledApps") { maskArg: Map<String, Any?>? ->
+            // A forma da máscara vem de JS (#482): entra na chave da cache, por
+            // isso mudar a forma deixa os PNGs antigos órfãos e força um redesenho.
+            val mask = IconMaskSpec.from(maskArg)
             val pm = context.packageManager
             val mainIntent = Intent(Intent.ACTION_MAIN, null).apply {
                 addCategory(Intent.CATEGORY_LAUNCHER)
@@ -116,11 +119,11 @@ class LauncherModule : Module() {
                 val packageName = resolveInfo.activityInfo.packageName
                 val icon = try {
                     val versionCode = getVersionCode(pm, packageName)
-                    val fileName = IconCache.fileName(packageName, versionCode)
+                    val fileName = IconCache.fileName(packageName, versionCode, mask.cacheKey)
                     validIconFileNames.add(fileName)
                     val iconFile = File(iconsDir, fileName)
                     if (!iconFile.exists()) {
-                        writeIconToFile(resolveInfo.loadIcon(pm), iconFile)
+                        writeIconToFile(resolveInfo.loadIcon(pm), iconFile, mask)
                     }
                     "file://" + iconFile.absolutePath
                 } catch (e: Exception) { "" }
@@ -158,7 +161,8 @@ class LauncherModule : Module() {
             apps
         }
 
-        AsyncFunction("getAppInfo") { packageName: String ->
+        AsyncFunction("getAppInfo") { packageName: String, maskArg: Map<String, Any?>? ->
+            val mask = IconMaskSpec.from(maskArg)
             // Single-package equivalent of getInstalledApps: used to refresh only
             // the package a PACKAGE_* broadcast named (#485) instead of rescanning
             // every installed app. Returns null when the package is gone or has no
@@ -176,10 +180,10 @@ class LauncherModule : Module() {
                     val appInfo = resolveInfo.activityInfo.applicationInfo
                     val iconsDir = File(context.filesDir, "icons").apply { mkdirs() }
                     val icon = try {
-                        val fileName = IconCache.fileName(packageName, getVersionCode(pm, packageName))
+                        val fileName = IconCache.fileName(packageName, getVersionCode(pm, packageName), mask.cacheKey)
                         val iconFile = File(iconsDir, fileName)
                         if (!iconFile.exists()) {
-                            writeIconToFile(resolveInfo.loadIcon(pm), iconFile)
+                            writeIconToFile(resolveInfo.loadIcon(pm), iconFile, mask)
                         }
                         "file://" + iconFile.absolutePath
                     } catch (e: Exception) { "" }
@@ -221,11 +225,11 @@ class LauncherModule : Module() {
             true
         }
 
-        AsyncFunction("getAppIcon") { packageName: String ->
+        AsyncFunction("getAppIcon") { packageName: String, maskArg: Map<String, Any?>? ->
             try {
                 val pm = context.packageManager
                 val icon = pm.getApplicationIcon(packageName)
-                drawableToBase64(icon)
+                drawableToBase64(icon, IconMaskSpec.from(maskArg))
             } catch (e: Exception) { "" }
         }
 
@@ -1333,8 +1337,12 @@ class LauncherModule : Module() {
         }
     }
 
-    private fun writeIconToFile(drawable: Drawable, file: File) {
-        val bitmap = applySquircleMask(drawableToBitmap(drawable))
+    private fun writeIconToFile(
+        drawable: Drawable,
+        file: File,
+        mask: IconMaskSpec = IconMaskSpec.DEFAULT
+    ) {
+        val bitmap = maskIcon(drawableToBitmap(drawable, mask), mask)
         val scaledBitmap = Bitmap.createScaledBitmap(bitmap, 128, 128, true)
         FileOutputStream(file).use { out ->
             scaledBitmap.compress(Bitmap.CompressFormat.PNG, 90, out)
@@ -1342,8 +1350,11 @@ class LauncherModule : Module() {
         if (bitmap != scaledBitmap) scaledBitmap.recycle()
     }
 
-    private fun drawableToBase64(drawable: Drawable): String {
-        val bitmap = applySquircleMask(drawableToBitmap(drawable))
+    private fun drawableToBase64(
+        drawable: Drawable,
+        mask: IconMaskSpec = IconMaskSpec.DEFAULT
+    ): String {
+        val bitmap = maskIcon(drawableToBitmap(drawable, mask), mask)
         val scaledBitmap = Bitmap.createScaledBitmap(bitmap, 128, 128, true)
         val outputStream = ByteArrayOutputStream()
         scaledBitmap.compress(Bitmap.CompressFormat.PNG, 90, outputStream)
@@ -1352,7 +1363,10 @@ class LauncherModule : Module() {
         return "data:image/png;base64," + Base64.encodeToString(bytes, Base64.NO_WRAP)
     }
 
-    private fun drawableToBitmap(drawable: Drawable): Bitmap {
+    private fun drawableToBitmap(
+        drawable: Drawable,
+        mask: IconMaskSpec = IconMaskSpec.DEFAULT
+    ): Bitmap {
         if (drawable is BitmapDrawable && drawable.bitmap != null) {
             return drawable.bitmap
         }
@@ -1371,7 +1385,7 @@ class LauncherModule : Module() {
             // segunda mascara recorta exactamente a mesma regiao. Se algum dia os
             // expoentes divergirem, isto passa a cortar duas formas diferentes —
             // e a razao pela qual ambos os sitios citam a constante.
-            composeAdaptiveIcon(drawable)?.let { return it }
+            composeAdaptiveIcon(drawable, mask)?.let { return it }
         }
         // Center-crop para quadrado (#480): pega no maior quadrado centrado da
         // origem e escala-o. Nunca distorce nem mete barras transparentes, por
@@ -1423,6 +1437,17 @@ class LauncherModule : Module() {
      *    after masking; that is the known-incomplete "dominant color" item of
      *    epic #465 and is explicitly out of scope here (#480 does not fix it).
      */
+    /**
+     * Applies [mask] to [src]: the superellipse mask at the requested exponent,
+     * or the bitmap untouched when the mask is 'original'. This is the single
+     * place where "no mask" is honoured — the drawable then reaches the caller
+     * exactly as the system gave it.
+     */
+    private fun maskIcon(src: Bitmap, mask: IconMaskSpec): Bitmap {
+        val exponent = mask.exponent ?: return src
+        return applySquircleMask(src, exponent)
+    }
+
     private fun applySquircleMask(src: Bitmap, n: Double = 4.7): Bitmap {
         val size = src.width.coerceAtMost(src.height)
         val out = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888)
@@ -1447,7 +1472,10 @@ class LauncherModule : Module() {
         }
     }
 
-    private fun composeAdaptiveIcon(drawable: AdaptiveIconDrawable): Bitmap? {
+    private fun composeAdaptiveIcon(
+        drawable: AdaptiveIconDrawable,
+        mask: IconMaskSpec = IconMaskSpec.DEFAULT
+    ): Bitmap? {
         val background = drawable.background ?: return null
         val foreground = drawable.foreground
 
@@ -1455,15 +1483,20 @@ class LauncherModule : Module() {
         val bitmap = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888)
         val canvas = Canvas(bitmap)
 
-        val maskPoints = AdaptiveIconCompositor.squirclePoints(size.toFloat())
-        val maskPath = Path().apply {
-            moveTo(maskPoints[0].first, maskPoints[0].second)
-            maskPoints.drop(1).forEach { (x, y) -> lineTo(x, y) }
-            close()
-        }
-
+        // 'original' não recorta nada: o fundo é desenhado inteiro e o call site
+        // (maskIcon) também não aplica máscara, por isso o resultado é o
+        // composite do sistema sem silhueta imposta.
+        val exponent = mask.exponent
         canvas.save()
-        canvas.clipPath(maskPath)
+        if (exponent != null) {
+            val maskPoints = AdaptiveIconCompositor.squirclePoints(size.toFloat(), exponent)
+            val maskPath = Path().apply {
+                moveTo(maskPoints[0].first, maskPoints[0].second)
+                maskPoints.drop(1).forEach { (x, y) -> lineTo(x, y) }
+                close()
+            }
+            canvas.clipPath(maskPath)
+        }
         background.setBounds(0, 0, size, size)
         background.draw(canvas)
         canvas.restore()

--- a/modules/launcher-module/android/src/test/java/com/iostoandroid/launcher/IconCacheTest.kt
+++ b/modules/launcher-module/android/src/test/java/com/iostoandroid/launcher/IconCacheTest.kt
@@ -13,14 +13,15 @@ class IconCacheTest {
 
     @Test
     fun `fileName encodes packageName and versionCode so an app update gets a new key`() {
+        // A forma da máscara entra na chave desde o #482; sem argumento usa o default.
         assertEquals(
-            "com.android.settings_1.png",
+            "com.android.settings_1_${IconCache.DEFAULT_SHAPE_KEY}.png",
             IconCache.fileName("com.android.settings", 1L)
         )
         // Same package, new versionCode after an update — different key entirely,
         // so the stale PNG is never mistaken for the new one.
         assertEquals(
-            "com.android.settings_2.png",
+            "com.android.settings_2_${IconCache.DEFAULT_SHAPE_KEY}.png",
             IconCache.fileName("com.android.settings", 2L)
         )
     }

--- a/modules/launcher-module/android/src/test/java/com/iostoandroid/launcher/IconMaskSpecTest.kt
+++ b/modules/launcher-module/android/src/test/java/com/iostoandroid/launcher/IconMaskSpecTest.kt
@@ -1,0 +1,119 @@
+package com.iostoandroid.launcher
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+/**
+ * Pure-JVM tests for the icon-shape mask spec (#482): what JS sends, what the
+ * native side does with it, and the cache-key invalidation that makes a shape
+ * change visible instead of serving the previously-masked PNG.
+ */
+class IconMaskSpecTest {
+
+    @Test
+    fun `a null mask falls back to the default squircle instead of disabling masking`() {
+        val spec = IconMaskSpec.from(null)
+        assertEquals(AdaptiveIconCompositor.DEFAULT_SQUIRCLE_EXPONENT, spec.exponent)
+        assertEquals(IconCache.DEFAULT_SHAPE_KEY, spec.cacheKey)
+        assertTrue(spec.hasMask)
+    }
+
+    @Test
+    fun `original means no mask at all`() {
+        val spec = IconMaskSpec.from(mapOf("shape" to "original", "exponent" to null, "cacheKey" to "original"))
+        assertNull(spec.exponent)
+        assertFalse(spec.hasMask)
+    }
+
+    @Test
+    fun `the exponent is clamped to the useful range, not rejected`() {
+        assertEquals(
+            IconMaskSpec.MAX_EXPONENT,
+            IconMaskSpec.from(mapOf("shape" to "squircle", "exponent" to 999.0, "cacheKey" to "k")).exponent
+        )
+        assertEquals(
+            IconMaskSpec.MIN_EXPONENT,
+            IconMaskSpec.from(mapOf("shape" to "squircle", "exponent" to -5.0, "cacheKey" to "k")).exponent
+        )
+    }
+
+    @Test
+    fun `NaN and infinity fall back to the default, never to zero`() {
+        for (bad in listOf(Double.NaN, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY)) {
+            val spec = IconMaskSpec.from(mapOf("shape" to "squircle", "exponent" to bad, "cacheKey" to "k"))
+            assertEquals(AdaptiveIconCompositor.DEFAULT_SQUIRCLE_EXPONENT, spec.exponent)
+        }
+    }
+
+    @Test
+    fun `a missing exponent on a masked shape is the default, not null`() {
+        val spec = IconMaskSpec.from(mapOf("shape" to "squircle", "cacheKey" to "k"))
+        assertEquals(AdaptiveIconCompositor.DEFAULT_SQUIRCLE_EXPONENT, spec.exponent)
+        assertTrue(spec.hasMask)
+    }
+
+    @Test
+    fun `an integer exponent from the bridge is accepted, not dropped`() {
+        val spec = IconMaskSpec.from(mapOf("shape" to "squircle", "exponent" to 3, "cacheKey" to "k"))
+        assertEquals(3.0, spec.exponent)
+    }
+
+    @Test
+    fun `a blank cacheKey falls back rather than producing a nameless file`() {
+        assertEquals(
+            IconCache.DEFAULT_SHAPE_KEY,
+            IconMaskSpec.from(mapOf("shape" to "", "cacheKey" to "  ")).cacheKey
+        )
+    }
+
+    // ── cache invalidation ──────────────────────────────────────────────
+
+    @Test
+    fun `changing the shape changes the cache filename, so the old PNG is orphaned`() {
+        val squircle = IconCache.fileName("com.a", 1L, "squircle4.7")
+        val circle = IconCache.fileName("com.a", 1L, "circle2.0")
+        assertNotEquals(squircle, circle)
+        // Antes: só o nome do pacote e a versão. A forma nova reutilizava o PNG
+        // antigo e a definição parecia não fazer nada.
+        assertEquals(listOf(squircle), IconCache.orphanedFiles(listOf(squircle, circle), setOf(circle)))
+    }
+
+    @Test
+    fun `changing only the exponent changes the cache filename too`() {
+        assertNotEquals(
+            IconCache.fileName("com.a", 1L, "squircle4.7"),
+            IconCache.fileName("com.a", 1L, "squircle3.0")
+        )
+    }
+
+    @Test
+    fun `the same shape and version yields the same filename, otherwise nothing would ever hit`() {
+        assertEquals(
+            IconCache.fileName("com.a", 1L, "squircle4.7"),
+            IconCache.fileName("com.a", 1L, "squircle4.7")
+        )
+    }
+
+    @Test
+    fun `a shape key with path separators cannot escape the icons directory`() {
+        val name = IconCache.fileName("com.a", 1L, "../../etc/passwd")
+        assertFalse(name.contains("/"))
+        assertEquals("com.a_1_......etc.passwd.png", name)
+    }
+
+    @Test
+    fun `an empty shape key falls back to the default key`() {
+        assertEquals("com.a_1_${IconCache.DEFAULT_SHAPE_KEY}.png", IconCache.fileName("com.a", 1L, ""))
+    }
+
+    @Test
+    fun `the versionCode key still invalidates on app update with the shape folded in`() {
+        val old = IconCache.fileName("com.a", 1L, "squircle4.7")
+        val new = IconCache.fileName("com.a", 2L, "squircle4.7")
+        assertEquals(listOf(old), IconCache.orphanedFiles(listOf(old, new), setOf(new)))
+    }
+}

--- a/modules/launcher-module/android/src/test/java/com/iostoandroid/launcher/IconMaskSpecTest.kt
+++ b/modules/launcher-module/android/src/test/java/com/iostoandroid/launcher/IconMaskSpecTest.kt
@@ -102,7 +102,7 @@ class IconMaskSpecTest {
     fun `a shape key with path separators cannot escape the icons directory`() {
         val name = IconCache.fileName("com.a", 1L, "../../etc/passwd")
         assertFalse(name.contains("/"))
-        assertEquals("com.a_1_......etc.passwd.png", name)
+        assertEquals("com.a_1_..-..-etc-passwd.png", name)
     }
 
     @Test

--- a/modules/launcher-module/src/index.ts
+++ b/modules/launcher-module/src/index.ts
@@ -164,18 +164,31 @@ export interface InstalledKeyboard {
   enabled: boolean;
 }
 
+/**
+ * Máscara a aplicar aos ícones, decidida em JS (src/utils/iconShape.ts) e
+ * aplicada nativamente. `exponent: null` significa "sem máscara" — o drawable
+ * do sistema tal como ele vem. `cacheKey` entra no nome do PNG em disco, o que
+ * é o que faz uma mudança de forma invalidar a cache em vez de devolver o
+ * ficheiro com a forma antiga.
+ */
+export interface IconMask {
+  shape: string;
+  exponent: number | null;
+  cacheKey: string;
+}
+
 interface LauncherModuleType {
   // Apps
-  getInstalledApps(): Promise<InstalledApp[]>;
+  getInstalledApps(mask?: IconMask): Promise<InstalledApp[]>;
   launchApp(packageName: string): Promise<boolean>;
-  getAppIcon(packageName: string): Promise<string>;
+  getAppIcon(packageName: string, mask?: IconMask): Promise<string>;
   /**
    * Single-package variant of getInstalledApps: resolves the launcher entry for
    * one package, or null when the package is not installed or has no launcher
    * activity. Used to refresh only the package a PACKAGE_* broadcast named,
    * instead of rescanning every installed app.
    */
-  getAppInfo(packageName: string): Promise<InstalledApp | null>;
+  getAppInfo(packageName: string, mask?: IconMask): Promise<InstalledApp | null>;
   isDefaultLauncher(): Promise<boolean>;
   openLauncherSettings(): Promise<boolean>;
   goHome(): Promise<boolean>;
@@ -384,8 +397,8 @@ function createBridgedModule(): LauncherModuleType {
   if (!nativeModule) return stub;
 
   return {
-    getInstalledApps: async () => {
-      try { return dedupeByPackageName<InstalledApp>(withCategory(await nativeModule.getInstalledApps())); }
+    getInstalledApps: async (mask?: IconMask) => {
+      try { return dedupeByPackageName<InstalledApp>(withCategory(await nativeModule.getInstalledApps(mask ?? null))); }
       catch (e) { console.error('LauncherModule.getInstalledApps failed:', e); reportBridgeError('getInstalledApps', e); return []; }
     },
     launchApp: async (packageName: string) => {
@@ -399,12 +412,12 @@ function createBridgedModule(): LauncherModuleType {
         return ok;
       } catch (e) { console.error('LauncherModule.launchApp failed:', e); reportBridgeError('launchApp', e); return false; }
     },
-    getAppIcon: async (packageName: string) => {
-      try { return await nativeModule.getAppIcon(packageName); }
+    getAppIcon: async (packageName: string, mask?: IconMask) => {
+      try { return await nativeModule.getAppIcon(packageName, mask ?? null); }
       catch (e) { console.error('LauncherModule.getAppIcon failed:', e); reportBridgeError('getAppIcon', e); return ''; }
     },
-    getAppInfo: async (packageName: string) => {
-      try { return await nativeModule.getAppInfo(packageName); }
+    getAppInfo: async (packageName: string, mask?: IconMask) => {
+      try { return await nativeModule.getAppInfo(packageName, mask ?? null); }
       catch (e) { console.error('LauncherModule.getAppInfo failed:', e); reportBridgeError('getAppInfo', e); return null; }
     },
     isDefaultLauncher: async () => {

--- a/src/screens/settings/WallpaperScreen.tsx
+++ b/src/screens/settings/WallpaperScreen.tsx
@@ -11,8 +11,21 @@ import {
   CupertinoNavigationBar,
   CupertinoListSection,
   CupertinoListTile,
+  CupertinoSegmentedControl,
+  CupertinoSlider,
   useAlert,
 } from '../../components';
+import { useApps } from '../../store/AppsStore';
+import {
+  ICON_SHAPES,
+  ICON_SHAPE_LABELS,
+  ICON_SHAPE_EXPONENT_MIN,
+  ICON_SHAPE_EXPONENT_MAX,
+  DEFAULT_ICON_SHAPE_EXPONENT,
+  normalizeIconShape,
+  clampIconShapeExponent,
+  previewCornerRatio,
+} from '../../utils/iconShape';
 import type { AppNavigationProp } from '../../navigation/types';
 
 const CUSTOM_WALLPAPER_KEY = '@iostoandroid/custom_wallpaper';
@@ -24,6 +37,17 @@ export function WallpaperScreen({ navigation }: { navigation: AppNavigationProp 
   const { settings, update } = useSettings();
   const [customWallpaper, setCustomWallpaper] = useState<string | null>(null);
   const alert = useAlert();
+  const { apps } = useApps();
+
+  // Forma dos ícones (#482). Vive neste ecrã porque é aqui que a aparência do
+  // ecrã inicial já se configura — ver o PR para a justificação.
+  const iconShape = normalizeIconShape(settings.iconShape);
+  const iconShapeExponent = clampIconShapeExponent(settings.iconShapeExponent);
+  const shapeIndex = Math.max(0, ICON_SHAPES.indexOf(iconShape));
+  // Pré-visualização com um ícone REAL: a primeira app instalada com ícone.
+  const previewIcon = apps.find((a) => !!a.icon)?.icon ?? null;
+  const previewRadius = PREVIEW_SIZE * previewCornerRatio(iconShape, iconShapeExponent);
+  const exponentDisabled = iconShape !== 'squircle';
 
   useEffect(() => {
     AsyncStorage.getItem(CUSTOM_WALLPAPER_KEY).then((uri) => {
@@ -151,6 +175,58 @@ export function WallpaperScreen({ navigation }: { navigation: AppNavigationProp 
           Selected: {selectedWallpaper.name}
         </Text>
 
+        {/* Forma dos ícones (#482) */}
+        <View style={{ paddingHorizontal: spacing.md, marginTop: spacing.md }}>
+          <CupertinoListSection header="Icon Shape">
+            <View style={styles.shapeRow}>
+              <CupertinoSegmentedControl
+                values={ICON_SHAPE_LABELS as string[]}
+                selectedIndex={shapeIndex}
+                onChange={(index) => update('iconShape', ICON_SHAPES[index])}
+              />
+            </View>
+            <View style={styles.previewRow}>
+              {previewIcon ? (
+                <Image
+                  source={{ uri: previewIcon }}
+                  style={{ width: PREVIEW_SIZE, height: PREVIEW_SIZE, borderRadius: previewRadius }}
+                  accessibilityLabel={`Icon shape preview, ${ICON_SHAPE_LABELS[shapeIndex]}`}
+                />
+              ) : (
+                <View
+                  style={{
+                    width: PREVIEW_SIZE,
+                    height: PREVIEW_SIZE,
+                    borderRadius: previewRadius,
+                    backgroundColor: colors.systemBlue,
+                  }}
+                  accessibilityLabel={`Icon shape preview, ${ICON_SHAPE_LABELS[shapeIndex]}`}
+                />
+              )}
+              <Text style={[typography.footnote, { color: colors.secondaryLabel }]}>
+                {iconShape === 'original'
+                  ? 'Original: system drawable, no mask'
+                  : `Exponent: ${iconShapeExponent.toFixed(1)}`}
+              </Text>
+            </View>
+            <View style={styles.sliderRow}>
+              <CupertinoSlider
+                value={iconShapeExponent}
+                minimumValue={ICON_SHAPE_EXPONENT_MIN}
+                maximumValue={ICON_SHAPE_EXPONENT_MAX}
+                disabled={exponentDisabled}
+                onValueChange={(value) =>
+                  update('iconShapeExponent', clampIconShapeExponent(value))
+                }
+              />
+            </View>
+            <CupertinoListTile
+              title="Reset Shape Exponent"
+              onPress={() => update('iconShapeExponent', DEFAULT_ICON_SHAPE_EXPONENT)}
+            />
+          </CupertinoListSection>
+        </View>
+
         {/* Set section */}
         <View style={{ paddingHorizontal: spacing.md }}>
           <CupertinoListSection header="Set Wallpaper">
@@ -181,8 +257,19 @@ export function WallpaperScreen({ navigation }: { navigation: AppNavigationProp 
   );
 }
 
+const PREVIEW_SIZE = 60;
+
 const styles = StyleSheet.create({
   container: { flex: 1 },
+  shapeRow: { paddingHorizontal: 16, paddingVertical: 12 },
+  previewRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 16,
+    paddingHorizontal: 16,
+    paddingBottom: 12,
+  },
+  sliderRow: { paddingHorizontal: 16, paddingBottom: 16 },
   gridContainer: {
     marginBottom: 8,
   },

--- a/src/store/AppsStore.tsx
+++ b/src/store/AppsStore.tsx
@@ -5,6 +5,7 @@ import { useAlert } from '../components';
 import { logger } from '../utils/logger';
 import { migrateAsyncStorageKey } from './storage';
 import { upsertApp, removeApp } from './appsIndexReducer';
+import { getIconMask, subscribeIconMask, type IconMaskOptions } from '../utils/iconShape';
 import type { PackageChange } from '../../modules/launcher-module/src';
 
 const STORAGE_KEY = '@iostoandroid/apps_layout';
@@ -201,6 +202,14 @@ export function AppsProvider({ children }: { children: React.ReactNode }) {
     ).slice(0, 4); // max 4 in dock
   }, []);
 
+  // Forma da máscara dos ícones (#482). Lida do módulo utils/iconShape (mesmo
+  // padrão de utils/haptics): o SettingsStore publica-a lá, e este store
+  // subscreve — sem acoplar o AppsProvider ao SettingsProvider.
+  const [iconMask, setIconMask] = useState<IconMaskOptions>(() => getIconMask());
+  useEffect(() => subscribeIconMask(setIconMask), []);
+  const iconMaskRef = React.useRef(iconMask);
+  iconMaskRef.current = iconMask;
+
   const loadApps = useCallback(async () => {
     if (Platform.OS !== 'android') {
       setState(prev => ({ ...prev, isLoading: false }));
@@ -249,7 +258,7 @@ export function AppsProvider({ children }: { children: React.ReactNode }) {
       if (!LauncherModule) throw new Error('LauncherModule unavailable');
 
       const [apps, defaultStatus] = await Promise.all([
-        LauncherModule.getInstalledApps(),
+        LauncherModule.getInstalledApps(iconMask),
         LauncherModule.isDefaultLauncher(),
       ]);
 
@@ -271,8 +280,11 @@ export function AppsProvider({ children }: { children: React.ReactNode }) {
         setState(prev => ({ ...prev, isLoading: false }));
       }
     }
-  }, [resolveDock]);
+  }, [resolveDock, iconMask]);
 
+  // loadApps depende de iconMask, por isso mudar a forma ou o expoente volta a
+  // pedir os ícones ao nativo com a chave de cache nova — a grelha actualiza sem
+  // reinstalar nem reiniciar.
   useEffect(() => {
     loadApps();
   }, [loadApps]);
@@ -315,7 +327,7 @@ export function AppsProvider({ children }: { children: React.ReactNode }) {
         // to be re-read rather than left as-is.
         try {
           const LauncherModule = await getLauncherModule();
-          const app = await LauncherModule?.getAppInfo(packageName);
+          const app = await LauncherModule?.getAppInfo(packageName, iconMaskRef.current);
           if (!mounted || !app) return; // not launchable, or unmounted meanwhile
           applyIndex(prev => upsertApp(prev, app));
         } catch (e) {

--- a/src/store/SettingsStore.tsx
+++ b/src/store/SettingsStore.tsx
@@ -3,6 +3,13 @@ import { AppState } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import type { LauncherModuleType } from '../../modules/launcher-module/src';
 import { setHapticsEnabled } from '../utils/haptics';
+import {
+  type IconShape,
+  DEFAULT_ICON_SHAPE_EXPONENT,
+  normalizeIconShape,
+  clampIconShapeExponent,
+  setIconMask,
+} from '../utils/iconShape';
 
 const STORAGE_KEY = '@iostoandroid/settings';
 
@@ -62,6 +69,17 @@ export interface SettingsState {
   updateAvailable: boolean;
   scheduledSummaryIdx: number;
   fontChoice: 'inter' | 'system';
+  /**
+   * Forma da máscara dos ícones do launcher (§1.6). 'original' = sem máscara,
+   * o drawable como o sistema o dá — é também o baseline de comparação.
+   */
+  iconShape: IconShape;
+  /**
+   * Expoente do superelipse do squircle. Gama útil 2.0–8.0; a especificação
+   * admite que 4.7 é um palpite que precisa de aferição, daí ser regulável.
+   * Só afecta a forma 'squircle' (ver effectiveIconExponent).
+   */
+  iconShapeExponent: number;
 }
 
 export const DEFAULT_SETTINGS: SettingsState = {
@@ -120,6 +138,8 @@ export const DEFAULT_SETTINGS: SettingsState = {
   updateAvailable: false,
   scheduledSummaryIdx: 0,
   fontChoice: 'inter',
+  iconShape: 'squircle',
+  iconShapeExponent: DEFAULT_ICON_SHAPE_EXPONENT,
 };
 
 interface SettingsContextValue {
@@ -165,7 +185,18 @@ export function SettingsProvider({
   useEffect(() => {
     AsyncStorage.getItem(STORAGE_KEY).then((stored) => {
       if (stored) {
-        try { setSettings((prev) => ({ ...prev, ...JSON.parse(stored) })); } catch { /* ignore */ }
+        try {
+          const parsed = JSON.parse(stored);
+          setSettings((prev) => ({
+            ...prev,
+            ...parsed,
+            // A forma e o expoente descem até ao Kotlin e definem a chave da
+            // cache de ícones: um valor corrompido no AsyncStorage produziria
+            // uma máscara indefinida, por isso normaliza-se na leitura.
+            iconShape: normalizeIconShape(parsed?.iconShape),
+            iconShapeExponent: clampIconShapeExponent(parsed?.iconShapeExponent),
+          }));
+        } catch { /* ignore */ }
       }
       setIsReady(true);
     });
@@ -253,6 +284,13 @@ export function SettingsProvider({
   useEffect(() => {
     setHapticsEnabled(settings.vibration !== false);
   }, [settings.vibration]);
+
+  // Publica a forma dos ícones (#482) para o AppsStore, que a passa à ponte
+  // nativa. setIconMask é no-op quando a chave de cache não muda, por isso
+  // reescolher a mesma forma não dispara um varrimento novo.
+  useEffect(() => {
+    setIconMask(settings.iconShape, settings.iconShapeExponent);
+  }, [settings.iconShape, settings.iconShapeExponent]);
 
   const update = useCallback(<K extends keyof SettingsState>(key: K, value: SettingsState[K]) => {
     setSettings((prev) => ({ ...prev, [key]: value }));

--- a/src/store/__tests__/AppsStore.iconShape.test.tsx
+++ b/src/store/__tests__/AppsStore.iconShape.test.tsx
@@ -1,0 +1,193 @@
+import React from 'react';
+import { renderHook, act } from '@testing-library/react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { AppsProvider, useApps } from '../AppsStore';
+import { SettingsProvider, useSettings } from '../SettingsStore';
+import { resetIconMaskForTests } from '../../utils/iconShape';
+// eslint-disable-next-line @typescript-eslint/no-require-imports -- default export of the jest-mocked module
+const LauncherModule = require('../../../modules/launcher-module/src').default;
+
+const app = { name: 'Apple', packageName: 'com.example.apple', icon: 'file:///icons/a_1_squircle4.7.png', isSystem: false };
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return <SettingsProvider gateFirstRender={false}>{children}</SettingsProvider>;
+}
+
+/** Monta settings e apps juntos, para mudar a forma e ver a grelha reagir. */
+function useBoth() {
+  return { settings: useSettings(), apps: useApps() };
+}
+
+function bothWrapper({ children }: { children: React.ReactNode }) {
+  return (
+    <SettingsProvider gateFirstRender={false}>
+      <AppsProvider>{children}</AppsProvider>
+    </SettingsProvider>
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // A máscara activa vive ao nível do módulo (utils/iconShape), como a cache de
+  // haptics: sem reset, a forma escolhida num teste vazava para o seguinte.
+  resetIconMaskForTests();
+  (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+  (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
+  (LauncherModule.getInstalledApps as jest.Mock).mockResolvedValue([app]);
+  (LauncherModule.isDefaultLauncher as jest.Mock).mockResolvedValue(false);
+});
+
+describe('AppsStore — a forma dos ícones desce até à ponte nativa (#482)', () => {
+  it('passa a máscara default (squircle 4.7) a getInstalledApps', async () => {
+    renderHook(() => useApps(), { wrapper: bothWrapper });
+    await act(async () => {});
+
+    expect(LauncherModule.getInstalledApps).toHaveBeenCalledWith(
+      expect.objectContaining({ shape: 'squircle', exponent: 4.7, cacheKey: 'squircle4.7' }),
+    );
+  });
+
+  it('mudar a forma volta a pedir os ícones com a chave de cache nova — a grelha actualiza sem reinstalar', async () => {
+    const { result } = renderHook(() => useBoth(), { wrapper: bothWrapper });
+    await act(async () => {});
+
+    const callsBefore = (LauncherModule.getInstalledApps as jest.Mock).mock.calls.length;
+
+    await act(async () => {
+      result.current.settings.update('iconShape', 'circle');
+    });
+    await act(async () => {});
+
+    const calls = (LauncherModule.getInstalledApps as jest.Mock).mock.calls;
+    expect(calls.length).toBeGreaterThan(callsBefore);
+    expect(calls[calls.length - 1][0]).toMatchObject({ shape: 'circle', cacheKey: 'circle2.0' });
+  });
+
+  it('mudar só o expoente também invalida a cache (chave diferente)', async () => {
+    const { result } = renderHook(() => useBoth(), { wrapper: bothWrapper });
+    await act(async () => {});
+    const callsBefore = (LauncherModule.getInstalledApps as jest.Mock).mock.calls.length;
+
+    await act(async () => {
+      result.current.settings.update('iconShapeExponent', 3.0);
+    });
+    await act(async () => {});
+
+    const calls = (LauncherModule.getInstalledApps as jest.Mock).mock.calls;
+    expect(calls.length).toBeGreaterThan(callsBefore);
+    expect(calls[calls.length - 1][0]).toMatchObject({ cacheKey: 'squircle3.0' });
+  });
+
+  it("'original' pede ao nativo sem máscara: exponent null", async () => {
+    const { result } = renderHook(() => useBoth(), { wrapper: bothWrapper });
+    await act(async () => {});
+
+    await act(async () => {
+      result.current.settings.update('iconShape', 'original');
+    });
+    await act(async () => {});
+
+    const calls = (LauncherModule.getInstalledApps as jest.Mock).mock.calls;
+    expect(calls[calls.length - 1][0]).toMatchObject({ shape: 'original', exponent: null });
+  });
+
+  it('subscreve e cancela: depois de desmontar, uma mudança de forma não actualiza nada', async () => {
+    const { result, unmount } = renderHook(() => useBoth(), { wrapper: bothWrapper });
+    await act(async () => {});
+    unmount();
+    const callsAfterUnmount = (LauncherModule.getInstalledApps as jest.Mock).mock.calls.length;
+
+    await act(async () => {
+      result.current.settings.update('iconShape', 'rounded');
+    });
+    await act(async () => {});
+
+    expect((LauncherModule.getInstalledApps as jest.Mock).mock.calls.length).toBe(callsAfterUnmount);
+  });
+
+  it('o inverso do fix: escolher a MESMA forma outra vez não volta a varrer os pacotes', async () => {
+    const { result } = renderHook(() => useBoth(), { wrapper: bothWrapper });
+    await act(async () => {});
+    const callsBefore = (LauncherModule.getInstalledApps as jest.Mock).mock.calls.length;
+
+    // Duplo toque no mesmo segmento — defeito recorrente neste repositório.
+    await act(async () => {
+      result.current.settings.update('iconShape', 'squircle');
+    });
+    await act(async () => {
+      result.current.settings.update('iconShape', 'squircle');
+    });
+    await act(async () => {});
+
+    expect((LauncherModule.getInstalledApps as jest.Mock).mock.calls.length).toBe(callsBefore);
+  });
+
+  it('AppsProvider sozinho, sem SettingsProvider, continua a montar e usa os defaults', async () => {
+    const { result } = renderHook(() => useApps(), {
+      wrapper: ({ children }: { children: React.ReactNode }) => <AppsProvider>{children}</AppsProvider>,
+    });
+    await act(async () => {});
+
+    expect(result.current.isLoading).toBe(false);
+    expect(LauncherModule.getInstalledApps).toHaveBeenCalledWith(
+      expect.objectContaining({ shape: 'squircle' }),
+    );
+  });
+});
+
+describe('SettingsStore — forma dos ícones persiste e é validada (#482)', () => {
+  it('tem os defaults da especificação: squircle e 4.7', async () => {
+    const { result } = renderHook(() => useSettings(), { wrapper });
+    await act(async () => {});
+
+    expect(result.current.settings.iconShape).toBe('squircle');
+    expect(result.current.settings.iconShapeExponent).toBe(4.7);
+  });
+
+  it('grava a forma escolhida no AsyncStorage — persiste entre arranques', async () => {
+    const { result } = renderHook(() => useSettings(), { wrapper });
+    await act(async () => {});
+
+    await act(async () => {
+      result.current.update('iconShape', 'rounded');
+    });
+
+    const writes = (AsyncStorage.setItem as jest.Mock).mock.calls.filter(
+      ([key]) => key === '@iostoandroid/settings',
+    );
+    expect(writes.length).toBeGreaterThan(0);
+    expect(JSON.parse(writes[writes.length - 1][1]).iconShape).toBe('rounded');
+  });
+
+  it('lê a forma persistida no arranque seguinte', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockImplementation((key: string) =>
+      Promise.resolve(
+        key === '@iostoandroid/settings'
+          ? JSON.stringify({ iconShape: 'circle', iconShapeExponent: 3.5 })
+          : null,
+      ),
+    );
+
+    const { result } = renderHook(() => useSettings(), { wrapper });
+    await act(async () => {});
+
+    expect(result.current.settings.iconShape).toBe('circle');
+    expect(result.current.settings.iconShapeExponent).toBe(3.5);
+  });
+
+  it('um valor corrompido em disco não desce até ao Kotlin: normaliza na leitura', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockImplementation((key: string) =>
+      Promise.resolve(
+        key === '@iostoandroid/settings'
+          ? JSON.stringify({ iconShape: 'blob', iconShapeExponent: 999 })
+          : null,
+      ),
+    );
+
+    const { result } = renderHook(() => useSettings(), { wrapper });
+    await act(async () => {});
+
+    expect(result.current.settings.iconShape).toBe('squircle');
+    expect(result.current.settings.iconShapeExponent).toBe(8.0);
+  });
+});

--- a/src/store/__tests__/AppsStore.packageEvents.test.tsx
+++ b/src/store/__tests__/AppsStore.packageEvents.test.tsx
@@ -62,7 +62,13 @@ describe('AppsStore — reacts to package install/uninstall broadcasts', () => {
       'com.example.banana',
       'com.example.cherry',
     ]);
-    expect(LauncherModule.getAppInfo).toHaveBeenCalledWith('com.example.banana');
+    // O segundo argumento é a máscara de forma dos ícones (#482): o refresh
+    // incremental tem de usar a MESMA forma que a grelha, senão a app recém
+    // instalada aparecia com a silhueta antiga.
+    expect(LauncherModule.getAppInfo).toHaveBeenCalledWith(
+      'com.example.banana',
+      expect.objectContaining({ shape: 'squircle', cacheKey: 'squircle4.7' }),
+    );
     expect(LauncherModule.getInstalledApps).not.toHaveBeenCalled();
   });
 

--- a/src/utils/__tests__/iconShape.test.ts
+++ b/src/utils/__tests__/iconShape.test.ts
@@ -1,0 +1,204 @@
+import {
+  ICON_SHAPES,
+  ICON_SHAPE_LABELS,
+  DEFAULT_ICON_SHAPE_EXPONENT,
+  ICON_SHAPE_EXPONENT_MIN,
+  ICON_SHAPE_EXPONENT_MAX,
+  isIconShape,
+  normalizeIconShape,
+  clampIconShapeExponent,
+  effectiveIconExponent,
+  iconShapeCacheKey,
+  iconMaskOptions,
+  previewCornerRatio,
+  getIconMask,
+  setIconMask,
+  subscribeIconMask,
+  resetIconMaskForTests,
+} from '../iconShape';
+
+beforeEach(() => {
+  resetIconMaskForTests();
+});
+
+describe('iconShape — as quatro formas', () => {
+  it('expõe exactamente as quatro formas da especificação, com etiquetas alinhadas', () => {
+    expect(ICON_SHAPES).toEqual(['squircle', 'circle', 'rounded', 'original']);
+    expect(ICON_SHAPE_LABELS).toHaveLength(ICON_SHAPES.length);
+  });
+
+  it('cada forma produz uma chave de cache distinta — a mesma chave serviria o PNG antigo', () => {
+    const keys = ICON_SHAPES.map((s) => iconShapeCacheKey(s, DEFAULT_ICON_SHAPE_EXPONENT));
+    expect(new Set(keys).size).toBe(ICON_SHAPES.length);
+  });
+
+  it("'original' não tem máscara nenhuma: expoente null", () => {
+    expect(effectiveIconExponent('original', 4.7)).toBeNull();
+    expect(iconMaskOptions('original', 4.7).exponent).toBeNull();
+  });
+
+  it('circle é o superelipse de expoente 2 e rounded o de 8', () => {
+    expect(effectiveIconExponent('circle', 4.7)).toBe(2.0);
+    expect(effectiveIconExponent('rounded', 4.7)).toBe(8.0);
+  });
+
+  it('o expoente do slider só afecta o squircle — circle/rounded/original ignoram-no', () => {
+    for (const shape of ['circle', 'rounded', 'original'] as const) {
+      expect(iconShapeCacheKey(shape, 2.0)).toBe(iconShapeCacheKey(shape, 8.0));
+    }
+    expect(iconShapeCacheKey('squircle', 2.0)).not.toBe(iconShapeCacheKey('squircle', 8.0));
+  });
+});
+
+describe('iconShape — chave de cache muda com a forma e com o expoente', () => {
+  it('mudar a forma muda a chave', () => {
+    expect(iconShapeCacheKey('squircle', 4.7)).not.toBe(iconShapeCacheKey('circle', 4.7));
+  });
+
+  it('mudar o expoente do squircle muda a chave', () => {
+    expect(iconShapeCacheKey('squircle', 4.7)).not.toBe(iconShapeCacheKey('squircle', 3.0));
+  });
+
+  it('a mesma forma e expoente dá sempre a mesma chave (senão a cache nunca acertava)', () => {
+    expect(iconShapeCacheKey('squircle', 4.7)).toBe(iconShapeCacheKey('squircle', 4.7));
+  });
+
+  it('arredonda a uma casa decimal — sem isso, cada micro-movimento do slider criava um PNG novo', () => {
+    expect(iconShapeCacheKey('squircle', 4.7001)).toBe(iconShapeCacheKey('squircle', 4.7));
+    expect(iconShapeCacheKey('squircle', 4.7)).toBe('squircle4.7');
+  });
+});
+
+describe('iconShape — fronteiras do expoente', () => {
+  it.each([
+    [ICON_SHAPE_EXPONENT_MIN, ICON_SHAPE_EXPONENT_MIN],
+    [ICON_SHAPE_EXPONENT_MAX, ICON_SHAPE_EXPONENT_MAX],
+    [ICON_SHAPE_EXPONENT_MIN - 0.1, ICON_SHAPE_EXPONENT_MIN],
+    [ICON_SHAPE_EXPONENT_MAX + 0.1, ICON_SHAPE_EXPONENT_MAX],
+    [0, ICON_SHAPE_EXPONENT_MIN],
+    [-100, ICON_SHAPE_EXPONENT_MIN],
+    [1e9, ICON_SHAPE_EXPONENT_MAX],
+  ])('clampIconShapeExponent(%p) -> %p', (input, expected) => {
+    expect(clampIconShapeExponent(input)).toBe(expected);
+  });
+
+  it.each([
+    [NaN],
+    [Infinity],
+    [-Infinity],
+    ['4.7'],
+    [null],
+    [undefined],
+    [{}],
+  ])('valor inválido (%p) volta ao default, não a 0 — 0 colapsaria a máscara', (input) => {
+    expect(clampIconShapeExponent(input)).toBe(DEFAULT_ICON_SHAPE_EXPONENT);
+  });
+});
+
+describe('iconShape — formas inválidas ou ausentes', () => {
+  it.each([['squircle'], ['circle'], ['rounded'], ['original']])('isIconShape(%p) é true', (s) => {
+    expect(isIconShape(s)).toBe(true);
+  });
+
+  it.each([[''], ['SQUIRCLE'], ['blob'], [null], [undefined], [42], [{}]])(
+    'valor não-forma (%p) normaliza para o default squircle',
+    (input) => {
+      expect(isIconShape(input)).toBe(false);
+      expect(normalizeIconShape(input)).toBe('squircle');
+    },
+  );
+});
+
+describe('iconShape — pré-visualização', () => {
+  it("'original' não arredonda nada (sem máscara)", () => {
+    expect(previewCornerRatio('original', 4.7)).toBe(0);
+  });
+
+  it('circle é meio lado — um círculo perfeito', () => {
+    expect(previewCornerRatio('circle', 4.7)).toBe(0.5);
+  });
+
+  it('subir o expoente do squircle aproxima o quadrado (raio menor)', () => {
+    expect(previewCornerRatio('squircle', 8.0)).toBeLessThan(previewCornerRatio('squircle', 2.0));
+  });
+
+  it('o raio nunca sai de [0.08, 0.5] mesmo com entradas absurdas', () => {
+    for (const e of [-1e6, 0, NaN, 1e6]) {
+      const r = previewCornerRatio('squircle', e as number);
+      expect(r).toBeGreaterThanOrEqual(0.08);
+      expect(r).toBeLessThanOrEqual(0.5);
+    }
+  });
+});
+
+describe('iconShape — máscara activa ao nível do módulo', () => {
+  it('começa no default squircle 4.7', () => {
+    expect(getIconMask()).toMatchObject({ shape: 'squircle', cacheKey: 'squircle4.7' });
+  });
+
+  it('notifica os subscritores quando a chave de cache muda', () => {
+    const listener = jest.fn();
+    subscribeIconMask(listener);
+
+    setIconMask('circle', 4.7);
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener.mock.calls[0][0]).toMatchObject({ shape: 'circle', cacheKey: 'circle2.0' });
+    expect(getIconMask().shape).toBe('circle');
+  });
+
+  it('não notifica quando a chave não muda — o duplo toque no mesmo segmento é no-op', () => {
+    const listener = jest.fn();
+    subscribeIconMask(listener);
+
+    setIconMask('squircle', 4.7);
+    setIconMask('squircle', 4.7);
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('mexer no expoente com circle escolhido não notifica: circle ignora o slider', () => {
+    setIconMask('circle', 4.7);
+    const listener = jest.fn();
+    subscribeIconMask(listener);
+
+    setIconMask('circle', 8.0);
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('cancelar a subscrição pára as notificações', () => {
+    const listener = jest.fn();
+    const unsubscribe = subscribeIconMask(listener);
+    unsubscribe();
+
+    setIconMask('rounded', 4.7);
+
+    expect(listener).not.toHaveBeenCalled();
+    // O estado interno mudou mesmo assim — só a notificação é que não chega.
+    expect(getIconMask().shape).toBe('rounded');
+  });
+
+  it('um valor corrompido nunca chega a ser publicado como tal', () => {
+    setIconMask('blob', NaN);
+    expect(getIconMask()).toMatchObject({ shape: 'squircle', exponent: DEFAULT_ICON_SHAPE_EXPONENT });
+  });
+});
+
+describe('iconMaskOptions — o que desce até ao Kotlin', () => {
+  it('normaliza forma e expoente corrompidos antes de os passar à ponte', () => {
+    expect(iconMaskOptions('blob', 'muito')).toEqual({
+      shape: 'squircle',
+      exponent: DEFAULT_ICON_SHAPE_EXPONENT,
+      cacheKey: 'squircle4.7',
+    });
+  });
+
+  it('mantém a forma escolhida e limita o expoente à gama útil', () => {
+    expect(iconMaskOptions('squircle', 99)).toEqual({
+      shape: 'squircle',
+      exponent: ICON_SHAPE_EXPONENT_MAX,
+      cacheKey: `squircle${ICON_SHAPE_EXPONENT_MAX.toFixed(1)}`,
+    });
+  });
+});

--- a/src/utils/iconShape.ts
+++ b/src/utils/iconShape.ts
@@ -1,0 +1,163 @@
+/**
+ * Forma da máscara dos ícones do launcher (§1.6 da ESPECIFICACAO.md).
+ *
+ * A máscara é aplicada NATIVAMENTE (LauncherModule.kt), por isso este módulo é
+ * puro: só decide qual é a forma efectiva e qual é a chave de cache que o lado
+ * nativo tem de usar. Sem React, sem react-native — testável isoladamente.
+ */
+
+export type IconShape = 'squircle' | 'circle' | 'rounded' | 'original';
+
+/** As quatro formas, na ordem em que aparecem no controlo segmentado. */
+export const ICON_SHAPES: readonly IconShape[] = ['squircle', 'circle', 'rounded', 'original'];
+
+/** Etiquetas para UI, alinhadas por índice com [ICON_SHAPES]. */
+export const ICON_SHAPE_LABELS: readonly string[] = ['Squircle', 'Circle', 'Rounded', 'Original'];
+
+/** Gama útil do expoente do superelipse (§1.6: o valor exacto é incerto). */
+export const ICON_SHAPE_EXPONENT_MIN = 2.0;
+export const ICON_SHAPE_EXPONENT_MAX = 8.0;
+/** Palpite da especificação para o squircle do iOS. */
+export const DEFAULT_ICON_SHAPE_EXPONENT = 4.7;
+
+/** Expoente fixo de um círculo perfeito (|x|^2 + |y|^2 = r^2). */
+const CIRCLE_EXPONENT = 2.0;
+/** Expoente do "quadrado arredondado": cantos curtos, lados quase rectos. */
+const ROUNDED_EXPONENT = 8.0;
+
+export function isIconShape(value: unknown): value is IconShape {
+  return typeof value === 'string' && (ICON_SHAPES as readonly string[]).includes(value);
+}
+
+/**
+ * Normaliza uma forma vinda do armazenamento persistido: qualquer coisa que não
+ * seja uma das quatro formas volta ao default, em vez de descer até ao Kotlin e
+ * lá produzir uma máscara indefinida.
+ */
+export function normalizeIconShape(value: unknown): IconShape {
+  return isIconShape(value) ? value : 'squircle';
+}
+
+/**
+ * Limita o expoente à gama útil. `NaN`, `Infinity`, strings e ausência voltam ao
+ * default — não a 0, que colapsaria a máscara e apagaria o ícone.
+ */
+export function clampIconShapeExponent(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return DEFAULT_ICON_SHAPE_EXPONENT;
+  if (value < ICON_SHAPE_EXPONENT_MIN) return ICON_SHAPE_EXPONENT_MIN;
+  if (value > ICON_SHAPE_EXPONENT_MAX) return ICON_SHAPE_EXPONENT_MAX;
+  return value;
+}
+
+/**
+ * Expoente que o nativo tem de usar de facto:
+ * - `circle` e `rounded` são superelipses de expoente fixo, por isso o slider
+ *   não os afecta (e a chave de cache também não muda com ele);
+ * - `original` não tem máscara nenhuma — devolve `null` para o nativo entregar
+ *   o drawable do sistema como está;
+ * - `squircle` é o único caso aferível, e usa o valor escolhido.
+ */
+export function effectiveIconExponent(shape: IconShape, exponent: number): number | null {
+  switch (shape) {
+    case 'original':
+      return null;
+    case 'circle':
+      return CIRCLE_EXPONENT;
+    case 'rounded':
+      return ROUNDED_EXPONENT;
+    case 'squircle':
+    default:
+      return clampIconShapeExponent(exponent);
+  }
+}
+
+/** Opções de máscara passadas à ponte nativa (`getInstalledApps`/`getAppIcon`). */
+export interface IconMaskOptions {
+  shape: IconShape;
+  /** null = sem máscara ('original'). */
+  exponent: number | null;
+  /** Segmento da chave de cache dos PNGs em disco. */
+  cacheKey: string;
+}
+
+/**
+ * Chave de cache da forma. Entra no nome do PNG em disco, e é por isso que mudar
+ * a forma (ou o expoente do squircle) invalida a cache: o ficheiro antigo deixa
+ * de corresponder a qualquer chave válida e é apagado como órfão.
+ *
+ * O expoente é fixado a uma casa decimal — o slider produz floats contínuos e
+ * sem arredondamento cada micro-movimento geraria um PNG novo em disco.
+ */
+export function iconShapeCacheKey(shape: IconShape, exponent: number): string {
+  const effective = effectiveIconExponent(shape, exponent);
+  return effective === null ? shape : `${shape}${effective.toFixed(1)}`;
+}
+
+/**
+ * Raio de canto, como fracção do lado, para a PRÉ-VISUALIZAÇÃO em JS. A máscara
+ * real é nativa (superelipse verdadeiro); aqui só se aproxima a silhueta com um
+ * borderRadius, porque é o que a View do RN sabe desenhar sem SVG:
+ *  - 'circle' -> 0.5 (raio = metade do lado, círculo perfeito);
+ *  - 'original' -> 0 (sem máscara, o drawable como vem);
+ *  - 'squircle'/'rounded' -> aproximação que decresce com o expoente, já que um
+ *    expoente maior aproxima o quadrado.
+ */
+export function previewCornerRatio(shape: IconShape, exponent: number): number {
+  if (shape === 'original') return 0;
+  if (shape === 'circle') return 0.5;
+  const effective = effectiveIconExponent(shape, exponent) ?? DEFAULT_ICON_SHAPE_EXPONENT;
+  // n=2 -> 0.5 (círculo); cresce o expoente, encolhe o raio; nunca abaixo de 0.08
+  const ratio = 0.5 * (2 / effective);
+  return Math.max(0.08, Math.min(0.5, ratio));
+}
+
+/** Constrói as opções de máscara a partir de valores possivelmente inválidos. */
+export function iconMaskOptions(shape: unknown, exponent: unknown): IconMaskOptions {
+  const safeShape = normalizeIconShape(shape);
+  const safeExponent = clampIconShapeExponent(exponent);
+  return {
+    shape: safeShape,
+    exponent: effectiveIconExponent(safeShape, safeExponent),
+    cacheKey: iconShapeCacheKey(safeShape, safeExponent),
+  };
+}
+
+// ── Máscara activa, ao nível do módulo ───────────────────────────────────
+//
+// Mesmo padrão de src/utils/haptics.ts: o SettingsStore empurra o valor para cá
+// e quem precisa dele lê-o daqui. É deliberadamente NÃO um import do
+// SettingsStore no AppsStore — dezenas de testes de ecrã fazem
+// jest.mock('.../SettingsStore') com um objecto parcial, e qualquer hook novo
+// que o AppsStore lhe fosse pedir viria undefined e derrubava essas suites.
+
+let currentMask: IconMaskOptions = iconMaskOptions('squircle', DEFAULT_ICON_SHAPE_EXPONENT);
+const listeners = new Set<(mask: IconMaskOptions) => void>();
+
+/** A máscara actualmente activa. */
+export function getIconMask(): IconMaskOptions {
+  return currentMask;
+}
+
+/**
+ * Publica a máscara escolhida nas definições. No-op quando a chave de cache não
+ * muda, para que voltar a escolher a mesma forma (duplo toque no segmento) não
+ * force um varrimento de pacotes novo.
+ */
+export function setIconMask(shape: unknown, exponent: unknown): void {
+  const next = iconMaskOptions(shape, exponent);
+  if (next.cacheKey === currentMask.cacheKey) return;
+  currentMask = next;
+  listeners.forEach((l) => l(next));
+}
+
+/** Subscreve mudanças de máscara. Devolve a função de cancelamento. */
+export function subscribeIconMask(listener: (mask: IconMaskOptions) => void): () => void {
+  listeners.add(listener);
+  return () => { listeners.delete(listener); };
+}
+
+/** Só para testes: volta ao default e larga os subscritores. */
+export function resetIconMaskForTests(): void {
+  currentMask = iconMaskOptions('squircle', DEFAULT_ICON_SHAPE_EXPONENT);
+  listeners.clear();
+}


### PR DESCRIPTION
## Resumo

feat/482: expõe a forma dos ícones (squircle/circle/rounded/original) e o expoente nas definições, com a forma na chave da cache de ícones

## Causa raiz

A especificação (§1.6) admite que a forma do ícone (superelipse, `n=4.7`) é um palpite não aferido, mas o código anterior tinha-a fixada no Kotlin sem forma de a mudar nem de a testar contra outras hipóteses (círculo, quadrado arredondado, sem máscara). Não havia estado no `SettingsStore`, nem caminho da forma até `LauncherModule.kt`, nem qualquer relação entre a forma escolhida e a chave da cache de PNGs mascarados em disco — o que faria uma mudança de forma parecer não fazer nada, porque os ficheiros antigos continuariam a ser servidos.

## O que mudou

- `src/utils/iconShape.ts` (novo, puro, sem React/react-native): tipo `IconShape`, normalização de valores persistidos inválidos (`normalizeIconShape`), `clampIconShapeExponent` (gama 2.0–8.0, `NaN`/`Infinity`/ausência voltam ao default 4.7 em vez de colapsarem a máscara a 0), `effectiveIconExponent` (mapeia forma→expoente real: `circle`=2.0 fixo, `rounded`=8.0 fixo, `original`=`null`, `squircle`=o valor escolhido), `iconShapeCacheKey` (a chave que entra no nome do ficheiro em cache — arredondada a uma casa decimal para não gerar um PNG por cada micro-movimento do slider), `previewCornerRatio` (aproximação em `borderRadius` para a pré-visualização em JS, já que a máscara real é nativa/superelipse), e um mecanismo publish/subscribe (`getIconMask`/`setIconMask`/`subscribeIconMask`) deliberadamente não acoplado via import directo do `AppsStore` ao `SettingsStore` — dezenas de suites de ecrã fazem `jest.mock('.../SettingsStore')` parcial, e um hook novo aí devolveria `undefined` e derrubaria essas suites (confirmado empiricamente: um acoplamento directo causava 63 falhas novas).
- `src/store/SettingsStore.tsx`: `iconShape`/`iconShapeExponent` lidos e normalizados do `AsyncStorage` (default `'squircle'`/`4.7`), persistidos entre arranques, e publicados via `setIconMask` sempre que mudam.
- `src/store/AppsStore.tsx`: subscreve `subscribeIconMask` e passa a máscara activa (`shape`, `exponent`, `cacheKey`) a `getInstalledApps`/`getAppInfo`; `loadApps` depende de `iconMask`, por isso mudar a forma dispara um novo varrimento sem reinstalar nada.
- `modules/launcher-module/src/index.ts`: expõe o tipo `IconMask` e reencaminha os campos da máscara para a ponte nativa.
- `modules/launcher-module/android/src/main/java/com/iostoandroid/launcher/IconMaskSpec.kt` (novo): `IconMaskSpec.from(...)` interpreta o mapa vindo do JS no lado Kotlin, com o mesmo default (squircle, 4.7) caso o valor não chegue.
- `modules/launcher-module/android/src/main/java/com/iostoandroid/launcher/LauncherModule.kt`: `getInstalledApps`/`getAppInfo`/`getAppIcon` recebem o `IconMaskSpec`; `maskIcon()` é o único ponto de aplicação da máscara, e é onde `'original'` devolve o bitmap intacto sem qualquer superelipse.
- `modules/launcher-module/android/src/main/java/com/iostoandroid/launcher/IconCache.kt`: `fileName()` ganhou o parâmetro `shapeKey`, que passa por `sanitizeShapeKey` (mantém letras/dígitos/`.`/`-`, tudo o resto vira `-`) antes de entrar no nome do ficheiro — impede que uma chave malformada vinda do JS escape do directório de cache. Por a forma estar na chave, mudar de squircle para círculo (ou mudar o expoente) já não bate no ficheiro antigo, e o mecanismo de órfãos existente apaga-o.
- `src/screens/settings/WallpaperScreen.tsx`: `CupertinoSegmentedControl` para a forma (squircle/circle/rounded/original) e `CupertinoSlider` para o expoente (só activo em squircle), com pré-visualização ao vivo de um ícone real usando `previewCornerRatio`.

## Porque assim

- **Ecrã escolhido — `WallpaperScreen.tsx`, não um ecrã novo**: já é o sítio da aparência do ecrã inicial (fundo, grelha) na app; um ecrã de "Ecrã inicial" à parte duplicaria navegação para uma única definição adicional.
- **Publish/subscribe em vez de o `AppsStore` importar o `SettingsStore` directamente**: ver acima — testado empiricamente que o import directo quebra dezenas de suites que mockam `SettingsStore` parcialmente. O padrão já existe no repositório (`utils/haptics.ts`) para o mesmo problema.
- **Chave de cache truncada a uma casa decimal**: sem isto, um slider contínuo geraria um ficheiro novo por cada frame de arrasto; a especificação também trata o expoente como um valor a testar em incrementos, não continuamente.
- **`circle`/`rounded` com expoente fixo**: são pontos de referência do espectro (n=2 e n=8), não posições do slider — só `squircle` é o caso aferível pela especificação.

## Critérios de aceitação

- [x] As 4 formas produzem resultado visivelmente diferente no ecrã inicial e no dock — `effectiveIconExponent` mapeia cada forma a um expoente distinto (2.0/8.0/variável/null) que chega ao `maskIcon()` nativo; `'original'` salta a máscara por completo.
- [x] Mudar a forma ou o expoente invalida a cache de ícones e a grelha actualiza sem reinstalar — a forma+expoente entram na chave de cache (`IconCache.fileName`/`sanitizeShapeKey`), o ficheiro antigo deixa de corresponder a nenhuma chave válida e é apanhado pelo mecanismo de órfãos já existente (`IconCache.orphanedFiles`); `AppsStore.loadApps` depende de `iconMask`, disparando o varrimento sem reinstalar.
- [x] Pré-visualização ao vivo no ecrã de definições — `WallpaperScreen.tsx` usa `previewCornerRatio(shape, exponent)` sobre um ícone real, actualizado a cada mudança do `CupertinoSegmentedControl`/`CupertinoSlider`.
- [x] `'original'` devolve de facto o drawable do sistema, sem máscara — `effectiveIconExponent('original', ...)` devolve `null`; no Kotlin, `maskIcon()` devolve o bitmap original quando o expoente é `null`, sem qualquer superelipse aplicada.
- [x] Definições persistem entre arranques — `SettingsStore.tsx` lê/escreve `iconShape`/`iconShapeExponent` no `AsyncStorage`, com `normalizeIconShape`/`clampIconShapeExponent` a proteger contra valores corrompidos na leitura.
- [x] Teste do store e teste de que a chave de cache muda com a forma e com o expoente — `src/utils/__tests__/iconShape.test.ts` (chave muda por forma e por expoente, clamp de valores inválidos, `original`→`null`), `src/store/__tests__/AppsStore.iconShape.test.tsx` e `src/store/__tests__/AppsStore.packageEvents.test.tsx`, mais `IconCacheTest.kt`/`IconMaskSpecTest.kt` do lado Kotlin (chave de cache distingue formas/expoentes, sanitização anti-path-traversal, fallback a default em chave vazia).

## Retrabalho (ronda 2)

O reviewer apontou um literal errado em `IconMaskSpecTest.kt`, teste `a shape key with path separators cannot escape the icons directory` (linha ~105): o valor esperado era `"com.a_1_......etc.passwd.png"`, mas `IconCache.sanitizeShapeKey` mapeia `/` para `-` (não para `.`) — o `.` já literal em `../../etc/passwd` fica intacto. Corrigido para `"com.a_1_..-..-etc-passwd.png"`, que é o que a função produz de facto (confirmado lendo `IconCache.sanitizeShapeKey`: mantém letras/dígitos/`.`/`-`, tudo o resto vira `-`).

Como pedido, corri os 19 testes de `IconCacheTest`+`IconMaskSpecTest` fora de Gradle/Android SDK (kotlinc 2.0.0 + JUnit 4.13.2 em JVM pura, via `kotlinc-jvm` instalado localmente para este efeito):

```
JUnit version 4.13.2
...................
Time: 0,026

OK (19 tests)
```

19/19 a passar, incluindo o teste corrigido.

## Testes

- **Passo vermelho (ronda 1, reconfirmado nesta ronda):** com os 3 ficheiros de produção principais revertidos (`SettingsStore.tsx`, `AppsStore.tsx`, `modules/launcher-module/src/index.ts`) e os testes novos no lugar, a suite falha nos testes que dependem da máscara publicada/subscrita.
- **Casos cobertos:** fronteiras do expoente (abaixo de 2.0, acima de 8.0, exactamente nos limites), valores inválidos (`NaN`, `Infinity`, string, `undefined` — todos voltam ao default em vez de colapsarem a máscara), forma persistida corrompida (`normalizeIconShape` volta a `'squircle'`), chave de cache estável para o mesmo par forma/expoente mas distinta entre pares diferentes, `original` devolvendo `null` de expoente, tentativa de path traversal na chave de cache (`../../etc/passwd` sanitizado sem `/` no resultado), chave vazia caindo no default.
- **Sanity-check:** feito na ronda 1 (documentado no PR original) e reconfirmado pelo reviewer com `git checkout HEAD~1` dos 3 ficheiros de produção — suite falhou nos testes novos, restaurado depois. Nesta ronda 2 o código de produção não mudou (só o literal do teste Kotlin), por isso não repeti o revert de produção; a prova de que o teste corrigido está ligado ao comportamento real é ele correr contra `IconCache.sanitizeShapeKey` de facto (JVM pura, 19/19) e não uma cópia reimplementada.
- `npm run lint`: 0 erros, 2 warnings pré-existentes (`ClockScreen.tsx`, `BridgeErrorReporting.test.tsx`), nenhum novo.
- `npx tsc --noEmit`: limpo.
- `npm test -- --maxWorkers=2`: 1256 passaram, 8 falharam, 1264 total, 141 suites (137 passaram, 4 falharam) — as mesmas 4 suites e os mesmos 8 testes da baseline (`LockScreen`, `SettingsScreen`, `WeatherScreen`, `FoldersStore`), zero regressão.
- Kotlin (JVM pura, fora de Gradle): 19/19 testes de `IconCacheTest`+`IconMaskSpecTest` a passar.

## Testes

1256 passaram, 8 falharam (as mesmas 8 da baseline em main, nas mesmas 4 suites), 141 suites; 19/19 testes Kotlin de IconCacheTest+IconMaskSpecTest a passar em JVM pura

## Linked Issue

Fixes #482