### PR TITLE
feat: reachable + voice-driven Siri from AssistiveTouch

### DIFF
--- a/docs/GAP_ANALYSIS.md
+++ b/docs/GAP_ANALYSIS.md
@@ -155,7 +155,7 @@ Many settings screens appear functional but immediately open Android's native se
 
 9. **No FaceTime Equivalent**: Video call explicitly blocked with an error message.
 
-10. **No Siri/Voice Assistant**: No voice interaction capability.
+10. **Siri (limited)**: Voice + text assistant in `SiriScreen`, reached from AssistiveTouch. Recognises Open/Call/Message/What Time; SET_ALARM parses but is not wired to the alarm store.
 
 ### Feature Parity Gaps vs Real iOS
 
@@ -172,7 +172,7 @@ Many settings screens appear functional but immediately open Android's native se
 | Mail app | Missing entirely |
 | Safari browser | Missing entirely |
 | App Store | Missing entirely |
-| Siri/voice assistant | Missing entirely |
+| Siri/voice assistant | Partial — voice + text via AssistiveTouch; small command grammar |
 | FaceTime | Blocked with error |
 | iMessage features (reactions, typing) | Missing |
 | Widgets (configurable) | Missing - static widgets only |

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -285,6 +285,11 @@ jest.mock('./modules/launcher-module/src', () => ({
   addHomePressedListener: jest.fn(() => jest.fn()),
   // AppsProvider subscribes to package install/remove/replace events (#485).
   addPackageChangedListener: jest.fn(() => jest.fn()),
+  // SiriScreen subscribes to these when the mic is tapped. Return a no-op
+  // unsubscribe so mount/unmount cycles don't blow up in tests.
+  addSpeechResultListener: jest.fn(() => jest.fn()),
+  addSpeechPartialResultListener: jest.fn(() => jest.fn()),
+  addSpeechErrorListener: jest.fn(() => jest.fn()),
   default: {
     getInstalledApps: jest.fn(() => Promise.resolve([])),
     launchApp: jest.fn(() => Promise.resolve(true)),
@@ -326,6 +331,9 @@ jest.mock('./modules/launcher-module/src', () => ({
     canWriteSystemSettings: jest.fn(() => Promise.resolve(false)),
     openWriteSettingsAccess: jest.fn(() => Promise.resolve(true)),
     setRingtone: jest.fn(() => Promise.resolve(false)),
+    startSpeechRecognition: jest.fn(() => Promise.resolve(true)),
+    stopSpeechRecognition: jest.fn(() => Promise.resolve(true)),
+    isSpeechRecognitionAvailable: jest.fn(() => Promise.resolve(true)),
   },
 }));
 

--- a/modules/launcher-module/src/index.ts
+++ b/modules/launcher-module/src/index.ts
@@ -729,6 +729,21 @@ export function addSpeechResultListener(
 }
 
 /**
+ * Subscribe to partial (in-flight) speech-to-text results.
+ * Fires repeatedly while the user is still speaking so callers can render a
+ * live transcript before the recognizer commits with onSpeechResult.
+ * Returns an unsubscribe function — call it in the useEffect cleanup.
+ */
+export function addSpeechPartialResultListener(
+  listener: (text: string) => void,
+): () => void {
+  const sub = addModuleListener('onSpeechPartialResult', (n: { text: string }) => {
+    listener(n.text);
+  });
+  return () => sub.remove();
+}
+
+/**
  * Subscribe to speech-recognition errors emitted by the native recognizer.
  * The callback receives the error message (string).
  * Returns an unsubscribe function — call it in the useEffect cleanup.

--- a/src/components/AssistiveTouch.tsx
+++ b/src/components/AssistiveTouch.tsx
@@ -28,6 +28,27 @@ import { IDLE_DIM_MS } from '../utils/gestureConfig';
 const { width: SCREEN_W, height: SCREEN_H } = Dimensions.get('window');
 const SNAP_SPRING = { damping: 18, stiffness: 220 } as const;
 
+/**
+ * Radial-menu popover geometry. Shared by the anchor maths and the grid styles
+ * so the cells provably fit: the popover clips its overflow, so a cell size the
+ * content box cannot hold silently drops menu items instead of wrapping them
+ * into view.
+ */
+export const MENU_GEOMETRY = {
+  width: 240,
+  height: 200,
+  padding: 10,
+  gap: 6,
+  columns: 3,
+  cellHeight: 84,
+  /** Top-level menu capacity, mirrored by the settings screen. */
+  maxItems: 6,
+} as const;
+
+const MENU_CONTENT_W = MENU_GEOMETRY.width - MENU_GEOMETRY.padding * 2;
+const MENU_CELL_W =
+  (MENU_CONTENT_W - MENU_GEOMETRY.gap * (MENU_GEOMETRY.columns - 1)) / MENU_GEOMETRY.columns;
+
 // ─── Menu item catalog ──────────────────────────────────────────────────────
 
 interface MenuItemDef {
@@ -353,9 +374,9 @@ export function AssistiveTouch({ navigationRef }: AssistiveTouchProps) {
       // Prepend the override, drop any pre-existing entry with the same id
       const override = CONTEXT_OVERRIDES[currentRoute] as MenuItemDef;
       const filtered = items.filter((m) => m.id !== override.id);
-      return [override, ...filtered].slice(0, 6);
+      return [override, ...filtered].slice(0, MENU_GEOMETRY.maxItems);
     }
-    return items.slice(0, 6);
+    return items.slice(0, MENU_GEOMETRY.maxItems);
   }, [menuItems, contextAwareMenu, currentRoute]);
 
   if (!visible) return null;
@@ -431,8 +452,8 @@ function RadialMenu({ items, onPick, buttonSize, anchorX, anchorY, isDark }: Rad
     const cx = anchorX.value + buttonSize / 2;
     const cy = anchorY.value + buttonSize / 2;
     const preferLeft = cx > SCREEN_W / 2;
-    const popWidth = 240;
-    const popHeight = 200;
+    const popWidth = MENU_GEOMETRY.width;
+    const popHeight = MENU_GEOMETRY.height;
     const gap = 14;
     const x = preferLeft ? cx - popWidth - gap : cx + gap;
     const y = Math.max(40, Math.min(SCREEN_H - popHeight - 40, cy - popHeight / 2));
@@ -507,24 +528,27 @@ const styles = StyleSheet.create({
     position: 'absolute',
     top: 0,
     left: 0,
-    width: 240,
-    height: 200,
+    width: MENU_GEOMETRY.width,
+    height: MENU_GEOMETRY.height,
     borderRadius: 20,
     overflow: 'hidden',
     zIndex: 55,
   },
   menuBlur: {
     flex: 1,
-    padding: 10,
+    padding: MENU_GEOMETRY.padding,
   },
   menuGrid: {
     flexDirection: 'row',
     flexWrap: 'wrap',
-    gap: 6,
+    gap: MENU_GEOMETRY.gap,
   },
   menuCell: {
-    width: '32%',
-    height: 88,
+    // Absolute width, not a percentage: at width '32%' three cells plus their
+    // gaps overflowed the 220pt content box, so the grid fell back to two
+    // columns and the popover clipped items 5 and 6 out of view.
+    width: MENU_CELL_W,
+    height: MENU_GEOMETRY.cellHeight,
     borderRadius: 14,
     alignItems: 'center',
     justifyContent: 'center',

--- a/src/components/CupertinoAlertDialog.tsx
+++ b/src/components/CupertinoAlertDialog.tsx
@@ -139,8 +139,11 @@ export function CupertinoAlertDialog({
                   },
                 ]}
                 onPress={() => {
-                  action.onPress();
+                  // Close first: an action that itself opens another alert
+                  // (e.g. "Limit Reached") would otherwise be hidden again by
+                  // this dismissal, since both setStates land in one batch.
                   onClose();
+                  action.onPress();
                 }}
               >
                 <Text

--- a/src/components/__tests__/AlertProvider.test.tsx
+++ b/src/components/__tests__/AlertProvider.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Text, Pressable } from 'react-native';
+import { render, fireEvent } from '../../test-utils';
+import { AlertProvider, useAlert } from '../AlertProvider';
+
+/** Opens an alert whose only action opens a second alert. */
+function NestedAlertTrigger() {
+  const alert = useAlert();
+  return (
+    <Pressable
+      accessibilityLabel="open"
+      onPress={() =>
+        alert('First', undefined, [
+          { text: 'Go deeper', onPress: () => alert('Second', 'Opened from an action') },
+        ])
+      }
+    >
+      <Text>trigger</Text>
+    </Pressable>
+  );
+}
+
+describe('AlertProvider', () => {
+  it('keeps an alert opened from inside another alert action visible', () => {
+    const { getByLabelText, getByText, queryByText } = render(
+      <AlertProvider>
+        <NestedAlertTrigger />
+      </AlertProvider>,
+    );
+
+    fireEvent.press(getByLabelText('open'));
+    expect(getByText('First')).toBeTruthy();
+
+    // Dismissal and the follow-up alert land in the same React batch; if the
+    // dismissal wins, the second alert never reaches the screen.
+    fireEvent.press(getByText('Go deeper'));
+    expect(getByText('Second')).toBeTruthy();
+    expect(queryByText('First')).toBeNull();
+  });
+});

--- a/src/components/__tests__/AssistiveTouch.test.tsx
+++ b/src/components/__tests__/AssistiveTouch.test.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import { act, render, fireEvent } from '../../test-utils';
-import { AssistiveTouch } from '../AssistiveTouch';
+import { AssistiveTouch, MENU_GEOMETRY } from '../AssistiveTouch';
 import { AssistiveTouchProvider, useAssistiveTouch } from '../../store/AssistiveTouchStore';
 import type { NavigationContainerRefWithCurrent } from '@react-navigation/native';
 import type { RootStackParamList } from '../../navigation/types';
@@ -297,5 +297,21 @@ describe('AssistiveTouch acção siri', () => {
     fireEvent.press(getByLabelText('Spotlight'));
     expect(navigationRef.navigate).toHaveBeenCalledWith('SpotlightSearch');
     expect(navigationRef.navigate).not.toHaveBeenCalledWith('Siri');
+  });
+});
+
+describe('AssistiveTouch menu geometry', () => {
+  // The popover clips its overflow, so cells that do not fit the content box
+  // drop menu items out of view instead of wrapping them onto a visible row.
+  const { width, height, padding, gap, columns, cellHeight, maxItems } = MENU_GEOMETRY;
+  const contentW = width - padding * 2;
+  const contentH = height - padding * 2;
+
+  it('fits a full menu inside the popover', () => {
+    const cellW = (contentW - gap * (columns - 1)) / columns;
+    expect(cellW * columns + gap * (columns - 1)).toBeLessThanOrEqual(contentW);
+
+    const rows = Math.ceil(maxItems / columns);
+    expect(rows * cellHeight + gap * (rows - 1)).toBeLessThanOrEqual(contentH);
   });
 });

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -27,7 +27,7 @@ export { GestureHost, useGestureHost, useOptionalGestureHost } from './GestureHo
 export type { GestureHostMode } from './GestureHost';
 export { BackEdgeSwipe } from './BackEdgeSwipe';
 export { QuickSwitchHomeBar } from './QuickSwitchHomeBar';
-export { AssistiveTouch } from './AssistiveTouch';
+export { AssistiveTouch, MENU_GEOMETRY } from './AssistiveTouch';
 export { ControlCenterOverlay } from './ControlCenterOverlay';
 export { NotificationCenterOverlay } from './NotificationCenterOverlay';
 export { SpotlightReveal } from './SpotlightReveal';

--- a/src/screens/SiriScreen.tsx
+++ b/src/screens/SiriScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   View,
   Text,
@@ -6,6 +6,9 @@ import {
   Pressable,
   ScrollView,
   StyleSheet,
+  Platform,
+  PermissionsAndroid,
+  Linking,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
@@ -16,8 +19,11 @@ import { useTheme } from '../theme/ThemeContext';
 import { parseCommand } from '../assistant/commandParser';
 import type { AppNavigationProp } from '../navigation/types';
 import { logger } from '../utils/logger';
+import { useAlert, SiriWaveform } from '../components';
+import { withAutoLockSuppressed } from '../utils/permissions';
 
 const GREETING = 'What can I help you with?';
+const LISTENING = 'Listening…';
 const NOT_SUPPORTED = "That's not supported yet.";
 
 /** Format a Date the way the assistant speaks a clock time ("2:05 PM"). */
@@ -45,6 +51,23 @@ function findContact(contacts: Contact[], query: string): Contact | undefined {
   });
 }
 
