### PR TITLE
Toggle «Show Page Dots» (iOS Home Screen & Dock): setting showPageDots (default true) controla a renderização dos page dots e ganha UI no settings (#603)

### DIFF
--- a/src/screens/LauncherHomeScreen.tsx
+++ b/src/screens/LauncherHomeScreen.tsx
@@ -511,10 +511,13 @@ const AppIcon = React.memo(function AppIcon({
 interface PageDotsProps {
   total: number;
   current: number;
+  show: boolean;
 }
 
-function PageDots({ total, current }: PageDotsProps) {
-  if (total <= 1) return null;
+function PageDots({ total, current, show }: PageDotsProps) {
+  // iOS «Home Screen & Dock → Show Page Dots»: escondido por setting mesmo
+  // quando há paginação, ou quando há só uma página.
+  if (total <= 1 || !show) return null;
   return (
     <View style={styles.pageDotsRow}>
       {Array.from({ length: total }).map((_, i) => (
@@ -1677,7 +1680,7 @@ export function LauncherHomeScreen() {
       {/* ---------------------------------------------------------------- */}
       {/* Page dots + Search label (iOS 16/17 style)                         */}
       {/* ---------------------------------------------------------------- */}
-      <PageDots total={totalPages} current={currentPage} />
+      <PageDots total={totalPages} current={currentPage} show={settings.showPageDots} />
       <Pressable
         style={styles.searchLabel}
         onPress={isJiggling ? exitJiggle : () => navigation.navigate('SpotlightSearch')}

--- a/src/screens/LauncherSettingsScreen.tsx
+++ b/src/screens/LauncherSettingsScreen.tsx
@@ -352,6 +352,17 @@ export function LauncherSettingsScreen() {
           }
         />
         <CupertinoListTile
+          title="Show Page Dots"
+          leading={{ name: 'apps', color: '#fff', backgroundColor: '#FF9500' }}
+          showChevron={false}
+          trailing={
+            <CupertinoSwitch
+              value={settings.showPageDots}
+              onValueChange={(v) => update('showPageDots', v)}
+            />
+          }
+        />
+        <CupertinoListTile
           title="Show App Names"
           leading={{ name: 'text-outline', color: '#fff', backgroundColor: '#8E8E93' }}
           showChevron={false}

--- a/src/screens/__tests__/LauncherHomeScreen.pageDotsToggle.test.tsx
+++ b/src/screens/__tests__/LauncherHomeScreen.pageDotsToggle.test.tsx
@@ -1,0 +1,135 @@
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { render, waitFor } from '../../test-utils';
+import * as AppsStore from '../../store/AppsStore';
+import * as FoldersStore from '../../store/FoldersStore';
+import { LauncherHomeScreen } from '../LauncherHomeScreen';
+
+// issue #603 — toggle «Show Page Dots» (iOS Home Screen & Dock). O launcher
+// renderiza sempre os page dots quando há >1 página; este teste trava que o
+// setting showPageDots (default true) controla a renderização e que false os
+// esconde — sem alterar o comportamento de layout do resto da home.
+
+const APP_NAMES = Array.from({ length: 26 }, (_, i) =>
+  String.fromCharCode(65 + (i % 26)) + (i >= 26 ? i : ''),
+);
+
+function makeApp(name: string): AppsStore.InstalledApp {
+  const pkg = `com.example.${name.toLowerCase()}`;
+  return { name, packageName: pkg, icon: `file:///${pkg}.png`, isSystem: false };
+}
+
+function mockApps(apps: AppsStore.InstalledApp[]) {
+  jest.spyOn(AppsStore, 'useApps').mockReturnValue({
+    apps,
+    homeApps: [],
+    dockApps: [],
+    nonDockApps: apps,
+    recentPackages: [],
+    recentApps: [],
+    isLoading: false,
+    refreshApps: jest.fn(() => Promise.resolve()),
+    launchApp: jest.fn(() => Promise.resolve(true)),
+    addToHome: jest.fn(),
+    removeFromHome: jest.fn(),
+    addToDock: jest.fn(),
+    removeFromDock: jest.fn(),
+    removeFromRecents: jest.fn(),
+    clearRecents: jest.fn(),
+    isDefaultLauncher: true,
+    openLauncherSettings: jest.fn(() => Promise.resolve()),
+    iconCacheSizeBytes: 0,
+    isRebuildingIconCache: false,
+    iconCacheRebuildProgress: null,
+    rebuildIconCache: jest.fn(() => Promise.resolve()),
+  } as ReturnType<typeof AppsStore.useApps>);
+}
+
+function mockFolders(folders: FoldersStore.AppFolder[]) {
+  jest.spyOn(FoldersStore, 'useFolders').mockReturnValue({
+    folders,
+    createFolder: jest.fn(),
+    renameFolder: jest.fn(),
+    addToFolder: jest.fn(),
+    removeFromFolder: jest.fn(),
+    deleteFolder: jest.fn(),
+    getFolderForApp: jest.fn((pkg: string) => folders.find((f) => f.apps.includes(pkg))),
+    isReady: true,
+  } as ReturnType<typeof FoldersStore.useFolders>);
+}
+
+function seedSettings(partial: Record<string, unknown>) {
+  (AsyncStorage.getItem as jest.Mock).mockImplementation((key: string) =>
+    key === '@iostoandroid/settings'
+      ? Promise.resolve(JSON.stringify(partial))
+      : Promise.resolve(null),
+  );
+}
+
+/** Conta os dots renderizados (estilo pageDot: width 7, height 7, radius 3.5). */
+function countPageDots(root: ReturnType<typeof render>): number {
+  // react-native style numbers come through unchanged in jsdom, so flatten + compare.
+  const all = root.UNSAFE_getAllByType(View);
+  return all.filter((n: { props?: { style?: unknown } }) => {
+    const s = StyleSheet.flatten(n.props?.style) as Record<string, unknown> | undefined;
+    return !!s && s.width === 7 && s.height === 7 && s.borderRadius === 3.5;
+  }).length;
+}
+
+// 26 apps reais + 14 virtuais = 40 itens; 4x6 = 24/page → 2 páginas (40 > 24).
+function manyApps() {
+  return APP_NAMES.map(makeApp);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('LauncherHomeScreen page dots toggle (#603)', () => {
+  it('renders page dots when there is more than one page and showPageDots is default', async () => {
+    seedSettings({ gridColumns: 4, gridRows: 6 });
+    mockApps(manyApps());
+    mockFolders([]);
+
+    const root = render(<LauncherHomeScreen />);
+    await waitFor(
+      () => expect(countPageDots(root)).toBeGreaterThan(0),
+      { timeout: 3000 },
+    );
+    expect(countPageDots(root)).toBeGreaterThanOrEqual(2);
+    root.unmount();
+  });
+
+  it('hides page dots when settings.showPageDots is false (even with >1 page)', async () => {
+    seedSettings({ gridColumns: 4, gridRows: 6, showPageDots: false });
+    mockApps(manyApps());
+    mockFolders([]);
+
+    const root = render(<LauncherHomeScreen />);
+    // Espera que a home monte (páginas presentes) antes de afirmar sobre os dots.
+    await waitFor(
+      () => expect(root.getByTestId('launcher-page-grid-0')).toBeTruthy(),
+      { timeout: 3000 },
+    );
+    // A grid continua lá (layout não regredido)...
+    expect(root.getByTestId('launcher-page-grid-0')).toBeTruthy();
+    // ...mas os dots desaparecem.
+    expect(countPageDots(root)).toBe(0);
+    root.unmount();
+  });
+
+  it('still renders the grid pages (no layout regression) when dots are hidden', async () => {
+    seedSettings({ gridColumns: 4, gridRows: 6, showPageDots: false });
+    mockApps(manyApps());
+    mockFolders([]);
+
+    const root = render(<LauncherHomeScreen />);
+    await waitFor(
+      () => expect(root.getByTestId('launcher-page-grid-1')).toBeTruthy(),
+      { timeout: 3000 },
+    );
+    expect(root.getByTestId('launcher-page-grid-1')).toBeTruthy();
+    root.unmount();
+  });
+});

--- a/src/screens/__tests__/LauncherSettingsScreen.test.tsx
+++ b/src/screens/__tests__/LauncherSettingsScreen.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, fireEvent, waitFor } from '../../test-utils';
+import { within } from '@testing-library/react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as SecureStore from 'expo-secure-store';
 import { LauncherSettingsScreen } from '../LauncherSettingsScreen';
@@ -109,5 +110,51 @@ describe('LauncherSettingsScreen', () => {
       expect(getByText('Enter New Passcode')).toBeTruthy();
     });
     expect(store.has('@iostoandroid/lock_pin')).toBe(true);
+  });
+});
+
+describe('LauncherSettingsScreen Show Page Dots toggle (#603)', () => {
+  it('renders a "Show Page Dots" switch in the Home Screen section, default ON', () => {
+    const { getByLabelText } = render(<LauncherSettingsScreen />);
+    const tile = getByLabelText('Show Page Dots');
+    const sw = within(tile).getByRole('switch');
+    expect(sw.props.accessibilityState.checked).toBe(true);
+  });
+
+  it('toggles showPageDots off and persists it to AsyncStorage', async () => {
+    const store = setupMemoryAsyncStorage();
+
+    const { getByLabelText } = render(<LauncherSettingsScreen />);
+    const tile = getByLabelText('Show Page Dots');
+    const sw = within(tile).getByRole('switch');
+
+    fireEvent.press(sw);
+
+    await waitFor(() => {
+      expect(
+        within(getByLabelText('Show Page Dots')).getByRole('switch').props.accessibilityState.checked,
+      ).toBe(false);
+    });
+
+    // Persiste entre arranques: o SettingsStore escreve o JSON completo.
+    await waitFor(() => {
+      const raw = store.get('@iostoandroid/settings');
+      expect(raw).toBeTruthy();
+      const parsed = JSON.parse(raw as string);
+      expect(parsed.showPageDots).toBe(false);
+    });
+  });
+
+  it('leaves showPageDots unset (true by default) when nothing is toggled', async () => {
+    const store = setupMemoryAsyncStorage();
+
+    render(<LauncherSettingsScreen />);
+
+    // O default true não precisa de ser escrito explicitamente para persistir
+    // o comportamento; mas se o store gravar, deve refletir true.
+    await waitFor(() => {
+      const raw = store.get('@iostoandroid/settings');
+      if (raw) expect(JSON.parse(raw).showPageDots ?? true).toBe(true);
+    });
   });
 });

--- a/src/store/SettingsStore.tsx
+++ b/src/store/SettingsStore.tsx
@@ -90,6 +90,13 @@ export interface SettingsState {
   /** Whether app names render under grid icons (issue #503). */
   showIconLabels: boolean;
   /**
+   * Whether the home-screen page dots (iOS «Home Screen & Dock → Show Page
+   * Dots») render when there is more than one page. Independent of
+   * `showIconLabels` — one hides the app-name text, the other hides the
+   * pagination indicator. Default true (iOS shows dots unless toggled off).
+   */
+  showPageDots: boolean;
+  /**
    * Whether the icon-expand animation plays when opening an app (§6.3).
    * Independent of `reduceMotion`: turning this off skips only the
    * icon-expand overlay, not other motion in the app. `reduceMotion` (or,
@@ -189,6 +196,7 @@ export const DEFAULT_SETTINGS: SettingsState = {
   gridRows: 6,
   iconSizeScale: 1.0,
   showIconLabels: true,
+  showPageDots: true,
   appLaunchAnimation: true,
   appLaunchDurationMs: 280,
   iconShape: 'squircle',


### PR DESCRIPTION
## Resumo

Toggle «Show Page Dots» (iOS Home Screen & Dock): setting showPageDots (default true) controla a renderização dos page dots e ganha UI no settings

## Causa raiz

O `LauncherHomeScreen` renderiza sempre o componente interno `PageDots` sempre que há mais de uma página (`src/screens/LauncherHomeScreen.tsx:517`, guarda `if (total <= 1) return null;`), sem qualquer gate por definição. Não existe qualquer setting `showPageDots` em lado nenhum (`grep` e `git log -S 'showPageDots'` → vazio), por isso o comportamento actual é invariável: os dots aparecem sempre com >1 página. O issue descrevia mal a localização — citava `:388`/`:390` para os page dots, mas essas linhas pertencem aos handlers de icon-jiggle; o componente real é `PageDots` em `:516`. O mecanismo (ausência de gate por settings) está correto; só a citação de linhas estava errada.

## O que mudou

- `src/store/SettingsStore.tsx`: acrescentado `showPageDots: boolean` à `SettingsState` e `showPageDots: true` ao `DEFAULT_SETTINGS`. O load por merge parcial (`...prev, ...parsed`) já normaliza campos em falta, por isso definições antigas guardadas continuam válidas (o setting é opcional no JSON persistido).
- `src/screens/LauncherHomeScreen.tsx`: `PageDots` ganhou prop `show: boolean`; a guarda passou a `if (total <= 1 || !show) return null;`. No local de render (`:1683`) passa-se `show={settings.showPageDots}`. `settings` já era lido no `LauncherHomeScreen` via `useSettings()` (`:785`), logo nenhum import novo foi preciso.
- `src/screens/LauncherSettingsScreen.tsx`: novo `CupertinoListTile` "Show Page Dots" na secção **Home Screen** (após "Show Search Label"), com `CupertinoSwitch value={settings.showPageDots}` a chamar `update('showPageDots', v)`. `useSettings`/`CupertinoSwitch` já eram usados no ficheiro.

## Porque assim

Passar `show` como prop em vez de ler `useSettings` dentro de `PageDots`: o `PageDots` é um componente interno puro de apresentação; manter a fonte de verdade no ecrã (que já tem `settings`) evita um hook oculto e mantém o componente testável e sem dependência de contexto. A guarda `!show` segue o mesmo padrão da `total <= 1` já existente (early return null), sem `?.`/``??``/try-catch que escondessem o caso. Default `true` espelha o iOS (dots visíveis salvo toggle off) e garante zero mudança de comportamento para utilizadores existentes (persistência por merge).

## Critérios de aceitação

- [x] **Toggle em `LauncherSettingsScreen` (Home Screen), default `true`** — tile "Show Page Dots" adicionado; teste confirma `accessibilityState.checked === true` no arranque.
- [x] **`false` → `pageDotsRow` não renderiza** — com `showPageDots:false` e >1 página, `countPageDots` retorna 0 (e a grid continua presente, logo sem regressão de layout).
- [x] **`true` → comportamento actual mantém-se** — default true renderiza os dots como antes (teste "renders page dots ... default" passa com >0 dots).
- [x] **Persiste entre arranques** — `SettingsStore` grava o JSON completo no `AsyncStorage`; teste confirma que após togglar, `parsed.showPageDots === false` no storage. Backward-compat: settings antigas sem a chave mantêm o default true (merge).
- [x] **Sem regressão de layout** — os `launcher-page-grid-0/1` continuam a montar com dots escondidos; os testes numéricos dos dots (`numericalSpec`, `pageDot width 7 / gap 9 / opacity 0.30`) não foram tocados e continuam a passar.

## Testes

- **Passo vermelho** (fix revertido via `git stash` dos 3 ficheiros de produção; output real do jest):

```
FAIL Android src/screens/__tests__/LauncherHomeScreen.pageDotsToggle.test.tsx (12.414 s)
  LauncherHomeScreen page dots toggle (#603)
    ✓ renders page dots when there is more than one page and showPageDots is default (2669 ms)
    ✕ hides page dots when settings.showPageDots is false (even with >1 page) (123 ms)
    ✓ still renders the grid pages (no layout regression) when dots are hidden (94 ms)

  ● LauncherHomeScreen page dots toggle (#603) › hides page dots when settings.showPageDots is false (even with >1 page)

    expect(received).toBe(expected) // Object.is equality
    Expected: 0
    Received: 3
      118 |     expect(countPageDots(root)).toBe(0);
          |                                 ^
```

  Sem o fix, o teste "hide" falha porque os dots renderizam sempre (3 dots com >1 página) — expõe o defeito, não um mock partido. Os outros dois passam (default true e grid monta), provando que o teste isola o gate e não a montagem do ecrã.

- **Casos cobertos** (além do caminho feliz):
  - *Inverso do fix*: `showPageDots:false` → 0 dots com grid intacta (teste "hides" + "still renders grid pages").
  - *Default*: `showPageDots` omitido → dots apresentes (caminho feliz, igual ao comportamento pré-fix).
  - *Persistência/assíncrono*: togglar o switch no SettingsScreen escreve `showPageDots:false` no AsyncStorage (teste "toggles ... persists"); e default true reflete-se no storage quando gravado.
  - Fronteiras cobertas indirectamente: `total <= 1` continua a esconder (guarda inalterada no caminho `true`).
  Cada teste falha por razão distinta (ausência do tile / dots presentes quando deviam estar ocultos / storage não reflete toggle).

- **Sanity-check**: `git stash push` dos 3 ficheiros de produção → `npx jest` desses 2 ficheiros de teste dá **3 failed, 6 passed** (o tile "Show Page Dots" não existe e os dots não escondem). `git stash pop` restaura → **9 passed, 0 failed**. Sem o fix, a suite que escrevi falha; com o fix, passa.

- **Verificações**: `npm run lint` → 0 erros (2 warnings pré-existentes em `ClockScreen.tsx`, fora do âmbito). `npx tsc --noEmit` → limpo (exit 0). `npm test -- --maxWorkers=2` → **1545 passed, 11 failed** em 161 suites. As 11 falhas são exatamente as 5 suites do baseline (withLauncherIntent, LockScreen, SettingsScreen, WeatherScreen, FoldersStore) — **nenhuma falha nova** introduzida por este trabalho.

## Testes

9 passaram, 0 falharam (os meus 2 ficheiros de teste); suite completa: 1545 passaram, 11 falharam (todas pré-existentes no baseline, 0 novas)

## Linked Issue

Fixes #603