### PR TITLE
Tap to Wake (#608): native wakeScreen() no LauncherModule + toggle tapToWake + consumo na home (#608)

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -336,6 +336,8 @@ jest.mock('./modules/launcher-module/src', () => ({
     startSpeechRecognition: jest.fn(() => Promise.resolve(true)),
     stopSpeechRecognition: jest.fn(() => Promise.resolve(true)),
     isSpeechRecognitionAvailable: jest.fn(() => Promise.resolve(true)),
+    // #608 Tap to Wake
+    wakeScreen: jest.fn(() => Promise.resolve()),
   },
 }));
 

--- a/modules/launcher-module/android/src/main/AndroidManifest.xml
+++ b/modules/launcher-module/android/src/main/AndroidManifest.xml
@@ -17,6 +17,8 @@
     <uses-permission android:name="android.permission.PACKAGE_USAGE_STATS"
         xmlns:tools="http://schemas.android.com/tools"
         tools:ignore="ProtectedPermissions" />
+    <!-- #608 Tap to Wake: needed to wake the (app-dimmed) screen via PowerManager.ACQUIRE_CAUSES_WAKEUP -->
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
 
     <application>
         <service

--- a/modules/launcher-module/android/src/main/java/com/iostoandroid/launcher/LauncherModule.kt
+++ b/modules/launcher-module/android/src/main/java/com/iostoandroid/launcher/LauncherModule.kt
@@ -9,6 +9,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
+import android.os.PowerManager
 import android.database.Cursor
 import android.graphics.Bitmap
 import android.graphics.BitmapShader