+// Loaded defensively via dynamic import so tests without the native module
+// still render, matching the pattern in AppsStore.
+async function getLauncherModuleExports(): Promise<
+  typeof import('../../modules/launcher-module/src') | null
+> {
+  try {
+    return await import('../../modules/launcher-module/src');
+  } catch {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports -- Metro supports require
+      return require('../../modules/launcher-module/src');
+    } catch {
+      return null;
+    }
+  }
+}
+
 interface SiriScreenProps {
   navigation: AppNavigationProp;
 }
@@ -55,9 +78,14 @@ export function SiriScreen({ navigation }: SiriScreenProps) {
   const insets = useSafeAreaInsets();
   const { apps, launchApp } = useApps();
   const { contacts } = useContacts();
+  const alert = useAlert();
 
   const [text, setText] = useState('');
   const [response, setResponse] = useState<string | null>(null);
+  const [listening, setListening] = useState(false);
+  // Availability is per-device — cached once, then used to disable the mic if
+  // the platform has no on-device recognizer (e.g. non-Android emulators).
+  const [voiceAvailable, setVoiceAvailable] = useState<boolean | null>(null);
   const inputRef = useRef<TextInput>(null);
 
   const findApp = useCallback(
@@ -70,11 +98,8 @@ export function SiriScreen({ navigation }: SiriScreenProps) {
     [apps],
   );
 
-  const handleSubmit = useCallback(() => {
-    const input = text;
+  const runCommand = useCallback((input: string) => {
     if (input.trim().length === 0) return;
-    setText('');
-
     const command = parseCommand(input);
 
     switch (command.type) {
@@ -125,9 +150,150 @@ export function SiriScreen({ navigation }: SiriScreenProps) {
         setResponse(NOT_SUPPORTED);
         return;
     }
-  }, [text, findApp, contacts, launchApp, navigation]);
+  }, [findApp, contacts, launchApp, navigation]);
+
+  const handleSubmit = useCallback(() => {
+    const input = text;
+    setText('');
+    runCommand(input);
+  }, [text, runCommand]);
+
+  // ── Voice recognition ──────────────────────────────────────────────────
+  // Query availability once so the mic can be disabled when the platform
+  // has no on-device recognizer.
+  useEffect(() => {
+    let cancelled = false;
+    getLauncherModuleExports().then((mod) => {
+      if (cancelled) return;
+      if (!mod?.default) { setVoiceAvailable(false); return; }
+      mod.default.isSpeechRecognitionAvailable()
+        .then((ok) => { if (!cancelled) setVoiceAvailable(!!ok); })
+        .catch(() => { if (!cancelled) setVoiceAvailable(false); });
+    });
+    return () => { cancelled = true; };
+  }, []);
+
+  // Subscribe to speech events while listening. Final result runs the same
+  // command pipeline as typed input; partial results stream into the field so
+  // the user sees their words appear.
+  useEffect(() => {
+    if (!listening) return;
+    let unsubResult: (() => void) | undefined;
+    let unsubPartial: (() => void) | undefined;
+    let unsubError: (() => void) | undefined;
+    let cancelled = false;
+
+    getLauncherModuleExports().then((mod) => {
+      if (cancelled || !mod) return;
+      unsubPartial = mod.addSpeechPartialResultListener?.((partial) => {
+        setText(partial);
+      });
+      unsubResult = mod.addSpeechResultListener?.((final) => {
+        setText('');
+        setListening(false);
+        runCommand(final);
+      });
+      unsubError = mod.addSpeechErrorListener?.((err) => {
+        setListening(false);
+        setResponse(`Couldn't hear you (${err}).`);
+      });
+    });
+
+    return () => {
+      cancelled = true;
+      unsubResult?.();
+      unsubPartial?.();
+      unsubError?.();
+    };
+  }, [listening, runCommand]);
+
+  const stopListening = useCallback(async () => {
+    setListening(false);
+    const mod = await getLauncherModuleExports();
+    await mod?.default?.stopSpeechRecognition().catch(() => {});
+  }, []);
+
+  const startListening = useCallback(async () => {
+    if (voiceAvailable === false) {
+      alert('Voice Not Available', 'Speech recognition is not available on this device.');
+      return;
+    }
+
+    // Ask for the microphone up front — the native recognizer will otherwise
+    // just fire onError with an opaque code the user can't act on.
+    if (Platform.OS === 'android') {
+      try {
+        const already = await PermissionsAndroid.check(
+          PermissionsAndroid.PERMISSIONS.RECORD_AUDIO,
+        );
+        if (!already) {
+          const result = await withAutoLockSuppressed(() => PermissionsAndroid.request(
+            PermissionsAndroid.PERMISSIONS.RECORD_AUDIO,
+            {
+              title: 'Listen to Voice Commands',
+              message: 'Allow the assistant to use the microphone for voice input?',
+              buttonPositive: 'Allow',
+              buttonNegative: 'Deny',
+            },
+          ));
+          if (result !== PermissionsAndroid.RESULTS.GRANTED) {
+            alert(
+              'Microphone Needed',
+              result === PermissionsAndroid.RESULTS.NEVER_ASK_AGAIN
+                ? 'Microphone access is disabled. Enable it in system settings to talk to the assistant.'
+                : 'Microphone access was denied. Voice commands need it to work.',
+              [
+                ...(result === PermissionsAndroid.RESULTS.NEVER_ASK_AGAIN
+                  ? [{ text: 'Open Settings', onPress: () => { Linking.openSettings().catch(() => {}); } }]
+                  : []),
+                { text: 'OK' },
+              ],
+            );
+            return;
+          }
+        }
+      } catch (e) {
+        logger.warn('SiriScreen', 'RECORD_AUDIO check failed', e);
+      }
+    }
+
+    setText('');
+    setResponse(LISTENING);
+    setListening(true);
+
+    const mod = await getLauncherModuleExports();
+    const started = await mod?.default?.startSpeechRecognition().catch(() => false);
+    if (!started) {
+      // Native side already emitted an error; but if the module was missing
+      // entirely, clear the listening state so the mic is tappable again.
+      setListening(false);
+      setResponse('Voice input is unavailable right now.');
+    }
+  }, [voiceAvailable, alert]);
+
+  const toggleListening = useCallback(() => {
+    if (listening) {
+      stopListening();
+    } else {
+      startListening();
+    }
+  }, [listening, stopListening, startListening]);
+
+  // Stop the recognizer if the screen unmounts mid-listen (back button, tab
+  // switch) so the mic doesn't stay held.
+  useEffect(() => () => {
+    getLauncherModuleExports().then((mod) => {
+      mod?.default?.stopSpeechRecognition().catch(() => {});
+    });
+  }, []);
 
   const styles = useMemo(() => createStyles(), []);
+  const micDisabled = voiceAvailable === false;
+  const micColor = listening
+    ? colors.systemRed
+    : micDisabled
+      ? colors.tertiaryLabel
+      : colors.systemBlue;
 
   return (
     <View style={[styles.container, { backgroundColor: colors.systemBackground }]}>
@@ -157,6 +323,12 @@ export function SiriScreen({ navigation }: SiriScreenProps) {
         </Text>
       </ScrollView>
 
+      {/* Bars sit above the input row so their motion reads as the mic
+          state, not decoration on the text field. */}
+      <View style={styles.waveformRow} pointerEvents="none">
+        <SiriWaveform listening={listening} />
+      </View>
+
       <View
         style={[
           styles.inputRow,
@@ -179,7 +351,22 @@ export function SiriScreen({ navigation }: SiriScreenProps) {
           accessibilityLabel="Ask Siri"
           autoFocus
           blurOnSubmit={false}
+          editable={!listening}
         />
+        <Pressable
+          onPress={toggleListening}
+          disabled={micDisabled}
+          hitSlop={10}
+          accessibilityRole="button"
+          accessibilityLabel={listening ? 'Stop listening' : 'Start voice input'}
+          accessibilityState={{ disabled: micDisabled, selected: listening }}
+          style={({ pressed }) => [
+            styles.micButton,
+            { opacity: pressed && !micDisabled ? 0.6 : 1 },
+          ]}
+        >
+          <Ionicons name={listening ? 'stop-circle' : 'mic'} size={28} color={micColor} />
+        </Pressable>
       </View>
     </View>
   );
@@ -193,16 +380,31 @@ function createStyles() {
     responseArea: { flex: 1 },
     responseContent: { padding: 24, flexGrow: 1, justifyContent: 'center' },
     responseText: { textAlign: 'center' },
+    waveformRow: {
+      alignItems: 'center',
+      justifyContent: 'center',
+      paddingVertical: 6,
+    },
     inputRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
       paddingHorizontal: 12,
       paddingTop: 8,
       borderTopWidth: StyleSheet.hairlineWidth,
+      gap: 8,
     },
     input: {
+      flex: 1,
       minHeight: 40,
       borderRadius: 20,
       paddingHorizontal: 16,
       paddingVertical: 8,
+    },
+    micButton: {
+      width: 40,
+      height: 40,
+      alignItems: 'center',
+      justifyContent: 'center',
     },
   });
 }

--- a/src/screens/__tests__/SiriScreen.test.tsx
+++ b/src/screens/__tests__/SiriScreen.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent } from '../../test-utils';
+import { render, fireEvent, act } from '../../test-utils';
 import { SiriScreen } from '../SiriScreen';
 import type { AppNavigationProp } from '../../navigation/types';
 import type { InstalledApp } from '../../store/AppsStore';
@@ -179,5 +179,143 @@ describe('SiriScreen', () => {
     mockLaunchApp.mockRejectedValueOnce(new Error('launch failed'));
     expect(() => submit('Open Calculator')).not.toThrow();
     expect(mockLaunchApp).toHaveBeenCalledWith('com.iostoandroid.calculator');
+  });
+});
+
+// ── Voice input ────────────────────────────────────────────────────────────
+// Hoisted mock of the launcher module. Tests then reach into
+// jest.requireMock(...) to capture the listener callbacks and to drive them.
+jest.mock('../../../modules/launcher-module/src', () => {
+  const listeners: {
+    result?: (t: string) => void;
+    partial?: (t: string) => void;
+    error?: (e: string) => void;
+  } = {};
+  return {
+    __esModule: true,
+    addHomePressedListener: jest.fn(() => jest.fn()),
+    addPackageChangedListener: jest.fn(() => jest.fn()),
+    addSpeechResultListener: jest.fn((fn: (t: string) => void) => {
+      listeners.result = fn;
+      return jest.fn();
+    }),
+    addSpeechPartialResultListener: jest.fn((fn: (t: string) => void) => {
+      listeners.partial = fn;
+      return jest.fn();
+    }),
+    addSpeechErrorListener: jest.fn((fn: (e: string) => void) => {
+      listeners.error = fn;
+      return jest.fn();
+    }),
+    __listeners: listeners,
+    default: {
+      // Fill in the AppsStore-touched surfaces so its background refresh does
+      // not spam "not a function" during these tests. Everything else is
+      // stubbed to a benign resolved value.
+      getInstalledApps: jest.fn(() => Promise.resolve([])),
+      isDefaultLauncher: jest.fn(() => Promise.resolve(false)),
+      getProcessStartAgeMs: jest.fn(() => Promise.resolve(-1)),
+      launchApp: jest.fn(() => Promise.resolve(true)),
+      startSpeechRecognition: jest.fn(() => Promise.resolve(true)),
+      stopSpeechRecognition: jest.fn(() => Promise.resolve(true)),
+      isSpeechRecognitionAvailable: jest.fn(() => Promise.resolve(true)),
+    },
+  };
+});
+
+describe('SiriScreen voice input', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const launcher = jest.requireMock('../../../modules/launcher-module/src');
+  const listeners = launcher.__listeners as {
+    result?: (t: string) => void;
+    partial?: (t: string) => void;
+    error?: (e: string) => void;
+  };
+
+  beforeEach(() => {
+    launcher.default.startSpeechRecognition.mockClear();
+    launcher.default.stopSpeechRecognition.mockClear();
+    launcher.default.isSpeechRecognitionAvailable.mockClear();
+    launcher.default.isSpeechRecognitionAvailable.mockResolvedValue(true);
+    listeners.result = undefined;
+    listeners.partial = undefined;
+    listeners.error = undefined;
+  });
+
+  async function renderScreen() {
+    const nav = makeNav();
+    const utils = render(<SiriScreen navigation={nav} />);
+    // Let the availability effect and the AppsStore background load settle.
+    await new Promise((r) => setTimeout(r, 0));
+    return { ...utils, nav };
+  }
+
+  async function tapMic(getByLabelText: (l: string) => unknown) {
+    await fireEvent.press(getByLabelText('Start voice input'));
+    // Allow the async permission + start chain to resolve and the listener
+    // effect to attach.
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+  }
+
+  it('exposes a mic button labelled for a voice-off state initially', async () => {
+    const { getByLabelText } = await renderScreen();
+    expect(getByLabelText('Start voice input')).toBeTruthy();
+  });
+
+  it('tapping the mic calls startSpeechRecognition and shows the listening state', async () => {
+    const { getByLabelText, getByText } = await renderScreen();
+    await tapMic(getByLabelText);
+    expect(launcher.default.startSpeechRecognition).toHaveBeenCalled();
+    expect(getByText('Listening…')).toBeTruthy();
+    expect(getByLabelText('Stop listening')).toBeTruthy();
+  });
+
+  it('an incoming final speech result runs the same command pipeline as typed input', async () => {
+    const { getByLabelText } = await renderScreen();
+    await tapMic(getByLabelText);
+    expect(listeners.result).toBeDefined();
+    await act(async () => { listeners.result?.('Open Calculator'); });
+    expect(mockLaunchApp).toHaveBeenCalledWith('com.iostoandroid.calculator');
+  });
+
+  it('a partial result populates the text field so the user sees the transcript', async () => {
+    const { getByLabelText } = await renderScreen();
+    await tapMic(getByLabelText);
+    expect(listeners.partial).toBeDefined();
+    await act(async () => { listeners.partial?.('open cal'); });
+    expect(getByLabelText('Ask Siri').props.value).toBe('open cal');
+  });
+
+  it('a speech error stops listening and surfaces the message', async () => {
+    const { getByLabelText, getByText } = await renderScreen();
+    await tapMic(getByLabelText);
+    expect(listeners.error).toBeDefined();
+    await act(async () => { listeners.error?.('no-match'); });
+    expect(getByText(/Couldn't hear you/i)).toBeTruthy();
+    expect(getByLabelText('Start voice input')).toBeTruthy();
+  });
+
+  it('tapping the mic while listening calls stopSpeechRecognition', async () => {
+    const { getByLabelText } = await renderScreen();
+    await tapMic(getByLabelText);
+    await fireEvent.press(getByLabelText('Stop listening'));
+    await new Promise((r) => setTimeout(r, 0));
+    expect(launcher.default.stopSpeechRecognition).toHaveBeenCalled();
+  });
+
+  it('when the recognizer is unavailable, tapping the mic does not start listening', async () => {
+    // isSpeechRecognitionAvailable resolves to false BEFORE render so the
+    // effect stores voiceAvailable=false. The warning itself is an alert, and
+    // asserting its text needs an AlertProvider in the tree — the point of
+    // this test is the guard, not the alert plumbing.
+    launcher.default.isSpeechRecognitionAvailable.mockResolvedValueOnce(false);
+    const { getByLabelText } = await renderScreen();
+    // Let the availability effect's three microtasks settle.
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+    await fireEvent.press(getByLabelText('Start voice input'));
+    await new Promise((r) => setTimeout(r, 0));
+    expect(launcher.default.startSpeechRecognition).not.toHaveBeenCalled();
   });
 });

--- a/src/screens/settings/AssistiveTouchSettingsScreen.tsx
+++ b/src/screens/settings/AssistiveTouchSettingsScreen.tsx
@@ -10,6 +10,7 @@ import {
   CupertinoSwitch,
   CupertinoSlider,
   useAlert,
+  MENU_GEOMETRY,
 } from '../../components';
 import {
   useAssistiveTouch,
@@ -34,6 +35,9 @@ const ACTION_OPTIONS: { id: AssistiveAction; label: string }[] = [
   { id: 'siri',             label: 'Siri' },
   { id: 'none',             label: 'None' },
 ];
+
+/** Top-level menu capacity — the popover renders exactly this many cells. */
+const MAX_MENU_ITEMS = MENU_GEOMETRY.maxItems;
 
 const ALL_MENU_ITEMS: { id: MenuItemId; label: string }[] = [
   { id: 'home',             label: 'Home' },
@@ -95,6 +99,12 @@ export function AssistiveTouchSettingsScreen({ navigation }: { navigation: AppNa
   );
 
   const addItem = useCallback(() => {
+    // Check the cap before offering a picker: the default menu is already full,
+    // so picking an item there could only ever fail.
+    if (assistive.menuItems.length >= MAX_MENU_ITEMS) {
+      alert('Limit Reached', `A menu can hold at most ${MAX_MENU_ITEMS} items. Remove one first.`);
+      return;
+    }
     const missing = ALL_MENU_ITEMS.filter((i) => !assistive.menuItems.includes(i.id));
     if (missing.length === 0) {
       alert('Menu Full', 'All available items are already in your menu.');
@@ -103,15 +113,9 @@ export function AssistiveTouchSettingsScreen({ navigation }: { navigation: AppNa
     alert(
       'Add to Menu',
       undefined,
-      missing.slice(0, 6).map((item) => ({
+      missing.map((item) => ({
         text: item.label,
-        onPress: () => {
-          if (assistive.menuItems.length >= 6) {
-            alert('Limit Reached', 'A menu can hold at most 6 items. Remove one first.');
-            return;
-          }
-          assistive.update({ menuItems: [...assistive.menuItems, item.id] });
-        },
+        onPress: () => assistive.update({ menuItems: [...assistive.menuItems, item.id] }),
       })),
     );
   }, [assistive, alert]);

--- a/src/screens/settings/__tests__/AssistiveTouchSettingsScreen.test.tsx
+++ b/src/screens/settings/__tests__/AssistiveTouchSettingsScreen.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, fireEvent } from '../../../test-utils';
 import { AssistiveTouchSettingsScreen } from '../AssistiveTouchSettingsScreen';
+import { AlertProvider } from '../../../components/AlertProvider';
 import type { MenuItemId } from '../../../store/AssistiveTouchStore';
 
 const mockUpdate = jest.fn();
@@ -79,5 +80,58 @@ describe('AssistiveTouchSettingsScreen', () => {
     );
     expect(queryByText('Customise Top Level Menu')).toBeNull();
     expect(queryByText('Reset to Defaults')).toBeNull();
+  });
+});
+
+// ── Top-level menu editing ──────────────────────────────────────────────────
+// These render inside a real AlertProvider: the picker and the cap warning are
+// alerts, so a stubbed no-op alert would hide the very behaviour under test.
+describe('AssistiveTouchSettingsScreen top-level menu', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseAssistive.mockReturnValue(assistive());
+  });
+
+  function renderScreen() {
+    return render(
+      <AlertProvider>
+        <AssistiveTouchSettingsScreen navigation={mockNavigation as never} />
+      </AlertProvider>,
+    );
+  }
+
+  it('the minus removes the item from the menu', () => {
+    const { getByLabelText } = renderScreen();
+    fireEvent.press(getByLabelText('Remove Spotlight'));
+    expect(mockUpdate).toHaveBeenCalledWith({
+      menuItems: ['home', 'multitask', 'notifications', 'controlCenter', 'settings'],
+    });
+  });
+
+  it('Add Item warns instead of opening an unusable picker when the menu is full', () => {
+    const { getByText, queryByText } = renderScreen();
+    fireEvent.press(getByText('Add Item'));
+    expect(getByText('Limit Reached')).toBeTruthy();
+    expect(queryByText('Add to Menu')).toBeNull();
+  });
+
+  it('Add Item offers Siri and appends it once there is a free slot', () => {
+    mockUseAssistive.mockReturnValue(
+      assistive({ menuItems: ['home', 'multitask', 'notifications', 'controlCenter', 'spotlight'] }),
+    );
+    const { getByText } = renderScreen();
+    fireEvent.press(getByText('Add Item'));
+    expect(getByText('Add to Menu')).toBeTruthy();
+    fireEvent.press(getByText('Siri'));
+    expect(mockUpdate).toHaveBeenCalledWith({
+      menuItems: ['home', 'multitask', 'notifications', 'controlCenter', 'spotlight', 'siri'],
+    });
+  });
+
+  it('the action picker offers Siri for a single tap', () => {
+    const { getByText } = renderScreen();
+    fireEvent.press(getByText('Single-Tap'));
+    fireEvent.press(getByText('Siri'));
+    expect(mockUpdate).toHaveBeenCalledWith({ singleTapAction: 'siri' });
   });
 });


### PR DESCRIPTION
## Summary

Two changes so the Siri entry point actually works end-to-end:

1. **Reachable from the menu.** The radial popover clipped items 5 and 6 because `menuCell` was `width: '32%'` — three cells + gaps overflowed the 220pt content box and the grid fell back to two columns. Add-Item silently no-op'd because the default menu is already at the 6-item cap and the guard lived inside each option's `onPress`. Alerts opened from inside another alert's action were swallowed because `CupertinoAlertDialog` closed after running the action, and both setStates landed in one batch.
2. **Voice input wired up.** The native `SpeechRecognizer` surfaces (start/stop/isAvailable + result/error events) existed but had no JS caller. `SiriScreen` now has a mic that requests `RECORD_AUDIO` with the same `withAutoLockSuppressed` pattern used for SMS, streams partial results into the field live, runs the final transcript through the existing `parseCommand` pipeline, and shows the pre-existing `SiriWaveform` while listening. A new `addSpeechPartialResultListener` wraps the already-emitted `onSpeechPartialResult` event.

`docs/GAP_ANALYSIS.md` refreshed — Siri is partial now, not missing.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean on touched files
- [x] `npx jest` — 1199 pass. The 8 remaining failures across SettingsScreen / FoldersStore / LockScreen / WeatherScreen reproduce on `main` before this change; no regressions from this PR.
- [x] New tests: `AlertProvider.test.tsx` (nested-alert dismissal), popover geometry invariant on `AssistiveTouch`, 4 tests on `AssistiveTouchSettingsScreen` (remove, cap warning, add Siri, map Single-Tap to Siri), 7 tests on `SiriScreen` (mic idle/start/partial/final/error/stop/unavailable).
- [ ] Smoke test on device: menu shows all 6 items, add Siri, tap mic, RECORD_AUDIO prompt, transcript streams in, "Open Calculator" launches Calculator.

---
_Generated by [Claude Code](https://claude.ai/code/session_019KsSpiD5Q91ibytnmCyMyt)_