### PR TITLE
feat(orchestrator): auto-resolve trivial version-bump conflicts

### DIFF
--- a/scripts/team/orchestrator.sh
+++ b/scripts/team/orchestrator.sh
@@ -629,6 +629,126 @@ corrida de review. Fechado. O branch fica no remoto se alguém quiser o diff." >
 #
 # A pergunta certa é sobre AQUELE issue, e a resposta está no registo de agentes
 # vivos.
+
+# ── Resolver trivial de conflitos de version-bump ───────────────────────────
+#
+# O auto-release bumpa o `package.json`/`app.json`/`package-lock.json` a cada
+# merge, e branches que ficam para trás na fila apanham conflitos nesses três
+# ficheiros — três ficheiros a que a implementação do branch quase nunca tocou.
+# Sem isto, cada bump em conflito custa um ciclo completo de agent (worktree,
+# npm install, resolver por intenção, push): 30-60s de quota só para escrever
+# `git checkout --theirs package.json`.
+#
+# Só resolve o caso trivial: TODOS os ficheiros em conflito estão na allowlist
+# ABAIXO **e** o branch, medido contra o merge-base, não tocou em nenhum deles.
+# A segunda parte é o que evita perder trabalho legítimo — um branch que
+# adicionou uma dependência tocou `package.json`, o guard falha, e o pipeline
+# normal trata o conflito como sempre.
+#
+# Um sucesso salta directamente para qa:review, poupando o implementador todo.
+BUMP_ALLOWLIST=(package.json app.json package-lock.json)
+
+resolve_trivial_bump_conflicts() {
+  local issue pr branch wt merge_base conflicted only_allowed real_touch
+  for issue in $(issues_with "$L_BLOCKED_IMPL"); do
+    branch="qa/issue-$issue"
+    pr=$(gh pr list --repo "$REPO" --head "$branch" --base "$BASE_BRANCH" \
+      --state open --json number,mergeable \
+      --jq '.[0] | select(.mergeable == "CONFLICTING") | .number' \
+      2>/dev/null || echo "")
+    [ -n "$pr" ] || continue
+
+    wt=$(wt_checkout "$branch" "resolve-$issue" 2>/dev/null) || continue
+    git -C "$wt" fetch origin "$BASE_BRANCH" >/dev/null 2>&1 || true
+
+    # Try the merge. A clean merge here means the CONFLICTING state was already
+    # stale; still worth pushing so the pipeline advances.
+    if git -C "$wt" merge --no-edit --no-ff "origin/$BASE_BRANCH" >/dev/null 2>&1; then
+      git -C "$wt" push -u origin "$branch" --force-with-lease >/dev/null 2>&1 && {
+        log "resolver: #$issue já mergável — só faltava sincronizar branch"
+        set_state "$issue" "$L_REVIEW"
+      }
+      wt_remove "$wt"
+      continue
+    fi
+
+    conflicted=$(git -C "$wt" diff --name-only --diff-filter=U 2>/dev/null || true)
+    [ -n "$conflicted" ] || { git -C "$wt" merge --abort >/dev/null 2>&1 || true; wt_remove "$wt"; continue; }
+
+    only_allowed=1
+    while IFS= read -r f; do
+      [ -n "$f" ] || continue
+      case " ${BUMP_ALLOWLIST[*]} " in
+        *" $f "*) ;;
+        *) only_allowed=0; break ;;
+      esac
+    done <<< "$conflicted"
+
+    if [ "$only_allowed" = 0 ]; then
+      log "resolver: #$issue conflita fora da allowlist — passa ao implementador"
+      git -C "$wt" merge --abort >/dev/null 2>&1 || true
+      wt_remove "$wt"
+      continue
+    fi
+
+    # Second guard: the branch's own changes to each bump file must be limited
+    # to the `.version` (or `.expo.version` for app.json) JSON field. A branch
+    # that added a real dependency has other fields differing from the base;
+    # taking theirs would silently discard it. Compared semantically with jq
+    # instead of by line, so pretty-print vs single-line JSON does not fool it.
+    merge_base=$(git -C "$wt" merge-base HEAD "origin/$BASE_BRANCH" 2>/dev/null || echo "")
+    real_touch=0
+    for f in $conflicted; do
+      local jq_filter
+      case "$f" in
+        app.json)          jq_filter='.expo.version = ""' ;;
+        package.json|package-lock.json) jq_filter='(.. | objects | .version?) |= ""' ;;
+        *)                 jq_filter='.' ;;
+      esac
+      local base_norm branch_norm
+      base_norm=$(git -C "$wt" show "$merge_base:$f" 2>/dev/null | jq -S "$jq_filter" 2>/dev/null || true)
+      branch_norm=$(git -C "$wt" show "HEAD:$f" 2>/dev/null | jq -S "$jq_filter" 2>/dev/null || true)
+      if [ -z "$base_norm" ] || [ -z "$branch_norm" ] || [ "$base_norm" != "$branch_norm" ]; then
+        real_touch=1
+        log "resolver: #$issue tocou $f fora do campo version — não é trivial, passa ao implementador"
+        break
+      fi
+    done
+    if [ "$real_touch" = 1 ]; then
+      git -C "$wt" merge --abort >/dev/null 2>&1 || true
+      wt_remove "$wt"
+      continue
+    fi
+
+    # Trivial case: take main's version of each bump file, commit, push.
+    for f in $conflicted; do
+      git -C "$wt" checkout --theirs -- "$f" >/dev/null 2>&1
+      git -C "$wt" add -- "$f" >/dev/null 2>&1
+    done
+    if ! git -C "$wt" -c user.name="qa-resolver" -c user.email="qa@local" \
+         commit --no-edit >/dev/null 2>&1; then
+      warn "resolver: #$issue commit falhou — passa ao implementador"
+      git -C "$wt" merge --abort >/dev/null 2>&1 || true
+      wt_remove "$wt"
+      continue
+    fi
+
+    if git -C "$wt" push -u origin "$branch" --force-with-lease >/dev/null 2>&1; then
+      log "resolver: #$issue conflito trivial resolvido ($(echo "$conflicted" | tr '\n' ' '))"
+      comment_issue "$issue" "## Orquestrador: conflito trivial de version-bump resolvido
+
+Os únicos ficheiros em conflito eram do allowlist do auto-release
+(\`${BUMP_ALLOWLIST[*]}\`) e este branch não os modificou. Foi feito
+\`git checkout --theirs\` a cada, commit do merge e push — a rever, sem gastar
+um implementador."
+      set_state "$issue" "$L_REVIEW"
+    else
+      warn "resolver: #$issue push falhou — o pipeline normal trata"
+    fi
+    wt_remove "$wt"
+  done
+}
+
 rescue_stuck_wip() {
   local issue pr
   for issue in $(issues_with "$L_WIP"); do
@@ -941,6 +1061,9 @@ while true; do
     log "subscrição Claude esgotada (volta às $(date -d "@$(( $(date +%s) + $(cooldown_remaining) ))" +%H:%M)) — implementadores em HERMES até lá"
   fi
 
+  # Bump conflitos triviais: uma passagem antes do resgate e do despacho para
+  # não gastar um implementador só por causa de package.json/app.json.
+  resolve_trivial_bump_conflicts
   rescue_stuck_wip
   close_orphan_prs
 

--- a/scripts/team/test-resolve-bump.sh
+++ b/scripts/team/test-resolve-bump.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# Isolated unit test for resolve_trivial_bump_conflicts.
+#
+# Builds a local bare "remote" and two clones, forces the two known conflict
+# shapes, source's the resolver, and asserts what it did.
+#
+# Runs offline — no gh, no network. It stubs out gh, wt_checkout/wt_remove,
+# set_state, comment_issue and log, so only the git side of the resolver is
+# under test.
+set -eo pipefail  # nounset would need every helper to guard $2 defaults
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+export TEAM_ROOT="$TMP"
+export WT_ROOT="$TMP/wt"
+export REPO="fake/fake"
+export BASE_BRANCH="main"
+mkdir -p "$WT_ROOT"
+
+# ── Set up a mini "origin" with a package.json and one feature branch ──────
+git init -q --bare "$TMP/origin.git"
+git clone -q "$TMP/origin.git" "$TMP/seed"
+(
+  cd "$TMP/seed"
+  git config user.email seed@local
+  git config user.name  seed
+  printf '{"version":"1.0.0","name":"x"}\n' > package.json
+  printf '{"expo":{"version":"1.0.0"}}\n'   > app.json
+  echo "// src"                             > code.ts
+  git add . && git commit -qm base
+  git branch -m main
+  git push -qu origin main
+
+  # Feature branch that BUMPED package.json too (racing with main's bump),
+  # producing a textual conflict on the same version line. This is the case
+  # the resolver is meant to short-circuit.
+  git checkout -qb qa/issue-42
+  printf '{"version":"0.9.9-branch","name":"x"}\n' > package.json
+  printf '{"expo":{"version":"0.9.9-branch"}}\n'   > app.json
+  echo "// feature" >> code.ts
+  git commit -qam feature
+  git push -qu origin qa/issue-42
+
+  # Feature branch that WOULD lose work: touches package.json (adds a dep).
+  git checkout -qb qa/issue-43 main
+  printf '{"version":"1.0.0","name":"x","dependencies":{"lodash":"^4"}}\n' > package.json
+  git commit -qam "add dep"
+  git push -qu origin qa/issue-43
+
+  # Main bumps to 1.1.0 on both bump files (auto-release-like) — this is what
+  # will conflict with the feature branches.
+  git checkout -q main
+  printf '{"version":"1.1.0","name":"x"}\n' > package.json
+  printf '{"expo":{"version":"1.1.0"}}\n'   > app.json
+  git commit -qam "chore: bump"
+  git push -q origin main
+)
+
+# The resolver expects a working repo at TEAM_ROOT.
+git clone -q "$TMP/origin.git" "$TEAM_ROOT/repo"
+git -C "$TEAM_ROOT/repo" fetch -q origin '+refs/heads/*:refs/remotes/origin/*'
+export TEAM_ROOT="$TEAM_ROOT/repo"
+
+# ── Stubs for the pipeline surfaces we don't want to hit ────────────────────
+declare -a CALLS
+gh() {
+  # We only care about `gh pr list ... --head qa/issue-N ...`.
+  case " $* " in
+    *" --head qa/issue-42 "*) echo 42 ;;
+    *" --head qa/issue-43 "*) echo 43 ;;
+    *) echo "" ;;
+  esac
+}
+export -f gh
+
+wt_checkout() {
+  local ref="$1" dir="$2" wt="$WT_ROOT/$dir"
+  git -C "$TEAM_ROOT" fetch -q origin "+refs/heads/$ref:refs/remotes/origin/$ref" 2>/dev/null || true
+  git -C "$TEAM_ROOT" worktree add -q --detach "$wt" "origin/$ref" >/dev/null 2>&1 || return 1
+  git -C "$wt" checkout -qB "$ref" 2>/dev/null || true
+  echo "$wt"
+}
+wt_remove() {
+  local wt="$1"; git -C "$TEAM_ROOT" worktree remove --force "$wt" >/dev/null 2>&1 || rm -rf "$wt"
+}
+comment_issue()  { CALLS+=("comment:$1"); }
+set_state()      { CALLS+=("state:$1=$2"); }
+log()            { echo "[test] $*" >&2; }
+warn()           { echo "[test] WARN $*" >&2; }
+issues_with()    { printf '%s\n' "$@"; }
+export -f wt_checkout wt_remove comment_issue set_state log warn issues_with
+
+L_BLOCKED_IMPL="qa:blocked-impl"
+L_REVIEW="qa:review"
+
+# ── The function under test ────────────────────────────────────────────────
+# Extract it from orchestrator.sh, source in isolation.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+tmpfn="$TMP/fn.sh"
+awk '/^BUMP_ALLOWLIST=/,/^resolve_trivial_bump_conflicts\(\) \{/{p=1} p{print} /^}$/&&p{exit}' \
+  "$SCRIPT_DIR/orchestrator.sh" > "$tmpfn"
+# awk stopped at the first '^}$', which is the function close. Good.
+# shellcheck disable=SC1090
+. "$tmpfn"
+
+# Sanity: prove wt_checkout works BEFORE calling the resolver.
+sanity_wt=$(wt_checkout qa/issue-42 sanity)
+[ -n "$sanity_wt" ] && [ -d "$sanity_wt" ] || { echo "FAIL: wt_checkout stub broken"; exit 1; }
+wt_remove "$sanity_wt"
+
+# ── Case 1: trivial-only bump conflict → resolves + promotes ───────────────
+issues_with() { echo 42; }; export -f issues_with
+CALLS=()
+resolve_trivial_bump_conflicts
+
+# Expect: a state:42=qa:review was recorded, and a comment on #42.
+match() { local needle="$1"; for c in "${CALLS[@]}"; do [[ "$c" == "$needle" ]] && return 0; done; return 1; }
+match "state:42=qa:review" || { echo "FAIL: #42 not promoted; calls=${CALLS[*]}"; exit 1; }
+match "comment:42"         || { echo "FAIL: #42 not commented; calls=${CALLS[*]}"; exit 1; }
+
+# And the branch actually got the merge pushed.
+git -C "$TEAM_ROOT" fetch -q origin qa/issue-42
+git -C "$TEAM_ROOT" show origin/qa/issue-42:package.json | grep -q '"1.1.0"' \
+  || { echo "FAIL: #42 branch did not adopt main's version"; exit 1; }
+
+# ── Case 2: branch touched package.json → resolver defers ──────────────────
+issues_with() { echo 43; }; export -f issues_with
+CALLS=()
+resolve_trivial_bump_conflicts
+
+if match "state:43=qa:review"; then
+  echo "FAIL: #43 must NOT be promoted — branch had real changes"
+  exit 1
+fi
+
+# The dep is still there on the remote — resolver did not overwrite it.
+git -C "$TEAM_ROOT" fetch -q origin qa/issue-43
+git -C "$TEAM_ROOT" show origin/qa/issue-43:package.json | grep -q '"lodash"' \
+  || { echo "FAIL: #43 lodash lost — resolver overwrote real changes"; exit 1; }
+
+echo "PASS: trivial resolves, real conflicts deferred"


### PR DESCRIPTION
## Summary

Every merge on `main` runs `auto-release.yml`, which bumps `package.json`, `app.json` and `package-lock.json`. Branches that fall behind in the queue collect a `CONFLICTING` mergeable state on those three files — three files the branch almost never actually modified. Today each such conflict costs one full implementer cycle (worktree, npm install, agent resolving by intent, push): 30-60s of quota per PR just to write `git checkout --theirs package.json`.

This adds `resolve_trivial_bump_conflicts` in `scripts/team/orchestrator.sh`, run once per orchestrator cycle before rescue/dispatch, over every issue in `qa:blocked-impl`:

- If merging `origin/main` into the PR head lands cleanly (stale CONFLICTING), push and promote to `qa:review`.
- If it conflicts, two guards run. First, **all** conflicting files must be in the bump allowlist (`package.json`, `app.json`, `package-lock.json`). Second, the branch's own diff against the merge-base, compared **semantically with jq** (so pretty-print vs single-line JSON does not fool it), must show no changes outside `.version` / `.expo.version`. A branch that added a dependency has other fields differing and is deferred to the implementer, unchanged.
- Trivial cases resolve with `git checkout --theirs` on each bump file, commit the merge, push force-with-lease, comment the outcome on the issue and promote to `qa:review`.

## Test plan

- [x] `bash -n` parses.
- [x] `shellcheck` clean on the new code (only pre-existing style warnings elsewhere in the file).
- [x] New offline harness at `scripts/team/test-resolve-bump.sh`: builds a bare "remote" and two branches — one racing with `main` on the version line only, one that also added `lodash`. Stubs out `gh`/state helpers, sources the resolver in isolation, and asserts the first is promoted while the second is left alone with its dependency intact. `PASS: trivial resolves, real conflicts deferred`.
- [ ] Observe on the live pipeline: expect `qa:blocked-impl` issues to shrink and `resolver:` lines to appear in the orchestrator log after each `main` merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_019KsSpiD5Q91ibytnmCyMyt)_