### PR TITLE
settings: picker de Tint (accent color) em Display & Brightness ligado a setAccentColor (#604)

### DIFF
--- a/src/screens/settings/DisplayBrightnessScreen.tsx
+++ b/src/screens/settings/DisplayBrightnessScreen.tsx
@@ -15,17 +15,27 @@ import {
   CupertinoActionSheet,
   CupertinoSlider,
 } from '../../components';
+import { AccentColors, type AccentColorKey } from '../../theme/CupertinoTheme';
 import type { AppNavigationProp } from '../../navigation/types';
 
 const NIGHT_SHIFT_KEY = '@iostoandroid/night_shift';
 
+const ACCENT_KEYS = Object.keys(AccentColors) as AccentColorKey[];
+
+/** 'blue' → 'Blue'. iOS lists the tint options with a capitalised label. */
+function accentLabel(key: AccentColorKey) {
+  return key.charAt(0).toUpperCase() + key.slice(1);
+}
+
 export function DisplayBrightnessScreen({ navigation }: { navigation: AppNavigationProp }) {
-  const { theme, typography, spacing, isDark, mode, setThemeMode } = useTheme();
+  const { theme, typography, spacing, isDark, mode, setThemeMode, accentColor, setAccentColor } =
+    useTheme();
   const { colors } = theme;
   const insets = useSafeAreaInsets();
   const { settings, update } = useSettings();
   const { brightness, setBrightness } = useDevice();
   const [showAutoLock, setShowAutoLock] = useState(false);
+  const [showTintPicker, setShowTintPicker] = useState(false);
   const [nightShiftEnabled, setNightShiftEnabled] = useState(false);
   const [nightShiftIntensity, setNightShiftIntensity] = useState(0.5);
 
@@ -122,6 +132,27 @@ export function DisplayBrightnessScreen({ navigation }: { navigation: AppNavigat
                 onChange={(i) => setThemeMode(i === 0 ? 'light' : i === 1 ? 'dark' : 'system')}
               />
             </View>
+          </CupertinoListSection>
+        </View>
+
+        {/* Tint (accent colour) */}
+        <View style={{ paddingHorizontal: spacing.md }}>
+          <CupertinoListSection header="Tint">
+            <CupertinoListTile
+              title="Tint"
+              trailing={
+                <View style={styles.tintTrailing}>
+                  <View
+                    testID="tint-swatch"
+                    style={[styles.tintSwatch, { backgroundColor: colors.accent }]}
+                  />
+                  <Text style={[typography.body, { color: colors.secondaryLabel }]}>
+                    {accentLabel(accentColor)}
+                  </Text>
+                </View>
+              }
+              onPress={() => setShowTintPicker(true)}
+            />
           </CupertinoListSection>
         </View>
 
@@ -234,6 +265,20 @@ export function DisplayBrightnessScreen({ navigation }: { navigation: AppNavigat
         ]}
         cancelLabel="Cancel"
       />
+
+      <CupertinoActionSheet
+        visible={showTintPicker}
+        onClose={() => setShowTintPicker(false)}
+        title="Tint"
+        options={ACCENT_KEYS.map((key) => ({
+          label: accentLabel(key),
+          onPress: () => {
+            setAccentColor(key);
+            setShowTintPicker(false);
+          },
+        }))}
+        cancelLabel="Cancel"
+      />
     </View>
   );
 }
@@ -271,5 +316,15 @@ const styles = StyleSheet.create({
     height: 6,
     borderRadius: 3,
     width: '100%',
+  },
+  tintTrailing: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  tintSwatch: {
+    width: 18,
+    height: 18,
+    borderRadius: 9,
   },
 });

--- a/src/screens/settings/__tests__/DisplayBrightnessTint.test.tsx
+++ b/src/screens/settings/__tests__/DisplayBrightnessTint.test.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { render, fireEvent } from '../../../test-utils';
+import { DisplayBrightnessScreen } from '../DisplayBrightnessScreen';
+import { AccentColors } from '../../../theme/CupertinoTheme';
+
+const mockNavigation = { navigate: jest.fn(), goBack: jest.fn(), push: jest.fn() };
+
+function renderScreen() {
+  return render(<DisplayBrightnessScreen navigation={mockNavigation as never} />);
+}
+
+/** The swatch's resolved backgroundColor, whatever shape the style prop has. */
+function swatchColor(node: { props: { style: unknown } }): string | undefined {
+  const flat = ([] as unknown[]).concat(node.props.style as unknown[]);
+  for (const entry of flat.reverse()) {
+    const bg = (entry as { backgroundColor?: string } | null)?.backgroundColor;
+    if (bg) return bg;
+  }
+  return undefined;
+}
+
+const ACCENT_LABELS = ['Blue', 'Purple', 'Pink', 'Red', 'Orange', 'Green'];
+
+describe('DisplayBrightnessScreen — Tint picker', () => {
+  it('renders a Tint tile showing the current accent (default Blue)', () => {
+    const { getByText, getByTestId } = renderScreen();
+    expect(getByText('Blue')).toBeTruthy();
+    const blue = [AccentColors.blue.light, AccentColors.blue.dark];
+    expect(blue).toContain(swatchColor(getByTestId('tint-swatch')));
+  });
+
+  it('keeps the picker closed until the tile is pressed (inverse of the fix)', () => {
+    const { queryByText, getByText } = renderScreen();
+    // 'Purple' only exists inside the action sheet options.
+    expect(queryByText('Purple')).toBeNull();
+    fireEvent.press(getByText('Tint'));
+    expect(queryByText('Purple')).toBeTruthy();
+  });
+
+  it('lists every key of AccentColors in the sheet', () => {
+    const { getByText, getAllByText } = renderScreen();
+    fireEvent.press(getByText('Tint'));
+    expect(ACCENT_LABELS).toHaveLength(Object.keys(AccentColors).length);
+    for (const label of ACCENT_LABELS) {
+      expect(getAllByText(label).length).toBeGreaterThan(0);
+    }
+  });
+
+  it('applies the chosen accent to the theme and closes the sheet', () => {
+    const { getByText, getByTestId, queryByText } = renderScreen();
+    fireEvent.press(getByText('Tint'));
+    fireEvent.press(getByText('Purple'));
+    const purple = [AccentColors.purple.light, AccentColors.purple.dark];
+    expect(purple).toContain(swatchColor(getByTestId('tint-swatch')));
+    // sheet dismissed → the option label is gone, only the tile trailing remains
+    expect(queryByText('Blue')).toBeNull();
+  });
+
+  it('survives choosing the same colour twice (double tap)', () => {
+    const { getByText, getAllByText, getByTestId } = renderScreen();
+    fireEvent.press(getByText('Tint'));
+    fireEvent.press(getByText('Green'));
+    fireEvent.press(getByText('Tint'));
+    // 'Green' now appears twice: the tile trailing and the sheet option.
+    const options = getAllByText('Green');
+    fireEvent.press(options[options.length - 1]);
+    const green = [AccentColors.green.light, AccentColors.green.dark];
+    expect(green).toContain(swatchColor(getByTestId('tint-swatch')));
+  });
+
+  it('switches again from a non-default accent (order independence)', () => {
+    const { getByText, getByTestId } = renderScreen();
+    fireEvent.press(getByText('Tint'));
+    fireEvent.press(getByText('Red'));
+    fireEvent.press(getByText('Tint'));
+    fireEvent.press(getByText('Orange'));
+    const orange = [AccentColors.orange.light, AccentColors.orange.dark];
+    expect(orange).toContain(swatchColor(getByTestId('tint-swatch')));
+  });
+});


### PR DESCRIPTION
## Resumo

settings: picker de Tint (accent color) em Display & Brightness ligado a setAccentColor

## Causa raiz

Não é um bug, é UI em falta: o estado do accent existia e estava completo, mas nada no `src/screens/` o escrevia.

- `src/theme/ThemeContext.tsx:103` — `useState<AccentColorKey>('blue')`; `setAccentColor` exposto no contexto e persistido em `ACCENT_STORAGE_KEY` (`:145` hidrata, efeito seguinte grava quando `isReady`).
- `src/theme/CupertinoTheme.ts:158-166` — `AccentColors` (6 chaves), aplicado em `:423-425` (`base.accent` e `base.systemBlue` seguem a chave escolhida).
- `grep setAccentColor src/screens/` → 0 resultados. Logo o valor ficava eternamente `'blue'`: o único caminho para mudar era o storage já ter um valor, o que nunca acontecia porque nada o escrevia.

Correcção ao issue: o caminho indicado (`src/screens/DisplayBrightnessScreen.tsx`) não existe — o ecrã está em `src/screens/settings/DisplayBrightnessScreen.tsx`. O `GeneralScreen.tsx` referido também está em `src/screens/settings/`. As linhas citadas do `CupertinoTheme.ts` estão desviadas (`AccentColors` em `:158`, não `:150`; aplicação em `:423-425`, não `:401-403`) — o padrão está correcto, os números não.

## O que mudou

`src/screens/settings/DisplayBrightnessScreen.tsx`
- Importa `AccentColors` / `AccentColorKey`; deriva `ACCENT_KEYS = Object.keys(AccentColors)` (a lista vem da paleta, não de um array duplicado — acrescentar uma cor ao tema passa a aparecer no picker sem tocar no ecrã).
- Consome `accentColor` e `setAccentColor` do `useTheme()`.
- Nova secção `Tint` depois da secção Appearance: `CupertinoListTile` "Tint" com trailing = swatch redondo (`testID="tint-swatch"`, cor = `colors.accent`, ou seja o valor já resolvido pelo tema) + o nome da cor actual.
- Novo `CupertinoActionSheet` (`showTintPicker`) com uma opção por chave de `AccentColors`, cada uma a chamar `setAccentColor(key)` e a fechar a folha. Padrão idêntico aos sheets de Auto-Lock/AirDrop já existentes.
- Dois estilos novos (`tintTrailing`, `tintSwatch`).

`src/screens/settings/__tests__/DisplayBrightnessTint.test.tsx` (novo) — 6 testes, monta o ecrã real através de `src/test-utils.tsx` (providers verdadeiros) e dispara presses verdadeiros; o accent é lido do swatch renderizado, portanto o assert atravessa `setAccentColor` → `ThemeContext` → `buildTheme` → estilo.

## Porque assim

- **Action sheet e não ecrã próprio:** o issue pede o padrão do AirDrop, e é o que o resto deste ecrã já usa (Auto-Lock). Um `CupertinoSegmentedControl` foi descartado: 6 cores não cabem e o iOS usa uma lista.
- **`ACCENT_KEYS` derivado de `Object.keys`** em vez de uma lista literal: evita que a paleta e o picker divirjam.
- **Swatch com `colors.accent`** em vez de `AccentColors[accentColor][isDark?...]` no ecrã: reusa a resolução light/dark que o tema já faz e prova, no próprio render, que `base.accent` seguiu a escolha.
- **Nada tocado no `ThemeContext`/`SettingsStore`:** a persistência já existia e funciona; confirmado por leitura (`ThemeContext.tsx:145` hidrata só se `storedAccent in AccentColors`, senão mantém `'blue'`).

## Critérios de aceitação

- [x] Picker de accent em Display & Brightness com **todas** as cores de `AccentColors` — teste `lists every key of AccentColors in the sheet` compara o número de labels verificadas com `Object.keys(AccentColors).length`, logo falha se a paleta crescer e o picker não.
- [x] A escolha aplica o accent ao tema — teste `applies the chosen accent to the theme and closes the sheet`: após escolher Purple, o `backgroundColor` do swatch é `AccentColors.purple.light|dark`, valor produzido por `CupertinoTheme.ts:423-425`.
- [x] Persistência entre arranques — não alterada; `ACCENT_STORAGE_KEY` é gravado pelo efeito em `ThemeContext.tsx` sempre que `accentColor` muda com `isReady`. Verificado por leitura; não escrevi teste de storage porque nada aqui mexeu nesse caminho.
- [x] Default `blue` mantém-se — teste `renders a Tint tile showing the current accent (default Blue)` sem nada no AsyncStorage.
- [x] **O que NÃO devia mudar:** o teste pré-existente `DisplayBrightnessScreen.test.tsx` (Light/Dark/Automatic) continua a passar sem alteração, e a suite completa tem exactamente as mesmas 11 falhas com e sem o fix (prova abaixo). Nenhum snapshot mudou (`Snapshots: 6 passed`, 0 written/updated). Não toquei em `ThemeContext.tsx`, `CupertinoTheme.ts` nem `SettingsStore.tsx`.

## Testes

**Passo vermelho** — `git stash push -- src/screens/settings/DisplayBrightnessScreen.tsx` (tira só o ecrã, deixa o teste novo):

```
      69 |   it('switches again from a non-default accent (order independence)', () => {
      70 |     const { getByText, getByTestId } = renderScreen();
    > 71 |     fireEvent.press(getByText('Tint'));
         |                     ^
      72 |     fireEvent.press(getByText('Red'));
      73 |     fireEvent.press(getByText('Tint'));
      74 |     fireEvent.press(getByText('Orange'));

      at Object.getByText (src/screens/settings/__tests__/DisplayBrightnessTint.test.tsx:71:21)

Test Suites: 1 failed, 1 total
Tests:       6 failed, 6 total
```

Os 6 falham por `Unable to find an element with text: Tint` — a árvore renderizada (impressa pelo jest) é o ecrã completo com Brightness, Appearance, Text Size, True Tone e Night Shift, e **sem** secção Tint. Falha pela razão certa: o componente monta, os providers funcionam, o que falta é o tile. Depois de `git stash pop`: `Tests: 6 passed`.

Confirmei também que o comportamento não estava já em `main`: `grep setAccentColor src/screens/` em `origin/main` dá 0 resultados, logo não estou a alegar um guard pré-existente.

**Casos cobertos além do caminho feliz:**
- *Inverso do fix* — `keeps the picker closed until the tile is pressed`: 'Purple' não existe na árvore antes do press (garante que a folha está fechada, não apenas que abre).
- *Repetição / duplo toque* — escolher Green, reabrir, escolher Green outra vez; o accent mantém-se e nada rebenta. Este teste apanhou uma ambiguidade real: depois da primeira escolha o label passa a existir duas vezes (trailing do tile + opção da folha), pelo que o teste tem de desambiguar pela última ocorrência.
- *Ordem / troca a partir de não-default* — Red e depois Orange; garante que o setter não é one-shot nem depende de partir de `'blue'`.
- *Completude da paleta* — asserção contra `Object.keys(AccentColors).length`, para o teste falhar se alguém acrescentar uma cor e o picker ficar atrás.
- Cada teste pode falhar por uma razão distinta (ausência do tile, folha aberta por omissão, cor em falta, accent não propagado, segunda escolha ignorada, estado preso).

**Sanity-check:** `git stash push -u -- src/screens/settings/` (fix + testes fora), suite completa → `5 failed, 155 passed, 160 total / 11 failed, 1545 passed, 1556 total`. Com o fix → `5 failed, 156 passed, 161 total / 11 failed, 1551 passed, 1562 total`. Mesmas 11 falhas, mesmas 5 suites, +1 suite e +6 testes a passar. Zero regressões.

As 11 falhas pré-existentes (baseline; nenhuma em ficheiro que toquei): FoldersStore (2), LockScreen (3), SettingsScreen › renders Dark Mode toggle, WeatherScreen (2), withLauncherIntent plugin (3).

**Verificações:**
- `npm run lint` → `✖ 2 problems (0 errors, 2 warnings)` — os 2 warnings são pré-existentes (`BridgeErrorReporting.test.tsx:2`, `ClockScreen.tsx:258`), nenhum nos meus ficheiros.
- `npx tsc --noEmit` → limpo, 0 output. Nenhum `any` novo.
- `npm test -- --maxWorkers=2` → `Tests: 11 failed, 1551 passed, 1562 total`, `Snapshots: 6 passed`.

## Testes

1551 passaram, 11 falharam (as mesmas 11 do baseline, nenhuma nova), 161 suites; os 6 testes novos passam todos

## Linked Issue

Fixes #604