@@ -748,6 +749,29 @@ class LauncherModule : Module() {
         AsyncFunction("isFlashlightOn") {
             // No direct API to check; track state in companion object
             flashlightState
+        }
+
+        // ── Wake Screen (Tap to Wake, #608) ──────────────────────────────
+        // Acorda o ecrã quando está apenas "dimmed" pela app (não apagado do
+        // SO). Expo RN não tem API para isto; precisa de native module.
+        //
+        // Limitação documentada: capturar um toque com o ecrã APAGADO do
+        // sistema exigiria um receiver de toque a nível de framework
+        // (fora do âmbito de um Expo module simples). Este método só é
+        // chamado quando a app já recebe o toque (ecrã dimmed/locked pela
+        // app), portanto acorda nesse caso — não o SO.
+        AsyncFunction("wakeScreen") {
+            try {
+                val pm = context.getSystemService(Context.POWER_SERVICE) as PowerManager
+                @Suppress("DEPRECATION")
+                val wakeLock = pm.newWakeLock(
+                    PowerManager.SCREEN_BRIGHT_WAKE_LOCK or PowerManager.ACQUIRE_CAUSES_WAKEUP,
+                    "iostoandroid:tapToWake"
+                )
+                wakeLock.setReferenceCounted(false)
+                wakeLock.acquire(500L)
+                wakeLock.release()
+            } catch (e: Exception) { /* falha silenciosa: o wake é best-effort */ }
         }
 
         // ── Call Log ─────────────────────────────────────────────────────

--- a/modules/launcher-module/src/__tests__/index.test.ts
+++ b/modules/launcher-module/src/__tests__/index.test.ts
@@ -109,7 +109,12 @@ describe('LauncherModule bridge error reporting', () => {
     const methods = Object.keys(mod.default) as (keyof LauncherModuleType)[];
     for (const method of methods) {
       const fn = (mod.default as unknown as Record<string, () => Promise<unknown>>)[method];
-      await expect(fn()).resolves.toBeDefined();
+      // The contract is "never throw, always report": methods that return a
+      // value resolve to that value, void methods resolve to undefined. We
+      // assert the rejection path is swallowed and routed to onBridgeError
+      // rather than relying on a defined return value (a Promise<void> method
+      // legitimately resolves to undefined — see wakeScreen, #608).
+      await expect(fn()).resolves.not.toThrow();
       expect(listener).toHaveBeenCalledWith(method, expect.any(Error));
     }
   });
@@ -513,5 +518,63 @@ describe('deduplication of launcher entries by packageName', () => {
     // Nenhuma app se perde: uma categoria malformada nao e razao para a esconder.
     expect(apps).toHaveLength(2);
     expect(apps.map((a) => a.category)).toEqual(['undefined', 'undefined']);
+  });
+});
+
+describe('wakeScreen — Tap to Wake bridge (#608)', () => {
+  let mod: typeof import('../index');
+  let listener: jest.Mock;
+  let unsubscribe: () => void;
+
+  beforeAll(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+  afterAll(() => {
+    (console.error as jest.Mock).mockRestore();
+  });
+  beforeEach(() => {
+    mockNativeModule = makeNativeModule(false);
+    mod = loadBridge();
+    listener = jest.fn();
+    unsubscribe = mod.onBridgeError(listener);
+  });
+  afterEach(() => {
+    unsubscribe();
+  });
+
+  it('is exposed as a Promise<void> method on the bridge', () => {
+    expect(typeof mod.default.wakeScreen).toBe('function');
+    // A Promise<void> method must resolve (to undefined), never reject, on success.
+    expect(mod.default.wakeScreen()).toBeInstanceOf(Promise);
+  });
+
+  it('calls the native wakeScreen function when invoked', async () => {
+    // Capture the same mock instance the proxy will hand back on every access.
+    const native = jest.fn(() => Promise.resolve());
+    mockNativeModule = makeNativeModule(false, { wakeScreen: native });
+    mod = loadBridge();
+    await mod.default.wakeScreen();
+    expect(native).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports a native failure to onBridgeError listeners instead of throwing', async () => {
+    mockNativeModule = makeNativeModule(true);
+    mod = loadBridge();
+    const failingListener = jest.fn();
+    const unsub = mod.onBridgeError(failingListener);
+
+    // Must swallow the rejection (Promise<void>): resolves, does not throw.
+    await expect(mod.default.wakeScreen()).resolves.toBeUndefined();
+    expect(failingListener).toHaveBeenCalledWith('wakeScreen', expect.any(Error));
+    unsub();
+  });
+
+  it('does not report to onBridgeError when the native call succeeds', async () => {
+    // default makeNativeModule(false) → wakeScreen resolves true/undefined.
+    const okListener = jest.fn();
+    const unsub = mod.onBridgeError(okListener);
+    await mod.default.wakeScreen();
+    expect(okListener).not.toHaveBeenCalled();
+    unsub();
   });
 });

--- a/modules/launcher-module/src/index.ts
+++ b/modules/launcher-module/src/index.ts
@@ -259,6 +259,8 @@ interface LauncherModuleType {
   // Flashlight
   setFlashlight(enabled: boolean): Promise<boolean>;
   isFlashlightOn(): Promise<boolean>;
+  // Wake Screen (Tap to Wake, #608) — wakes the (app-dimmed) screen on tap
+  wakeScreen(): Promise<void>;
   // Call Log
   getCallLog(limit: number): Promise<CallLogEntry[]>;
   makeCall(number: string): Promise<boolean>;
@@ -342,6 +344,7 @@ const stub: LauncherModuleType = {
   getAppStorageStats: async () => [],
   setFlashlight: async () => false,
   isFlashlightOn: async () => false,
+  wakeScreen: async () => { /* stub: app-dimmed wake is best-effort / no-op off-Android */ },
   getCallLog: async () => [],
   makeCall: async () => false,
   getNotifications: async () => [],
@@ -568,6 +571,10 @@ function createBridgedModule(): LauncherModuleType {
     isFlashlightOn: async () => {
       try { return await nativeModule.isFlashlightOn(); }
       catch (e) { console.error('LauncherModule.isFlashlightOn failed:', e); reportBridgeError('isFlashlightOn', e); return false; }
+    },
+    wakeScreen: async () => {
+      try { await nativeModule.wakeScreen(); }
+      catch (e) { console.error('LauncherModule.wakeScreen failed:', e); reportBridgeError('wakeScreen', e); }
     },
     getCallLog: async (limit: number) => {
       try { return await nativeModule.getCallLog(limit); }

--- a/src/__mocks__/launcherModule.js
+++ b/src/__mocks__/launcherModule.js
@@ -45,5 +45,7 @@ module.exports = {
     uninstallApp: jest.fn(() => Promise.resolve(true)),
     clearIconCache: jest.fn(() => Promise.resolve(0)),
     getIconCacheSizeBytes: jest.fn(() => Promise.resolve(0)),
+    // #608 Tap to Wake
+    wakeScreen: jest.fn(() => Promise.resolve()),
   },
 };

--- a/src/screens/LauncherHomeScreen.tsx
+++ b/src/screens/LauncherHomeScreen.tsx
@@ -34,7 +34,7 @@ import Animated, {
 import * as Haptics from 'expo-haptics';
 import * as NavigationBar from 'expo-navigation-bar';
 
-import { addHomePressedListener } from '../../modules/launcher-module/src';
+import { addHomePressedListener, LauncherModuleType } from '../../modules/launcher-module/src';
 import { useApps, InstalledApp } from '../store/AppsStore';
 import { AppLibraryContent } from './AppLibraryScreen';
 import { useSettings } from '../store/SettingsStore';
@@ -789,6 +789,13 @@ export function LauncherHomeScreen() {
   const colors = launcherTheme.colors;
   const alert = useAlert();
 
+  // Tap to Wake (#608): the HOME-press effect below is registered with deps
+  // [openFolder, currentPage] (it must not re-subscribe on every render), so
+  // its closure would otherwise capture a stale `settings.tapToWake`. Mirror
+  // the latest value into a ref so the handler always reads the live setting.
+  const tapToWakeRef = useRef(settings.tapToWake);
+  tapToWakeRef.current = settings.tapToWake;
+
   // Grid density (issue #503): columns/icon-scale reshape the geometry, so
   // they're derived per-render from settings instead of the module-level
   // defaults above (which stay 4 cols / scale 1, for callers — dock, folder
@@ -1146,6 +1153,15 @@ export function LauncherHomeScreen() {
   useEffect(() => {
     return addHomePressedListener(() => {
       markWarmStartBegin();
+      // Tap to Wake (#608): when enabled, a tap on the (app-dimmed) screen
+      // wakes it. The native HOME intent only arrives while the app is in the
+      // foreground — i.e. the screen is dimmed by the app, not powered off by
+      // the system — so this is the realistic envelope (documented in the PR).
+      if (tapToWakeRef.current) {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports -- mirror SettingsStore.syncFromDevice: require() (not await import()) resolves through Jest's moduleNameMapper and is mockable in tests
+        const launcher = require('../../modules/launcher-module/src') as { default: LauncherModuleType };
+        launcher.default.wakeScreen().catch(() => {});
+      }
       const action = resolveHomePressAction({
         isFolderOpen: openFolder !== null,
         isOnFirstPage: currentPage === 0,

--- a/src/screens/__tests__/LauncherHomeScreen.homePress.test.tsx
+++ b/src/screens/__tests__/LauncherHomeScreen.homePress.test.tsx
@@ -14,7 +14,8 @@
  * named `addHomePressedListener` export.
  */
 import React from 'react';
-import { render } from '../../test-utils';
+import { render, waitFor, act } from '../../test-utils';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
 // Names must start with "mock" (case-insensitive) — jest.mock factories are
 // hoisted above imports/const, and jest only allows writing to out-of-scope
@@ -87,6 +88,8 @@ jest.mock('../../../modules/launcher-module/src', () => ({
     openUsageAccessSettings: jest.fn(() => Promise.resolve(true)),
     getScreenTimeStats: jest.fn(() => Promise.resolve([])),
     getTodayScreenTime: jest.fn(() => Promise.resolve({ totalMinutes: 0, topApps: [] })),
+    // #608 Tap to Wake
+    wakeScreen: jest.fn(() => Promise.resolve()),
   },
 }));
 
@@ -119,5 +122,58 @@ describe('LauncherHomeScreen HOME button wiring (#508)', () => {
   it('does not throw when the native HOME event fires against a mounted screen', () => {
     render(<LauncherHomeScreen />);
     expect(() => mockCapturedHomePressedCb!()).not.toThrow();
+  });
+});
+
+describe('LauncherHomeScreen Tap to Wake wiring (#608)', () => {
+  // Reuse the homePress mock's addHomePressedListener capture, but drive the
+  // LauncherModule default (incl. wakeScreen) so we can assert the gate.
+  beforeEach(() => {
+    mockCapturedHomePressedCb = null;
+    // jest.setup.js provides a wakeScreen mock on the default module; ensure it
+    // is present for the require() inside the screen's HOME handler.
+  });
+
+  function loadHome(tapToWake: boolean) {
+    (AsyncStorage.getItem as jest.Mock).mockImplementation((key: string) =>
+      key === '@iostoandroid/settings'
+        ? Promise.resolve(JSON.stringify({ tapToWake }))
+        : Promise.resolve(null),
+    );
+    render(<LauncherHomeScreen />);
+  }
+
+  it('calls mod.wakeScreen() when the HOME event fires and settings.tapToWake is enabled', async () => {
+    loadHome(true);
+    await waitFor(() => expect(mockCapturedHomePressedCb).toEqual(expect.any(Function)));
+
+    const { default: launcher } = jest.requireMock('../../../modules/launcher-module/src') as {
+      default: { wakeScreen: jest.Mock };
+    };
+    launcher.wakeScreen.mockClear();
+    expect(launcher.wakeScreen).not.toHaveBeenCalled();
+
+    act(() => { mockCapturedHomePressedCb!(); });
+
+    await waitFor(() => expect(launcher.wakeScreen).toHaveBeenCalledTimes(1));
+  });
+
+  it('does NOT call mod.wakeScreen() when settings.tapToWake is disabled', async () => {
+    loadHome(false);
+    await waitFor(() => expect(mockCapturedHomePressedCb).toEqual(expect.any(Function)));
+
+    const { default: launcher } = jest.requireMock('../../../modules/launcher-module/src') as {
+      default: { wakeScreen: jest.Mock };
+    };
+
+    // The shared module-level mock may carry calls from the enabled test above;
+    // clear before firing so we assert only this test's HOME press.
+    launcher.wakeScreen.mockClear();
+
+    act(() => { mockCapturedHomePressedCb!(); });
+
+    // The wakeScreen gate must stay closed: even after firing HOME, no call.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(launcher.wakeScreen).not.toHaveBeenCalled();
   });
 });

--- a/src/screens/settings/DisplayBrightnessScreen.tsx
+++ b/src/screens/settings/DisplayBrightnessScreen.tsx
@@ -173,6 +173,16 @@ export function DisplayBrightnessScreen({ navigation }: { navigation: AppNavigat
               }
               showChevron={false}
             />
+            <CupertinoListTile
+              title="Tap to Wake"
+              trailing={
+                <CupertinoSwitch
+                  value={settings.tapToWake}
+                  onValueChange={(v) => update('tapToWake', v)}
+                />
+              }
+              showChevron={false}
+            />
           </CupertinoListSection>
         </View>
 

--- a/src/store/SettingsStore.tsx
+++ b/src/store/SettingsStore.tsx
@@ -48,6 +48,8 @@ export interface SettingsState {
   trueTone: boolean;
   autoLock: string;
   raiseToWake: boolean;
+  /** When true, tapping the (app-dimmed) screen wakes it — Tap to Wake (#608). */
+  tapToWake: boolean;
   airdrop: 'off' | 'contactsOnly' | 'everyone';
   backgroundAppRefresh: 'off' | 'wifi' | 'wifiAndCellular';
   dateTimeAutomatic: boolean;
@@ -158,6 +160,7 @@ export const DEFAULT_SETTINGS: SettingsState = {
   trueTone: true,
   autoLock: '5 Minutes',
   raiseToWake: true,
+  tapToWake: false,
   airdrop: 'contactsOnly',
   backgroundAppRefresh: 'wifi',
   dateTimeAutomatic: true,


### PR DESCRIPTION
## Resumo

Tap to Wake (#608): native wakeScreen() no LauncherModule + toggle tapToWake + consumo na home

## Causa raiz

O issue assume que o #607 «entrega o toggle + persistência» de Tap to Wake. Por inspeção de código isso **não é verdade**: não existe qualquer `tapToWake` (nem `TapToWake`/`tap_to_wake`) em lado nenhum do repositório — `grep` a `tapToWake|TapToWake|Tap to Wake|tap_to_wake` devolve 0 resultados — e não há histórico de git (`git log --all`) para um #607 deste tipo. O que existe é o **irmão** `raiseToWake` (`SettingsStore.tsx:50`, toggle em `DisplayBrightnessScreen.tsx:167-174`, default `true`), mas também ele não tem consumidor que acorde ecrã. O #607, portanto, não está no `main` cortado por este worktree.

Regra do pipeline: «o código ganha». Como a aceitação do próprio issue exige que `LauncherHomeScreen` chame `mod.wakeScreen()` quando `settings.tapToWake`, implementei o toggle mínimo (defeito real que faltava) para que os critérios de aceitação do issue sejam cumpríveis — e documento a divergência abaixo. A peça nativa `wakeScreen()` em si não existia (`LauncherModule.kt` só tinha `AsyncFunction`s de display/flashlight), logo era o trabalho real deste issue.

Mecanismo do consumo: o handler de HOME (`LauncherHomeScreen.tsx`) está num `useEffect` com deps `[openFolder, currentPage]` que **não re-subscreve** a cada render. Ler `settings.tapToWake` directamente ali capturaria um valor obsoleto (o default `false` da primeira render, antes do `AsyncStorage` carregar). Por isso o gate lê um `tapToWakeRef` actualizado por render (`LauncherHomeScreen.tsx:792-794`), garantindo que o valor vivo é usado.

## O que mudou

- **`modules/launcher-module/android/src/main/java/com/iostoandroid/launcher/LauncherModule.kt`**: novo `AsyncFunction("wakeScreen")` junto da secção Flashlight (após `isFlashlightOn`, ~`:754`). Pede `PowerManager`, cria um `SCREEN_BRIGHT_WAKE_LOCK or ACQUIRE_CAUSES_WAKEUP` (tag `iostoandroid:tapToWake`), `acquire(500L)` + `release()`, com `setReferenceCounted(false)`. Import `android.os.PowerManager` adicionado. Falha é best-effort (catch silencioso).
- **`modules/launcher-module/android/src/main/AndroidManifest.xml`**: adicionada `<uses-permission android:name="android.permission.WAKE_LOCK" />` (aceitação do issue).
- **`modules/launcher-module/src/index.ts`**: `wakeScreen(): Promise<void>` na `LauncherModuleType` (`:261`), no stub (`:347`) e o wrapper real `wakeScreen: async () => { try { await nativeModule.wakeScreen() } catch(e){ reportBridgeError('wakeScreen', e) } }` (`:576`) — segue o padrão de `getWifiInfo`/`setFlashlight`.
- **`src/store/SettingsStore.tsx`**: campo `tapToWake: boolean` na `SettingsState` (`:50`) e default `tapToWake: false` (`:162`). Persistido via `AsyncStorage` como os outros (merge em `setSettings`).
- **`src/screens/settings/DisplayBrightnessScreen.tsx`**: toggle «Tap to Wake» logo abaixo de «Raise to Wake» (`:176-185`), ligado a `update('tapToWake', v)`.
- **`src/screens/LauncherHomeScreen.tsx`**: `tapToWakeRef` (`:792-794`) e, no handler de HOME (`:1158-1163`), quando `tapToWakeRef.current` é true, chama `mod.wakeScreen()` (com `.catch(()=>{})` para não quebrar o reset da home). Documentado no comentário que o wake só ocorre com ecrã dimmed-pela-app, não SO apagado.
- **Mocks partilhados** (`jest.setup.js`, `src/__mocks__/launcherModule.js`, `src/screens/__tests__/LauncherHomeScreen.homePress.test.tsx`): espelhado `wakeScreen: jest.fn(() => Promise.resolve())` para os ~30 testes que montam a home não rebentarem com `undefined`.
- **`modules/launcher-module/src/__tests__/index.test.ts`**: bloco `wakeScreen — Tap to Wake bridge (#608)` (4 testes) + ajuste do teste pré-existente «reports failures for every bridge method» (ver abaixo).
- **`src/screens/__tests__/LauncherHomeScreen.homePress.test.tsx`**: bloco `LauncherHomeScreen Tap to Wake wiring (#608)` (2 testes: gate ligado e desligado).

## Porque assim

- **Toggle mínimo em falta**: o issue descrevia mal o estado (assumiu #607 entregue). Implementar o `tapToWake` + persistência + UI é o caminho defensável para cumprir a aceitação «LauncherHomeScreen chama mod.wakeScreen() quando settings.tapToWake». Decisão registada; se o curador preferir que o toggle viva noutro ecrã, é reversível.
- **`Promise<void>` e não `Promise<boolean>`**: acordar ecrã não tem valor de retorno útil; evita inventar um booleano falso. Isto obrigou a corrigir o teste existente «reports failures for every bridge method» que fazia `resolves.toBeDefined()` — um `Promise<void>` resolve a `undefined` e quebrava esse assert. Mantive a intenção real do teste («nunca lança, sempre reporta via onBridgeError») trocando para `resolves.not.toThrow()`. É o único teste alheio que toquei e a alteração preserva o seu contrato.
- **`tapToWakeRef` em vez de `settings` nas deps do effect**: re-subscrever o listener de HOME a cada mudança de setting seria custoso e mudaria o comportamento de subscrição testado noutros testes; o ref lê o valor vivo sem re-subscrever.
- **`require()` dentro do handler** (com `eslint-disable @typescript-eslint/no-require-imports`): espelha `SettingsStore.syncFromDevice` — `await import()` rebenta sob o ambiente CommonJS do Jest, `require()` resolve pelo moduleNameMapper e é mockável.
- **Limitação documentada**: capturar toque com o ecrã APAGADO do SO exigiria um receiver de framework; este issue acorda o ecrã sempre que a app recebe o toque (ecrã dimmed/locked pela app). Escrito no Kotlin, no handler e no PR.

## Critérios de aceitação

- [x] `wakeScreen` exposto no Kotlin + TS, segue o padrão de `getWifiInfo`/`setFlashlight` — `LauncherModule.kt` (`AsyncFunction("wakeScreen")`), `index.ts` (type `:261`, wrapper `:576`). Testado por `wakeScreen — Tap to Wake bridge` (4 testes).
- [x] `LauncherHomeScreen` chama `mod.wakeScreen()` quando `settings.tapToWake` — `LauncherHomeScreen.tsx:1158-1163`, via `tapToWakeRef`. Testado pelo bloco de wiring (ligado → 1 chamada; desligado → 0 chamadas).
- [x] `AndroidManifest.xml` tem `WAKE_LOCK` — adicionado em `modules/launcher-module/android/src/main/AndroidManifest.xml`.
- [x] Teste/typecheck do module passa — `modules/launcher-module/src/__tests__/index.test.ts` (PASS, 32→36 testes) e `tsc --noEmit` limpo.
- [x] PR documenta que só acorda ecrã apagado-pela-app, não o SO — comentários em Kotlin, handler e neste corpo.
- [x] **O que NÃO devia mudar**: o toggle segue o padrão irmão `raiseToWake` (default `false`, UI em `DisplayBrightnessScreen`); nenhuma outra setting, ecrã ou bridge foi tocada. Confirmado por `git status --porcelain` (10 ficheiros, todos relacionados com este issue). Os 4 mocks partilhados só ganharam `wakeScreen` espelhado, sem alterar comportamento de testes alheios.

## Testes

- **Passo vermelho** (fix revertido via `git stash push -- <ficheiros de produção>`, correr, `git stash pop`):

```
$ npx jest modules/launcher-module/src/__tests__/index.test.ts src/screens/__tests__/LauncherHomeScreen.homePress.test.tsx
...
  ● wakeScreen — Tap to Wake bridge (#608) › is exposed as a Promise<void> method on the bridge
      > 546 |     expect(typeof mod.default.wakeScreen).toBe('function');
  ● wakeScreen — Tap to Wake bridge (#608) › calls the native wakeScreen function when invoked
      TypeError: mod.default.wakeScreen is not a function
        > 556 |     await mod.default.wakeScreen();
  ● wakeScreen — Tap to Wake bridge (#608) › reports a native failure to onBridgeError listeners instead of throwing
      TypeError: mod.default.wakeScreen is not a function
        > 567 |     await expect(mod.default.wakeScreen()).resolves.toBeUndefined();
  ● wakeScreen — Tap to Wake bridge (#608) › does not report to onBridgeError when the native call succeeds
      TypeError: mod.default.wakeScreen is not a function
        > 576 |     await mod.default.wakeScreen();
  ● LauncherHomeScreen Tap to Wake wiring (#608) › calls mod.wakeScreen() when the HOME event fires and settings.tapToWake is enabled
      expect(jest.fn()).toHaveBeenCalledTimes(expected)
      Expected number of calls: 1
      Received number of calls: 0
        > 158 |     await waitFor(() => expect(launcher.wakeScreen).toHaveBeenCalledTimes(1));
  Test Suites: 2 failed, 2 total
  Tests:       5 failed, 36 passed, 41 total
```

Com o fix restaurado:

```
$ npx jest modules/launcher-module/src/__tests__/index.test.ts src/screens/__tests__/LauncherHomeScreen.homePress.test.tsx
Test Suites: 2 passed, 2 total
Tests:       41 passed, 41 total
```

- **Casos cobertos além do caminho feliz**:
  - *Fronteiras/vazio*: método `Promise<void>` que resolve a `undefined` (não lança) — testado em «is exposed» e «does not report… succeeds».
  - *Inválido/hostil*: native rebenta (`makeNativeModule(true)`) → wrapper envia para `onBridgeError` e resolve (não lança) — «reports a native failure… instead of throwing».
  - *O inverso do fix*: `tapToWake: false` → `wakeScreen` NUNCA é chamado — «does NOT call mod.wakeScreen() when settings.tapToWake is disabled».
  - *Ligado*: `tapToWake: true` + HOME → exatamente 1 chamada a `wakeScreen` — «calls mod.wakeScreen() when the HOME event fires…».
  - Cada teste falha por razão diferente (tipo em falta vs 0 chamadas vs listener não notificado), pelo que não são redundantes.

- **Sanity-check**: reverti os 6 ficheiros de produção com `git stash push -- …`, corri a suite `wakeScreen`/`tapToWake` → 5 falharam (RED acima); `git stash pop` → 41 passaram. Os meus testes estão ligados ao comportamento; sem o fix não passam.

- **Verificações**:
  - `npm run lint` → 0 erros (2 warnings pré-existentes em ficheiros que não toquei: `BridgeErrorReporting.test.tsx`, `ClockScreen.tsx`).
  - `npx tsc --noEmit` → limpo (exit 0).
  - `npm test -- --maxWorkers=2` → 1545 passaram, 11 falharam, 1556 total. As 11 falhas = 8 nas 4 suites do baseline documentado (`FoldersStore`, `SettingsScreen`, `LockScreen`, `WeatherScreen`) + 3 em `plugins/__tests__/withLauncherIntent.test.js`. Confirmei ambos os conjuntos em `main` limpo (stash de tudo): idênticos 8/41 nas 4 suites e 3/3 no withLauncherIntent — **nenhuma falha nova introduzida por este trabalho**. O `withLauncherIntent` falha no `main` limpo (lê `android/app/src/main/AndroidManifest.xml`, ficheiro que não toquei).

## Nota sobre o issue

O issue afirma que o #607 entregou o toggle; isso **não está no código nem no git**. Implementei o `tapToWake` (setting + default + persistência + UI) para satisfazer a aceitação do próprio issue. Se o curador considerar que o toggle deve vir num PR separado do #607, o consumer e o native method continuam válidos e o toggle pode ser movido.

## Testes

1545 passaram, 11 falharam (todos pré-existentes no baseline), 1556 total; os meus 6 testes wakeScreen/tapToWake passam

## Linked Issue

Fixes #608