### PR TITLE
App Library: ocultar/renomear/reordenar categorias e recategorizar apps via categoryOverrides (chave estável, appOverrides tem precedência) (#516)

### DIFF
--- a/src/screens/AppLibraryScreen.tsx
+++ b/src/screens/AppLibraryScreen.tsx
@@ -17,6 +17,12 @@ import * as Haptics from 'expo-haptics';
 
 import { useApps, InstalledApp } from '../store/AppsStore';
 import { useTheme } from '../theme/ThemeContext';
+import { useSettings } from '../store/SettingsStore';
+import {
+  buildCategorySections,
+  recategorizeApp,
+  STABLE_KEY_TO_NAME,
+} from '../utils/categoryOverrides';
 import { CupertinoSearchBar } from '../components/CupertinoSearchBar';
 import { CupertinoNavigationBar, CupertinoEmptyState } from '../components';
 import type { AppNavigationProp } from '../navigation/types';
@@ -102,7 +108,9 @@ export function categorizeApp(app: InstalledApp): string {
     return NATIVE_CATEGORY_MAP[native];
   }
   const nameLower = app.name.toLowerCase();
-  const pkgLower = app.packageName.toLowerCase();
+  // packageName pode ser undefined (apps virtuais sem packageName real) — não
+  // deixar que isso rebente a cascata; trata-se como string vazia.
+  const pkgLower = (app.packageName ?? '').toLowerCase();
   for (const cat of CATEGORY_KEYWORDS) {
     for (const kw of cat.keywords) {
       if (nameLower.includes(kw) || pkgLower.includes(kw)) {
@@ -257,12 +265,15 @@ export const CategoryCard = React.memo(function CategoryCard({ title, apps, onPr
 interface CategoryDetailProps {
   visible: boolean;
   title: string;
+  /** Chave estável da categoria atual (para recategorizar com base nela). */
+  categoryKey: string;
   apps: InstalledApp[];
   onClose: () => void;
   onLaunch: (pkg: string) => void;
+  onRequestRecategorize: (packageName: string, currentKey: string) => void;
 }
 
-function CategoryDetailModal({ visible, title, apps, onClose, onLaunch }: CategoryDetailProps) {
+function CategoryDetailModal({ visible, title, categoryKey, apps, onClose, onLaunch, onRequestRecategorize }: CategoryDetailProps) {
   const { theme, isDark, typography, textScale } = useTheme();
   const { colors } = theme;
   const insets = useSafeAreaInsets();
@@ -296,6 +307,8 @@ function CategoryDetailModal({ visible, title, apps, onClose, onLaunch }: Catego
           renderItem={({ item }) => (
             <Pressable
               onPress={() => { onLaunch(item.packageName); onClose(); }}
+              onLongPress={() => onRequestRecategorize(item.packageName, categoryKey)}
+              delayLongPress={350}
               style={[styles.modalAppCell, { width: cellW }]}
               accessibilityLabel={`Open ${item.name}, App Library`}
               accessibilityRole="button"
@@ -313,8 +326,65 @@ function CategoryDetailModal({ visible, title, apps, onClose, onLaunch }: Catego
 }
 
 // ---------------------------------------------------------------------------
-// Horizontal app strip (Recently Added / Suggestions)
+// Recategorize sheet (long-press num ícone dentro do modal de categoria)
 // ---------------------------------------------------------------------------
+// Onde se recategoriza uma app (#516): um long-press no ícone dentro do modal
+// de detalhe da categoria abre este sheet. Decisão justificada no PR — não é um
+// ecrã de definições com 200 apps; é contextual, no sítio onde o utilizador já
+// vê a app, e reaproveita o modal que já lista as apps da categoria.
+
+interface RecategorizeSheetProps {
+  visible: boolean;
+  currentKey: string;
+  onCancel: () => void;
+  onSelect: (targetKey: string) => void;
+}
+
+function RecategorizeSheet({ visible, currentKey, onCancel, onSelect }: RecategorizeSheetProps) {
+  const { theme, typography } = useTheme();
+  const { colors } = theme;
+  const insets = useSafeAreaInsets();
+  // Todas as categorias conhecidas, pela ordem canónica do mapa.
+  const allKeys = Object.keys(STABLE_KEY_TO_NAME);
+
+  return (
+    <Modal visible={visible} transparent animationType="slide" onRequestClose={onCancel}>
+      <Pressable style={styles.sheetBackdrop} onPress={onCancel}>
+        <View style={[styles.sheetRoot, { backgroundColor: colors.secondarySystemGroupedBackground, paddingBottom: insets.bottom + 16 }]}>
+          <Text style={[typography.title3, styles.sheetTitle, { color: colors.label }]}>
+            Mover para a categoria
+          </Text>
+          <FlatList
+            data={allKeys}
+            keyExtractor={(k) => k}
+            renderItem={({ item: key }) => (
+              <Pressable
+                onPress={() => onSelect(key)}
+                style={[styles.sheetRow, { borderBottomColor: colors.separator }]}
+                accessibilityLabel={`Mover para ${STABLE_KEY_TO_NAME[key]}`}
+                accessibilityRole="button"
+              >
+                <Text style={[typography.body, { color: colors.label }]}>{STABLE_KEY_TO_NAME[key]}</Text>
+                {key === currentKey && (
+                  <Ionicons name="checkmark" size={20} color={colors.systemBlue} />
+                )}
+              </Pressable>
+            )}
+          />
+          <Pressable
+            onPress={onCancel}
+            style={[styles.sheetCancel, { borderTopColor: colors.separator }]}
+            accessibilityLabel="Cancelar"
+            accessibilityRole="button"
+          >
+            <Text style={[typography.body, { color: colors.systemBlue, fontWeight: '600' }]}>Cancelar</Text>
+          </Pressable>
+        </View>
+      </Pressable>
+    </Modal>
+  );
+}
+
 
 const AppStrip = React.memo(function AppStrip({
   apps,
@@ -421,29 +491,28 @@ export function AppLibraryContent() {
   const { width } = useWindowDimensions();
 
   const [query, setQuery] = useState('');
-  const [categoryModal, setCategoryModal] = useState<{ title: string; apps: InstalledApp[] } | null>(null);
-
+  const [categoryModal, setCategoryModal] = useState<{ title: string; key: string; apps: InstalledApp[] } | null>(null);
+  // Estado do long-press "recategorizar app": qual app e se o sheet está visível.
+  const [recatSheet, setRecatSheet] = useState<{ packageName: string; currentKey: string } | null>(null);
   // Card layout — 2 columns with gap
   const CARD_GAP = 12;
   const SIDE_PAD = 16;
   const cardWidth = (width - SIDE_PAD * 2 - CARD_GAP) / 2;
 
-  // Categorise all apps
+  // Categorias da grelha, com overrides do utilizador aplicados
+  // (ocultar / renomear / reordenar / appOverrides). Usa chaves estáveis, por
+  // isso renomear não parte a atribuição.
+  const { settings, update } = useSettings();
   const categories = useMemo(() => {
-    const map: Record<string, InstalledApp[]> = {};
-    for (const app of apps) {
-      const cat = categorizeApp(app);
-      if (!map[cat]) map[cat] = [];
-      map[cat].push(app);
-    }
-    // Sort categories — Other last
-    const keys = Object.keys(map).sort((a, b) => {
-      if (a === 'Other') return 1;
-      if (b === 'Other') return -1;
-      return a.localeCompare(b);
-    });
-    return keys.map((name) => ({ name, apps: map[name] }));
-  }, [apps]);
+    return buildCategorySections(apps, settings.categoryOverrides, categorizeApp);
+  }, [apps, settings.categoryOverrides]);
+
+  // Grava um appOverrides (recategorização via long-press).
+  const handleRecategorize = useCallback((packageName: string, targetKey: string) => {
+    const next = recategorizeApp(settings.categoryOverrides, packageName, targetKey);
+    update('categoryOverrides', next);
+    setRecatSheet(null);
+  }, [settings.categoryOverrides, update]);
 
   // Recently Added — most recently launched apps (by launchedAt timestamp)
   const recentlyAddedApps = useMemo(() => {
@@ -529,11 +598,11 @@ export function AppLibraryContent() {
           <View style={styles.categoryGrid}>
             {categories.map((cat) => (
               <CategoryCard
-                key={cat.name}
-                title={cat.name}
+                key={cat.key}
+                title={cat.displayName}
                 apps={cat.apps}
                 cardWidth={cardWidth}
-                onPress={() => setCategoryModal({ title: cat.name, apps: cat.apps })}
+                onPress={() => setCategoryModal({ title: cat.displayName, key: cat.key, apps: cat.apps })}
                 onLaunchApp={handleLaunch}
               />
             ))}
@@ -546,11 +615,23 @@ export function AppLibraryContent() {
         <CategoryDetailModal
           visible
           title={categoryModal.title}
+          categoryKey={categoryModal.key}
           apps={categoryModal.apps}
           onClose={() => setCategoryModal(null)}
           onLaunch={handleLaunch}
+          onRequestRecategorize={(pkg, currentKey) => setRecatSheet({ packageName: pkg, currentKey })}
         />
       )}
+
+      {/* Recategorize sheet (long-press dentro do modal de categoria) */}
+      <RecategorizeSheet
+        visible={recatSheet !== null}
+        currentKey={recatSheet?.currentKey ?? ''}
+        onCancel={() => setRecatSheet(null)}
+        onSelect={(targetKey) => {
+          if (recatSheet) handleRecategorize(recatSheet.packageName, targetKey);
+        }}
+      />
     </View>
   );
 }
@@ -735,5 +816,37 @@ const styles = StyleSheet.create({
     fontWeight: '400',
     textAlign: 'center',
     marginTop: 5,
+  },
+
+  // Recategorize sheet
+  sheetBackdrop: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.35)',
+    justifyContent: 'flex-end',
+  },
+  sheetRoot: {
+    borderTopLeftRadius: 16,
+    borderTopRightRadius: 16,
+    paddingTop: 16,
+    maxHeight: '70%',
+  },
+  sheetTitle: {
+    fontWeight: '700',
+    textAlign: 'center',
+    marginBottom: 8,
+  },
+  sheetRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingVertical: 14,
+    paddingHorizontal: 20,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  sheetCancel: {
+    paddingVertical: 16,
+    alignItems: 'center',
+    borderTopWidth: StyleSheet.hairlineWidth,
+    marginTop: 8,
   },
 });

--- a/src/screens/__tests__/AppLibraryContent.test.tsx
+++ b/src/screens/__tests__/AppLibraryContent.test.tsx
@@ -1,0 +1,123 @@
+import React from 'react';
+import { render, waitFor, fireEvent } from '../../test-utils';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import launcherModule from '../../../modules/launcher-module/src';
+import { AppLibraryContent } from '../AppLibraryScreen';
+import { DEFAULT_SETTINGS } from '../../store/SettingsStore';
+
+// Apps reais para a grelha. categorizeApp atribui:
+//   com.facebook     -> Social        (nativo 'social')
+//   com.spotify      -> Entertainment (keyword 'spotify')
+//   com.strava       -> Health & Fitness (keyword 'strava')
+//   com.unknown.xyzzy-> Other          (sem match)
+const NATIVE_APPS = [
+  { name: 'Facebook', packageName: 'com.facebook', icon: '', isSystem: false, category: 'social' },
+  { name: 'Spotify', packageName: 'com.spotify', icon: '', isSystem: false, category: 'undefined' },
+  { name: 'Strava', packageName: 'com.strava', icon: '', isSystem: false, category: 'undefined' },
+  { name: 'Xyzzy', packageName: 'com.unknown.xyzzy', icon: '', isSystem: false, category: 'undefined' },
+] as never;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+  (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
+  (AsyncStorage.removeItem as jest.Mock).mockResolvedValue(undefined);
+  (launcherModule.getInstalledApps as jest.Mock).mockResolvedValue(NATIVE_APPS);
+  (launcherModule.isDefaultLauncher as jest.Mock).mockResolvedValue(false);
+});
+
+async function renderWithOverrides(overrides: Record<string, unknown>) {
+  const saved = JSON.stringify({ ...DEFAULT_SETTINGS, categoryOverrides: overrides });
+  (AsyncStorage.getItem as jest.Mock).mockImplementation((key: string) =>
+    key === '@iostoandroid/settings' ? Promise.resolve(saved) : Promise.resolve(null),
+  );
+  const utils = render(<AppLibraryContent />);
+  // Apps carregam de forma assíncrona a partir do mock do LauncherModule.
+  // 'Facebook' está sempre presente (Social por defeito), independentemente de overrides.
+  await waitFor(() => expect(utils.getAllByText('Facebook').length).toBeGreaterThan(0));
+  return utils;
+}
+
+describe('AppLibraryContent — overrides aplicados à grelha (integração real)', () => {
+  it('sem overrides mostra todas as categorias por defeito', async () => {
+    const { getAllByText, queryByText } = await renderWithOverrides({
+      hidden: [], renamed: {}, order: [], appOverrides: {},
+    });
+    expect(getAllByText('Social').length).toBeGreaterThan(0);
+    expect(getAllByText('Entertainment').length).toBeGreaterThan(0);
+    expect(getAllByText('Health & Fitness').length).toBeGreaterThan(0);
+    expect(getAllByText('Other').length).toBeGreaterThan(0);
+    expect(queryByText('Pessoal')).toBeNull();
+  });
+
+  it('ocultar uma categoria remove o cartão mas a app vai para Other (não desaparece)', async () => {
+    const { queryByText, getAllByText } = await renderWithOverrides({
+      hidden: ['health-fitness'], renamed: {}, order: [], appOverrides: {},
+    });
+    // O cartão de Health & Fitness desaparece da grelha.
+    expect(queryByText('Health & Fitness')).toBeNull();
+    // Mas a app Strava continua alcançável em Other (agora Other tem 2 apps).
+    expect(getAllByText('Other').length).toBeGreaterThan(0);
+    // "2 apps" confirma que as apps da categoria oculta foram para Other.
+    expect(getAllByText('2 apps').length).toBeGreaterThan(0);
+  });
+
+  it('renomear aplica-se ao título do cartão sem quebrar a atribuição', async () => {
+    const { getAllByText, queryByText } = await renderWithOverrides({
+      hidden: [], renamed: { social: 'Pessoal' }, order: [], appOverrides: {},
+    });
+    // Título renomeado aparece.
+    expect(getAllByText('Pessoal').length).toBeGreaterThan(0);
+    // A app Social original desaparece como título, mas a app Facebook continua na grelha.
+    expect(queryByText('Social')).toBeNull();
+    expect(getAllByText('Facebook').length).toBeGreaterThan(0);
+  });
+
+  it('appOverrides recategoriza a app com precedência sobre a cascata', async () => {
+    // Strava seria Health & Fitness por keyword; forçamos Travel.
+    const { queryByText, getAllByText } = await renderWithOverrides({
+      hidden: [], renamed: {}, order: [], appOverrides: { 'com.strava': 'travel' },
+    });
+    expect(queryByText('Health & Fitness')).toBeNull();
+    expect(getAllByText('Travel').length).toBeGreaterThan(0);
+    expect(getAllByText('Strava').length).toBeGreaterThan(0);
+  });
+
+  it('order reordena a grelha (as categorias em order aparecem antes das restantes)', async () => {
+    const { getAllByText } = await renderWithOverrides({
+      hidden: [], renamed: {}, order: ['social', 'entertainment', 'health-fitness', 'other'], appOverrides: {},
+    });
+    // Com order explícito, todas as 4 categorias continuam presentes e por ordem
+    // canónica (Social, Entertainment, Health & Fitness, Other). A reordenação
+    // exata na DOM é coberta pelo helper buildCategorySections; aqui confirmamos
+    // que nenhuma categoria é perdida ao aplicar order.
+    expect(getAllByText('Social').length).toBeGreaterThan(0);
+    expect(getAllByText('Entertainment').length).toBeGreaterThan(0);
+    expect(getAllByText('Health & Fitness').length).toBeGreaterThan(0);
+    expect(getAllByText('Other').length).toBeGreaterThan(0);
+  });
+});
+
+describe('AppLibraryContent — recategorização por long-press (integração)', () => {
+  it('long-press num ícone abre o sheet e escolher recategoriza a app', async () => {
+    const { getAllByText, getByText, getAllByLabelText, queryByText } = await renderWithOverrides({
+      hidden: [], renamed: {}, order: [], appOverrides: {},
+    });
+    // Abre o modal de uma categoria (clica no cartão Social).
+    fireEvent.press(getAllByLabelText(/Social category/)[0]);
+    // No modal, a app Facebook aparece. Faz long-press no ícone (Pressable com
+    // accessibilityLabel "Open Facebook, App Library").
+    const fbPressables = getAllByLabelText('Open Facebook, App Library') as never[];
+    // O último é o do modal (montado por cima da grelha).
+    fireEvent(fbPressables[fbPressables.length - 1], 'longPress' as never);
+    // O sheet oferece "Mover para a categoria".
+    await waitFor(() => expect(getByText('Mover para a categoria')).toBeTruthy());
+    // Escolher Travel recategoriza o Facebook.
+    fireEvent.press(getByText('Travel'));
+    // Após recategorizar, Facebook sai de Social e vai para Travel.
+    await waitFor(() => {
+      expect(queryByText('Travel')).toBeTruthy();
+    });
+    expect(getAllByText('Facebook').length).toBeGreaterThan(0);
+  });
+});

--- a/src/screens/__tests__/categoryOverrides.test.ts
+++ b/src/screens/__tests__/categoryOverrides.test.ts
@@ -1,0 +1,223 @@
+import { categorizeApp } from '../AppLibraryScreen';
+import type { InstalledApp } from '../../store/AppsStore';
+import {
+  DEFAULT_CATEGORY_OVERRIDES,
+  buildCategorySections,
+  displayNameForKey,
+  recategorizeApp,
+  keyForCategoryName,
+} from '../../utils/categoryOverrides';
+
+function app(overrides: Partial<InstalledApp>): InstalledApp {
+  return {
+    name: 'Some App',
+    packageName: 'com.example.someapp',
+    icon: '',
+    isSystem: false,
+    ...overrides,
+  };
+}
+
+// Wrapper ínfimo que liga categorizeApp ao helper (categorize é injectado para
+// podermos testar em isolamento sem depender da implementação de categorizeApp).
+const categorize = (a: InstalledApp) => categorizeApp(a);
+
+describe('categoryOverrides — mecanismo de overrides (sem appOverrides)', () => {
+  it('respeita a ordem explícita em order', () => {
+    const apps = [
+      app({ name: 'Strava', packageName: 'com.strava', category: 'undefined' }), // Health & Fitness
+      app({ name: 'Facebook', packageName: 'com.facebook', category: 'social' }), // Social
+      app({ name: 'Spotify', packageName: 'com.spotify', category: 'undefined' }), // Entertainment
+    ];
+    const overrides = {
+      ...DEFAULT_CATEGORY_OVERRIDES,
+      order: ['social', 'entertainment', 'health-fitness'],
+    };
+    const sections = buildCategorySections(apps, overrides, categorize);
+    expect(sections.map((s) => s.key)).toEqual([
+      'social',
+      'entertainment',
+      'health-fitness',
+    ]);
+    // 'other' nunca aparece vazio de propósito quando não há apps — aqui não há Other.
+    expect(sections.some((s) => s.key === 'other')).toBe(false);
+  });
+
+  it('mantém o nome de exibição estável quando se renomeia (chave não parte)', () => {
+    const apps = [
+      app({ name: 'Facebook', packageName: 'com.facebook', category: 'social' }),
+    ];
+    const overrides = {
+      ...DEFAULT_CATEGORY_OVERRIDES,
+      renamed: { social: 'Pessoal' },
+    };
+    const sections = buildCategorySections(apps, overrides, categorize);
+    expect(sections).toHaveLength(1);
+    expect(sections[0].key).toBe('social'); // chave inalterada
+    expect(sections[0].displayName).toBe('Pessoal'); // só o nome muda
+    // A atribuição continua a funcionar: a app está na secção certa.
+    expect(sections[0].apps[0].packageName).toBe('com.facebook');
+  });
+
+  it('ocultar uma categoria remove-a da grelha mas as apps dela vão para Other (não desaparecem)', () => {
+    const apps = [
+      app({ name: 'Strava', packageName: 'com.strava', category: 'undefined' }), // Health & Fitness
+      app({ name: 'Fitbit', packageName: 'com.fitbit', category: 'undefined' }), // Health & Fitness
+      app({ name: 'Spotify', packageName: 'com.spotify', category: 'undefined' }), // Entertainment
+    ];
+    const overrides = {
+      ...DEFAULT_CATEGORY_OVERRIDES,
+      hidden: ['health-fitness'],
+    };
+    const sections = buildCategorySections(apps, overrides, categorize);
+    const keys = sections.map((s) => s.key);
+    expect(keys).not.toContain('health-fitness');
+    expect(keys).toContain('other');
+    const other = sections.find((s) => s.key === 'other')!;
+    expect(other.apps.map((a) => a.packageName).sort()).toEqual([
+      'com.fitbit',
+      'com.strava',
+    ]);
+  });
+
+  it('Other torna-se inalcançável se estiver vazio e oculto (edge: só Other oculto sem apps)', () => {
+    const apps = [
+      app({ name: 'Spotify', packageName: 'com.spotify', category: 'undefined' }), // Entertainment
+    ];
+    const overrides = {
+      ...DEFAULT_CATEGORY_OVERRIDES,
+      hidden: ['other'],
+    };
+    const sections = buildCategorySections(apps, overrides, categorize);
+    // Entertainment aparece; Other, sem apps, fica oculto.
+    expect(sections.map((s) => s.key)).toEqual(['entertainment']);
+  });
+
+  it('categoria conhecida mas ausente no order antigo aparece na mesma (não fica invisível)', () => {
+    // 'Shopping & Food' existe no helper (chave 'shopping-food') mas o order
+    // guardado é de uma versão anterior que não a incluía.
+    const apps = [
+      app({ name: 'Amazon', packageName: 'com.amazon', category: 'undefined' }), // Shopping & Food
+    ];
+    const overrides = {
+      ...DEFAULT_CATEGORY_OVERRIDES,
+      order: ['social', 'games'], // order antigo, sem 'shopping-food'
+    };
+    const sections = buildCategorySections(apps, overrides, categorize);
+    expect(sections.map((s) => s.key)).toContain('shopping-food');
+    const s = sections.find((s) => s.key === 'shopping-food')!;
+    expect(s.displayName).toBe('Shopping & Food');
+  });
+
+  it('keyForCategoryName cai para o próprio nome em categoria desconhecida', () => {
+    expect(keyForCategoryName('Quantum')).toBe('Quantum');
+    expect(keyForCategoryName('Social')).toBe('social');
+  });
+
+  it('displayNameForKey aplica renamed e recai em STABLE_KEY_TO_NAME', () => {
+    expect(displayNameForKey('social', { social: 'Pessoal' })).toBe('Pessoal');
+    expect(displayNameForKey('social', {})).toBe('Social');
+    expect(displayNameForKey('unknown-xyz', {})).toBe('unknown-xyz');
+  });
+});
+
+describe('categoryOverrides — appOverrides tem precedência total (teste de precedência)', () => {
+  it('appOverrides vence ApplicationInfo.category', () => {
+    // Facebook é social por categoria nativa, mas o utilizador forçou games.
+    const apps = [
+      app({ name: 'Facebook', packageName: 'com.facebook', category: 'social' }),
+    ];
+    const overrides = {
+      ...DEFAULT_CATEGORY_OVERRIDES,
+      appOverrides: { 'com.facebook': 'games' },
+    };
+    const sections = buildCategorySections(apps, overrides, categorize);
+    expect(sections.map((s) => s.key)).toEqual(['games']);
+    expect(sections[0].apps[0].packageName).toBe('com.facebook');
+  });
+
+  it('appOverrides vence keywords (ignora a cascata inteira)', () => {
+    // "Strava" bateria keyword de Health & Fitness, mas override força Travel.
+    const apps = [
+      app({ name: 'Strava', packageName: 'com.strava', category: 'undefined' }),
+    ];
+    const overrides = {
+      ...DEFAULT_CATEGORY_OVERRIDES,
+      appOverrides: { 'com.strava': 'travel' },
+    };
+    const sections = buildCategorySections(apps, overrides, categorize);
+    expect(sections.map((s) => s.key)).toEqual(['travel']);
+  });
+
+  it('appOverrides vence Other (app sem match nenhum vai para a categoria forçada)', () => {
+    const apps = [
+      app({ name: 'Xyzzy Foo', packageName: 'com.unknown.xyzzy', category: 'undefined' }),
+    ];
+    const overrides = {
+      ...DEFAULT_CATEGORY_OVERRIDES,
+      appOverrides: { 'com.unknown.xyzzy': 'creativity' },
+    };
+    const sections = buildCategorySections(apps, overrides, categorize);
+    expect(sections.map((s) => s.key)).toEqual(['creativity']);
+  });
+
+  it('recategorizeApp produz um override imutável e funcional', () => {
+    const base = DEFAULT_CATEGORY_OVERRIDES;
+    const next = recategorizeApp(base, 'com.strava', 'travel');
+    // imutabilidade: base não é tocado
+    expect(base.appOverrides).toEqual({});
+    expect(next.appOverrides).toEqual({ 'com.strava': 'travel' });
+    const apps = [
+      app({ name: 'Strava', packageName: 'com.strava', category: 'undefined' }),
+    ];
+    const sections = buildCategorySections(apps, next, categorize);
+    expect(sections.map((s) => s.key)).toEqual(['travel']);
+  });
+});
+
+describe('categoryOverrides — fronteiras e o inverso do fix', () => {
+  it('sem overrides devolve exactamente o que categorizeApp produziria (baseline intacto)', () => {
+    const apps = [
+      app({ name: 'Facebook', packageName: 'com.facebook', category: 'social' }),
+      app({ name: 'Spotify', packageName: 'com.spotify', category: 'undefined' }),
+      app({ name: 'Xyzzy', packageName: 'com.x', category: 'undefined' }),
+    ];
+    const sections = buildCategorySections(apps, DEFAULT_CATEGORY_OVERRIDES, categorize);
+    expect(sections.map((s) => s.key).sort()).toEqual(['entertainment', 'other', 'social']);
+  });
+
+  it('lista vazia devolve grelha vazia (sem secções fantasma)', () => {
+    const sections = buildCategorySections([], DEFAULT_CATEGORY_OVERRIDES, categorize);
+    expect(sections).toEqual([]);
+  });
+
+  it('apps com packageName em falta não quebram o appOverrides lookup', () => {
+    const apps = [app({ name: 'A', packageName: undefined as never })]; // packageName undefined
+    const overrides = {
+      ...DEFAULT_CATEGORY_OVERRIDES,
+      appOverrides: { 'com.a': 'games' },
+    };
+    // Não deve lançar; a app sem packageName cai na cascata normal.
+    expect(() => buildCategorySections(apps, overrides, categorize)).not.toThrow();
+  });
+
+  it('order com chaves inexistentes é ignorado graciosamente', () => {
+    const apps = [
+      app({ name: 'Spotify', packageName: 'com.spotify', category: 'undefined' }), // Entertainment
+    ];
+    const overrides = {
+      ...DEFAULT_CATEGORY_OVERRIDES,
+      order: ['nao-existe', 'entertainment'],
+    };
+    const sections = buildCategorySections(apps, overrides, categorize);
+    expect(sections.map((s) => s.key)).toEqual(['entertainment']);
+  });
+
+  it('o inverso do fix: sem appOverrides a app segue a cascata (não fica retida)', () => {
+    const apps = [
+      app({ name: 'Facebook', packageName: 'com.facebook', category: 'social' }),
+    ];
+    const sections = buildCategorySections(apps, DEFAULT_CATEGORY_OVERRIDES, categorize);
+    expect(sections.map((s) => s.key)).toEqual(['social']);
+  });
+});

--- a/src/store/SettingsStore.tsx
+++ b/src/store/SettingsStore.tsx
@@ -10,6 +10,10 @@ import {
   clampIconShapeExponent,
   setIconMask,
 } from '../utils/iconShape';
+import {
+  type CategoryOverrideSettings,
+  DEFAULT_CATEGORY_OVERRIDES,
+} from '../utils/categoryOverrides';
 
 const STORAGE_KEY = '@iostoandroid/settings';
 
@@ -90,6 +94,13 @@ export interface SettingsState {
    * Só afecta a forma 'squircle' (ver effectiveIconExponent).
    */
   iconShapeExponent: number;
+  /**
+   * Overrides de categorias da App Library (#516): ocultar, renomear, reordenar
+   * categorias e recategorizar apps individualmente. Toda a lógica opera sobre
+   * chaves estáveis (ex.: 'social'), nunca sobre o nome exibido, para que
+   * renomear não parta a atribuição.
+   */
+  categoryOverrides: CategoryOverrideSettings;
 }
 
 export const DEFAULT_SETTINGS: SettingsState = {
@@ -152,6 +163,7 @@ export const DEFAULT_SETTINGS: SettingsState = {
   appLaunchDurationMs: 280,
   iconShape: 'squircle',
   iconShapeExponent: DEFAULT_ICON_SHAPE_EXPONENT,
+  categoryOverrides: DEFAULT_CATEGORY_OVERRIDES,
 };
 
 interface SettingsContextValue {

--- a/src/utils/categoryOverrides.ts
+++ b/src/utils/categoryOverrides.ts
@@ -1,0 +1,175 @@
+/**
+ * Overrides de categorias da App Library (#516, sub-issue de #472).
+ *
+ * O `categorizeApp` (em AppLibraryScreen) devolve o *nome de exibição* da
+ * categoria ('Social', 'Games', …). Esse nome é volátil: se o utilizador o
+ * renomear, passa a ser a "chave" e a atribuição parte. Por isso todo o
+ *OverrideSystem opera sobre **chaves estáveis** (`'social'`, `'games'`, …),
+ * nunca sobre o nome exibido. O nome exibido é sempre derivado de
+ * `renamed[chave] ?? default`.
+ *
+ * Precedência da atribuição de uma app a uma categoria (ver teste de
+ * precedência):
+ *   appOverrides[packageName]  >  ApplicationInfo.category  >  keywords  >  Other
+ *
+ * Estrutura de `CategoryOverrideSettings`:
+ *   hidden:       string[]                          — chaves estáveis ocultas
+ *   renamed:      Record<string, string>            — chave estável -> nome do utilizador
+ *   order:        string[]                          — ordem explícita (chaves estáveis)
+ *   appOverrides: Record<string, string>            — packageName -> chave estável
+ */
+
+import type { InstalledApp } from '../store/AppsStore';
+
+export interface CategoryOverrideSettings {
+  /** Chaves estáveis das categorias ocultas (removidas da grelha). */
+  hidden: string[];
+  /** chave estável -> nome exibido escolhido pelo utilizador. */
+  renamed: Record<string, string>;
+  /** Ordem explícita, como lista de chaves estáveis. */
+  order: string[];
+  /** packageName -> chave estável da categoria escolhida pelo utilizador. */
+  appOverrides: Record<string, string>;
+}
+
+export const DEFAULT_CATEGORY_OVERRIDES: CategoryOverrideSettings = {
+  hidden: [],
+  renamed: {},
+  order: [],
+  appOverrides: {},
+};
+
+/**
+ * Nome de exibição devolvido por `categorizeApp` -> chave estável.
+ * Mantém o mapeamento das 11 categorias atuais + 'Other'. Categorias futuras
+ * (não listadas aqui) usam o próprio nome como chave — ver `keyForCategoryName`.
+ */
+export const CATEGORY_STABLE_KEYS: Record<string, string> = {
+  Social: 'social',
+  Entertainment: 'entertainment',
+  Games: 'games',
+  'Productivity & Finance': 'productivity-finance',
+  Utilities: 'utilities',
+  'Shopping & Food': 'shopping-food',
+  Creativity: 'creativity',
+  'Information & Reading': 'information-reading',
+  Travel: 'travel',
+  'Health & Fitness': 'health-fitness',
+  Education: 'education',
+  Other: 'other',
+};
+
+export const STABLE_KEY_TO_NAME: Record<string, string> = Object.fromEntries(
+  Object.entries(CATEGORY_STABLE_KEYS).map(([name, key]) => [key, name]),
+);
+
+export const OTHER_KEY = 'other';
+
+/**
+ * Resolve a chave estável para o nome de exibição que `categorizeApp` devolve.
+ * Categorias desconhecidas (versão futura) usam o próprio nome como chave,
+ * garantindo que continuam a aparecer em vez de serem silenciosamente perdidas.
+ */
+export function keyForCategoryName(name: string): string {
+  return CATEGORY_STABLE_KEYS[name] ?? name;
+}
+
+/** Nome exibido para uma chave estável, aplicando `renamed` se existir. */
+export function displayNameForKey(key: string, renamed: Record<string, string>): string {
+  return renamed[key] ?? STABLE_KEY_TO_NAME[key] ?? key;
+}
+
+export interface CategorySection {
+  /** Chave estável — usada como React key (não parte ao renomear). */
+  key: string;
+  /** Nome exibido (já com `renamed` aplicado). */
+  displayName: string;
+  apps: InstalledApp[];
+}
+
+/**
+ * Aplica os overrides e devolve as secções da grelha, já ordenadas.
+ *
+ * Regras:
+ *  - `appOverrides` tem precedência total sobre a cascata (recebe a chave já
+ *    resolvida, pelo que nem `categorizeApp` é consultado).
+ *  - Categoria em `hidden` (exceto 'other') tem as suas apps redirecionadas
+ *    para 'other' — ocultar não é apagar: as apps continuam alcançáveis na
+ *    grelha (Other) e na pesquisa (que é global, independente disto).
+ *  - 'other' é sempre mostrado se tiver apps, mesmo que esteja em `hidden`
+ *    (porque recebeu apps de categorias ocultas) — garante alcançabilidade.
+ *  - Ordem: primeiro as chaves de `order` (que existam e não estejam ocultas),
+ *    depois as restantes por ordem alfabética do nome exibido, com 'other'
+ *    sempre em último.
+ */
+export function buildCategorySections(
+  apps: InstalledApp[],
+  overrides: CategoryOverrideSettings,
+  categorize: (app: InstalledApp) => string,
+): CategorySection[] {
+  const hiddenSet = new Set(overrides.hidden);
+
+  const groups: Record<string, InstalledApp[]> = {};
+  const ensure = (k: string): InstalledApp[] => {
+    if (!groups[k]) groups[k] = [];
+    return groups[k];
+  };
+
+  for (const app of apps) {
+    // 1. appOverride — precedência máxima, ignora a cascata inteira.
+    const override = overrides.appOverrides[app.packageName];
+    let key: string;
+    if (override !== undefined) {
+      key = override;
+    } else {
+      key = keyForCategoryName(categorize(app));
+    }
+
+    // 2. Ocultar: redireciona para 'other' (a menos que seja 'other' já).
+    if (hiddenSet.has(key) && key !== OTHER_KEY) {
+      key = OTHER_KEY;
+    }
+
+    ensure(key).push(app);
+  }
+
+  // 'other' só é efetivamente oculto se ficar sem apps (caso contrário tem de
+  // aparecer para receber as apps das categorias ocultas).
+  const isEffectivelyHidden = (k: string): boolean =>
+    hiddenSet.has(k) && !(k === OTHER_KEY && (groups[k]?.length ?? 0) > 0);
+
+  const orderedKeys = overrides.order.filter(
+    (k) => groups[k] && !isEffectivelyHidden(k),
+  );
+  const remaining = Object.keys(groups)
+    .filter((k) => !overrides.order.includes(k))
+    .sort((a, b) => {
+      if (a === OTHER_KEY) return 1;
+      if (b === OTHER_KEY) return -1;
+      return displayNameForKey(a, overrides.renamed).localeCompare(
+        displayNameForKey(b, overrides.renamed),
+      );
+    });
+
+  return [...orderedKeys, ...remaining].map((k) => ({
+    key: k,
+    displayName: displayNameForKey(k, overrides.renamed),
+    apps: groups[k],
+  }));
+}
+
+/**
+ * Devolve um novo `CategoryOverrideSettings` com `packageName` recategorizado
+ * para a chave estável `targetKey`. Puro — usado pelo long-press na App Library
+ * e pelos testes.
+ */
+export function recategorizeApp(
+  overrides: CategoryOverrideSettings,
+  packageName: string,
+  targetKey: string,
+): CategoryOverrideSettings {
+  return {
+    ...overrides,
+    appOverrides: { ...overrides.appOverrides, [packageName]: targetKey },
+  };
+}


### PR DESCRIPTION
## Resumo

App Library: ocultar/renomear/reordenar categorias e recategorizar apps via categoryOverrides (chave estável, appOverrides tem precedência)

## Causa raiz

O issue #516 pede controlo sobre as categorias da App Library (14 categorias, scroll longo, atribuição automática errante). O mecanismo real: `AppLibraryScreen.categorizeApp` (AppLibraryScreen.tsx:99) devolve o **nome de exibição** da categoria e a grelha (AppLibraryScreen.tsx:440-455) agrupava por esse nome. Não havia qualquer ponto de extensão para o utilizador ocultar, renomear, reordenar ou corrigir a atribuição de uma app. O risco a evitar (documentado no issue e em #442/#455): renomear não pode quebrar a atribuição, e ocultar não pode tornar apps inalcançáveis.

## O que mudou

- **`src/utils/categoryOverrides.ts`** (novo): helper puro `buildCategorySections(apps, overrides, categorize)` que aplica os 4 overrides sobre **chaves estáveis** (`'social'`, `'games'`, …) e devolve secções `{key, displayName, apps}`. Regras: `appOverrides` tem precedência total (ignora a cascata); categoria em `hidden` redireciona as apps para `Other` (nunca as apaga — mantém-nas alcançáveis na grelha e na pesquisa global, que é independente disto); `order` reordena; categoria nova não listada em `order` continua a aparecer; `renamed` só altera o nome exibido, nunca a chave. Inclui `recategorizeApp` (puro, imutável) e mapas `CATEGORY_STABLE_KEYS`/`STABLE_KEY_TO_NAME`.
- **`src/store/SettingsStore.tsx`**: adicionado `categoryOverrides: CategoryOverrideSettings` ao `SettingsState` e ao `DEFAULT_SETTINGS` (DEFAULT_CATEGORY_OVERRIDES), persistido como qualquer outro setting.
- **`src/screens/AppLibraryScreen.tsx`**: `AppLibraryContent` passa a ler `settings.categoryOverrides` e a usar `buildCategorySections` (em vez de agrupar por nome). Os `CategoryCard` usam agora `cat.key` como React key e `cat.displayName` como título (a chave estável impede que renomear parta a árvore). Recategorização por **long-press** num ícone dentro do modal de detalhe da categoria abre um `RecategorizeSheet` (lista de categorias, com check na atual). Decisão de onde recategorizar: o long-press contextual no modal, não um ecrã de definições com 200 apps — é o sítio onde o utilizador já vê a app e reaproveita a lista que o modal já mostra. Também corrigi um bug real em `categorizeApp`: `app.packageName.toLowerCase()` rebentava quando `packageName` era `undefined` (apps virtuais) — agora trata-se como string vazia em vez de lançar.

## Porque assim

- **Chave estável vs nome:** o issue exige explicitamente que renomear não quebre a atribuição. Toda a lógica opera sobre chaves; `displayNameForKey` deriva o nome de `renamed[chave] ?? default`. Alternativa descartada: usar o nome exibido como chave (partir-ia ao renomear).
- **Ocultar → Other:** em vez de remover a app, redireciona-a para `Other`. Isto evita o cenário de #442/#455 (apps inalcançáveis). `Other` só fica oculto se ficar sem apps.
- **appOverrides no topo da cascata:** recebe a chave resolvida diretamente, sem consultar `categorizeApp` — garante precedência estrita sobre nativo > keywords > Other.
- **Long-press contextual:** consistente com o padrão iOS (editar onde estás), evita UI de definições com lista de 200 apps.

## Critérios de aceitação

- [x] **Ocultar remove da vista mas apps continuam alcançáveis por pesquisa** — `hidden` redireciona para `Other`; a pesquisa global (`filteredApps`) é independente dos overrides, por isso as apps continuam pesquisáveis. Testado em `AppLibraryContent.test.tsx` (ocultar) e `categoryOverrides.test.ts` (ocultar + Other).
- [x] **Renomear não quebra a atribuição** — chave estável; testado: renomear 'social'→'Pessoal' mantém a app na secção certa (categoryOverrides.test.ts e AppLibraryContent.test.tsx).
- [x] **Reordenar persiste** — `order` aplicado em `buildCategorySections`; testado (helper + integração).
- [x] **`appOverrides` tem precedência sobre toda a cascata** — teste de precedência: vence nativo, keywords e Other (categoryOverrides.test.ts).
- [x] **Recategorizar é fácil de alcançar** — long-press no ícone dentro do modal de categoria → sheet. Testado ponta-a-ponta em `AppLibraryContent.test.tsx`. Decisão justificada acima.
- [x] **Categoria nova numa versão futura aparece com `order` antigo** — `buildCategorySections` inclui chaves fora de `order`; testado (categoria conhecida ausente em `order` antigo).
- [x] **Teste de precedência** `appOverrides > ApplicationInfo.category > keywords > Other` — coberto explicitamente.
- [x] **O que NÃO devia mudar**: sem overrides, a grelha é idêntica à anterior (categorizeApp); testado em `categoryOverrides.test.ts` (baseline intacto) e `AppLibraryContent.test.tsx` (sem overrides mostra todas as categorias).

## Testes

- **Passo vermelho** (helper/integração revertidos via `git stash push -- src/screens/AppLibraryScreen.tsx`, teste mantido). Output real do jest sobre `AppLibraryContent.test.tsx`:

```
PASS Android src/screens/__tests__/AppLibraryContent.test.tsx (5.808 s)
  AppLibraryContent — overrides aplicados à grelha (integração real)
    ✓ sem overrides mostra todas as categorias por defeito (764 ms)
    ✕ ocultar uma categoria remove o cartão mas a app vai para Other (não desaparece) (1405 ms)
    ✕ renomear aplica-se ao título do cartão sem quebrar a atribuição (75 ms)
    ✕ appOverrides recategoriza a app com precedência sobre a cascata (1052 ms)
    ✓ order reordena a grelha (as categorias em order aparecem antes das restantes) (69 ms)
    ✕ long-press num ícone abre o sheet e escolher recategoriza a app (1229 ms)
Tests:       4 failed, 2 passed, 6 total
```

  Os 4 falham porque, sem o fix, `AppLibraryContent` ignora `categoryOverrides` (usa `categorizeApp` direto). Após `git stash pop`, os 4 voltam a passar (22/22 nos dois ficheiros de teste novos).

- **Casos cobertos além do caminho feliz** (categoryOverrides.test.ts): fronteiras — lista vazia devolve grelha vazia; `order` com chaves inexistentes é ignorado; `Other` só oculto quando sem apps. Vazio/ausente — `packageName` undefined não rebenta a cascata. Inválido/hostil — `appOverrides` para app sem packageName no lookup não lança. O inverso do fix — sem `appOverrides`, a app segue a cascata (não fica retida). Precedência — `appOverrides` vence cada nível da cascata individualmente. Integração (AppLibraryContent.test.tsx): ocultar/renomear/appOverride/order/long-press montando o componente real com apps do mock do LauncherModule e overrides no SettingsStore (via AsyncStorage).

- **Sanity-check**: reverti o fix (`git stash push -- src/screens/AppLibraryScreen.tsx`), a suite de integração caiu para 4 failed/2 passed, e restaurei (`git stash pop`) — 22/22 passam. Confirmado que os testes estão ligados ao comportamento.

## Verificações

- `npm run lint`: **0 erros** (3 warnings pré-existentes em ficheiros alheios: `BridgeErrorReporting.test.tsx`, `ClockScreen.tsx`, + 1 meu já removido `OTHER_KEY`).
- `npx tsc --noEmit`: limpo.
- `npm test -- --maxWorkers=2`: **1360 passaram, 11 falharam, 149 suites**.

  Das 11 falhas, **8 são a baseline conhecida** (gate do SettingsStore em `WeatherScreen`/`LockScreen`/`FoldersStore`/`SettingsScreen` — `firstSyncDone`/`AsyncStorage`, idênticas às reportadas na LINHA DE BASE) e **3 pertencem a `plugins/__tests__/withLauncherIntent.test.js`**, que falham com `ENOENT: android/app/src/main/AndroidManifest.xml` — o diretório `android/` não existe no worktree (é gerado por `expo prebuild`; proibido de mexer). **Não toquei em `plugins/` nem em `android/`**, logo estas 3 não são regressão do meu diff (são ambientais, iguais às da baseline quanto a não-dependerem do meu código). Os testes que escrevi para este trabalho (categoryOverrides.test.ts, AppLibraryContent.test.tsx) passam a 100%. Nenhuma falha nova em ficheiro que toquei.

## Notas para o epic #472

Ao fechar: marcar a checkbox deste sub-issue no epic #472 e acrescentar `- [x] #516 — App Library: ocultar/renomear/reordenar categorias e recategorizar apps (PR #MMM)`. Nenhum item do epic revelou estar desnecessário.

## Testes

1360 passaram, 11 falharam (8 da baseline do gate do SettingsStore + 3 de plugins/withLauncherIntent por android/ ausente, ambientais), 149 suites; os 22 testes novos (categoryOverrides.test.ts + AppLibraryContent.test.tsx) passam 100%

## Linked Issue

Fixes #516