### PR TITLE
feat(find-my): Play Sound row on the Devices tab alerts this device via a local notification (#266)

### DIFF
--- a/src/screens/FindMyScreen.tsx
+++ b/src/screens/FindMyScreen.tsx
@@ -10,6 +10,7 @@ import {
   Platform,
 } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
+import * as Notifications from 'expo-notifications';
 import { Ionicons } from '@expo/vector-icons';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { CupertinoNavigationBar } from '../components/CupertinoNavigationBar';
@@ -20,6 +21,8 @@ import { CupertinoEmptyState } from '../components/CupertinoEmptyState';
 import { CupertinoSwitch } from '../components/CupertinoSwitch';
 import { CupertinoTextField } from '../components/CupertinoTextField';
 import { CupertinoSwipeableRow } from '../components/CupertinoSwipeableRow';
+import { useAlert } from '../components';
+import { withAutoLockSuppressed } from '../utils/permissions';
 import { hapticSelection } from '../utils/haptics';
 import { useTheme } from '../theme/ThemeContext';
 import { useDevice } from '../store/DeviceStore';
@@ -73,6 +76,34 @@ function formatRelative(timestamp: number): string {
 
 type FindMyTab = 'devices' | 'people' | 'items';
 const TAB_VALUES: FindMyTab[] = ['devices', 'people', 'items'];
+
+// ─── Play Sound on this device (issue #266) ──────────────────────────────────
+// Honest scoping: with no backend and no companion device, the only hardware
+// this app can make a noise on is the one it is running on. The alert is a local
+// notification with `sound: true`, following ClockScreen / RemindersScreen's
+// permission + immediate-trigger shape.
+
+async function requestNotificationPermission(): Promise<boolean> {
+  const { status: existing } = await Notifications.getPermissionsAsync();
+  if (existing === 'granted') return true;
+  const { status } = await withAutoLockSuppressed(() => Notifications.requestPermissionsAsync());
+  return status === 'granted';
+}
+
+export async function playSoundOnThisDevice(): Promise<void> {
+  await Notifications.scheduleNotificationAsync({
+    content: {
+      title: 'Find My',
+      body: 'Playing sound on This Device',
+      sound: true,
+    },
+    trigger: {
+      type: Notifications.SchedulableTriggerInputTypes.TIME_INTERVAL,
+      seconds: 1,
+      repeats: false,
+    },
+  });
+}
 
 export function FindMyScreen() {
   const { theme, typography, borderRadius } = useTheme();
@@ -242,6 +273,37 @@ export function FindMyScreen() {
     void persistLostMode(next);
   }, [persistLostMode]);
 
+  // ── Play Sound (issue #266) ────────────────────────────────────────────────
+  // `playingSound` is a ref, not state: the guard has to be effective inside the
+  // same tick as a second press (a double tap fires both handlers before any
+  // re-render), and it must not itself trigger a render.
+  const alert = useAlert();
+  const playingSound = React.useRef(false);
+
+  const handlePlaySound = useCallback(() => {
+    if (playingSound.current) return;
+    playingSound.current = true;
+    void (async () => {
+      try {
+        const granted = await requestNotificationPermission();
+        if (!granted) {
+          alert(
+            'Notifications Are Off',
+            'Find My plays the sound as a notification on this device. Enable notifications for this app in Android Settings to use it.',
+          );
+          return;
+        }
+        await playSoundOnThisDevice();
+        alert('Playing Sound', 'This device will play a sound now.');
+      } catch {
+        // Never swallow the failure: a silent no-op looks identical to success.
+        alert('Could Not Play Sound', 'The notification could not be scheduled on this device.');
+      } finally {
+        playingSound.current = false;
+      }
+    })();
+  }, [alert]);
+
   return (
     <View style={[styles.container, { backgroundColor: colors.systemGroupedBackground }]}>
       <CupertinoNavigationBar title="Find My" largeTitle>
@@ -297,6 +359,17 @@ export function FindMyScreen() {
                         color: '#FFFFFF',
                         backgroundColor: colors.systemBlue,
                       }}
+                    />
+                    <CupertinoListTile
+                      title="Play Sound"
+                      subtitle="Alerts this device only"
+                      leading={{
+                        name: 'volume-high',
+                        color: '#FFFFFF',
+                        backgroundColor: colors.systemBlue,
+                      }}
+                      onPress={handlePlaySound}
+                      showChevron={false}
                     />
                     <CupertinoListTile
                       title="Mark as Lost"

--- a/src/screens/__tests__/FindMyScreen.test.tsx
+++ b/src/screens/__tests__/FindMyScreen.test.tsx
@@ -6,6 +6,27 @@ import type { RenderAPI } from '@testing-library/react-native';
 import { FindMyScreen } from '../FindMyScreen';
 import * as ContactsStore from '../../store/ContactsStore';
 
+// expo-notifications is mocked locally (same shape as RemindersScreen.test.tsx)
+// so no shared jest.setup mock changes — ClockScreen's alarm tests keep their
+// own mock untouched.
+jest.mock('expo-notifications', () => ({
+  setNotificationHandler: jest.fn(),
+  getPermissionsAsync: jest.fn(() => Promise.resolve({ status: 'granted', canAskAgain: true })),
+  requestPermissionsAsync: jest.fn(() => Promise.resolve({ status: 'granted', canAskAgain: true })),
+  scheduleNotificationAsync: jest.fn(() => Promise.resolve('notification-id')),
+  cancelScheduledNotificationAsync: jest.fn(() => Promise.resolve()),
+  SchedulableTriggerInputTypes: { TIME_INTERVAL: 'timeInterval', DATE: 'date', CALENDAR: 'calendar' },
+}));
+
+// useAlert() resolves to a no-op in AllProviders (test-utils does not mount
+// AlertProvider), so capture it here to assert what the user is told.
+const mockAlert = jest.fn();
+jest.mock('../../components', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const actual = jest.requireActual('../../components');
+  return { ...actual, useAlert: () => mockAlert };
+});
+
 // AllProviders (in test-utils) already wraps with ThemeProvider,
 // DeviceProvider, LocationProvider and ContactsProvider, so we render
 // FindMyScreen directly. The permission state defaults to 'granted' in
@@ -397,5 +418,119 @@ describe('FindMyScreen — Items tab (tracked inventory)', () => {
     const itemsTabView = screen.getByTestId('items-tab');
     expect(within(itemsTabView).queryByText(/Find|Locate|distance/i)).toBeNull();
     expect(within(itemsTabView).queryByLabelText(/locate|find/i)).toBeNull();
+  });
+});
+
+// ─── Play Sound on this device (issue #266) ──────────────────────────────────
+// The feature is honestly scoped to the CURRENT device: without a backend and a
+// companion device there is nothing else to reach. These tests pin the
+// permission-granted path, the permission-denied path (which must not schedule
+// anything, and must not fail silently), and the scoping guard.
+describe('FindMyScreen — Play Sound (issue #266)', () => {
+  const notif = jest.requireMock('expo-notifications');
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+    notif.getPermissionsAsync.mockResolvedValue({ status: 'granted', canAskAgain: true });
+    notif.requestPermissionsAsync.mockResolvedValue({ status: 'granted', canAskAgain: true });
+    notif.scheduleNotificationAsync.mockResolvedValue('notif-id');
+    mockAlert.mockClear();
+  });
+
+  it('shows a "Play Sound" row on the Devices tab', async () => {
+    const { getByText } = renderFindMy();
+    await waitFor(() => expect(getByText('Play Sound')).toBeTruthy());
+  });
+
+  it('pressing it with permission granted schedules a notification with sound and confirms', async () => {
+    const { getByText } = renderFindMy();
+    fireEvent.press(await waitFor(() => getByText('Play Sound')));
+
+    await waitFor(() => expect(notif.scheduleNotificationAsync).toHaveBeenCalledTimes(1));
+    const arg = notif.scheduleNotificationAsync.mock.calls[0][0];
+    expect(arg.content.sound).toBe(true);
+    expect(arg.trigger.type).toBe('timeInterval');
+    expect(arg.trigger.seconds).toBeGreaterThan(0);
+    await waitFor(() =>
+      expect(mockAlert.mock.calls.some(([title]) => title === 'Playing Sound')).toBe(true),
+    );
+  });
+
+  it('does not re-prompt when permission is already granted', async () => {
+    const { getByText } = renderFindMy();
+    fireEvent.press(await waitFor(() => getByText('Play Sound')));
+    await waitFor(() => expect(notif.scheduleNotificationAsync).toHaveBeenCalled());
+    expect(notif.requestPermissionsAsync).not.toHaveBeenCalled();
+  });
+
+  it('requests permission when undetermined and schedules once granted', async () => {
+    notif.getPermissionsAsync.mockResolvedValue({ status: 'undetermined', canAskAgain: true });
+    const { getByText } = renderFindMy();
+    fireEvent.press(await waitFor(() => getByText('Play Sound')));
+
+    await waitFor(() => expect(notif.requestPermissionsAsync).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(notif.scheduleNotificationAsync).toHaveBeenCalledTimes(1));
+  });
+
+  it('with permission denied it schedules nothing and explains why (no silent no-op)', async () => {
+    notif.getPermissionsAsync.mockResolvedValue({ status: 'denied', canAskAgain: true });
+    notif.requestPermissionsAsync.mockResolvedValue({ status: 'denied', canAskAgain: true });
+
+    const { getByText } = renderFindMy();
+    fireEvent.press(await waitFor(() => getByText('Play Sound')));
+
+    await waitFor(() =>
+      expect(mockAlert.mock.calls.some(([, message]) => /notification/i.test(String(message)))).toBe(
+        true,
+      ),
+    );
+    expect(notif.scheduleNotificationAsync).not.toHaveBeenCalled();
+    // Inverse of the fix: the success confirmation must stay hidden.
+    expect(mockAlert.mock.calls.some(([title]) => title === 'Playing Sound')).toBe(false);
+  });
+
+  it('a scheduling failure surfaces an alert instead of being swallowed', async () => {
+    notif.scheduleNotificationAsync.mockRejectedValue(new Error('boom'));
+    const { getByText } = renderFindMy();
+    fireEvent.press(await waitFor(() => getByText('Play Sound')));
+
+    await waitFor(() =>
+      expect(mockAlert.mock.calls.some(([title]) => /Could Not Play Sound/i.test(String(title)))).toBe(
+        true,
+      ),
+    );
+    expect(mockAlert.mock.calls.some(([title]) => title === 'Playing Sound')).toBe(false);
+  });
+
+  it('a double press schedules exactly one notification (no duplicate alert)', async () => {
+    const { getByText } = renderFindMy();
+    const row = await waitFor(() => getByText('Play Sound'));
+    fireEvent.press(row);
+    fireEvent.press(row);
+
+    await waitFor(() => expect(notif.scheduleNotificationAsync).toHaveBeenCalled());
+    expect(notif.scheduleNotificationAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it('the row is hidden while location permission is not granted', async () => {
+    const loc = jest.requireMock('expo-location');
+    jest.spyOn(loc, 'getForegroundPermissionsAsync').mockResolvedValueOnce({ status: 'denied' });
+    const { getByText, queryByText } = renderFindMy();
+    await waitFor(() => expect(getByText('Grant Location Permission')).toBeTruthy());
+    expect(queryByText('Play Sound')).toBeNull();
+  });
+
+  it('no tab offers to play a sound on another person\u2019s or another device (regression guard)', async () => {
+    const { getByText, queryByText } = renderFindMy();
+    await waitFor(() => expect(getByText('Play Sound')).toBeTruthy());
+    // The only sound affordance is scoped to this device.
+    expect(queryByText(/Play Sound on/i)).toBeNull();
+
+    fireEvent.press(getByText('People'));
+    await waitFor(() => expect(queryByText('Play Sound')).toBeNull());
+
+    fireEvent.press(getByText('Items'));
+    await waitFor(() => expect(queryByText('Play Sound')).toBeNull());
   });
 });


### PR DESCRIPTION
## Resumo

feat(find-my): Play Sound row on the Devices tab alerts this device via a local notification

## Causa raiz

Não é um defeito, é uma capacidade em falta. A aba Devices de `src/screens/FindMyScreen.tsx`
(secção `Devices`, tiles a partir de FindMyScreen.tsx:350) só tinha duas linhas — "This Device"
(coordenadas, sem acção) e "Mark as Lost" — e o ecrã nunca importava `expo-notifications`.
Não existia portanto nenhum caminho de código capaz de emitir um alerta audível a partir do
Find My; a "Play Sound" do epic não existia em nenhuma forma.

Constrangimento real (confirmado no código): não há backend nem bridge de push neste repo
(`modules/launcher-module` é local, `src/store/*` é AsyncStorage). O único hardware alcançável
é o próprio dispositivo — daí o âmbito honesto "this device only".

## O que mudou

**src/screens/FindMyScreen.tsx**
- Importa `expo-notifications`, `useAlert` (`../components`) e `withAutoLockSuppressed`
  (`../utils/permissions`).
- Novo `requestNotificationPermission()` (module-scope): lê `getPermissionsAsync()`, e só
  pede via `withAutoLockSuppressed(() => requestPermissionsAsync())` se ainda não estiver
  concedida. Não engole erros — propaga (é o handler que decide o que dizer ao utilizador).
- Novo `playSoundOnThisDevice()` exportado: `scheduleNotificationAsync` com
  `content.sound: true` e trigger `SchedulableTriggerInputTypes.TIME_INTERVAL, seconds: 1,
  repeats: false` (a mesma forma de ClockScreen/RemindersScreen).
- Novo `handlePlaySound` no componente: pede permissão → agenda → alerta de confirmação
  ("Playing Sound"). Se negada, alerta explicativo ("Notifications Are Off") e **não** agenda.
  Se o agendamento falhar, alerta "Could Not Play Sound" — nunca no-op silencioso.
  Guard de duplo toque via `React.useRef` (não estado: um duplo toque dispara os dois
  handlers no mesmo tick, antes de qualquer re-render).
- Nova `CupertinoListTile` "Play Sound" (`leading` `volume-high`, subtitle
  "Alerts this device only", `showChevron={false}`) entre "This Device" e "Mark as Lost",
  dentro do mesmo ramo `permissionStatus === 'granted'`.

**src/screens/__tests__/FindMyScreen.test.tsx**
- Mock local de `expo-notifications` (mesma forma do já usado em `RemindersScreen.test.tsx`)
  e mock de `useAlert` via `jest.mock('../../components')` (padrão de `ConversationScreen.test.tsx`).
  Nenhum mock partilhado (`jest.setup.js`) foi tocado — os testes de alarme do ClockScreen
  ficam intactos.
- Novo `describe('FindMyScreen — Play Sound (issue #266)')` com 9 testes.

## Porque assim

- **Notificação local em vez de `expo-av`/tom sintetizado**: o issue e o epic apontam
  explicitamente o padrão do ClockScreen, já é dependência (`~0.32.11`), e respeita o canal
  de som/volume do sistema. Descartei `expo-av` (dependência nova + ficheiro de áudio a
  empacotar) e um `Vibration.vibrate()` (não é som).
- **`useRef` em vez de `useState` para o guard de duplo toque**: com estado, o segundo
  `press` no mesmo tick ainda leria `false`. O teste de duplo toque falharia.
- **Alerta em todos os ramos de falha**: o issue pede "no silent no-op"; um `try/catch`
  vazio tornaria um agendamento falhado indistinguível de sucesso.
- **Subtitle "Alerts this device only"**: reforça o âmbito no próprio UI, sem sugerir
  alcance a outro dispositivo.

## Critérios de aceitação

- [x] A aba Devices mostra uma linha "Play Sound" — teste `shows a "Play Sound" row on the Devices tab`.
- [x] Com permissão concedida, o press chama `scheduleNotificationAsync` com `sound: true` e mostra confirmação — asserção sobre `mock.calls[0][0].content.sound === true`, `trigger.type === 'timeInterval'`, `trigger.seconds > 0`, e alerta com título `Playing Sound`.
- [x] Com permissão negada não chama `scheduleNotificationAsync` e mostra alerta explicativo — `expect(scheduleNotificationAsync).not.toHaveBeenCalled()` + mensagem que contém /notification/i.
- [x] Nenhum elemento de UI em Devices/People/Items sugere som noutro dispositivo — teste de guard: `queryByText(/Play Sound on/i)` é null e "Play Sound" não aparece em People nem em Items.
- [x] Testes de alarme do ClockScreen inalterados — nenhum mock partilhado alterado (mock de `expo-notifications` é local a este ficheiro de teste); `ClockScreen.test.tsx` continua verde na suite completa.
- [x] Novos testes cobrem granted e denied (ver acima), mais undetermined, falha de agendamento, duplo toque e ausência da linha sem permissão de localização.
- [x] **Não devia mudar**: as linhas "This Device" e "Mark as Lost", as abas People/Items e a persistência de lost-mode/items — os 20 testes pré-existentes de `FindMyScreen.test.tsx` continuam a passar sem alteração, e nenhum snapshot mudou (`Snapshots: 6 passed`, 0 escritos).

## Testes

**Passo vermelho** (teste escrito, `src/screens/FindMyScreen.tsx` em stash):

```
$ git stash push -- src/screens/FindMyScreen.tsx
$ npx jest src/screens/__tests__/FindMyScreen.test.tsx

    ✕ shows a "Play Sound" row on the Devices tab (1004 ms)
    ✕ pressing it with permission granted schedules a notification with sound and confirms (1009 ms)
    ✕ does not re-prompt when permission is already granted (1005 ms)
    ✕ requests permission when undetermined and schedules once granted (1007 ms)
    ✕ with permission denied it schedules nothing and explains why (no silent no-op) (1007 ms)
    ✕ a scheduling failure surfaces an alert instead of being swallowed (1006 ms)
    ✕ a double press schedules exactly one notification (no duplicate alert) (1008 ms)
    ✕ no tab offers to play a sound on another person’s or another device (regression guard) (1008 ms)
Tests:       8 failed, 21 passed, 29 total

  ● FindMyScreen — Play Sound (issue #266) › shows a "Play Sound" row on the Devices tab

      524 |   it('no tab offers to play a sound on another person’s or another device (regression guard)', async () => {
      525 |     const { getByText, queryByText } = renderFindMy();
    > 526 |     await waitFor(() => expect(getByText('Play Sound')).toBeTruthy());
          |                  ^
```

(falha por "Unable to find an element with text: Play Sound" — ou seja pela razão certa:
a linha não existe. Os 21 restantes eram os testes pré-existentes, que passavam já.)

Com o fix aplicado: `Tests: 29 passed, 29 total` nesta suite.

**Casos cobertos além do caminho feliz:**
- *Permissão*: granted (não re-pergunta), undetermined (pergunta e depois agenda), denied
  (não agenda, alerta explicativo).
- *Inverso do fix*: no ramo denied e no ramo de erro, asserção explícita de que o alerta
  "Playing Sound" **não** aparece.
- *Falha assíncrona*: `scheduleNotificationAsync` rejeitado → alerta de erro, não silêncio.
- *Repetição*: duplo press consecutivo → exactamente 1 `scheduleNotificationAsync`
  (o duplo toque é defeito recorrente neste repo).
- *Ausente*: sem permissão de localização a secção Devices não é renderizada — a linha
  "Play Sound" tem de estar ausente também.
- *Guard de âmbito*: nenhuma das três abas oferece som noutro dispositivo/pessoa.

**Sanity-check:** `git stash push -- src/screens/FindMyScreen.tsx` (mantendo os testes) →
suite falha com 8 testes vermelhos (output acima) → `git stash pop` restaurou. Confirmado
também que o comportamento não estava já em `main`: `git diff origin/main -- src/screens/FindMyScreen.tsx`
mostra os únicos `Notifications.*` e a única tile "Play Sound" a serem introduzidos por este trabalho.

**Verificações:**
- `npm run lint`: ✖ 2 problems (**0 errors**, 2 warnings) — ambos os warnings pré-existentes
  (`BridgeErrorReporting.test.tsx:2`, `ClockScreen.tsx:258`), nenhum em ficheiros que toquei.
- `npx tsc --noEmit`: limpo (sem output).
- `npm test -- --maxWorkers=2`: `Test Suites: 5 failed, 153 passed, 158 total` /
  `Tests: 11 failed, 1515 passed, 1526 total`, `Snapshots: 6 passed`.
  As 11 falhas são **todas pré-existentes** e nenhuma toca em Find My: FoldersStore (2),
  LockScreen (3), SettingsScreen (1), WeatherScreen (2), withLauncherIntent plugin (3).
  Provado com `git stash` dos meus dois ficheiros e a correr só essas 5 suites:
  `Tests: 11 failed, 33 passed, 44 total` — número idêntico sem o meu trabalho.
  (Nota: o `baseline.json` referido no briefing tem `failed_tests: null`, pelo que a
  comparação foi feita empiricamente com stash, não pelo ficheiro.)

## Testes

1515 passaram, 11 falharam (todas pre-existentes, provadas com git stash), 158 suites; FindMyScreen.test.tsx: 29/29 passaram

## Linked Issue

Fixes #266