### PR TITLE
qa/issue-481: dock/sheet/card/dialog radii pass to Shape tokens (dock 34, sheet 13, card 10) — AC de captura reformulado para verificação numérica (#481)

### DIFF
--- a/src/components/CupertinoAlertDialog.tsx
+++ b/src/components/CupertinoAlertDialog.tsx
@@ -7,7 +7,7 @@ import Animated, {
   withTiming,
 } from 'react-native-reanimated';
 import { useTheme } from '../theme/ThemeContext';
-import { BorderRadius } from '../theme/CupertinoTheme';
+import { Shape } from '../theme/CupertinoTheme';
 import { useGestureReduceMotion } from '../utils/useGestureReduceMotion';
 
 interface AlertAction {
@@ -78,11 +78,12 @@ export function CupertinoAlertDialog({
         </Animated.View>
 
         <Animated.View
+          testID="alert-dialog"
           style={[
             styles.dialog,
             {
               backgroundColor: dialogBg,
-              borderRadius: BorderRadius.card14,
+              borderRadius: Shape.card.radius,
             },
             dialogStyle,
           ]}

--- a/src/components/CupertinoCard.tsx
+++ b/src/components/CupertinoCard.tsx
@@ -10,7 +10,7 @@ interface CupertinoCardProps {
 }
 
 export const CupertinoCard = React.memo(function CupertinoCard({ title, subtitle, children, style }: CupertinoCardProps) {
-  const { theme, typography, spacing, borderRadius, shadows } = useTheme();
+  const { theme, typography, spacing, shape, shadows } = useTheme();
   const { colors } = theme;
 
   return (
@@ -22,7 +22,7 @@ export const CupertinoCard = React.memo(function CupertinoCard({ title, subtitle
           backgroundColor: theme.dark
             ? colors.secondarySystemBackground
             : colors.systemBackground,
-          borderRadius: borderRadius.medium,
+          borderRadius: shape.card.radius,
           padding: spacing.md,
         },
         style,

--- a/src/components/CupertinoShareSheet.tsx
+++ b/src/components/CupertinoShareSheet.tsx
@@ -14,7 +14,7 @@ import { Ionicons } from '@expo/vector-icons';
 import * as Clipboard from 'expo-clipboard';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTheme } from '../theme/ThemeContext';
-import { BorderRadius } from '../theme/CupertinoTheme';
+import { BorderRadius, Shape } from '../theme/CupertinoTheme';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -114,7 +114,7 @@ export function CupertinoShareSheet({ visible, onClose, title, url, text, onAddT
       <View style={styles.overlay}>
         <Pressable style={StyleSheet.absoluteFill} onPress={onClose} />
 
-        <View style={[styles.sheet, { paddingBottom: insets.bottom + 8 }]}>
+        <View testID="share-sheet" style={[styles.sheet, { paddingBottom: insets.bottom + 8 }]}>
           <GlassSurface
             intensity={85}
             tint={dark ? 'dark' : 'light'}
@@ -204,8 +204,8 @@ const styles = StyleSheet.create({
     backgroundColor: 'rgba(0,0,0,0.35)',
   },
   sheet: {
-    borderTopLeftRadius: 16,
-    borderTopRightRadius: 16,
+    borderTopLeftRadius: Shape.sheet.radius,
+    borderTopRightRadius: Shape.sheet.radius,
     overflow: 'hidden',
     paddingTop: 8,
   },

--- a/src/components/__tests__/CupertinoAlertDialog.test.tsx
+++ b/src/components/__tests__/CupertinoAlertDialog.test.tsx
@@ -2,6 +2,12 @@ import React from 'react';
 import { Text } from 'react-native';
 import { render } from '../../test-utils';
 import { CupertinoAlertDialog } from '../CupertinoAlertDialog';
+import { Shape } from '../../theme/CupertinoTheme';
+
+function flattenStyle(style: unknown): Record<string, unknown>[] {
+  if (Array.isArray(style)) return style.flat(Infinity).filter(Boolean) as Record<string, unknown>[];
+  return style ? [style as Record<string, unknown>] : [];
+}
 
 describe('CupertinoAlertDialog', () => {
   it('renders action labels with numberOfLines={1} to prevent overflow', () => {
@@ -27,5 +33,26 @@ describe('CupertinoAlertDialog', () => {
     actionLabels.forEach((label) => {
       expect(label.props.numberOfLines).toBe(1);
     });
+  });
+
+  // #481: the alert dialog is a "cartão" surface per §1.6 and must consume
+  // Shape.card (10), not the old BorderRadius.card14 (14).
+  it('renders the dialog at the Shape.card radius (10)', () => {
+    const { getByTestId } = render(
+      <CupertinoAlertDialog
+        visible
+        onClose={jest.fn()}
+        title="Confirm Action"
+        actions={[{ label: 'OK', onPress: jest.fn() }]}
+      />,
+    );
+
+    const dialog = getByTestId('alert-dialog');
+    const flat = flattenStyle(dialog.props.style);
+    const radiusStyle = flat.find((s) => 'borderRadius' in s) as { borderRadius: number } | undefined;
+
+    expect(radiusStyle).toBeDefined();
+    expect(radiusStyle?.borderRadius).toBe(Shape.card.radius);
+    expect(radiusStyle?.borderRadius).toBe(10);
   });
 });

--- a/src/components/__tests__/CupertinoCard.test.tsx
+++ b/src/components/__tests__/CupertinoCard.test.tsx
@@ -6,6 +6,7 @@ import { Text } from 'react-native';
 // that gate off — see the comment there.
 import { render as renderWithTheme } from '../../test-utils';
 import { CupertinoCard } from '../CupertinoCard';
+import { Shape } from '../../theme/CupertinoTheme';
 
 describe('CupertinoCard', () => {
   it('renders with title and subtitle', () => {
@@ -45,5 +46,22 @@ describe('CupertinoCard', () => {
     expect(shadowStyle).toBeDefined();
     expect(shadowStyle?.shadowColor).toBe('#000');
     expect(shadowStyle?.elevation).toBe(4);
+  });
+
+  it('uses the Shape.card radius token (10), not the old BorderRadius.medium (12) — spec §1.6', () => {
+    const { root } = renderWithTheme(
+      <CupertinoCard>
+        <Text>Card</Text>
+      </CupertinoCard>,
+    );
+
+    const styles = root.props.style;
+    const radiusStyle = Array.isArray(styles)
+      ? styles.find((s) => s && typeof s === 'object' && 'borderRadius' in s)
+      : null;
+
+    expect(radiusStyle).toBeDefined();
+    expect(radiusStyle?.borderRadius).toBe(Shape.card.radius);
+    expect(radiusStyle?.borderRadius).toBe(10);
   });
 });

--- a/src/components/__tests__/CupertinoShareSheet.test.tsx
+++ b/src/components/__tests__/CupertinoShareSheet.test.tsx
@@ -1,9 +1,15 @@
 import React from 'react';
 import { render, fireEvent } from '../../test-utils';
 import { CupertinoShareSheet } from '../CupertinoShareSheet';
+import { Shape } from '../../theme/CupertinoTheme';
 
 const mockOnClose = jest.fn();
 const mockOnAdd = jest.fn();
+
+function flattenStyle(style: unknown): Record<string, unknown>[] {
+  if (Array.isArray(style)) return style.flat(Infinity).filter(Boolean) as Record<string, unknown>[];
+  return style ? [style as Record<string, unknown>] : [];
+}
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -102,5 +108,24 @@ describe('CupertinoShareSheet', () => {
     expect(mockOnClose).toHaveBeenCalledTimes(1);
     // With no reading-list handler, the reading-list option must stay absent.
     expect(mockOnAdd).not.toHaveBeenCalled();
+  });
+
+  // #481: the sheet's top corners must consume Shape.sheet (13), not the old
+  // literal (16) — outside the §1.6 range of 10–13.
+  it('renders the sheet top corners at the Shape.sheet radius (13)', () => {
+    const { getByTestId } = render(
+      <CupertinoShareSheet visible onClose={mockOnClose} title="Page" url="https://example.com" />,
+    );
+
+    const sheet = getByTestId('share-sheet');
+    const flat = flattenStyle(sheet.props.style);
+    const radiusStyle = flat.find((s) => 'borderTopLeftRadius' in s) as
+      | { borderTopLeftRadius: number; borderTopRightRadius: number }
+      | undefined;
+
+    expect(radiusStyle).toBeDefined();
+    expect(radiusStyle?.borderTopLeftRadius).toBe(Shape.sheet.radius);
+    expect(radiusStyle?.borderTopRightRadius).toBe(Shape.sheet.radius);
+    expect(radiusStyle?.borderTopLeftRadius).toBe(13);
   });
 });

--- a/src/components/__tests__/__snapshots__/CupertinoCard.test.tsx.snap.android
+++ b/src/components/__tests__/__snapshots__/CupertinoCard.test.tsx.snap.android
@@ -19,7 +19,7 @@ exports[`CupertinoCard renders with title and subtitle 1`] = `
       },
       {
         "backgroundColor": "#FFFFFF",
-        "borderRadius": 12,
+        "borderRadius": 10,
         "padding": 16,
       },
       undefined,
@@ -89,7 +89,7 @@ exports[`CupertinoCard renders without title 1`] = `
       },
       {
         "backgroundColor": "#FFFFFF",
-        "borderRadius": 12,
+        "borderRadius": 10,
         "padding": 16,
       },
       undefined,

--- a/src/screens/LauncherHomeScreen.tsx
+++ b/src/screens/LauncherHomeScreen.tsx
@@ -39,6 +39,7 @@ import { useApps, InstalledApp } from '../store/AppsStore';
 import { AppLibraryContent } from './AppLibraryScreen';
 import { useSettings } from '../store/SettingsStore';
 import { useTheme } from '../theme/ThemeContext';
+import { Shape } from '../theme/CupertinoTheme';
 import { useDevice } from '../store/DeviceStore';
 import { useFolders, AppFolder } from '../store/FoldersStore';
 import {
@@ -1707,7 +1708,7 @@ const styles = StyleSheet.create({
   },
   dockBlur: {
     overflow: 'hidden',
-    borderRadius: 22,
+    borderRadius: Shape.dock.radius,
     paddingVertical: 10,
     paddingHorizontal: 16,
     backgroundColor: 'rgba(0,0,0,0.3)',

--- a/src/screens/__tests__/LauncherHomeScreen.test.tsx
+++ b/src/screens/__tests__/LauncherHomeScreen.test.tsx
@@ -11,6 +11,7 @@ import {
 } from '../LauncherHomeScreen';
 import * as DeviceStore from '../../store/DeviceStore';
 import * as AppsStore from '../../store/AppsStore';
+import { Shape } from '../../theme/CupertinoTheme';
 
 function flattenStyle(style: unknown): Record<string, unknown>[] {
   if (Array.isArray(style)) return style.flat(Infinity).filter(Boolean) as Record<string, unknown>[];
@@ -21,6 +22,41 @@ describe('LauncherHomeScreen', () => {
   it('renders without crashing', () => {
     const { toJSON } = render(<LauncherHomeScreen />);
     expect(toJSON()).toBeTruthy();
+  });
+
+  // #481: dock corner radius must consume Shape.dock (34), not the old
+  // hand-picked literal (22) — 35% below spec §1.6.
+  it('renders the dock at the Shape.dock radius (34)', () => {
+    jest.spyOn(AppsStore, 'useApps').mockReturnValue({
+      apps: [],
+      homeApps: [],
+      dockApps: [],
+      nonDockApps: [],
+      recentPackages: [],
+      recentApps: [],
+      isLoading: false,
+      refreshApps: jest.fn(() => Promise.resolve()),
+      launchApp: jest.fn(() => Promise.resolve(true)),
+      addToHome: jest.fn(),
+      removeFromHome: jest.fn(),
+      addToDock: jest.fn(),
+      removeFromDock: jest.fn(),
+      removeFromRecents: jest.fn(),
+      clearRecents: jest.fn(),
+      isDefaultLauncher: true,
+      openLauncherSettings: jest.fn(() => Promise.resolve()),
+    } as ReturnType<typeof AppsStore.useApps>);
+
+    const { UNSAFE_getByType } = render(<LauncherHomeScreen />);
+    const dockBlur = UNSAFE_getByType('BlurView' as never);
+    const flat = flattenStyle(dockBlur.props.style);
+    const radiusStyle = flat.find((s) => 'borderRadius' in s) as { borderRadius: number } | undefined;
+
+    expect(radiusStyle).toBeDefined();
+    expect(radiusStyle?.borderRadius).toBe(Shape.dock.radius);
+    expect(radiusStyle?.borderRadius).toBe(34);
+
+    jest.restoreAllMocks();
   });
 
   it('renders the home screen container', () => {


### PR DESCRIPTION
## Resumo

qa/issue-481: dock/sheet/card/dialog radii pass to Shape tokens (dock 34, sheet 13, card 10) — AC de captura reformulado para verificação numérica

## Causa raiz

Raios divergentes da tabela §1.6, todos com literais/tokens antigos em vez de `Shape`:

- `src/screens/LauncherHomeScreen.tsx` (dock) — `borderRadius: 22` (arco circular fixo, devia ser 34).
- `src/components/CupertinoShareSheet.tsx` (sheet) — `borderTopLeftRadius`/`borderTopRightRadius: 16` (devia ser 13).
- `src/components/CupertinoCard.tsx` (cartão) — `borderRadius: BorderRadius.medium` = 12 (devia ser `Shape.card.radius` = 10). Nota: a linha `CupertinoTheme.ts:254` citada no issue original já não é o site de uso — é a definição do próprio token, deslocada por commits posteriores (#475/#479); o site de uso real é `CupertinoCard.tsx:25`.
- `src/components/CupertinoAlertDialog.tsx` (dialog, classificado como cartão) — `BorderRadius.card14` = 14 (devia ser `Shape.card.radius` = 10).

## O que mudou

- `src/screens/LauncherHomeScreen.tsx` — `dockBlur.borderRadius` passa de `22` para `Shape.dock.radius` (34).
- `src/components/CupertinoShareSheet.tsx` — `sheet.borderTopLeftRadius`/`borderTopRightRadius` passam de `16` para `Shape.sheet.radius` (13). Import de `BorderRadius` mantido — ainda usado por `previewCard`/`optionIconWrap`, fora do âmbito deste issue.
- `src/components/CupertinoCard.tsx` — `borderRadius: BorderRadius.medium` passa para `borderRadius: shape.card.radius` (10).
- `src/components/CupertinoAlertDialog.tsx` — `borderRadius: BorderRadius.card14` passa para `borderRadius: Shape.card.radius` (10). Import de `BorderRadius` removido (deixou de ser usado no ficheiro).
- 4 ficheiros de teste novos (`CupertinoAlertDialog.test.tsx`, `CupertinoCard.test.tsx`, `CupertinoShareSheet.test.tsx`, `LauncherHomeScreen.test.tsx`) e 1 snapshot actualizado (`CupertinoCard.test.tsx.snap.android`, reflectindo `borderRadius: 10`).
- Cápsulas (`CupertinoSwitch.tsx`, `CupertinoSlider.tsx`, `AssistiveTouch.tsx`, `CupertinoButton.tsx`) **não tocadas** — confirmado por `git diff --name-only origin/main...HEAD`.

## Porque assim

Estas superfícies (dock, sheet, cartão, dialog) não são ícones — a superelipse real exigiria SVG/Skia, decisão já tomada no epic #465 de não implementar. **Esta PR só acerta o número do raio**, mantendo o arco circular por decisão explícita, não por esquecimento — registado aqui para o próximo leitor não abrir issue duplicado.

O issue original também pedia uma captura de ecrã antes/depois do dock como critério de aceitação. Esse critério pressupõe uma ferramenta interactiva (`adb`, emulador Android, `xcrun`, `maestro`/`detox`) que este pipeline headless não tem — confirmado: `which adb`, `which emulator`, `which xcrun` não devolvem nada, e `npx maestro`/`npx detox` não estão instalados/funcionais. Depois de dois ciclos implementador→reviewer→curator sobre este exacto ponto, a decisão registada (curator, comentário anterior) é: reformular o critério para uma verificação numérica equivalente, já coberta por teste, e mover a validação visual para QA manual pós-merge. Esta PR aplica essa reformulação — sem alterar uma linha do código já revisto e aprovado.

A proporção do dock (22→34) pode parecer visualmente estranha por a altura do dock estar errada (~108 vs ~96 da §2) — isso é sub-issue do epic #469, não deste; apenas anotado, não corrigido aqui.

## Critérios de aceitação

- [x] Dock, sheets, cartões e dialogs consomem `Shape`, sem literais de raio — confirmado por leitura dos 4 sites (ver "O que mudou").
- [x] Raio do dock a 34 — `LauncherHomeScreen.tsx`, `dockBlur.borderRadius = Shape.dock.radius` (34); verificado por teste que lê o estilo resolvido do nó `dockBlur` montado (não uma cópia da fórmula).
- [x] Cápsulas intactas — `CupertinoSwitch.tsx:100,107`, `CupertinoSlider.tsx:123,129,141`, `AssistiveTouch.tsx:503`, `CupertinoButton.tsx:52,59` ausentes do diff, confirmado.
- [x] Nota no PR a registar arco circular por decisão — secção "Porque assim" acima.
- [x] **Reformulado** (era "Captura antes/depois do dock"): este critério passa a ser verificado numericamente — `Shape.dock.radius === 34` no estilo resolvido de `dockBlur`, coberto pelo teste `LauncherHomeScreen.test.tsx` ("renders the dock at the Shape.dock radius (34)"), já passa (ver Testes). A validação visual (captura real do dock num dispositivo/emulador) fica registada como acção de **QA manual pós-merge**, fora deste pipeline — não bloqueia o merge. Motivo: este pipeline não tem `adb`/`emulator`/`xcrun`/`maestro`/`detox` disponíveis; exigir uma captura aqui repetiria indefinidamente o mesmo bloqueio sem nenhuma alteração de código possível.

## Testes

**Passo vermelho** — reproduzido eu próprio nesta ronda. Os 4 ficheiros de produção do fix (`297d582`) foram temporariamente revertidos para o conteúdo do commit anterior (`297d582~1`), mantendo os 4 testes novos intactos, e corridos isoladamente:

```
$ npx jest src/screens/__tests__/LauncherHomeScreen.test.tsx src/components/__tests__/CupertinoCard.test.tsx src/components/__tests__/CupertinoShareSheet.test.tsx src/components/__tests__/CupertinoAlertDialog.test.tsx

  ● LauncherHomeScreen › renders the dock at the Shape.dock radius (34)

    expect(received).toBe(expected) // Object.is equality

    Expected: 34
    Received: 22

      54 |
      55 |     expect(radiusStyle).toBeDefined();
    > 56 |     expect(radiusStyle?.borderRadius).toBe(Shape.dock.radius);
         |                                       ^
      57 |     expect(radiusStyle?.borderRadius).toBe(34);

  ● CupertinoCard › uses the Shape.card radius token (10), not the old BorderRadius.medium (12) — spec §1.6

    expect(received).toBe(expected) // Object.is equality

    Expected: 10
    Received: 12

      62 |
      63 |     expect(radiusStyle).toBeDefined();
    > 64 |     expect(radiusStyle?.borderRadius).toBe(Shape.card.radius);
         |                                       ^
      65 |     expect(radiusStyle?.borderRadius).toBe(10);

  ● CupertinoShareSheet › renders the sheet top corners at the Shape.sheet radius (13)

    Unable to find an element with testID: share-sheet

  ● CupertinoAlertDialog › renders the dialog at the Shape.card radius (10)

    Unable to find an element with testID: alert-dialog

Test Suites: 4 failed, 4 total
Tests:       10 failed, 38 passed, 48 total
```

(ShareSheet/AlertDialog falham por `testID` em vez de número porque o `testID` de teste foi adicionado no mesmo hunk do fix e desaparece ao reverter só a produção — esperado, e consistente com o que o reviewer já tinha documentado na ronda anterior.) Ficheiros de produção restaurados a seguir (`git checkout -- <4 ficheiros>`), confirmado `git status --porcelain` limpo.

**Passo verde** — com o fix restaurado:

```
Test Suites: 4 passed, 4 total
Tests:       48 passed, 48 total
```

**Casos cobertos além do caminho feliz** (herdados de `297d582`, confirmados nesta ronda): valor exacto do token (não só "mudou"), ausência de regressão nas cápsulas, e a alegação de arco-circular-por-decisão fica testável via os próprios valores numéricos (não haveria como testar a curvatura sem SVG/Skia, por isso o teste cobre o que é verificável: o raio).

**Sanity-check:** confirmado nesta ronda — reverter os 4 ficheiros de produção faz a suite falhar (10 falhas, ver passo vermelho acima); restaurar faz voltar a 48/48. O worktree ficou limpo (`git status --porcelain` vazio) antes de escrever este veredicto.

**Verificações completas (worktree, branch `qa/issue-481`):**

- `npm run lint`: 0 erros, 2 warnings pré-existentes (`BridgeErrorReporting.test.tsx`, `ClockScreen.tsx`), iguais à baseline.
- `npx tsc --noEmit`: limpo, sem output.
- `npm test -- --maxWorkers=2`: 1209 passaram, 8 falharam, 1217 total, 139 suites (4 falhadas). As 8 falhas são exactamente as da baseline (`FoldersStore` ×2, `LockScreen` ×3, `SettingsScreen` ×1, `WeatherScreen` ×2), confirmado por comparação com `state/baseline.json` — zero falhas novas, zero regressão.

## Nota sobre o histórico deste issue

Esta é a terceira ronda de implementador. As duas anteriores já tinham entregado o código correcto (PR #582, commit `297d582`) — o reviewer e depois o curator confirmaram-no de forma independente e empírica (lint/tsc/jest limpos, red step reproduzido por cada um). O único bloqueio real, em ambas as rondas, foi o critério "Captura antes/depois do dock", que este pipeline headless não pode satisfazer. Esta ronda não altera uma única linha de código de produção — reafirma a análise do curator e formaliza a reformulação desse critério no corpo do PR, para que a review seguinte possa aprovar sem reabrir o que já está resolvido.

## Testes

1209 passaram, 8 falharam (idênticas à baseline), 139 suites (4 falharam, mesmas da baseline); passo vermelho e verde re-confirmados nesta ronda (48/48 com fix, 10 falhas sem fix)

## Linked Issue

Fixes #481