### PR TITLE
qa/issue-492: unify spring physics into src/theme/springPresets.ts, deprecate AnimationConfig, fix dead §13.3 comment (#492)

### DIFF
--- a/src/components/AssistiveTouch.tsx
+++ b/src/components/AssistiveTouch.tsx
@@ -24,9 +24,10 @@ import { useTheme } from '../theme/ThemeContext';
 import { hapticImpact, hapticNotification, hapticSelection } from '../utils/haptics';
 import { useGestureReduceMotion, settle } from '../utils/useGestureReduceMotion';
 import { IDLE_DIM_MS } from '../utils/gestureConfig';
+import { assistiveTouchSnap, assistiveTouchMenuReveal } from '../theme/springPresets';
 
 const { width: SCREEN_W, height: SCREEN_H } = Dimensions.get('window');
-const SNAP_SPRING = { damping: 18, stiffness: 220 } as const;
+const SNAP_SPRING = assistiveTouchSnap;
 
 /**
  * Radial-menu popover geometry. Shared by the anchor maths and the grid styles
@@ -194,7 +195,7 @@ export function AssistiveTouch({ navigationRef }: AssistiveTouchProps) {
     fullyOpenTimer.current = setTimeout(() => setFullyOpen(true), 150);
     menuScale.value = reduceMotion
       ? withTiming(1, { duration: 150 })
-      : withSpring(1, { damping: 14, stiffness: 220 });
+      : withSpring(1, assistiveTouchMenuReveal);
     menuOpacity.value = withTiming(1, { duration: 160 });
     wake();
   }, [menuScale, menuOpacity, wake, hapticFeedback, reduceMotion]);

--- a/src/components/CupertinoActionSheet.tsx
+++ b/src/components/CupertinoActionSheet.tsx
@@ -12,6 +12,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTheme } from '../theme/ThemeContext';
 import { hapticImpact } from '../utils/haptics';
 import { useGestureReduceMotion } from '../utils/useGestureReduceMotion';
+import { actionSheetPresent } from '../theme/springPresets';
 
 interface ActionSheetOption {
   label: string;
@@ -48,12 +49,12 @@ export function CupertinoActionSheet({
     if (visible) {
       translateY.value = reduceMotion
         ? withTiming(0, { duration: 180 })
-        : withSpring(0, { damping: 25, stiffness: 300 });
+        : withSpring(0, actionSheetPresent);
       backdropOpacity.value = withTiming(1, { duration: 250 });
     } else {
       translateY.value = reduceMotion
         ? withTiming(400, { duration: 150 })
-        : withSpring(400, { damping: 25, stiffness: 300 });
+        : withSpring(400, actionSheetPresent);
       backdropOpacity.value = withTiming(0, { duration: 200 });
     }
     // Shared values are stable refs; reduceMotion is a reactive dep

--- a/src/components/CupertinoAlertDialog.tsx
+++ b/src/components/CupertinoAlertDialog.tsx
@@ -9,6 +9,7 @@ import Animated, {
 import { useTheme } from '../theme/ThemeContext';
 import { BorderRadius } from '../theme/CupertinoTheme';
 import { useGestureReduceMotion } from '../utils/useGestureReduceMotion';
+import { alertDialogPresent } from '../theme/springPresets';
 
 interface AlertAction {
   label: string;
@@ -40,7 +41,7 @@ export function CupertinoAlertDialog({
 
   useEffect(() => {
     if (visible) {
-      scale.value = reduceMotion ? withTiming(1, { duration: 150 }) : withSpring(1, { damping: 25, stiffness: 500 });
+      scale.value = reduceMotion ? withTiming(1, { duration: 150 }) : withSpring(1, alertDialogPresent);
       opacity.value = withTiming(1, { duration: 200 });
     } else {
       scale.value = withTiming(1.2, { duration: 150 });

--- a/src/components/CupertinoSwipeableRow.tsx
+++ b/src/components/CupertinoSwipeableRow.tsx
@@ -11,6 +11,7 @@ import * as Haptics from 'expo-haptics';
 import { hapticImpact } from '../utils/haptics';
 import { useTheme } from '../theme/ThemeContext';
 import { useGestureReduceMotion, settle } from '../utils/useGestureReduceMotion';
+import { feedbackSettle } from '../theme/springPresets';
 
 export interface SwipeAction {
   label: string;
@@ -28,7 +29,7 @@ interface CupertinoSwipeableRowProps {
 }
 
 const ACTION_WIDTH = 74;
-const SPRING_CONFIG = { damping: 20, stiffness: 300 };
+const SPRING_CONFIG = feedbackSettle;
 
 export function CupertinoSwipeableRow({
   children,

--- a/src/components/NotificationBanner.tsx
+++ b/src/components/NotificationBanner.tsx
@@ -15,6 +15,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTheme } from '../theme/ThemeContext';
 import { hapticNotification } from '../utils/haptics';
 import { useGestureReduceMotion } from '../utils/useGestureReduceMotion';
+import { notificationBannerEnter, notificationBannerScale, feedbackSettle } from '../theme/springPresets';
 
 export interface BannerNotification {
   id: string;
@@ -66,8 +67,8 @@ export function NotificationBanner({ notification, onDismiss }: Props) {
         translateY.value = withTiming(0, { duration: 150 });
         scale.value = withTiming(1, { duration: 150 });
       } else {
-        translateY.value = withSpring(0, { damping: 22, stiffness: 350, mass: 0.8 });
-        scale.value = withSpring(1, { damping: 22, stiffness: 350 });
+        translateY.value = withSpring(0, notificationBannerEnter);
+        scale.value = withSpring(1, notificationBannerScale);
       }
 
       // Auto-dismiss after 5s (iOS style)
@@ -97,7 +98,7 @@ export function NotificationBanner({ notification, onDismiss }: Props) {
       } else {
         // Snap back — translateY is a literal dp offset, e.velocityY is
         // already dp/sec, no conversion needed.
-        translateY.value = withSpring(0, { damping: 20, stiffness: 300, velocity: e.velocityY });
+        translateY.value = withSpring(0, { ...feedbackSettle, velocity: e.velocityY });
       }
     });
 

--- a/src/screens/LauncherHomeScreen.tsx
+++ b/src/screens/LauncherHomeScreen.tsx
@@ -61,6 +61,7 @@ import { zones, gestureConfig, dpPerMsToPtPerSec } from '../utils/gestureConfig'
 import { useVelocityBuffer, pushSample, sampledVelocity } from '../utils/gestureVelocity';
 import { commitForSpotlight, commitForTodayView } from '../utils/gestureMachine';
 import { settle, useGestureReduceMotion } from '../utils/useGestureReduceMotion';
+import { launcherIconPress } from '../theme/springPresets';
 import { markGridVisible, markWarmStartBegin } from '../utils/perfMetrics';
 import type { AppNavigationProp } from '../navigation/types';
 import type { SettingsState } from '../store/SettingsStore';
@@ -335,13 +336,13 @@ function AppIcon({ app, cellWidth, onPress, onLongPress, isJiggling, onDelete, b
   const handlePressIn = useCallback(() => {
     if (isJiggling) return;
     // eslint-disable-next-line react-hooks/immutability
-    pressScale.value = withSpring(0.85, { damping: 12, stiffness: 200 });
+    pressScale.value = withSpring(0.85, launcherIconPress);
     hapticImpact(Haptics.ImpactFeedbackStyle.Light).catch(() => {});
   }, [isJiggling, pressScale]);
 
   const handlePressOut = useCallback(() => {
     // eslint-disable-next-line react-hooks/immutability
-    pressScale.value = withSpring(1.0, { damping: 12, stiffness: 200 });
+    pressScale.value = withSpring(1.0, launcherIconPress);
   }, [pressScale]);
 
   return (

--- a/src/screens/MessageBubble.tsx
+++ b/src/screens/MessageBubble.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import { View, Text, StyleSheet, Pressable, Image, Dimensions } from 'react-native';
 import Animated, { useSharedValue, useAnimatedStyle, withSpring } from 'react-native-reanimated';
+import { reactionPickerPop } from '../theme/springPresets';
 import { Ionicons } from '@expo/vector-icons';
 import type { DeviceSms } from '../store/DeviceStore';
 import type { CupertinoColors } from '../theme/CupertinoTheme';
@@ -52,7 +53,7 @@ export const MessageBubble = React.memo(function MessageBubble({
   const pickerScale = useSharedValue(showReactionPicker ? 1 : 0);
 
   useEffect(() => {
-    pickerScale.value = withSpring(showReactionPicker ? 1 : 0, { damping: 18, stiffness: 400 });
+    pickerScale.value = withSpring(showReactionPicker ? 1 : 0, reactionPickerPop);
   }, [showReactionPicker, pickerScale]);
 
   const pickerStyle = useAnimatedStyle(() => ({

--- a/src/theme/CupertinoTheme.ts
+++ b/src/theme/CupertinoTheme.ts
@@ -376,7 +376,21 @@ export const Shadows = StyleSheet.create({
   },
 });
 
-// Animation constants matching iOS spring dynamics
+/**
+ * @deprecated Legacy spring vocabulary (issue #492) — do not add new consumers.
+ * New code should import a named preset from `src/theme/springPresets.ts` instead.
+ * Kept as-is, values unchanged, until existing consumers migrate: aligning these to
+ * the new vocabulary's numbers would change on-screen behaviour, and #492's ressalva
+ * forbids that without a before/after capture.
+ *
+ * Nearest-by-usage mapping to the new vocabulary (name only — NOT equal in value,
+ * see springPresets.ts for the actual numbers):
+ *   springBouncy  (d10/s150) → wobble      (playful overshoot)
+ *   springSnappy  (d20/s400) → snap        (fast, decisive settle)
+ *   springGentle  (d25/s200) → sheet       (soft modal presentation)
+ *   defaultSpring (d20/s300) → interactive (control feedback: switch, segmented control)
+ *   gentleSpring  (d15/s150) → navigation  (screen-level transition)
+ */
 export const AnimationConfig = {
   springBouncy: { damping: 10, stiffness: 150, mass: 1 },
   springSnappy: { damping: 20, stiffness: 400, mass: 1 },

--- a/src/theme/__tests__/springPresets.test.ts
+++ b/src/theme/__tests__/springPresets.test.ts
@@ -1,0 +1,62 @@
+import {
+  navigation,
+  interactive,
+  sheet,
+  wobble,
+  snap,
+  SpringPresets,
+  actionSheetPresent,
+  alertDialogPresent,
+  assistiveTouchSnap,
+  assistiveTouchMenuReveal,
+  reactionPickerPop,
+  notificationBannerEnter,
+  notificationBannerScale,
+  launcherIconPress,
+  feedbackSettle,
+} from '../springPresets';
+
+describe('springPresets — §3.1 usage-named vocabulary', () => {
+  it('defines the five presets from ESPECIFICACAO.md §3.1, by usage not by feel', () => {
+    expect(navigation).toEqual({ damping: 18, stiffness: 180, mass: 1 });
+    expect(interactive).toEqual({ damping: 12, stiffness: 220, mass: 1 });
+    expect(sheet).toEqual({ damping: 20, stiffness: 160, mass: 1 });
+    expect(wobble).toEqual({ damping: 8, stiffness: 300, mass: 0.8 });
+    expect(snap).toEqual({ damping: 26, stiffness: 400, mass: 1 });
+  });
+
+  it('wobble is the only §3.1 preset with mass different from 1', () => {
+    const massOneCount = Object.values(SpringPresets).filter((p) => p.mass === 1).length;
+    expect(massOneCount).toBe(4);
+    expect(SpringPresets.wobble.mass).not.toBe(1);
+  });
+
+  it('exposes exactly the five presets under one vocabulary object', () => {
+    expect(Object.keys(SpringPresets).sort()).toEqual(
+      ['interactive', 'navigation', 'sheet', 'snap', 'wobble'].sort(),
+    );
+  });
+
+  it('no two of the five presets share the same (damping, stiffness, mass) tuple', () => {
+    const seen = new Set<string>();
+    for (const p of Object.values(SpringPresets)) {
+      const key = `${p.damping}/${p.stiffness}/${p.mass}`;
+      expect(seen.has(key)).toBe(false);
+      seen.add(key);
+    }
+  });
+
+  it('consolidates the pre-existing inline call-site springs unchanged (no value drift)', () => {
+    // These match the literals that used to be scattered across component files —
+    // consolidation must not silently alter behaviour (issue #492 ressalva).
+    expect(actionSheetPresent).toEqual({ damping: 25, stiffness: 300, mass: 1 });
+    expect(alertDialogPresent).toEqual({ damping: 25, stiffness: 500, mass: 1 });
+    expect(assistiveTouchSnap).toEqual({ damping: 18, stiffness: 220, mass: 1 });
+    expect(assistiveTouchMenuReveal).toEqual({ damping: 14, stiffness: 220, mass: 1 });
+    expect(reactionPickerPop).toEqual({ damping: 18, stiffness: 400, mass: 1 });
+    expect(notificationBannerEnter).toEqual({ damping: 22, stiffness: 350, mass: 0.8 });
+    expect(notificationBannerScale).toEqual({ damping: 22, stiffness: 350, mass: 1 });
+    expect(launcherIconPress).toEqual({ damping: 12, stiffness: 200, mass: 1 });
+    expect(feedbackSettle).toEqual({ damping: 20, stiffness: 300, mass: 1 });
+  });
+});

--- a/src/theme/springPresets.ts
+++ b/src/theme/springPresets.ts
@@ -1,0 +1,54 @@
+/**
+ * Single vocabulary for spring physics (issue #492).
+ *
+ * Before this file, the project had three parallel spring vocabularies —
+ * `AnimationConfig` (CupertinoTheme.ts), `gestureConfig.spring` (utils/gestureConfig.ts)
+ * and ~20 inline `{ damping, stiffness }` literals at call sites — none of which
+ * matched ESPECIFICACAO.md §3.1's five usage-named presets.
+ *
+ * This file is the one source of truth going forward. It does NOT replace
+ * `gestureConfig.spring` (those values are tuned against real gesture release
+ * velocity and are intentionally a different order of magnitude — see the comment
+ * on `gestureConfig.spring`), and it does NOT change any existing numeric value:
+ * per the issue's ressalva, §3.1's values are the spec author's own estimates
+ * (marked [E], unvalidated against this app's real feel) and swapping them in for
+ * tuned production values without a before/after capture could make the product
+ * worse. Adopting a shared vocabulary and re-tuning values are separate concerns.
+ */
+
+export interface SpringConfig {
+  damping: number;
+  stiffness: number;
+  mass: number;
+}
+
+// ESPECIFICACAO.md §3.1 — the five presets, named by usage so they survive future
+// re-tuning. Values are the spec's own [E] estimates; nothing in the app currently
+// applies them, so no behaviour changes as a result of adding them.
+export const navigation: SpringConfig = { damping: 18, stiffness: 180, mass: 1 };
+export const interactive: SpringConfig = { damping: 12, stiffness: 220, mass: 1 };
+export const sheet: SpringConfig = { damping: 20, stiffness: 160, mass: 1 };
+export const wobble: SpringConfig = { damping: 8, stiffness: 300, mass: 0.8 };
+export const snap: SpringConfig = { damping: 26, stiffness: 400, mass: 1 };
+
+export const SpringPresets = { navigation, interactive, sheet, wobble, snap } as const;
+
+// Component-tuned springs, consolidated here from the inline literals that used to
+// live at each call site. Values are UNCHANGED from their original call sites — none
+// of them matches a §3.1 preset closely enough to merge without a before/after
+// capture, so each keeps its own name instead of being forced into one of the five
+// above. The point of consolidating them here is that every spring value in the app
+// now has exactly one place it's defined, not that they share a preset.
+export const actionSheetPresent: SpringConfig = { damping: 25, stiffness: 300, mass: 1 };
+export const alertDialogPresent: SpringConfig = { damping: 25, stiffness: 500, mass: 1 };
+export const assistiveTouchSnap: SpringConfig = { damping: 18, stiffness: 220, mass: 1 };
+export const assistiveTouchMenuReveal: SpringConfig = { damping: 14, stiffness: 220, mass: 1 };
+export const reactionPickerPop: SpringConfig = { damping: 18, stiffness: 400, mass: 1 };
+export const notificationBannerEnter: SpringConfig = { damping: 22, stiffness: 350, mass: 0.8 };
+export const notificationBannerScale: SpringConfig = { damping: 22, stiffness: 350, mass: 1 };
+export const launcherIconPress: SpringConfig = { damping: 12, stiffness: 200, mass: 1 };
+// Shared by NotificationBanner's swipe-to-dismiss snap-back and
+// CupertinoSwipeableRow's row settle — both used this exact tuple independently
+// before this file existed (it also happens to equal AnimationConfig.defaultSpring;
+// kept as its own export since AnimationConfig is deprecated).
+export const feedbackSettle: SpringConfig = { damping: 20, stiffness: 300, mass: 1 };

--- a/src/utils/gestureConfig.ts
+++ b/src/utils/gestureConfig.ts
@@ -66,7 +66,15 @@ export const gestureConfig = {
   cardDismissDp: 84,
   cardDismissVelocity: -0.9,
 
-  // Springs — per §13.3 of spec
+  // Springs — tuned empirically against real on-device gesture feel, NOT from
+  // ESPECIFICACAO.md §3.1's estimated presets (see src/theme/springPresets.ts).
+  // Stiffness here runs 3-4x higher than the theme's springs because these settle
+  // a gesture that's already moving — `resolveSpringConfig` (useGestureReduceMotion.ts)
+  // merges in the real release velocity, so a spring tuned for a standstill UI
+  // transition reads as sluggish/laggy mid-drag. Do not "align" these to
+  // springPresets.ts without a before/after capture (issue #492).
+  // (The previous "§13.3" reference was dead: the current spec's §13 is "Aferição"
+  // and has no subsections — issue #492.)
   spring: {
     fastSettle: { stiffness: 760, damping: 58, mass: 1 },
     mediumSettle: { stiffness: 680, damping: 52, mass: 1 },


### PR DESCRIPTION
## Resumo

qa/issue-492: unify spring physics into src/theme/springPresets.ts, deprecate AnimationConfig, fix dead §13.3 comment

## Causa raiz

O projecto tinha três vocabulários de mola paralelos, confirmados em `main` (aa84954):

- `AnimationConfig` em `src/theme/CupertinoTheme.ts:380-387` (5 presets nomeados pela sensação: `springBouncy`, `springSnappy`, `springGentle`, `defaultSpring`, `gentleSpring`).
- `gestureConfig.spring` em `src/utils/gestureConfig.ts:70-79`, com o comentário morto «per §13.3 of spec» — a §13 actual é «Aferção» e não tem subsecções.
- ~10 configs inline distintos em 8 ficheiros de componentes (`CupertinoActionSheet`, `CupertinoAlertDialog`, `MessageBubble`, `NotificationBanner` x3, `LauncherHomeScreen` x2, `CupertinoSwipeableRow`, `AssistiveTouch` x2), nenhum coincidindo com `AnimationConfig` nem com `gestureConfig.spring`.

Nenhum destes coincidia com os 5 presets de §3.1 da especificação (`navigation 18/180/1 · interactive 12/220/1 · sheet 20/160/1 · wobble 8/300/0.8 · snap 26/400/1`).

**Nota:** `ESPECIFICACAO.md` não existe neste repositório/worktree (confirmado por busca exaustiva); os valores de §3.1 usados abaixo são os citados literalmente no corpo deste issue.

**Desvio do nome de ficheiro proposto:** o issue pede `src/theme/motion.ts`, mas esse ficheiro já existe no repositório (issue #488, `rubberBand`/`clampWithRubberBand` — física de scroll elástico, sem relação com molas de spring). Criar o módulo lá apagaria/colidiria com trabalho alheio não coberto por este issue. Escolhi `src/theme/springPresets.ts` como nome alternativo mais defensável, e documentei a escolha aqui.

## O que mudou

- **`src/theme/springPresets.ts` (novo)**: fonte única de verdade para física de mola.
  - Exporta os 5 presets de §3.1 nomeados por uso (`navigation`, `interactive`, `sheet`, `wobble`, `snap`), com os valores citados no issue — nenhum call-site os consome ainda, por isso a sua adição não altera comportamento nenhum.
  - Exporta 8 constantes adicionais (`actionSheetPresent`, `alertDialogPresent`, `assistiveTouchSnap`, `assistiveTouchMenuReveal`, `reactionPickerPop`, `notificationBannerEnter`, `notificationBannerScale`, `launcherIconPress`) e uma partilhada (`feedbackSettle`) que consolidam os ~10 literais inline **sem alterar nenhum valor numérico**.
- **`src/theme/CupertinoTheme.ts:380-399`**: `AnimationConfig` marcado `@deprecated` com JSDoc mapeando cada uma das 5 chaves antigas para o preset novo mais próximo **por uso** (não por valor — os valores não mudam). Continua export e funcional; `CupertinoSwitch.tsx` e `CupertinoSegmentedControl.tsx` continuam a consumí-lo sem alteração.
- **`src/utils/gestureConfig.ts:69-79`**: comentário «per §13.3 of spec» substituído por explicação real — valores afinados contra gestos reais (não das estimativas [E] da §3.1), e stiffness 3-4x mais alto porque `resolveSpringConfig` funde a velocidade real de largada do gesto (mola tunada para um standstill pareceria lenta a meio de um drag). `gestureConfig.spring` **não foi tocado** nos valores.
- **8 ficheiros de componentes**: cada literal inline `{ damping, stiffness }` substituído pela constante nomeada equivalente de `springPresets.ts` (mesmo valor numérico, só a referência mudou):
  - `CupertinoActionSheet.tsx:51,56` → `actionSheetPresent`
  - `CupertinoAlertDialog.tsx:43` → `alertDialogPresent`
  - `MessageBubble.tsx:55` → `reactionPickerPop`
  - `NotificationBanner.tsx:69-70` → `notificationBannerEnter` / `notificationBannerScale`; `NotificationBanner.tsx:100` (spread com `velocity: e.velocityY` dinâmico) → `{ ...feedbackSettle, velocity: e.velocityY }`
  - `LauncherHomeScreen.tsx:338,344` → `launcherIconPress`
  - `CupertinoSwipeableRow.tsx:31` (`SPRING_CONFIG`) → `feedbackSettle`
  - `AssistiveTouch.tsx:29` (`SNAP_SPRING`) → `assistiveTouchSnap`; `AssistiveTouch.tsx:197` → `assistiveTouchMenuReveal`
- **`src/theme/__tests__/springPresets.test.ts` (novo)**: 5 testes cobrindo os valores dos 5 presets §3.1, a unicidade de `mass` no `wobble`, a ausência de tuplos duplicados, e que as 9 constantes consolidadas mantêm exactamente os valores que estavam inline.

## Porque assim

A «ressalva importante» do próprio issue probe alinhar valores às estimativas [E] da §3.1 sem uma captura antes/depois — que não é possível produzir num ambiente headless sem dispositivo/emulador. Ao mesmo tempo o AC pede que as ~20 configs inline consumam «presets nomeados». Resolvi a tensão assim: os 5 presets de §3.1 existem no vocabulário (para uso futuro), mas os call-sites existentes são migrados para constantes nomeadas **com o valor original inalterado** — nenhum dos ~10 literais coincidia exactamente com um preset §3.1, por isso forçar essa correspondência teria mudado comportamento real sem prova visual. Isto cumpre «um só vocabulário, uma só fonte de verdade» sem apostar no feel do produto.

Duas exceções deliberadas a esta regra «zero mudança de valor», ambas seguras porque os números já eram idênticos nos dois call-sites: `NotificationBanner`'s swipe-dismiss (`{damping:20,stiffness:300}` + `velocity` dinâmico) e `CupertinoSwipeableRow`'s `SPRING_CONFIG` (`{damping:20,stiffness:300}`) partilham agora `feedbackSettle` — dedup de um valor duplicado, não uma mudança de valor (esse tuplo também coincide com `AnimationConfig.defaultSpring`, mas optei por uma constante própria em vez de fazer novos consumidores dependerem de uma API deprecated).

`gestureConfig.spring` foi mantido tal como o issue pede — só o comentário mudou, os 7 valores continuam idânticos.

## Critérios de aceitação

- [x] `src/theme/springPresets.ts` existe com os 5 presets nomeados por uso — nome diferente do pedido (`motion.ts`) porque esse nome já estava ocupado por trabalho do issue #488; explicado acima.
- [x] `AnimationConfig` deprecado com mapeamento documentado, ainda a funcionar — `CupertinoSwitch.tsx` e `CupertinoSegmentedControl.tsx` continuam a compilar e a passar nos seus testes sem alteração.
- [x] As configs inline nos 8 ficheiros de componentes tocados consomem presets nomeados — lista completa acima. `gestureConfig.spring` fica de fora deliberadamente (ver abaixo).
- [x] `gestureConfig.spring` mantido, com a proveniência documentada e o comentário «§13.3» corrigido — `src/utils/gestureConfig.ts:69-79`.
- [x] Nenhum valor de mola alterado sem captura antes/depois no PR — confirmado por teste (`springPresets.test.ts` → «consolidates ... unchanged») e por `git diff` (nenhuma linha muda um número, só referências).
- [x] Testes existentes de gestos verdes, sem alterar expectativas — suite completa: 1210 passaram, 8 falharam (idêntico à baseline de `main`, mesmas 4 suites: `LockScreen`, `SettingsScreen`, `WeatherScreen`, `FoldersStore`); nenhuma falha nova nos ficheiros tocados.

## Testes

**Passo vermelho** (com `src/theme/springPresets.ts` removido, teste mantido):

```
FAIL Android src/theme/__tests__/springPresets.test.ts
  ● Test suite failed to run

    Cannot find module '../springPresets' from 'src/theme/__tests__/springPresets.test.ts'

    > 1 | import {
        | ^
      2 |   navigation,
      3 |   interactive,
      4 |   sheet,

      at Resolver._throwModNotFoundError (node_modules/jest-resolve/build/resolver.js:427:11)
      at Object.<anonymous> (src/theme/__tests__/springPresets.test.ts:1:1)

Test Suites: 1 failed, 1 total
Tests:       0 total
```

Depois de restaurar `src/theme/springPresets.ts`:

```
PASS Android src/theme/__tests__/springPresets.test.ts
  springPresets — §3.1 usage-named vocabulary
    ✓ defines the five presets from ESPECIFICACAO.md §3.1, by usage not by feel (13 ms)
    ✓ wobble is the only §3.1 preset with mass different from 1 (2 ms)
    ✓ exposes exactly the five presets under one vocabulary object (2 ms)
    ✓ no two of the five presets share the same (damping, stiffness, mass) tuple (3 ms)
    ✓ consolidates the pre-existing inline call-site springs unchanged (no value drift) (5 ms)

Tests:       5 passed, 5 total
```

**Casos cobertos:** valores exactos dos 5 presets §3.1 (não só golden path); a inváriante única do `wobble` (único com `mass ≠ 1`); ausência de tuplos duplicados entre os 5 presets (fronteira — detectaria um copy-paste); e, mais importante, que as 8 constantes consolidadas + `feedbackSettle` mantêm **exactamente** os valores que estavam inline antes — este último teste é o que protege contra o próprio risco que o issue avisa (mudar valores sem captura).

**Sanity-check:** `mv src/theme/springPresets.ts /tmp/...` (fix fora, teste mantido) → suite falha com «Cannot find module» (acima). Restaurado o ficheiro → suite volta a passar (5/5). Ficheiro is untracked, por isso usei `mv` em vez de `git stash` (stash partilhado entre worktrees).

**`npm run lint`:** 0 erros, 2 warnings pré-existentes (`BridgeErrorReporting.test.tsx`, `ClockScreen.tsx`) — idêntico à baseline.

**`npx tsc --noEmit`:** limpo, sem output.

**`npm test -- --maxWorkers=2`:** `Test Suites: 4 failed, 136 passed, 140 total` / `Tests: 8 failed, 1210 passed, 1218 total`. As 4 suites e os 8 testes que falham são exactamente os da baseline (`LockScreen`, `SettingsScreen`, `WeatherScreen`, `FoldersStore` — causados pelo `firstSyncDone` assíncrono do `SettingsStore`, não relacionado com este issue). Nenhuma falha nova.

## Testes

1210 passaram, 8 falharam (idêntico à baseline de main), 140 suites (136 passaram, 4 falharam); springPresets.test.ts: 5/5 passaram

## Linked Issue

Fixes #492