### PR TITLE
qa/issue-496: migrar o feedback de toque ad hoc para o primitivo useCupertinoPress (via CupertinoPressable), escala do ícone do launcher 0.85 -> 0.96 e token único de cor para linhas de lista premidas (#496)

### DIFF
--- a/src/__tests__/AndroidRippleRemoval.test.tsx
+++ b/src/__tests__/AndroidRippleRemoval.test.tsx
@@ -92,7 +92,10 @@ describe('Issue #494: Android Ripple Removal', () => {
       );
 
       expect(appIconSection).toContain('pressScale');
-      expect(appIconSection).toContain('withSpring(0.85');
+      // #496 replaced the ad hoc 0.85 with the shared §3.2 press scale constant.
+      // The assertion is still "the icon springs its press scale on press-in";
+      // only the magnitude moved into src/hooks/useCupertinoPress.ts.
+      expect(appIconSection).toContain('withSpring(CUPERTINO_PRESS_SCALE');
       expect(appIconSection).toContain('handlePressIn');
       expect(appIconSection).toContain('handlePressOut');
     });
@@ -107,8 +110,10 @@ describe('Issue #494: Android Ripple Removal', () => {
         content.indexOf('function FolderIcon') + 1500
       );
 
-      // Should have a style prop with pressed state handling
-      expect(folderSection).toMatch(/style.*pressed/);
+      // #496: the folder icon now gets its press feedback from the shared
+      // primitive via CupertinoPressable instead of an inline
+      // `opacity: pressed ? 0.6 : 1`.
+      expect(folderSection).toMatch(/<CupertinoPressable/);
     });
 
     it('LauncherHomeScreen default launcher button should have opacity feedback', () => {
@@ -121,8 +126,8 @@ describe('Issue #494: Android Ripple Removal', () => {
         content.indexOf('Set as default launcher') + 500
       );
 
-      // Should have a style prop with pressed state handling
-      expect(defaultBannerSection).toMatch(/style.*pressed/);
+      // #496: migrated to the shared primitive (was `opacity: pressed ? 0.7 : 1`).
+      expect(defaultBannerSection).toMatch(/<CupertinoPressable/);
     });
 
     it('CallScreen control button should have opacity feedback', () => {
@@ -158,11 +163,11 @@ describe('Issue #494: Android Ripple Removal', () => {
       const content = fs.readFileSync(filePath, 'utf8');
 
       // Menu cell should have style feedback
-      const pressableStart = content.indexOf('<Pressable', content.indexOf('items.map'));
+      const pressableStart = content.indexOf('<CupertinoPressable', content.indexOf('items.map'));
       const menuCellSection = content.substring(pressableStart, pressableStart + 500);
 
-      // Should have a style prop with pressed state handling
-      expect(menuCellSection).toMatch(/style.*pressed/);
+      // #496: migrated to the shared primitive (was `opacity: pressed ? 0.65 : 1`).
+      expect(menuCellSection).toMatch(/<CupertinoPressable/);
     });
 
     it('TodayViewScreen widget card should have opacity feedback', () => {

--- a/src/__tests__/pressFeedbackConvention.test.ts
+++ b/src/__tests__/pressFeedbackConvention.test.ts
@@ -1,0 +1,114 @@
+import fs from 'fs';
+import path from 'path';
+
+// Issue #496 / epic #468 — one touch-feedback convention in the app.
+//
+// The audit found four concurrent press-feedback conventions. Convention 3
+// (`style={({ pressed }) => [..., { opacity: pressed ? N : 1 }]}` with six
+// different Ns) is migrated to the useCupertinoPress primitive, via
+// CupertinoPressable. Convention 4 (a pressed backgroundColor swap on
+// full-width list rows) stays — it is the correct iOS behaviour for rows — but
+// the colour must come from a single theme token.
+//
+// These are source-level assertions on purpose: the property under test is
+// "no site anywhere in src/ reintroduces an ad hoc value", which is a property
+// of the whole tree and cannot be observed by mounting one component.
+
+const SRC = path.resolve(__dirname, '..');
+
+function collect(dir: string, out: string[] = []): string[] {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === '__tests__' || entry.name === '__snapshots__') continue;
+      collect(full, out);
+    } else if (/\.tsx?$/.test(entry.name)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+const FILES = collect(SRC);
+
+function lines(file: string): Array<{ n: number; text: string }> {
+  return fs
+    .readFileSync(file, 'utf8')
+    .split('\n')
+    .map((text, i) => ({ n: i + 1, text }));
+}
+
+/** Comment lines are excluded: the migration notes legitimately quote the old
+ *  pattern to explain what was replaced. */
+function isComment(text: string): boolean {
+  return /^\s*(\/\/|\*|\/\*)/.test(text);
+}
+
+function hits(predicate: (text: string) => boolean): string[] {
+  const found: string[] = [];
+  for (const file of FILES) {
+    for (const { n, text } of lines(file)) {
+      if (isComment(text)) continue;
+      if (predicate(text)) found.push(`${path.relative(SRC, file)}:${n}: ${text.trim()}`);
+    }
+  }
+  return found;
+}
+
+describe('press feedback convention — no ad hoc opacity (§3.2)', () => {
+  it('has zero `opacity: pressed ? N : 1` sites in src/', () => {
+    const offenders = hits((t) => /opacity:\s*pressed\s*\?/.test(t));
+    expect(offenders).toEqual([]);
+  });
+
+  it('has zero inline `pressed ?` opacity inside a style callback array in src/', () => {
+    const offenders = hits((t) => /\{\s*opacity:\s*pressed\s*\?/.test(t));
+    expect(offenders).toEqual([]);
+  });
+});
+
+describe('press feedback convention — list rows keep a single colour token', () => {
+  it('every remaining `backgroundColor: pressed ? X` uses colors.pressedRowBackground', () => {
+    const offenders = hits(
+      (t) =>
+        /backgroundColor:\s*pressed\s*\?/.test(t) &&
+        !/pressed\s*\?\s*colors\.pressedRowBackground/.test(t),
+    );
+    expect(offenders).toEqual([]);
+  });
+
+  it('the theme actually defines the token for both schemes', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { SystemColors } = require('../theme/CupertinoTheme') as {
+      SystemColors: { light: Record<string, string>; dark: Record<string, string> };
+    };
+    expect(typeof SystemColors.light.pressedRowBackground).toBe('string');
+    expect(typeof SystemColors.dark.pressedRowBackground).toBe('string');
+    // The two schemes must differ, otherwise the pressed row is invisible in one of them.
+    expect(SystemColors.light.pressedRowBackground).not.toBe(
+      SystemColors.dark.pressedRowBackground,
+    );
+  });
+});
+
+describe('press feedback convention — launcher icon scale', () => {
+  const launcher = fs.readFileSync(path.join(SRC, 'screens/LauncherHomeScreen.tsx'), 'utf8');
+
+  it('no longer springs the app icon to the ad hoc 0.85 scale', () => {
+    expect(launcher).not.toMatch(/withSpring\(\s*0\.85\s*,/);
+  });
+
+  it('uses the shared §3.2 press scale constant for the app icon press-in', () => {
+    expect(launcher).toMatch(/withSpring\(\s*CUPERTINO_PRESS_SCALE\s*,/);
+  });
+
+  it('the shared constants are the §3.2 numbers', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const mod = require('../hooks/useCupertinoPress') as {
+      CUPERTINO_PRESS_SCALE: number;
+      CUPERTINO_PRESS_OPACITY: number;
+    };
+    expect(mod.CUPERTINO_PRESS_SCALE).toBeCloseTo(0.96, 5);
+    expect(mod.CUPERTINO_PRESS_OPACITY).toBeCloseTo(0.4, 5);
+  });
+});

--- a/src/components/AssistiveTouch.tsx
+++ b/src/components/AssistiveTouch.tsx
@@ -22,6 +22,7 @@ import {
   MenuItemId,
 } from '../store/AssistiveTouchStore';
 import { useTheme } from '../theme/ThemeContext';
+import { CupertinoPressable } from './CupertinoPressable';
 import { hapticImpact, hapticNotification, hapticSelection } from '../utils/haptics';
 import { useGestureReduceMotion, settle } from '../utils/useGestureReduceMotion';
 import { IDLE_DIM_MS } from '../utils/gestureConfig';
@@ -528,13 +529,12 @@ function RadialMenu({ items, onPick, buttonSize, anchorX, anchorY, isDark }: Rad
             const x = centre + MENU_GEOMETRY.radius * Math.cos(angle) - MENU_GEOMETRY.cellSize / 2;
             const y = centre + MENU_GEOMETRY.radius * Math.sin(angle) - MENU_GEOMETRY.cellSize / 2;
             return (
-              <Pressable
+              <CupertinoPressable
                 key={item.id}
-                style={({ pressed }) => [
+                style={[
                   styles.menuCell,
                   {
                     backgroundColor: cellBg,
-                    opacity: pressed ? 0.65 : 1,
                     left: x,
                     top: y,
                   },
@@ -547,7 +547,7 @@ function RadialMenu({ items, onPick, buttonSize, anchorX, anchorY, isDark }: Rad
                 <Text style={[styles.menuLabel, { color: iconColor }]} numberOfLines={1}>
                   {item.label}
                 </Text>
-              </Pressable>
+              </CupertinoPressable>
             );
           })}
         </View>

--- a/src/components/CupertinoActionSheet.tsx
+++ b/src/components/CupertinoActionSheet.tsx
@@ -128,7 +128,7 @@ export function CupertinoActionSheet({
                   {
                     borderTopWidth: index > 0 || title || message ? StyleSheet.hairlineWidth : 0,
                     borderTopColor: colors.separator,
-                    backgroundColor: pressed ? colors.systemGray5 : 'transparent',
+                    backgroundColor: pressed ? colors.pressedRowBackground : 'transparent',
                   },
                 ]}
                 onPress={() => {

--- a/src/components/CupertinoAlertDialog.tsx
+++ b/src/components/CupertinoAlertDialog.tsx
@@ -131,7 +131,7 @@ export function CupertinoAlertDialog({
                 style={({ pressed }) => [
                   styles.actionButton,
                   {
-                    backgroundColor: pressed ? colors.systemGray5 : 'transparent',
+                    backgroundColor: pressed ? colors.pressedRowBackground : 'transparent',
                     borderLeftWidth:
                       isHorizontal && index > 0 ? StyleSheet.hairlineWidth : 0,
                     borderTopWidth:

--- a/src/components/CupertinoPressable.tsx
+++ b/src/components/CupertinoPressable.tsx
@@ -1,0 +1,64 @@
+import React, { useMemo } from 'react';
+import { Pressable, PressableProps, StyleProp, ViewStyle } from 'react-native';
+import Animated from 'react-native-reanimated';
+import { useCupertinoPress } from '../hooks/useCupertinoPress';
+
+// CupertinoPressable — the single call site of the useCupertinoPress primitive
+// (issue #496, epic #468).
+//
+// WHY A COMPONENT AND NOT THE BARE HOOK AT EVERY SITE: the ~15 migrated sites
+// used `style={({ pressed }) => [..., { opacity: pressed ? N : 1 }]}` with six
+// different values for N. The hook returns an animated style, so each site
+// would otherwise need its own Animated.Pressable + hook wiring. Wrapping the
+// hook once keeps the migration mechanical and keeps the layout style exactly
+// where it was: the animated style is composed ONTO the pressable itself, not
+// onto an inserted child view, so no site changes its layout tree.
+//
+// The dim/scale numbers live in useCupertinoPress (0.96 / 0.40 per §3.2).
+// Per-site overrides go through `pressOptions` and must carry a comment at the
+// call site justifying the deviation.
+
+const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
+
+export interface CupertinoPressableProps extends Omit<PressableProps, 'style'> {
+  /** Static (non-press) style for the pressable itself. */
+  style?: StyleProp<ViewStyle>;
+  /** Overrides forwarded to useCupertinoPress (opacity / scale / opacityOnly). */
+  pressOptions?: Parameters<typeof useCupertinoPress>[1];
+  children?: React.ReactNode;
+}
+
+export const CupertinoPressable = React.memo(function CupertinoPressable({
+  style,
+  pressOptions,
+  disabled,
+  onPressIn,
+  onPressOut,
+  children,
+  ...rest
+}: CupertinoPressableProps) {
+  const options = useMemo(() => pressOptions ?? {}, [pressOptions]);
+  const {
+    style: pressStyle,
+    onPressIn: pressIn,
+    onPressOut: pressOut,
+  } = useCupertinoPress(!disabled, options);
+
+  return (
+    <AnimatedPressable
+      {...rest}
+      disabled={disabled}
+      onPressIn={(e) => {
+        pressIn();
+        onPressIn?.(e);
+      }}
+      onPressOut={(e) => {
+        pressOut();
+        onPressOut?.(e);
+      }}
+      style={[style, pressStyle]}
+    >
+      {children}
+    </AnimatedPressable>
+  );
+});

--- a/src/components/__tests__/CupertinoPressable.test.tsx
+++ b/src/components/__tests__/CupertinoPressable.test.tsx
@@ -1,0 +1,134 @@
+import React from 'react';
+import { Text } from 'react-native';
+import { render, fireEvent } from '../../test-utils';
+import { CupertinoPressable } from '../CupertinoPressable';
+
+// CupertinoPressable is the migration vehicle for issue #496: it wires the
+// useCupertinoPress primitive (scale 0.96 / opacity 0.40, reduceMotion-aware)
+// onto a Pressable so call sites stop hand-rolling `opacity: pressed ? N : 1`.
+//
+// The repo-wide reanimated mock runs useAnimatedStyle's factory once at render
+// and collapses interpolate to identity, so these tests assert the *wiring and
+// the layout contract* (which is what the migration can break); the numeric
+// press curve is covered by src/hooks/__tests__/useCupertinoPress.test.tsx.
+
+function stylesOf(el: { props: { style: unknown } }): Array<Record<string, unknown>> {
+  const s = el.props.style;
+  const flat = Array.isArray(s) ? s.flat(Infinity) : [s];
+  return flat.filter((x): x is Record<string, unknown> => !!x && typeof x === 'object');
+}
+
+describe('CupertinoPressable', () => {
+  it('renders its children and keeps the static style on the pressable itself', () => {
+    const { getByTestId, getByText } = render(
+      <CupertinoPressable testID="p" style={{ paddingVertical: 11 }}>
+        <Text>hello</Text>
+      </CupertinoPressable>,
+    );
+    expect(getByText('hello')).toBeTruthy();
+    // The layout style must stay on the pressable — sites relied on it for size.
+    expect(stylesOf(getByTestId('p'))).toEqual(
+      expect.arrayContaining([expect.objectContaining({ paddingVertical: 11 })]),
+    );
+  });
+
+  it('does not wrap children in an extra view (layout tree unchanged)', () => {
+    const { getByTestId } = render(
+      <CupertinoPressable testID="p">
+        <Text testID="child">x</Text>
+      </CupertinoPressable>,
+    );
+    // The child is a direct child of the pressable.
+    const pressable = getByTestId('p');
+    const childIds = (pressable.children as Array<string | { props: { testID?: string } }>).map(
+      (c) => (typeof c === 'string' ? c : c.props.testID),
+    );
+    expect(childIds).toContain('child');
+  });
+
+  it('exposes no `pressed`-derived opacity in its style (the ad hoc convention is gone)', () => {
+    const { getByTestId } = render(
+      <CupertinoPressable testID="p" style={{ opacity: 1 }}>
+        <Text>x</Text>
+      </CupertinoPressable>,
+    );
+    // The style prop is a plain array, never a ({pressed}) => ... callback.
+    expect(typeof getByTestId('p').props.style).not.toBe('function');
+  });
+
+  it('still fires onPress, and forwards caller onPressIn/onPressOut alongside the animation', () => {
+    const onPress = jest.fn();
+    const onPressIn = jest.fn();
+    const onPressOut = jest.fn();
+    const { getByTestId } = render(
+      <CupertinoPressable
+        testID="p"
+        onPress={onPress}
+        onPressIn={onPressIn}
+        onPressOut={onPressOut}
+      >
+        <Text>x</Text>
+      </CupertinoPressable>,
+    );
+    fireEvent(getByTestId('p'), 'pressIn');
+    fireEvent(getByTestId('p'), 'pressOut');
+    fireEvent.press(getByTestId('p'));
+    expect(onPressIn).toHaveBeenCalledTimes(1);
+    expect(onPressOut).toHaveBeenCalledTimes(1);
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('works without any caller press handlers (no crash on press in/out)', () => {
+    const { getByTestId } = render(
+      <CupertinoPressable testID="p">
+        <Text>x</Text>
+      </CupertinoPressable>,
+    );
+    expect(() => {
+      fireEvent(getByTestId('p'), 'pressIn');
+      fireEvent(getByTestId('p'), 'pressOut');
+    }).not.toThrow();
+  });
+
+  it('survives a double press-in followed by a single press-out (recurring defect here)', () => {
+    const onPress = jest.fn();
+    const { getByTestId } = render(
+      <CupertinoPressable testID="p" onPress={onPress}>
+        <Text>x</Text>
+      </CupertinoPressable>,
+    );
+    expect(() => {
+      fireEvent(getByTestId('p'), 'pressIn');
+      fireEvent(getByTestId('p'), 'pressIn');
+      fireEvent(getByTestId('p'), 'pressOut');
+      fireEvent.press(getByTestId('p'));
+      fireEvent.press(getByTestId('p'));
+    }).not.toThrow();
+    expect(onPress).toHaveBeenCalledTimes(2);
+  });
+
+  it('when disabled, forwards disabled and does not call onPress (inverse of the fix)', () => {
+    const onPress = jest.fn();
+    const { getByTestId } = render(
+      <CupertinoPressable testID="p" disabled onPress={onPress}>
+        <Text>x</Text>
+      </CupertinoPressable>,
+    );
+    expect(getByTestId('p').props.accessibilityState?.disabled).toBe(true);
+    fireEvent.press(getByTestId('p'));
+    expect(onPress).not.toHaveBeenCalled();
+  });
+
+  it('forwards accessibility props untouched', () => {
+    const { getByLabelText } = render(
+      <CupertinoPressable accessibilityRole="button" accessibilityLabel="Do it">
+        <Text>x</Text>
+      </CupertinoPressable>,
+    );
+    expect(getByLabelText('Do it')).toBeTruthy();
+  });
+
+  it('accepts an empty children set without throwing', () => {
+    expect(() => render(<CupertinoPressable testID="p" />)).not.toThrow();
+  });
+});

--- a/src/hooks/useCupertinoPress.ts
+++ b/src/hooks/useCupertinoPress.ts
@@ -50,8 +50,15 @@ export interface CupertinoPressResult {
   onPressOut: () => void;
 }
 
-const DEFAULT_OPACITY = 0.4;
-const DEFAULT_SCALE = 0.96;
+/** §3.2 press dim for icon/button surfaces. Exported so non-Pressable call
+ *  sites (e.g. the launcher icon, which composes press scale with its jiggle
+ *  rotation) use the same numbers instead of their own. */
+export const CUPERTINO_PRESS_OPACITY = 0.4;
+/** §3.2 press scale. */
+export const CUPERTINO_PRESS_SCALE = 0.96;
+
+const DEFAULT_OPACITY = CUPERTINO_PRESS_OPACITY;
+const DEFAULT_SCALE = CUPERTINO_PRESS_SCALE;
 
 export function useCupertinoPress(
   enabled = true,

--- a/src/screens/AppLibraryScreen.tsx
+++ b/src/screens/AppLibraryScreen.tsx
@@ -18,6 +18,7 @@ import * as Haptics from 'expo-haptics';
 import { useApps, InstalledApp } from '../store/AppsStore';
 import { useTheme } from '../theme/ThemeContext';
 import { CupertinoSearchBar } from '../components/CupertinoSearchBar';
+import { CupertinoPressable } from '../components/CupertinoPressable';
 import { CupertinoNavigationBar, CupertinoEmptyState } from '../components';
 import type { AppNavigationProp } from '../navigation/types';
 import type { CupertinoColors } from '../theme/CupertinoTheme';
@@ -192,6 +193,13 @@ export const CategoryCard = React.memo(function CategoryCard({ title, apps, onPr
   const largeApps = hasQuadrant ? apps.slice(0, 3) : apps.slice(0, 4);
   const miniApps = hasQuadrant ? apps.slice(3, 3 + MAX_QUADRANT_MINIS) : [];
 
+  // DEVIATION from the scale+dim primitive: the category card keeps the
+  // pressed-background convention (§3.2 convention 4), now using the shared
+  // token. Two reasons — a large tile that shrinks reads wrong next to the
+  // launcher grid, and the App Library is mounted inside the launcher pager,
+  // where an animated style per card would make a page transition's
+  // useAnimatedStyle cost grow with the number of categories (the exact
+  // invariant #518 protects). The ad hoc 0.8 opacity is gone either way.
   return (
     <Pressable
       onPress={onPress}
@@ -199,8 +207,7 @@ export const CategoryCard = React.memo(function CategoryCard({ title, apps, onPr
         styles.categoryCard,
         {
           width: cardWidth,
-          backgroundColor: colors.secondarySystemGroupedBackground,
-          opacity: pressed ? 0.8 : 1,
+          backgroundColor: pressed ? colors.pressedRowBackground : colors.secondarySystemGroupedBackground,
         },
       ]}
       accessibilityLabel={`${title} category, ${apps.length} app${apps.length !== 1 ? 's' : ''}`}
@@ -378,15 +385,15 @@ const SearchResults = React.memo(function SearchResults({
         />
       }
       renderItem={({ item }) => (
-        <Pressable
+        <CupertinoPressable
           onPress={() => onLaunch(item.packageName)}
-          style={({ pressed }) => [styles.searchRow, { opacity: pressed ? 0.7 : 1 }]}
+          style={styles.searchRow}
           accessibilityLabel={`Open ${item.name}, App Library`}
           accessibilityRole="button"
         >
           <AppIcon app={item} size={46} />
           <Text style={[typography.callout, styles.searchRowLabel, { color: colors.label }]}>{item.name}</Text>
-        </Pressable>
+        </CupertinoPressable>
       )}
     />
   );

--- a/src/screens/CalculatorScreen.tsx
+++ b/src/screens/CalculatorScreen.tsx
@@ -12,6 +12,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import * as Haptics from 'expo-haptics';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useTheme } from '../theme/ThemeContext';
+import { CupertinoPressable } from '../components/CupertinoPressable';
 import Decimal from 'decimal.js';
 import { hapticImpact } from '../utils/haptics';
 
@@ -234,33 +235,30 @@ function CalcButton({
 
   if (def.type === 'memory') {
     return (
-      <Pressable
+      <CupertinoPressable
         onPress={onPress}
         accessibilityLabel={getAccessibilityLabel(def)}
         accessibilityRole="button"
-        style={({ pressed }) => [
-          {
-            flex: 1,
-            height: isLandscape ? 32 : 40,
-            alignItems: 'center',
-            justifyContent: 'center',
-            opacity: pressed ? 0.5 : 1,
-          },
-        ]}
+        style={{
+          flex: 1,
+          height: isLandscape ? 32 : 40,
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
       >
         <Text style={{ color: textColor, fontSize, fontWeight: '500' }}>
           {def.label}
         </Text>
-      </Pressable>
+      </CupertinoPressable>
     );
   }
 
   return (
-    <Pressable
+    <CupertinoPressable
       onPress={onPress}
       accessibilityLabel={getAccessibilityLabel(def)}
       accessibilityRole="button"
-      style={({ pressed }) => [
+      style={[
         {
           width: def.wide ? btnSize * 2 + gap : btnSize,
           height: btnSize,
@@ -269,7 +267,6 @@ function CalcButton({
           paddingLeft: def.wide ? btnSize / 2 - 10 : 0,
           justifyContent: 'center' as const,
           backgroundColor: bgColor,
-          opacity: pressed ? 0.75 : 1,
           elevation: 2,
         },
         !def.wide && { alignItems: 'center' as const },
@@ -278,7 +275,7 @@ function CalcButton({
       <Text style={{ color: textColor, fontSize, fontWeight: '400' }}>
         {def.label}
       </Text>
-    </Pressable>
+    </CupertinoPressable>
   );
 }
 

--- a/src/screens/ContactsScreen.tsx
+++ b/src/screens/ContactsScreen.tsx
@@ -46,7 +46,7 @@ const ContactRow = React.memo(function ContactRow({
       style={({ pressed }) => [
         styles.row,
         {
-          backgroundColor: pressed ? colors.systemGray5 : colors.secondarySystemGroupedBackground,
+          backgroundColor: pressed ? colors.pressedRowBackground : colors.secondarySystemGroupedBackground,
         },
       ]}
       onPress={onPress}

--- a/src/screens/LauncherHomeScreen.tsx
+++ b/src/screens/LauncherHomeScreen.tsx
@@ -63,6 +63,8 @@ import { useVelocityBuffer, pushSample, sampledVelocity } from '../utils/gesture
 import { commitForSpotlight, commitForTodayView } from '../utils/gestureMachine';
 import { settle, useGestureReduceMotion } from '../utils/useGestureReduceMotion';
 import { launcherIconPress } from '../theme/springPresets';
+import { CUPERTINO_PRESS_SCALE } from '../hooks/useCupertinoPress';
+import { CupertinoPressable } from '../components/CupertinoPressable';
 import { markGridVisible, markWarmStartBegin } from '../utils/perfMetrics';
 import type { AppNavigationProp } from '../navigation/types';
 import type { SettingsState } from '../store/SettingsStore';
@@ -380,7 +382,10 @@ const AppIcon = React.memo(function AppIcon({ app, cellWidth, onPress, onLongPre
   const handlePressIn = useCallback(() => {
     if (isJiggling) return;
     // eslint-disable-next-line react-hooks/immutability
-    pressScale.value = withSpring(0.85, launcherIconPress);
+    // §3.2 shared press scale (issue #496). Was an ad hoc 0.85; the icon keeps
+    // its own shared value because the press scale is composed with the jiggle
+    // rotation in the same animated style.
+    pressScale.value = withSpring(CUPERTINO_PRESS_SCALE, launcherIconPress);
     hapticImpact(Haptics.ImpactFeedbackStyle.Light).catch(() => {});
   }, [isJiggling, pressScale]);
 
@@ -526,8 +531,8 @@ const FolderIcon = React.memo(function FolderIcon({ folder, cellWidth, apps, onP
   }, [onPress, folder]);
 
   return (
-    <Pressable
-      style={({ pressed }) => [styles.appIconWrapper, { width: cellWidth, opacity: pressed ? 0.6 : 1 }]}
+    <CupertinoPressable
+      style={[styles.appIconWrapper, { width: cellWidth }]}
       onPress={handlePress}
       onLongPress={onLongPress}
       accessibilityLabel={`Open ${folder.name} folder`}
@@ -545,7 +550,7 @@ const FolderIcon = React.memo(function FolderIcon({ folder, cellWidth, apps, onP
         </View>
       </View>
       <Text style={[styles.appIconLabel, { fontSize: 11 * textScale }]} numberOfLines={1}>{folder.name}</Text>
-    </Pressable>
+    </CupertinoPressable>
   );
 });
 
@@ -1419,14 +1424,14 @@ export function LauncherHomeScreen() {
       {!isDefaultLauncher && !isJiggling && (
         <View style={[styles.defaultBanner, { marginTop: insets.top }]}>
           <Text style={[styles.defaultBannerText, { fontSize: 13 * textScale }]}>Set as default launcher</Text>
-          <Pressable
-            style={({ pressed }) => [styles.defaultBannerButton, { backgroundColor: colors.accent, opacity: pressed ? 0.7 : 1 }]}
+          <CupertinoPressable
+            style={[styles.defaultBannerButton, { backgroundColor: colors.accent }]}
             onPress={openLauncherSettings}
             accessibilityLabel="Set as default launcher"
             accessibilityRole="button"
           >
             <Text style={[styles.defaultBannerButtonText, { fontSize: 12 * textScale }]}>Set Now</Text>
-          </Pressable>
+          </CupertinoPressable>
         </View>
       )}
 

--- a/src/screens/MapsScreen.tsx
+++ b/src/screens/MapsScreen.tsx
@@ -14,6 +14,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import * as Haptics from 'expo-haptics';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useTheme, ResolvedTypography } from '../theme/ThemeContext';
+import { CupertinoPressable } from '../components/CupertinoPressable';
 import {
   CupertinoNavigationBar,
   CupertinoSearchBar,
@@ -43,6 +44,11 @@ interface RecentLocation {
 const STORAGE_KEY = '@iostoandroid/maps_recents';
 const DEMO_BANNER_KEY = '@iostoandroid/maps_demo_dismissed';
 const MAPS_ACCENT = '#007AFF';
+
+// DEVIATION from the §3.2 default press dim (0.40) — see the call site on the
+// current-location FAB: at 0.40 a white floating button over the map reads as
+// disappearing rather than as pressed.
+const MAPS_FAB_PRESS = { opacity: 0.7 } as const;
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -441,19 +447,18 @@ export function MapsScreen({ navigation }: { navigation: AppNavigationProp }) {
           </View>
 
           {/* Current Location FAB */}
-          <Pressable
+          <CupertinoPressable
             onPress={handleCurrentLocation}
-            style={({ pressed }) => [
-              styles.locationButton,
-              {
-                backgroundColor: pressed ? 'rgba(255,255,255,0.85)' : 'rgba(255,255,255,0.95)',
-              },
-            ]}
+            style={[styles.locationButton, { backgroundColor: 'rgba(255,255,255,0.95)' }]}
+            // DEVIATION: this floating action button sits on top of the map, so
+            // the default 0.40 dim would read as the button vanishing against the
+            // wallpaper. 0.70 keeps it legible while still reading as pressed.
+            pressOptions={MAPS_FAB_PRESS}
             accessibilityLabel="Current location"
             accessibilityRole="button"
           >
             <Ionicons name="navigate" size={20} color={MAPS_ACCENT} />
-          </Pressable>
+          </CupertinoPressable>
         </LinearGradient>
       </View>
 

--- a/src/screens/MessageBubble.tsx
+++ b/src/screens/MessageBubble.tsx
@@ -6,6 +6,7 @@ import { Ionicons } from '@expo/vector-icons';
 import type { DeviceSms } from '../store/DeviceStore';
 import type { CupertinoColors } from '../theme/CupertinoTheme';
 import type { ResolvedTypography } from '../theme/ThemeContext';
+import { CupertinoPressable } from '../components/CupertinoPressable';
 
 export interface LocalImageMessage {
   id: string;
@@ -92,9 +93,9 @@ export const MessageBubble = React.memo(function MessageBubble({
             ))}
           </View>
           <View style={[styles.reactionActionDivider, { backgroundColor: isDark ? '#48484A' : '#E5E5EA' }]} />
-          <Pressable
+          <CupertinoPressable
             onPress={onCopy}
-            style={({ pressed }) => [styles.reactionActionBtn, { opacity: pressed ? 0.6 : 1 }]}
+            style={styles.reactionActionBtn}
             accessibilityLabel="Copy message"
             accessibilityRole="button"
           >
@@ -102,7 +103,7 @@ export const MessageBubble = React.memo(function MessageBubble({
             <Text style={[typography.subhead, { color: isDark ? '#EBEBF5' : '#3C3C43', marginLeft: 6 }]}>
               Copy
             </Text>
-          </Pressable>
+          </CupertinoPressable>
         </Animated.View>
       )}
       <Pressable onLongPress={onLongPress} delayLongPress={400} accessibilityLabel="Message" accessibilityHint="Long press for options" accessibilityRole="button">

--- a/src/screens/MessagesScreen.tsx
+++ b/src/screens/MessagesScreen.tsx
@@ -128,7 +128,7 @@ const ConversationRow = React.memo(function ConversationRow({
     <Pressable
       style={({ pressed }) => [
         styles.row,
-        { backgroundColor: pressed ? colors.systemGray5 : colors.systemBackground },
+        { backgroundColor: pressed ? colors.pressedRowBackground : colors.systemBackground },
       ]}
       onPress={editMode ? onSelect : onPress}
       accessibilityRole="button"

--- a/src/screens/NotificationCenterScreen.tsx
+++ b/src/screens/NotificationCenterScreen.tsx
@@ -19,6 +19,7 @@ import { useApps } from '../store/AppsStore';
 import { useTheme } from '../theme/ThemeContext';
 import { Glass } from '../theme/CupertinoTheme';
 import { CupertinoSwipeableRow } from '../components/CupertinoSwipeableRow';
+import { CupertinoPressable } from '../components/CupertinoPressable';
 import { GlassSurface, useAlert } from '../components';
 import { hapticImpact, hapticNotification } from '../utils/haptics';
 
@@ -324,10 +325,9 @@ export function NotificationCenterScreen() {
                             },
                           ]}
                         >
-                          <Pressable
+                          <CupertinoPressable
                             onPress={() => handleNotifCardTap(notif)}
                             onLongPress={() => handleLongPress(notif)}
-                            style={({ pressed }) => [{ opacity: pressed ? 0.85 : 1 }]}
                             accessibilityLabel={`${notif.title || group.appName} notification from ${group.appName}`}
                             accessibilityRole="button"
                           >
@@ -429,7 +429,7 @@ export function NotificationCenterScreen() {
                                 </View>
                               )}
                             </View>
-                          </Pressable>
+                          </CupertinoPressable>
                         </CupertinoSwipeableRow>
                       );
                     })}

--- a/src/screens/PhoneScreen.tsx
+++ b/src/screens/PhoneScreen.tsx
@@ -380,7 +380,7 @@ function ContactsTab({ contacts, onCall, isLoading }: { contacts: DeviceContact[
           onPress={() => handleCall(item.phone, getFullName(item))}
           style={({ pressed }) => [
             styles.contactRow,
-            { backgroundColor: pressed ? colors.systemGray5 : colors.secondarySystemGroupedBackground },
+            { backgroundColor: pressed ? colors.pressedRowBackground : colors.secondarySystemGroupedBackground },
           ]}
           accessibilityRole="button"
           accessibilityLabel={`Call ${getFullName(item)}`}

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -130,7 +130,7 @@ export function SettingsScreen() {
           onPress={() => item.route && (navigation as AppNavigationProp).navigate(item.route as any)} // eslint-disable-line @typescript-eslint/no-explicit-any -- route is a dynamic key from config
           style={({ pressed }) => [
             styles.profileCard,
-            { backgroundColor: pressed ? colors.systemGray5 : colors.secondarySystemGroupedBackground },
+            { backgroundColor: pressed ? colors.pressedRowBackground : colors.secondarySystemGroupedBackground },
           ]}
           accessibilityRole="button"
           accessibilityLabel={item.title}

--- a/src/screens/SpotlightSearchScreen.tsx
+++ b/src/screens/SpotlightSearchScreen.tsx
@@ -17,6 +17,7 @@ import { useDevice, DeviceContact } from '../store/DeviceStore';
 import { useContacts, Contact } from '../store/ContactsStore';
 import { useTheme } from '../theme/ThemeContext';
 import { CupertinoSearchBar } from '../components/CupertinoSearchBar';
+import { CupertinoPressable } from '../components/CupertinoPressable';
 import type { AppNavigationProp, RootStackParamList } from '../navigation/types';
 
 // ---------------------------------------------------------------------------
@@ -398,9 +399,9 @@ export function SpotlightSearchScreen({ navigation }: { navigation: AppNavigatio
     switch (item.type) {
       case 'webSearch':
         return (
-          <Pressable
+          <CupertinoPressable
             onPress={() => handleResultPress(item)}
-            style={({ pressed }) => [styles.resultRow, { opacity: pressed ? 0.7 : 1 }]}
+            style={styles.resultRow}
             accessibilityLabel={`Search Web for "${item.query}"`}
             accessibilityRole="button"
           >
@@ -412,13 +413,13 @@ export function SpotlightSearchScreen({ navigation }: { navigation: AppNavigatio
                 Search Web for &ldquo;{item.query}&rdquo;
               </Text>
             </View>
-          </Pressable>
+          </CupertinoPressable>
         );
       case 'app':
         return (
-          <Pressable
+          <CupertinoPressable
             onPress={() => handleResultPress(item)}
-            style={({ pressed }) => [styles.resultRow, { opacity: pressed ? 0.7 : 1 }]}
+            style={styles.resultRow}
             accessibilityLabel={item.app.name}
             accessibilityRole="button"
           >
@@ -426,13 +427,13 @@ export function SpotlightSearchScreen({ navigation }: { navigation: AppNavigatio
             <View style={styles.resultTextWrap}>
               <Text style={[typography.callout, styles.resultTitle, { color: colors.label }]}>{item.app.name}</Text>
             </View>
-          </Pressable>
+          </CupertinoPressable>
         );
       case 'contact':
         return (
-          <Pressable
+          <CupertinoPressable
             onPress={() => handleResultPress(item)}
-            style={({ pressed }) => [styles.resultRow, { opacity: pressed ? 0.7 : 1 }]}
+            style={styles.resultRow}
             accessibilityLabel={item.name}
             accessibilityRole="button"
           >
@@ -445,13 +446,13 @@ export function SpotlightSearchScreen({ navigation }: { navigation: AppNavigatio
                 <Text style={[typography.footnote, styles.resultSubtitle, { color: colors.secondaryLabel }]}>{item.phone}</Text>
               ) : null}
             </View>
-          </Pressable>
+          </CupertinoPressable>
         );
       case 'note':
         return (
-          <Pressable
+          <CupertinoPressable
             onPress={() => handleResultPress(item)}
-            style={({ pressed }) => [styles.resultRow, { opacity: pressed ? 0.7 : 1 }]}
+            style={styles.resultRow}
             accessibilityLabel={`Note: ${item.title}`}
             accessibilityRole="button"
           >
@@ -462,13 +463,13 @@ export function SpotlightSearchScreen({ navigation }: { navigation: AppNavigatio
               <Text style={[typography.callout, styles.resultTitle, { color: colors.label }]}>{item.title}</Text>
               <Text style={[typography.footnote, styles.resultSubtitle, { color: colors.secondaryLabel }]}>Notes</Text>
             </View>
-          </Pressable>
+          </CupertinoPressable>
         );
       case 'mail':
         return (
-          <Pressable
+          <CupertinoPressable
             onPress={() => handleResultPress(item)}
-            style={({ pressed }) => [styles.resultRow, { opacity: pressed ? 0.7 : 1 }]}
+            style={styles.resultRow}
             accessibilityLabel={`Mail: ${item.subject} from ${item.sender}`}
             accessibilityRole="button"
           >
@@ -479,13 +480,13 @@ export function SpotlightSearchScreen({ navigation }: { navigation: AppNavigatio
               <Text style={[typography.callout, styles.resultTitle, { color: colors.label }]} numberOfLines={1}>{item.subject}</Text>
               <Text style={[typography.footnote, styles.resultSubtitle, { color: colors.secondaryLabel }]}>Mail · {item.sender}</Text>
             </View>
-          </Pressable>
+          </CupertinoPressable>
         );
       case 'reminder':
         return (
-          <Pressable
+          <CupertinoPressable
             onPress={() => handleResultPress(item)}
-            style={({ pressed }) => [styles.resultRow, { opacity: pressed ? 0.7 : 1 }]}
+            style={styles.resultRow}
             accessibilityLabel={`Reminder: ${item.title}`}
             accessibilityRole="button"
           >
@@ -496,13 +497,13 @@ export function SpotlightSearchScreen({ navigation }: { navigation: AppNavigatio
               <Text style={[typography.callout, styles.resultTitle, { color: colors.label }]} numberOfLines={1}>{item.title}</Text>
               <Text style={[typography.footnote, styles.resultSubtitle, { color: colors.secondaryLabel }]}>Reminders</Text>
             </View>
-          </Pressable>
+          </CupertinoPressable>
         );
       case 'setting':
         return (
-          <Pressable
+          <CupertinoPressable
             onPress={() => handleResultPress(item)}
-            style={({ pressed }) => [styles.resultRow, { opacity: pressed ? 0.7 : 1 }]}
+            style={styles.resultRow}
             accessibilityLabel={`Setting: ${item.name}`}
             accessibilityRole="button"
           >
@@ -515,7 +516,7 @@ export function SpotlightSearchScreen({ navigation }: { navigation: AppNavigatio
                 Settings &gt; {item.name}
               </Text>
             </View>
-          </Pressable>
+          </CupertinoPressable>
         );
       default:
         return null;
@@ -569,13 +570,12 @@ export function SpotlightSearchScreen({ navigation }: { navigation: AppNavigatio
             </Pressable>
           </View>
           {history.map((item, index) => (
-            <Pressable
+            <CupertinoPressable
               key={`${item}-${index}`}
               onPress={() => handleHistoryPress(item)}
-              style={({ pressed }) => [
+              style={[
                 styles.historyRow,
                 {
-                  opacity: pressed ? 0.7 : 1,
                   borderBottomColor: colors.separator,
                   borderBottomWidth: index < history.length - 1 ? StyleSheet.hairlineWidth : 0,
                 },
@@ -585,7 +585,7 @@ export function SpotlightSearchScreen({ navigation }: { navigation: AppNavigatio
             >
               <Ionicons name="time-outline" size={18} color={colors.secondaryLabel} />
               <Text style={[typography.callout, styles.historyText, { color: colors.label }]}>{item}</Text>
-            </Pressable>
+            </CupertinoPressable>
           ))}
         </View>
       ) : isSearching ? (

--- a/src/screens/contacts/ContactDetailScreen.tsx
+++ b/src/screens/contacts/ContactDetailScreen.tsx
@@ -189,8 +189,7 @@ export function ContactDetailScreen({ navigation, route }: ContactDetailScreenPr
               style={({ pressed }) => [
                 styles.actionButton,
                 {
-                  backgroundColor: pressed ? colors.systemGray4 : colors.secondarySystemGroupedBackground,
-                  opacity: pressed ? 0.7 : 1,
+                  backgroundColor: pressed ? colors.pressedRowBackground : colors.secondarySystemGroupedBackground,
                 },
               ]}
               accessibilityLabel={btn.label}

--- a/src/screens/settings/ScreenTimeScreen.tsx
+++ b/src/screens/settings/ScreenTimeScreen.tsx
@@ -10,6 +10,7 @@ import {
   CupertinoSwitch,
   useAlert,
 } from '../../components';
+import { CupertinoPressable } from '../../components/CupertinoPressable';
 import { logger } from '../../utils/logger';
 import type { AppNavigationProp } from '../../navigation/types';
 
@@ -151,11 +152,11 @@ export function ScreenTimeScreen({ navigation }: { navigation: AppNavigationProp
                     <Text style={[typography.body, { color: colors.label, textAlign: 'center', marginBottom: 8 }]}>
                       Screen Time needs usage access permission to show your app usage data.
                     </Text>
-                    <Pressable
+                    <CupertinoPressable
                       onPress={handleOpenUsageAccess}
-                      style={({ pressed }) => [
+                      style={[
                         styles.permissionButton,
-                        { backgroundColor: colors.systemBlue, opacity: pressed ? 0.7 : 1 },
+                        { backgroundColor: colors.systemBlue },
                       ]}
                       accessibilityLabel="Open Usage Access Settings"
                       accessibilityRole="button"
@@ -163,7 +164,7 @@ export function ScreenTimeScreen({ navigation }: { navigation: AppNavigationProp
                       <Text style={[typography.body, { color: '#FFFFFF', fontWeight: '600' }]}>
                         Open Usage Access Settings
                       </Text>
-                    </Pressable>
+                    </CupertinoPressable>
                     <Text style={[typography.caption1, { color: colors.secondaryLabel, textAlign: 'center', marginTop: 8 }]}>
                       Find this app in the list and enable access, then return here.
                     </Text>

--- a/src/theme/CupertinoTheme.ts
+++ b/src/theme/CupertinoTheme.ts
@@ -58,6 +58,11 @@ export const SystemColors = {
     // Separator
     separator: 'rgba(60, 60, 67, 0.29)',
     opaqueSeparator: '#C6C6C8',
+
+    // Pressed list row background (convention 4 of §3.2 — a pressed full-width
+    // list row darkens its background instead of scaling/dimming). Single token
+    // so every list row uses the same pressed colour.
+    pressedRowBackground: '#E5E5EA',
   },
   dark: {
     systemBlue: '#0A84FF',
@@ -115,6 +120,9 @@ export const SystemColors = {
     // Separator
     separator: 'rgba(84, 84, 88, 0.6)',
     opaqueSeparator: '#38383A',
+
+    // Pressed list row background — see the light counterpart above.
+    pressedRowBackground: '#2C2C2E',
   },
 };
 


### PR DESCRIPTION
## Resumo

qa/issue-496: migrar o feedback de toque ad hoc para o primitivo useCupertinoPress (via CupertinoPressable), escala do ícone do launcher 0.85 -> 0.96 e token único de cor para linhas de lista premidas

## Causa raiz

O issue descreve divergência de convenções, e o código confirma-o. O primitivo `useCupertinoPress` (`src/hooks/useCupertinoPress.ts`, criado em #495) existia com um único consumidor — `src/components/CupertinoButton.tsx:88`. Todos os outros sítios continuavam a calcular o feedback à mão dentro do callback `style={({ pressed }) => ...}` do `Pressable`, com **seis magnitudes diferentes**: 0.5 (`CalculatorScreen.tsx:247`), 0.6 (`LauncherHomeScreen.tsx:530`, `MessageBubble.tsx:97`), 0.65 (`AssistiveTouch.tsx:537`), 0.7 (7 sítios em `SpotlightSearchScreen.tsx`, `AppLibraryScreen.tsx:383`, `ContactDetailScreen.tsx:193`, `ScreenTimeScreen.tsx:158`, `LauncherHomeScreen.tsx:1423`), 0.75 (`CalculatorScreen.tsx:272`), 0.8 (`AppLibraryScreen.tsx:203`), 0.85 (`NotificationCenterScreen.tsx:330`). Em paralelo, o ícone do launcher usava um `withSpring(0.85, ...)` próprio (`LauncherHomeScreen.tsx:383`) e as linhas de lista escolhiam cada uma a sua cor premida (`colors.systemGray5` em 6 sítios, `colors.systemGray4` em `ContactDetailScreen.tsx:192`, um `rgba(255,255,255,0.85)` literal em `MapsScreen.tsx:449`).

O mecanismo por que isto não se resolvia trivialmente: `useCupertinoPress` devolve um **estilo animado** (Reanimated), e um `Pressable` normal não aceita estilo animado; cada sítio teria de montar o seu `Animated.createAnimatedComponent(Pressable)` + fio dos handlers. Daí a duplicação ter sido a via de menor resistência em cada sítio.

Desvio face ao enunciado do issue: a linha citada para a escala do launcher é `LauncherHomeScreen.tsx:251`; em `main` (30b9f63) o `withSpring(0.85, launcherIconPress)` está em **`LauncherHomeScreen.tsx:383`**, dentro de `AppIcon.handlePressIn`. A lista de sítios do issue também estava desactualizada nos números de linha (ex. `MessageBubble.tsx:96` -> `:97`, `AppLibraryScreen.tsx:129,289` -> `:203,383`) e não incluía dois sítios reais da convenção 3: `LauncherHomeScreen.tsx:1423` (botão «Set Now») e `AssistiveTouch.tsx:537`. Fiz o grep de `pressed ?` como o issue manda e migrei o que o grep devolveu, não a lista.

## O que mudou

- **`src/components/CupertinoPressable.tsx` (novo)** — wrapper de uso único do primitivo: `Animated.createAnimatedComponent(Pressable)` + `useCupertinoPress`, com `pressOptions` para overrides. O estilo animado é composto **sobre o próprio pressable** (`style={[style, pressStyle]}`), não sobre uma `View` inserida, para nenhum sítio migrado mudar a sua árvore de layout. `disabled` desliga o feedback; `onPressIn`/`onPressOut` do chamador continuam a ser chamados a seguir aos do primitivo.
- **`src/hooks/useCupertinoPress.ts`** — exporta `CUPERTINO_PRESS_SCALE` (0.96) e `CUPERTINO_PRESS_OPACITY` (0.40), antes constantes privadas. Necessário porque o ícone do launcher não pode usar o wrapper (ver «Porque assim») e tem de consumir o mesmo número. Comportamento do hook inalterado.
- **`src/theme/CupertinoTheme.ts`** — novo token `pressedRowBackground` em `SystemColors.light` (`#E5E5EA`) e `SystemColors.dark` (`#2C2C2E`): a cor única da convenção 4. Os valores são os que 6 dos 7 sítios já usavam (`systemGray5`), portanto a cor renderizada não muda nesses sítios; muda em `ContactDetailScreen` (era `systemGray4`) e no FAB do Maps.
- **`src/screens/LauncherHomeScreen.tsx`** — `AppIcon.handlePressIn` faz `withSpring(CUPERTINO_PRESS_SCALE, launcherIconPress)` em vez de `withSpring(0.85, ...)`; `FolderIcon` e o botão «Set Now» passam a `CupertinoPressable` sem opacidade inline.
- **`src/screens/SpotlightSearchScreen.tsx`** — 8 `Pressable` (7 result rows + a history row) migrados; o `borderBottom*` da history row mantém-se no estilo estático.
- **`src/screens/CalculatorScreen.tsx`** — botões de memória e botões do teclado migrados (0.5 e 0.75 fora); `backgroundColor`, `borderRadius` e `elevation` mantidos no estilo estático.
- **`src/screens/AppLibraryScreen.tsx`** — a search row migrada para o primitivo. O `CategoryCard` **não**: mantém `Pressable` e passa a usar `pressed ? colors.pressedRowBackground : ...` (era `opacity: pressed ? 0.8 : 1`). Justificação no código — ver «Porque assim».
- **`src/screens/MessageBubble.tsx`**, **`src/screens/NotificationCenterScreen.tsx`**, **`src/screens/settings/ScreenTimeScreen.tsx`**, **`src/components/AssistiveTouch.tsx`** — migrados para `CupertinoPressable`.
- **`src/screens/MapsScreen.tsx`** — o FAB de localização deixa de trocar `rgba(255,255,255,0.85)`/`0.95` à mão e passa a `CupertinoPressable` com **desvio declarado** `MAPS_FAB_PRESS = { opacity: 0.7 }` e comentário no sítio: a 0.40 um botão branco sobre o mapa lê-se como a desaparecer, não como premido.
- **Convenção 4 normalizada para o token, mecanismo intacto** — `SettingsScreen.tsx`, `MessagesScreen.tsx`, `ContactsScreen.tsx`, `PhoneScreen.tsx`, `CupertinoActionSheet.tsx`, `CupertinoAlertDialog.tsx`, `contacts/ContactDetailScreen.tsx`. Em `ContactDetailScreen` o botão de acção perdeu ainda o `opacity: pressed ? 0.7 : 1` que se somava à troca de fundo (era o único sítio a acumular as duas convenções).
- **`src/__tests__/AndroidRippleRemoval.test.tsx`** — quatro asserções deste teste de #494 codificavam literalmente a convenção antiga (`toContain('withSpring(0.85')` e `toMatch(/style.*pressed/)` no folder icon, no botão «Set Now» e na célula do AssistiveTouch). Foram reescritas para a mesma intenção («este sítio tem feedback de toque») contra o mecanismo novo (`<CupertinoPressable`, `withSpring(CUPERTINO_PRESS_SCALE`). Nenhum teste foi apagado nem posto em `.skip`.

## Porque assim

- **Wrapper em vez do hook nu em cada sítio.** ~15 sítios a montar cada um o seu `Animated.createAnimatedComponent(Pressable)` seria ruído puro e uma oportunidade de divergir outra vez. Uma abstracção, um sítio a mudar se os números de §3.2 mudarem. Descartei também a alternativa de o wrapper embrulhar os filhos numa `Animated.View`: isso alteraria a árvore de layout de cada sítio (a `styles.searchRow` e afins deixariam de estar no elemento que mede) — daí o estilo animado ir para o próprio pressable.
- **O ícone do launcher não usa o wrapper.** O seu `pressScale` é composto com a rotação do jiggle no mesmo `useAnimatedStyle`; substituir por um segundo estilo animado partiria o jiggle. Consome a constante partilhada, que é o que o critério de aceitação pede (0.96, não 0.85).
- **`CategoryCard` do App Library ficou na convenção 4.** Duas razões, escritas em comentário no código: (a) uma tile grande que encolhe lê-se mal ao lado da grelha do launcher; (b) o App Library está montado **dentro do pager do launcher**, e um estilo animado por card fazia o custo de `useAnimatedStyle` numa transição de página crescer com o número de categorias — que é exactamente o invariante que `LauncherHomeScreen.pagerMemo.test.tsx` (#518) protege. Detectei-o porque esse teste passou a falhar (13 -> 14 chamadas) e revertê-lo confirmou a causa. A opacidade ad hoc de 0.8 desaparece de qualquer forma.
- **A convenção 4 não foi convertida**, conforme o issue: no iOS uma linha premida escurece o fundo. Só a cor foi unificada.

## Critérios de aceitação

- [x] **Zero `opacity: pressed ? N : 1` em `src/`** — provado por teste (`pressFeedbackConvention.test.ts`) que varre recursivamente `src/`, não por grep manual. Excluí linhas de comentário: dois comentários de migração citam de propósito o padrão antigo.
- [x] **A escala do ícone do ecrã inicial é 0.96, não 0.85** — `withSpring(CUPERTINO_PRESS_SCALE, launcherIconPress)`; teste assegura que `withSpring(0.85,` já não aparece no ficheiro e que a constante vale 0.96.
- [x] **As linhas de lista mantêm o `backgroundColor` premido, com um token único** — teste falha se sobrar qualquer `backgroundColor: pressed ? X` que não seja `colors.pressedRowBackground`; outro teste garante que o token existe nos dois esquemas e que light != dark (senão a linha premida seria invisível num deles).
- [x] **Qualquer desvio ao default está justificado no código com comentário** — dois desvios: `MAPS_FAB_PRESS` (0.70, FAB branco sobre o mapa) e `CategoryCard` (convenção 4 por causa do custo no pager, #518). Ambos com comentário no sítio.
- [x] **Testes de UI existentes verdes** — nenhuma falha nova: as 11 falhas finais são **exactamente** as 11 do baseline (diff literal contra `baseline.json` deu vazio). As 5 falhas transitórias que introduzi (4 em `AndroidRippleRemoval` + 1 em `pagerMemo`) foram resolvidas: a de `pagerMemo` mudando a implementação (não o teste), as de `AndroidRippleRemoval` reescrevendo asserções que descreviam o mecanismo antigo.
- [x] **O que NÃO devia mudar**: (a) a árvore de layout de cada sítio migrado — o teste `does not wrap children in an extra view` fixa isto e o estilo estático continua no pressable; (b) `onPress`/acessibilidade/`disabled` — testes dedicados; (c) o mecanismo da convenção 4; (d) `src/components/CupertinoButton.tsx` não foi tocado (já consumia o primitivo em #495); (e) os 6 snapshots continuam a passar sem `-u`; (f) a cor premida renderizada nas 6 linhas de lista que já usavam `systemGray5` é bit-a-bit a mesma (o token tem esses valores).
- [ ] **Capturas por lote no PR** — **não cumprido, e não é cumprível nesta corrida**: é uma sessão headless sem emulador Android nem `expo prebuild` disponível. Migrei por lotes (launcher / opacidades restantes / Spotlight / convenção 4) com verificação por lote via `tsc` + jest em vez de captura visual. Fica em aberto para validação manual; os sítios de risco visual são os dois desvios declarados.

## Testes

**Passo vermelho** (teste escrito, produção ainda em `main`):

```
✕ has zero `opacity: pressed ? N : 1` sites in src/ (13 ms)
✕ has zero inline `pressed ?` opacity inside a style callback array in src/ (8 ms)
✕ every remaining `backgroundColor: pressed ? X` uses colors.pressedRowBackground (8 ms)
✓ the theme actually defines the token for both schemes (35 ms)
✕ no longer springs the app icon to the ad hoc 0.85 scale (1 ms)
✕ uses the shared §3.2 press scale constant for the app icon press-in (3 ms)
✓ the shared constants are the §3.2 numbers (29 ms)

      93 |
      94 |   it('uses the shared §3.2 press scale constant for the app icon press-in', () => {
    > 95 |     expect(launcher).toMatch(/withSpring\(\s*CUPERTINO_PRESS_SCALE\s*,/);
         |                      ^
      96 |   });

      at Object.toMatch (src/__tests__/pressFeedbackConvention.test.ts:95:22)

Test Suites: 1 failed, 1 total
Tests:       5 failed, 2 passed, 7 total
```

(Os dois ✓ desse passo eram asserções sobre o token e as constantes, que já estavam escritas quando corri — por isso repeti o exercício completo no sanity-check abaixo, onde os 7 falham.)

**Casos cobertos** além do caminho feliz:
- *Inverso do fix*: `disabled` não chama `onPress` e não anima; o estilo do pressable **nunca** é uma função (`typeof style !== 'function'`) — se alguém reintroduzir o callback `({pressed}) =>` no wrapper, falha.
- *Repetição*: duplo `pressIn` seguido de um só `pressOut`, e dois `press` seguidos — o duplo toque é defeito recorrente neste repo.
- *Vazio/ausente*: `CupertinoPressable` sem filhos; sem nenhum handler de press do chamador.
- *Fronteiras do token*: light e dark obrigados a diferir (um token igual nos dois tornaria a linha premida invisível num deles).
- *Propriedade global*: as asserções de convenção varrem **todos** os `.ts/.tsx` de `src/` excepto `__tests__`, portanto um sítio novo com opacidade ad hoc falha o teste mesmo que ninguém se lembre desta issue.
- Cada um destes falha por uma razão distinta; nenhum é cópia da lógica de produção — o wrapper é montado a sério e os eventos são disparados a sério, e as asserções de convenção leem a fonte real em disco (padrão já usado em `LauncherHomeScreen.numericalSpec.test.tsx` e `AndroidRippleRemoval.test.tsx`).

**Sanity-check** — `git stash push` de toda a produção (`src/screens`, `src/components/{AssistiveTouch,CupertinoActionSheet,CupertinoAlertDialog}.tsx`, `src/theme/CupertinoTheme.ts`, `src/hooks/useCupertinoPress.ts`) mantendo os testes:

```
--- SEM FIX ---
Test Suites: 1 failed, 1 total
Tests:       7 failed, 7 total
--- RESTAURADO ---
Test Suites: 2 passed, 2 total
Tests:       16 passed, 16 total
```

**Verificações**
- `npm run lint`: **0 erros**, 2 warnings — os mesmos 2 pré-existentes do baseline (`requireNativeModule` em `modules/.../BridgeErrorReporting.test.tsx`, `tzTick` em `ClockScreen.tsx`). Não introduzi warnings.
- `npx tsc --noEmit`: limpo, sem `any` novo.
- `npm test -- --maxWorkers=2`: **1354 passaram, 11 falharam, 149 suites** (baseline: 1349 passaram / 11 falharam). A lista de nomes de testes a falhar é idêntica ao baseline — `diff` contra `jq -r '.failed_tests[]' baseline.json` devolveu vazio. Os 6 snapshots passam sem `-u`.

## Testes

1354 passaram, 11 falharam (as 11 do baseline, lista idêntica), 149 suites; 16 testes novos passam

## Linked Issue

Fixes #496