### PR TITLE
Adiciona toggle "New Apps Go To" (newAppsToHome) que mantém apps recém-instaladas só na App Library quando desligado (#601)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -360,7 +360,11 @@ function ReachabilityShifter({ children }: { children: React.ReactNode }) {
  */
 function AppsProviderWithIconTreatment({ children }: { children: React.ReactNode }) {
   const { settings } = useSettings();
-  return <AppsProvider iconTreatment={settings.iconTreatment}>{children}</AppsProvider>;
+  return (
+    <AppsProvider iconTreatment={settings.iconTreatment} newAppsToHome={settings.newAppsToHome}>
+      {children}
+    </AppsProvider>
+  );
 }
 
 export default function App() {

--- a/src/screens/LauncherSettingsScreen.tsx
+++ b/src/screens/LauncherSettingsScreen.tsx
@@ -19,6 +19,7 @@ import {
   CupertinoButton,
   CupertinoSegmentedControl,
   CupertinoSlider,
+  CupertinoActionSheet,
   useAlert,
 } from '../components';
 import { logger } from '../utils/logger';
@@ -87,6 +88,7 @@ export function LauncherSettingsScreen() {
 
   const alert = useAlert();
   const [showPinModal, setShowPinModal] = useState(false);
+  const [showNewAppsPicker, setShowNewAppsPicker] = useState(false);
   const [pinStep, setPinStep] = useState<'current' | 'new' | 'confirm'>('current');
   const [pinInput, setPinInput] = useState('');
   const [newPin, setNewPin] = useState('');
@@ -306,6 +308,17 @@ export function LauncherSettingsScreen() {
       {/* ── Home Screen ────────────────────────────────────────── */}
       <CupertinoListSection header="Home Screen">
         <CupertinoListTile
+          title="New Apps Go To"
+          leading={{ name: 'apps', color: '#fff', backgroundColor: '#5856D6' }}
+          showChevron
+          trailing={
+            <Text style={[typography.body, { color: colors.secondaryLabel }]}>
+              {settings.newAppsToHome ? 'Home Screen' : 'App Library Only'}
+            </Text>
+          }
+          onPress={() => setShowNewAppsPicker(true)}
+        />
+        <CupertinoListTile
           title="Show Badge Counts"
           leading={{ name: 'notifications', color: '#fff', backgroundColor: '#FF3B30' }}
           showChevron={false}
@@ -474,6 +487,24 @@ export function LauncherSettingsScreen() {
           </Pressable>
         </Pressable>
       </Modal>
+
+      {/* ── New Apps destination (#601) ────────────────────────── */}
+      <CupertinoActionSheet
+        visible={showNewAppsPicker}
+        onClose={() => setShowNewAppsPicker(false)}
+        title="New Apps Go To"
+        options={[
+          {
+            label: 'App Library Only',
+            onPress: () => { update('newAppsToHome', false); setShowNewAppsPicker(false); },
+          },
+          {
+            label: 'Home Screen',
+            onPress: () => { update('newAppsToHome', true); setShowNewAppsPicker(false); },
+          },
+        ]}
+        cancelLabel="Cancel"
+      />
 
       {/* ── Diagnostics (#517) ─────────────────────────────────── */}
       <CupertinoListSection header="Diagnostics">

--- a/src/store/AppsStore.tsx
+++ b/src/store/AppsStore.tsx
@@ -9,6 +9,7 @@ import { getIconMask, subscribeIconMask, type IconMaskOptions } from '../utils/i
 import type { PackageChange } from '../../modules/launcher-module/src';
 
 const STORAGE_KEY = '@iostoandroid/apps_layout';
+const LIBRARY_ONLY_KEY = '@iostoandroid/library_only';
 const APPS_INDEX_KEY = '@iostoandroid/apps_index';
 const RECENTS_KEY = '@iostoandroid/recent_apps';
 const RECENTS_LEGACY_KEY = '@recent_apps';
@@ -75,6 +76,14 @@ interface AppsState {
   homeApps: HomeApp[];
   dockApps: string[]; // package names for bottom dock (max 4)
   isLoading: boolean;
+  /**
+   * Packages the user (or the "App Library Only" default) has asked to keep off
+   * the home screen. Apps here still appear in the App Library. Seeded at
+   * install time when settings.newAppsToHome is false (#601) and grown by the
+   * home-grid long-press "Remove from Home" path — removeFromHome() is kept as
+   * the user-facing equivalent so behaviour is unified.
+   */
+  libraryOnlyApps: string[];
 }
 
 export interface IconCacheRebuildProgress {
@@ -87,6 +96,13 @@ interface AppsContextValue {
   homeApps: HomeApp[];
   dockApps: InstalledApp[];
   nonDockApps: InstalledApp[];
+  /**
+   * Packages kept off the home screen (#601); they still appear in the App
+   * Library. Optional on the context value only so older test mocks that cast a
+   * hand-built object to AppsContextValue keep type-checking — the real provider
+   * always populates it.
+   */
+  libraryOnlyApps?: string[];
   recentPackages: string[];
   recentApps: RecentApp[];
   isLoading: boolean;
@@ -160,6 +176,7 @@ const DEFAULT_ICON_TREATMENT = 'mask-adaptive-only';
 export function AppsProvider({
   children,
   iconTreatment = DEFAULT_ICON_TREATMENT,
+  newAppsToHome = true,
 }: {
   children: React.ReactNode;
   /**
@@ -168,6 +185,13 @@ export function AppsProvider({
    * every existing AppsStore test mounts it without a SettingsProvider above.
    */
   iconTreatment?: string;
+  /**
+   * Whether freshly installed apps go to the home screen (#601). Passed down
+   * from SettingsStore by the app shell (see App.tsx) so AppsProvider stays
+   * usable on its own — every existing AppsStore test mounts it without a
+   * SettingsProvider above, and defaults to true (the current behaviour).
+   */
+  newAppsToHome?: boolean;
 }) {
   const alert = useAlert();
   const alertRef = React.useRef(alert);
@@ -177,6 +201,7 @@ export function AppsProvider({
     homeApps: [],
     dockApps: DEFAULT_DOCK,
     isLoading: true,
+    libraryOnlyApps: [],
   });
   const [isDefault, setIsDefault] = useState(false);
   const [recentApps, setRecentApps] = useState<RecentApp[]>([]);
@@ -214,6 +239,26 @@ export function AppsProvider({
         } catch (e) { logger.warn('AppsStore', 'failed to parse recent apps', e); }
       }
     })();
+  }, []);
+
+  // Load the "App Library Only" set (#601) — persisted separately from the
+  // layout so a reset of the dock/home layout doesn't silently un-hide apps.
+  useEffect(() => {
+    (async () => {
+      const raw = await AsyncStorage.getItem(LIBRARY_ONLY_KEY);
+      if (raw) {
+        try {
+          const parsed = JSON.parse(raw);
+          if (Array.isArray(parsed)) {
+            setState(prev => ({ ...prev, libraryOnlyApps: parsed.filter((p): p is string => typeof p === 'string') }));
+          }
+        } catch (e) { logger.warn('AppsStore', 'failed to parse library-only set', e); }
+      }
+    })();
+  }, []);
+
+  const persistLibraryOnly = useCallback((pkgs: string[]) => {
+    AsyncStorage.setItem(LIBRARY_ONLY_KEY, JSON.stringify(pkgs));
   }, []);
 
   const addToRecents = useCallback(async (packageName: string) => {
@@ -295,12 +340,13 @@ export function AppsProvider({
     }
 
     if (cachedApps) {
-      setState({
+      setState(prev => ({
+        ...prev,
         allApps: cachedApps,
         homeApps,
         dockApps: resolveDock(cachedApps, dockApps),
         isLoading: false,
-      });
+      }));
     }
 
     try {
@@ -315,11 +361,30 @@ export function AppsProvider({
       setIsDefault(defaultStatus);
       AsyncStorage.setItem(APPS_INDEX_KEY, JSON.stringify(apps));
 
-      setState({
-        allApps: apps,
-        homeApps,
-        dockApps: resolveDock(apps, dockApps),
-        isLoading: false,
+      // #601: when new apps are set to go to the App Library only, any package
+      // we have not seen before (not in the cached index) is seeded into
+      // libraryOnlyApps so it lands in the App Library instead of the home
+      // screen. Apps already known to the launcher are left untouched — the
+      // setting only affects apps first discovered while it is off.
+      setState(prev => {
+        const known = new Set(cachedApps?.map(c => c.packageName) ?? []);
+        const seeded = !newAppsToHome
+          ? apps
+              .map((a: InstalledApp) => a.packageName)
+              .filter((pkg: string) => !prev.libraryOnlyApps.includes(pkg) && !known.has(pkg))
+          : [];
+        const libraryOnlyApps = seeded.length > 0
+          ? [...prev.libraryOnlyApps, ...seeded]
+          : prev.libraryOnlyApps;
+        if (seeded.length > 0) persistLibraryOnly(libraryOnlyApps);
+        return {
+          ...prev,
+          allApps: apps,
+          homeApps,
+          dockApps: resolveDock(apps, dockApps),
+          isLoading: false,
+          libraryOnlyApps,
+        };
       });
     } catch (e) {
       logger.warn('AppsStore', 'background apps refresh failed', e);
@@ -330,7 +395,7 @@ export function AppsProvider({
         setState(prev => ({ ...prev, isLoading: false }));
       }
     }
-  }, [resolveDock, iconMask, iconTreatment]);
+  }, [resolveDock, iconMask, iconTreatment, newAppsToHome, persistLibraryOnly]);
 
   // loadApps depende de iconMask, por isso mudar a forma ou o expoente volta a
   // pedir os ícones ao nativo com a chave de cache nova — a grelha actualiza sem
@@ -419,21 +484,25 @@ export function AppsProvider({
   const addToHome = useCallback((packageName: string) => {
     setState(prev => {
       const exists = prev.homeApps.some(a => a.packageName === packageName);
-      if (exists) return prev;
-      const maxPos = prev.homeApps.reduce((max, a) => Math.max(max, a.position), -1);
-      const homeApps = [...prev.homeApps, { packageName, position: maxPos + 1 }];
+      const homeApps = exists ? prev.homeApps : [...prev.homeApps, { packageName, position: prev.homeApps.reduce((max, a) => Math.max(max, a.position), -1) + 1 }];
+      const libraryOnlyApps = prev.libraryOnlyApps.filter(p => p !== packageName);
+      if (libraryOnlyApps.length !== prev.libraryOnlyApps.length) persistLibraryOnly(libraryOnlyApps);
       persist(prev.dockApps, homeApps);
-      return { ...prev, homeApps };
+      return { ...prev, homeApps, libraryOnlyApps };
     });
-  }, [persist]);
+  }, [persist, persistLibraryOnly]);
 
   const removeFromHome = useCallback((packageName: string) => {
     setState(prev => {
       const homeApps = prev.homeApps.filter(a => a.packageName !== packageName);
+      const libraryOnlyApps = prev.libraryOnlyApps.includes(packageName)
+        ? prev.libraryOnlyApps
+        : [...prev.libraryOnlyApps, packageName];
       persist(prev.dockApps, homeApps);
-      return { ...prev, homeApps };
+      persistLibraryOnly(libraryOnlyApps);
+      return { ...prev, homeApps, libraryOnlyApps };
     });
-  }, [persist]);
+  }, [persist, persistLibraryOnly]);
 
   const addToDock = useCallback((packageName: string) => {
     setState(prev => {
@@ -519,8 +588,8 @@ export function AppsProvider({
   );
 
   const nonDockApps = useMemo(() =>
-    state.allApps.filter(a => !state.dockApps.includes(a.packageName)),
-    [state.allApps, state.dockApps]
+    state.allApps.filter(a => !state.dockApps.includes(a.packageName) && !state.libraryOnlyApps.includes(a.packageName)),
+    [state.allApps, state.dockApps, state.libraryOnlyApps],
   );
 
   // Derive recentPackages (string[]) for backward compatibility
@@ -531,6 +600,7 @@ export function AppsProvider({
     homeApps: state.homeApps,
     dockApps,
     nonDockApps,
+    libraryOnlyApps: state.libraryOnlyApps,
     recentPackages,
     recentApps,
     isLoading: state.isLoading,

--- a/src/store/SettingsStore.tsx
+++ b/src/store/SettingsStore.tsx
@@ -117,6 +117,14 @@ export interface SettingsState {
    * renomear não parta a atribuição.
    */
   categoryOverrides: CategoryOverrideSettings;
+  /**
+   * Newly Downloaded Apps destination (iOS «Home Screen & Dock → Newly
+   * Downloaded Apps»). When true (default) a freshly installed app is shown on
+   * the home screen; when false it appears only in the App Library. Already-
+   * installed apps are never moved — the setting only affects apps first seen
+   * after it was turned off (#601).
+   */
+  newAppsToHome: boolean;
 }
 
 export const DEFAULT_SETTINGS: SettingsState = {
@@ -186,6 +194,7 @@ export const DEFAULT_SETTINGS: SettingsState = {
   iconShape: 'squircle',
   iconShapeExponent: DEFAULT_ICON_SHAPE_EXPONENT,
   categoryOverrides: DEFAULT_CATEGORY_OVERRIDES,
+  newAppsToHome: true,
 };
 
 interface SettingsContextValue {

--- a/src/store/__tests__/AppsStore.test.tsx
+++ b/src/store/__tests__/AppsStore.test.tsx
@@ -293,3 +293,112 @@ describe('AppsStore — icon cache (#486: treatment threading, size, manual rebu
     });
   });
 });
+
+describe('AppsStore — new apps destination (#601: newAppsToHome)', () => {
+  const banana = { name: 'Banana', packageName: 'com.example.banana', icon: 'file:///icons/b_1.png', isSystem: false };
+
+  // A wrapper that forwards the setting under test, like the app shell
+  // (App.tsx → AppsProviderWithIconTreatment) does with settings.newAppsToHome.
+  const makeWrapper = (newAppsToHome: boolean) => {
+    const Wrapper = ({ children }: { children: React.ReactNode }) => (
+      <AppsProvider newAppsToHome={newAppsToHome}>{children}</AppsProvider>
+    );
+    Wrapper.displayName = `AppsProviderWithNewAppsToHome(${newAppsToHome})`;
+    return Wrapper;
+  };
+  const wrapperWith = makeWrapper;
+
+  beforeEach(() => {
+    (LauncherModule.getIconCacheSizeBytes as jest.Mock).mockResolvedValue(0);
+    (LauncherModule.clearIconCache as jest.Mock).mockResolvedValue(0);
+    (LauncherModule.getAppInfo as jest.Mock).mockResolvedValue(null);
+  });
+
+  it('newAppsToHome=true (default): a freshly installed app lands on the home screen', async () => {
+    // No cached index → the native scan returns a brand-new package.
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+    (LauncherModule.getInstalledApps as jest.Mock).mockResolvedValue([banana]);
+
+    const { result } = renderHook(() => useApps(), { wrapper: wrapperWith(true) });
+    await act(async () => {});
+    await act(async () => {});
+
+    expect(result.current.apps.map(a => a.packageName)).toContain('com.example.banana');
+    expect(result.current.nonDockApps.map(a => a.packageName)).toContain('com.example.banana');
+    expect(result.current.libraryOnlyApps).not.toContain('com.example.banana');
+  });
+
+  it('newAppsToHome=false: a freshly installed app is kept off the home screen (App Library only)', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+    (LauncherModule.getInstalledApps as jest.Mock).mockResolvedValue([banana]);
+
+    const { result } = renderHook(() => useApps(), { wrapper: wrapperWith(false) });
+    await act(async () => {});
+    await act(async () => {});
+
+    // Still listed in the full app set (so the App Library renders it)…
+    expect(result.current.apps.map(a => a.packageName)).toContain('com.example.banana');
+    // …but excluded from the home grid…
+    expect(result.current.nonDockApps.map(a => a.packageName)).not.toContain('com.example.banana');
+    // …and recorded so it stays off home across restarts.
+    expect(result.current.libraryOnlyApps).toContain('com.example.banana');
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      '@iostoandroid/library_only',
+      expect.stringContaining('com.example.banana'),
+    );
+  });
+
+  it('newAppsToHome=false does NOT hide apps that were already known before the toggle was off', async () => {
+    // The cached index already contains banana → it is an "existing" app, not new.
+    (AsyncStorage.getItem as jest.Mock).mockImplementation((key: string) =>
+      Promise.resolve(key === APPS_INDEX_KEY ? JSON.stringify([banana]) : null),
+    );
+    // Native scan agrees banana is still installed (no change).
+    (LauncherModule.getInstalledApps as jest.Mock).mockResolvedValue([banana]);
+
+    const { result } = renderHook(() => useApps(), { wrapper: wrapperWith(false) });
+    await act(async () => {});
+    await act(async () => {});
+
+    // A previously-known app stays on the home screen even with the toggle off.
+    expect(result.current.nonDockApps.map(a => a.packageName)).toContain('com.example.banana');
+    expect(result.current.libraryOnlyApps).not.toContain('com.example.banana');
+  });
+
+  it('removeFromHome adds the package to libraryOnlyApps so it leaves the home grid', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+    (LauncherModule.getInstalledApps as jest.Mock).mockResolvedValue([banana]);
+
+    const { result } = renderHook(() => useApps(), { wrapper: wrapperWith(true) });
+    await act(async () => {});
+    await act(async () => {});
+    expect(result.current.nonDockApps.map(a => a.packageName)).toContain('com.example.banana');
+
+    await act(async () => {
+      result.current.removeFromHome('com.example.banana');
+    });
+
+    expect(result.current.nonDockApps.map(a => a.packageName)).not.toContain('com.example.banana');
+    expect(result.current.libraryOnlyApps).toContain('com.example.banana');
+  });
+
+  it('addToHome removes the package from libraryOnlyApps so it returns to the home grid', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+    (LauncherModule.getInstalledApps as jest.Mock).mockResolvedValue([banana]);
+
+    const { result } = renderHook(() => useApps(), { wrapper: wrapperWith(true) });
+    await act(async () => {});
+    await act(async () => {});
+
+    await act(async () => {
+      result.current.removeFromHome('com.example.banana');
+    });
+    expect(result.current.nonDockApps.map(a => a.packageName)).not.toContain('com.example.banana');
+
+    await act(async () => {
+      result.current.addToHome('com.example.banana');
+    });
+    expect(result.current.nonDockApps.map(a => a.packageName)).toContain('com.example.banana');
+    expect(result.current.libraryOnlyApps).not.toContain('com.example.banana');
+  });
+});


### PR DESCRIPTION
## Resumo

Adiciona toggle "New Apps Go To" (newAppsToHome) que mantém apps recém-instaladas só na App Library quando desligado

## Causa raiz

O issue descrevia mal o mecanismo. Afirmava que `src/store/AppsStore.tsx` tem um `reconcile` em `:163` que chama `addToHome` para tudo o que não está no dock, e que `addToHome` (`:267`) empurra apps para `homeApps`. **Nenhum dos dois é verdade no código actual:**

- Não existe nenhum `reconcile` em `AppsStore.tsx` (confirmado por `git log -S` e leitura do ficheiro).
- `addToHome` está definido (`:477`) mas **nunca é chamado em lado nenhum do código de produção** — só aparece em mocks de teste. É código vestigial.
- A grelha do home (`src/screens/LauncherHomeScreen.tsx:1218`) renderiza `nonDockApps`, que é **todos os apps instalados exceto o dock** (`AppsStore.tsx:583`), e NÃO `homeApps`. Por isso, hoje, toda a app instalada aparece sempre no home, independentemente de `homeApps`. A App Library (`AppLibraryScreen.tsx:493`) renderiza a lista completa `apps`. O defeito real é: não há forma de uma app recém-instalada ficar só na App Library.

A fonte de dados do home é `nonDockApps`. O fix atua aí.

## O que mudou

- **`src/store/SettingsStore.tsx`** — novo campo `newAppsToHome: boolean` na `SettingsState` (default `true`), com respetiva entrada em `DEFAULT_SETTINGS`. Persiste em `@iostoandroid/settings` via o mecanismo já existente de `setSettings`.
- **`src/store/AppsStore.tsx`** — novo estado `libraryOnlyApps: string[]` (apps mantidos fora do home; continuam na App Library). Carregado de `@iostoandroid/library_only` no arranque. `loadApps` semeia em `libraryOnlyApps` qualquer package **nunca antes visto** (ausente do cached index) quando `newAppsToHome === false`, e persiste-o. `nonDockApps` (a fonte do home) passa a excluir `libraryOnlyApps`. `addToHome`/`removeFromHome` passam a gerir `libraryOnlyApps` (unificando o caminho de utilizador com o do setting) — `removeFromHome` adiciona ao conjunto, `addToHome` remove. A prop `newAppsToHome` é injetada no `AppsProvider` pelo app shell.
- **`App.tsx`** — `AppsProviderWithIconTreatment` passa `newAppsToHome={settings.newAppsToHome}` ao `AppsProvider` (padrão idêntico ao de `iconTreatment`).
- **`src/screens/LauncherSettingsScreen.tsx`** — novo `CupertinoListTile` "New Apps Go To" na secção **Home Screen**, com `CupertinoActionSheet` (Off = App Library Only / On = Home Screen), igual ao padrão do `GeneralScreen` (AirDrop). Default `true` (preserva comportamento atual).
- **`src/store/__tests__/AppsStore.test.tsx`** — novo `describe` cobre ambos os ramos (ver Testes).

## Porque assim

A abordagem do issue (tocar em `addToHome`/`homeApps`) não funcionaria: `homeApps` não é o que decide o que aparece no home. Atuar em `nonDockApps` — a única fonte real — é o que efectivamente move apps entre home e App Library. Usei um conjunto persistido `libraryOnlyApps` em vez de depender de `homeApps` porque `homeApps` não é consumido pela grelha; o conjunto é também o que `removeFromHome` (long-press no home) já precisava para sobreviver a reinícios, pelo que unificar os dois caminhos evita lógica duplicada. Rejeitei esconder o erro (não há `try/catch` nem `any`): a exclusão é explícita em `nonDockApps`.

Decisão registada: apps já conhecidas (no cached index) NÃO são movidas quando o toggle é desligado — o setting só afeta apps descobertas enquanto está off, tal como o iOS (não reordena o que já está no home). Isto é testado explicitamente.

## Critérios de aceitação

- [x] Toggle em `LauncherSettingsScreen` (Home Screen), default `true` — tile + action sheet adicionados; `DEFAULT_SETTINGS.newAppsToHome = true`.
- [x] `false` → app recém-instalada NÃO aparece no home, só na App Library — testado via `nonDockApps` (excluída) + `apps` (presente) + `libraryOnlyApps` (incluída) + persistência em `@iostoandroid/library_only`.
- [x] `true` → comportamento actual mantém-se — testado: app recém-instalada aparece em `nonDockApps`, `libraryOnlyApps` vazio.
- [x] Persiste entre arranques (`@iostoandroid/settings` para o flag; `@iostoandroid/library_only` para o conjunto) — flag via `SettingsStore`; conjunto carregado e persistido em `AppsStore`.
- [x] Teste em `src/store/__tests__/AppsStore.test.tsx` cobre ambos os ramos — 5 testes (true / false / known-apps-untouched / removeFromHome / addToHome).
- [x] O que NÃO devia mudar: a App Library continua a mostrar todas as apps (`apps` não é filtrado); apps já conhecidas não são movidas quando o toggle desliga; o dock e `homeApps` mantêm-se. Confirmado pelos testes (App Library via `apps` incluir banana mesmo com toggle off; known-apps test) e por `nonDockApps` continuar a excluir só dock+libraryOnly.

## Testes

- **Passo vermelho** (fix revertido, `git stash` dos ficheiros de produção):

  ```
  Test Suites: 1 failed, 1 total
  Tests:       5 failed, 14 passed, 19 total

  ● AppsStore — new apps destination (#601: newAppsToHome) › newAppsToHome=false: a freshly installed app is kept off the home screen (App Library only)
      Expected value: not "com.example.banana"
      Received array:     ["com.example.banana"]
      376 |     expect(result.current.nonDockApps.map(a => a.packageName)).not.toContain('com.example.banana');
          |                                                                    ^
  ```
  (os 5 testes novos falham todos pelo motivo certo: banana aparece em `nonDockApps` quando não devia e `libraryOnlyApps` não é gerido. Os 14 testes pré-existentes continuam a passar.)

- **Casos cobertos para além do caminho feliz:** (1) fronteira — app já conhecida vs nova; (2) o inverso do fix — `newAppsToHome=true` mantém no home; (3) o inverso do `removeFromHome` — `addToHome` devolve a app ao home removendo-a de `libraryOnlyApps`; (4) persistência — `@iostoandroid/library_only` escrito; (5) não-regressão — apps conhecidas não são escondidas. Cada teste falha por razão diferente (presença/ausência em `nonDockApps`, presença em `libraryOnlyApps`, escrita em storage).

- **Sanity-check:** reverti os 4 ficheiros de produção (`git stash`), corri `npx jest src/store/__tests__/AppsStore.test.tsx` → os 5 testes novos falharam e os 14 antigos passaram; restaurei com `git stash pop`. Prova que os testes estão ligados ao comportamento.

- **Resultado das verificações obrigatórias (worktree, contra a baseline que já tinha 8 falhas em 4 suites):**
  - `npm run lint`: **0 erros** (2 warnings pré-existentes em `ClockScreen.tsx` e `BridgeErrorReporting.test.tsx`, sem relação com este trabalho).
  - `npx tsc --noEmit`: limpo.
  - `npm test -- --maxWorkers=2`: **1520 passaram, 11 falharam, 158 suites**. As 11 falhas = as 8 da baseline (FoldersStore×2, LockScreen×3, SettingsScreen×1, WeatherScreen×2) + 3 do suite `plugins/withLauncherIntent` que **também falham sem as minhas alterações** (verifiquei com `git stash` de tudo: o suite falha na mesma) — portanto NÃO são introduzidas por este trabalho. **Critério de regressão cumprido: não há falhas novas em ficheiros que toquei.**
  - Os 5 testes que escrevi para este trabalho passam sempre.

## Testes

1520 passaram, 11 falharam (8 da baseline + 3 pré-existentes no suite plugins/withLauncherIntent, não causadas por este trabalho), 158 suites; os 5 testes novos de AppsStore.test.tsx passam

## Linked Issue

Fixes #601