### PR TITLE
feat/611: Face ID & Passcode — faceIdForUnlock + requirePasscodeAfter nas Settings e respeitados no LockScreen (#611)

### DIFF
--- a/src/screens/LauncherSettingsScreen.tsx
+++ b/src/screens/LauncherSettingsScreen.tsx
@@ -31,6 +31,11 @@ import {
   type PerfBudgetKey,
   type PerfMetrics,
 } from '../utils/perfMetrics';
+import {
+  REQUIRE_PASSCODE_LABELS,
+  REQUIRE_PASSCODE_OPTIONS,
+  normalizeRequirePasscodeAfter,
+} from '../utils/passcodePolicy';
 
 /**
  * #517: os números de arranque têm de ser legíveis em runtime, e não podem
@@ -89,6 +94,7 @@ export function LauncherSettingsScreen() {
   const alert = useAlert();
   const [showPinModal, setShowPinModal] = useState(false);
   const [showNewAppsPicker, setShowNewAppsPicker] = useState(false);
+  const [showRequirePasscodePicker, setShowRequirePasscodePicker] = useState(false);
   const [pinStep, setPinStep] = useState<'current' | 'new' | 'confirm'>('current');
   const [pinInput, setPinInput] = useState('');
   const [newPin, setNewPin] = useState('');
@@ -485,6 +491,30 @@ export function LauncherSettingsScreen() {
             />
           }
         />
+        {/* #611 — sub-opção do master `biometricUnlock` (iOS «iPhone Unlock»). */}
+        <CupertinoListTile
+          title="Face ID for Unlock"
+          leading={{ name: 'scan', color: '#fff', backgroundColor: '#5856D6' }}
+          showChevron={false}
+          trailing={
+            <CupertinoSwitch
+              value={settings.faceIdForUnlock}
+              onValueChange={(v) => update('faceIdForUnlock', v)}
+            />
+          }
+        />
+        {/* #611 — iOS «Require Passcode». */}
+        <CupertinoListTile
+          title="Require Passcode"
+          leading={{ name: 'time', color: '#fff', backgroundColor: '#FF3B30' }}
+          showChevron
+          trailing={
+            <Text style={[typography.body, { color: colors.secondaryLabel }]}>
+              {REQUIRE_PASSCODE_LABELS[normalizeRequirePasscodeAfter(settings.requirePasscodeAfter)]}
+            </Text>
+          }
+          onPress={() => setShowRequirePasscodePicker(true)}
+        />
         <CupertinoListTile
           title="Change Passcode"
           leading={{ name: 'keypad', color: '#fff', backgroundColor: '#8E8E93' }}
@@ -542,6 +572,21 @@ export function LauncherSettingsScreen() {
             onPress: () => { update('newAppsToHome', true); setShowNewAppsPicker(false); },
           },
         ]}
+        cancelLabel="Cancel"
+      />
+
+      {/* ── Require Passcode after (#611) ──────────────────────── */}
+      <CupertinoActionSheet
+        visible={showRequirePasscodePicker}
+        onClose={() => setShowRequirePasscodePicker(false)}
+        title="Require Passcode"
+        options={REQUIRE_PASSCODE_OPTIONS.map((option) => ({
+          label: REQUIRE_PASSCODE_LABELS[option],
+          onPress: () => {
+            update('requirePasscodeAfter', option);
+            setShowRequirePasscodePicker(false);
+          },
+        }))}
         cancelLabel="Cancel"
       />
 

--- a/src/screens/LockScreen.tsx
+++ b/src/screens/LockScreen.tsx
@@ -75,10 +75,25 @@ function formatNotifTime(timestamp: number): string {
 
 import { WALLPAPERS, darkenHex } from '../utils/wallpapers';
 import { hapticImpact, hapticNotification } from '../utils/haptics';
+import { isPasscodeRequired } from '../utils/passcodePolicy';
 
 const LOCK_PIN_KEY = 'lock_pin';
 const LOCK_PIN_STORAGE_KEY = '@iostoandroid/lock_pin';
 const LOCK_PIN_LEGACY_KEY = '@lock_pin';
+/** Epoch ms do último desbloqueio bem-sucedido — base do «Require Passcode» (#611). */
+const LAST_UNLOCK_KEY = '@iostoandroid/last_unlock_at';
+
+/** Lê o último desbloqueio; devolve null quando não existe ou está corrompido. */
+async function readLastUnlockAt(): Promise<number | null> {
+  try {
+    const raw = await AsyncStorage.getItem(LAST_UNLOCK_KEY);
+    if (!raw) return null;
+    const parsed = Number(raw);
+    return Number.isFinite(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
 
 const { height: SCREEN_HEIGHT } = Dimensions.get('window');
 
@@ -312,7 +327,7 @@ function NotificationGroupCard({
 export function LockScreen({ navigation, onUnlock }: { navigation?: AppNavigationProp; onUnlock?: () => void }) {
   const insets = useSafeAreaInsets();
   const device = useDevice();
-  const { settings } = useSettings();
+  const { settings, isReady: settingsReady } = useSettings();
   const { apps } = useApps();
   const { textScale } = useTheme();
 
@@ -539,7 +554,12 @@ export function LockScreen({ navigation, onUnlock }: { navigation?: AppNavigatio
   // Biometric unlock on mount
   const triggerBiometric = async () => {
     try {
-      const LocalAuth = await import('expo-local-authentication');
+      // require(), not `await import(...)`: Metro compiles both to the same
+      // synchronous module load, but a bare `import()` throws under Jest's
+      // CommonJS environment, which made this catch swallow every call and
+      // turned the biometric prompt into a permanent no-op in tests.
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const LocalAuth = require('expo-local-authentication') as typeof import('expo-local-authentication');
       const hasHardware = await LocalAuth.hasHardwareAsync();
       const isEnrolled = await LocalAuth.isEnrolledAsync();
 
@@ -570,9 +590,28 @@ export function LockScreen({ navigation, onUnlock }: { navigation?: AppNavigatio
   };
 
   useEffect(() => {
-    triggerBiometric();
+    // Esperar pelo AsyncStorage do SettingsStore: decidir antes disso usaria os
+    // defaults ('immediately' + Face ID ligado) em vez das escolhas do
+    // utilizador, e o «Require Passcode» nunca se aplicaria.
+    if (!settingsReady) return;
+    // #611 «Require Passcode»: dentro do intervalo escolhido desde o último
+    // desbloqueio, o ecrã de bloqueio aparece mas não exige autenticação — o
+    // swipe-up basta. Fora do intervalo (ou sem registo), exige.
+    let cancelled = false;
+    (async () => {
+      const lastUnlockAt = await readLastUnlockAt();
+      if (cancelled) return;
+      if (!isPasscodeRequired(settings.requirePasscodeAfter, lastUnlockAt, Date.now())) return;
+      // `biometricUnlock` é o master on/off; `faceIdForUnlock` a sub-opção.
+      if (!settings.biometricUnlock || !settings.faceIdForUnlock) {
+        setShowPasscode(true);
+        return;
+      }
+      triggerBiometric();
+    })();
+    return () => { cancelled = true; };
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [settingsReady]);
 
   // Swipe-up animation
   const translateY = useSharedValue(0);
@@ -590,6 +629,8 @@ export function LockScreen({ navigation, onUnlock }: { navigation?: AppNavigatio
 
   const handleUnlock = () => {
     hapticNotification(Haptics.NotificationFeedbackType.Success).catch(() => {});
+    // Registar o instante alimenta a decisão de #611 no próximo bloqueio.
+    AsyncStorage.setItem(LAST_UNLOCK_KEY, String(Date.now())).catch(() => {});
     if (onUnlock) {
       onUnlock();
     } else {

--- a/src/screens/__tests__/LauncherSettingsScreen.faceIdPasscode.test.tsx
+++ b/src/screens/__tests__/LauncherSettingsScreen.faceIdPasscode.test.tsx
@@ -1,0 +1,152 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '../../test-utils';
+import { within } from '@testing-library/react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as SecureStore from 'expo-secure-store';
+import { LauncherSettingsScreen } from '../LauncherSettingsScreen';
+
+// #611 — «Face ID & Passcode»: toggle "Face ID for Unlock" e picker
+// "Require Passcode" na secção Lock Screen das Launcher Settings.
+
+jest.mock('expo-secure-store', () => ({
+  getItemAsync: jest.fn(async () => null),
+  setItemAsync: jest.fn(async () => {}),
+  deleteItemAsync: jest.fn(async () => {}),
+}));
+
+const SETTINGS_KEY = '@iostoandroid/settings';
+
+function setupMemoryAsyncStorage(initial: Record<string, string> = {}) {
+  const store = new Map<string, string>(Object.entries(initial));
+  (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) =>
+    store.has(key) ? store.get(key) : null,
+  );
+  (AsyncStorage.setItem as jest.Mock).mockImplementation(async (key: string, value: string) => {
+    store.set(key, value);
+  });
+  (AsyncStorage.removeItem as jest.Mock).mockImplementation(async (key: string) => {
+    store.delete(key);
+  });
+  return store;
+}
+
+// Espera até o blob persistido satisfazer o predicado — o provider grava os
+// defaults no mount, por isso «houve uma escrita» não prova nada.
+async function waitForPersisted(
+  store: Map<string, string>,
+  predicate: (settings: Record<string, unknown>) => boolean,
+) {
+  await waitFor(() => {
+    const raw = store.get(SETTINGS_KEY);
+    expect(raw).toBeTruthy();
+    expect(predicate(JSON.parse(raw as string))).toBe(true);
+  }, { timeout: 3000 });
+  return JSON.parse(store.get(SETTINGS_KEY) as string);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  setupMemoryAsyncStorage();
+  (SecureStore.getItemAsync as jest.Mock).mockResolvedValue(null);
+  (SecureStore.setItemAsync as jest.Mock).mockResolvedValue(undefined);
+});
+
+describe('LauncherSettingsScreen — Face ID & Passcode (#611)', () => {
+  it('mostra "Face ID for Unlock" ligado por omissão', async () => {
+    const { getByLabelText } = render(<LauncherSettingsScreen />);
+    const tile = await waitFor(() => getByLabelText('Face ID for Unlock'));
+    expect(within(tile).getByRole('switch').props.accessibilityState.checked).toBe(true);
+  });
+
+  it('desligar "Face ID for Unlock" persiste faceIdForUnlock=false', async () => {
+    const store = setupMemoryAsyncStorage();
+    const { getByLabelText } = render(<LauncherSettingsScreen />);
+
+    const sw = within(getByLabelText('Face ID for Unlock')).getByRole('switch');
+    fireEvent.press(sw);
+
+    await waitFor(() =>
+      expect(
+        within(getByLabelText('Face ID for Unlock')).getByRole('switch').props.accessibilityState.checked,
+      ).toBe(false),
+    );
+    await waitForPersisted(store, (s) => s.faceIdForUnlock === false);
+  });
+
+  it('mostra "Require Passcode" com o valor "Immediately" por omissão', async () => {
+    const { getByLabelText, getByText } = render(<LauncherSettingsScreen />);
+    await waitFor(() => expect(getByLabelText('Require Passcode')).toBeTruthy());
+    expect(getByText('Immediately')).toBeTruthy();
+  });
+
+  it('escolher "After 5 minutes" no picker persiste requirePasscodeAfter=5min e actualiza o valor mostrado', async () => {
+    const store = setupMemoryAsyncStorage();
+    const { getByLabelText, getByText } = render(<LauncherSettingsScreen />);
+
+    fireEvent.press(getByLabelText('Require Passcode'));
+    await waitFor(() => expect(getByText('After 5 minutes')).toBeTruthy());
+    fireEvent.press(getByText('After 5 minutes'));
+
+    await waitForPersisted(store, (s) => s.requirePasscodeAfter === '5min');
+    await waitFor(() =>
+      expect(within(getByLabelText('Require Passcode')).getByText('After 5 minutes')).toBeTruthy(),
+    );
+  });
+
+  it('o picker oferece as seis opções do iOS, de imediato a 4 horas', async () => {
+    const { getByLabelText, getByText, getAllByText } = render(<LauncherSettingsScreen />);
+    fireEvent.press(getByLabelText('Require Passcode'));
+    await waitFor(() => expect(getByText('After 1 minute')).toBeTruthy());
+    // 'Immediately' aparece duas vezes: no valor do tile e na opção do sheet.
+    expect(getAllByText('Immediately').length).toBe(2);
+    for (const label of [
+      'After 1 minute',
+      'After 5 minutes',
+      'After 15 minutes',
+      'After 1 hour',
+      'After 4 hours',
+    ]) {
+      expect(getByText(label)).toBeTruthy();
+    }
+  });
+
+  it('lê o valor persistido de um arranque anterior em vez do default', async () => {
+    setupMemoryAsyncStorage({
+      [SETTINGS_KEY]: JSON.stringify({ requirePasscodeAfter: '1hour', faceIdForUnlock: false }),
+    });
+
+    const { getByLabelText } = render(<LauncherSettingsScreen />);
+
+    await waitFor(() =>
+      expect(within(getByLabelText('Require Passcode')).getByText('After 1 hour')).toBeTruthy(),
+    );
+    expect(
+      within(getByLabelText('Face ID for Unlock')).getByRole('switch').props.accessibilityState.checked,
+    ).toBe(false);
+  });
+
+  it('um requirePasscodeAfter corrompido no armazenamento cai em "Immediately"', async () => {
+    setupMemoryAsyncStorage({
+      [SETTINGS_KEY]: JSON.stringify({ requirePasscodeAfter: 'depois-do-almoço' }),
+    });
+
+    const { getByLabelText } = render(<LauncherSettingsScreen />);
+
+    await waitFor(() =>
+      expect(within(getByLabelText('Require Passcode')).getByText('Immediately')).toBeTruthy(),
+    );
+  });
+
+  it('"Biometric Unlock" continua a ser o master on/off e mantém-se independente do Face ID', async () => {
+    const store = setupMemoryAsyncStorage();
+    const { getByLabelText } = render(<LauncherSettingsScreen />);
+
+    fireEvent.press(within(getByLabelText('Biometric Unlock')).getByRole('switch'));
+
+    await waitForPersisted(store, (s) => s.biometricUnlock === false);
+    // O inverso do fix: desligar o master não desliga o Face ID toggle.
+    expect(
+      within(getByLabelText('Face ID for Unlock')).getByRole('switch').props.accessibilityState.checked,
+    ).toBe(true);
+  });
+});

--- a/src/screens/__tests__/LockScreen.requirePasscode.test.tsx
+++ b/src/screens/__tests__/LockScreen.requirePasscode.test.tsx
@@ -1,0 +1,160 @@
+import React from 'react';
+import { render, waitFor, act } from '../../test-utils';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as SecureStore from 'expo-secure-store';
+import * as LocalAuth from 'expo-local-authentication';
+import { LockScreen } from '../LockScreen';
+
+// #611 — «Require Passcode after»: dentro do intervalo escolhido o desbloqueio
+// não deve pedir biometria nem passcode; passado o intervalo, pede.
+
+jest.mock('expo-secure-store', () => ({
+  getItemAsync: jest.fn(async () => null),
+  setItemAsync: jest.fn(async () => {}),
+  deleteItemAsync: jest.fn(async () => {}),
+}));
+
+jest.mock('expo-local-authentication', () => ({
+  hasHardwareAsync: jest.fn(async () => true),
+  isEnrolledAsync: jest.fn(async () => true),
+  authenticateAsync: jest.fn(async () => ({ success: false })),
+}));
+
+const SETTINGS_KEY = '@iostoandroid/settings';
+const LAST_UNLOCK_KEY = '@iostoandroid/last_unlock_at';
+
+function setupMemoryAsyncStorage(initial: Record<string, string> = {}) {
+  const store = new Map<string, string>(Object.entries(initial));
+  (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) =>
+    store.has(key) ? store.get(key) : null,
+  );
+  (AsyncStorage.setItem as jest.Mock).mockImplementation(async (key: string, value: string) => {
+    store.set(key, value);
+  });
+  (AsyncStorage.removeItem as jest.Mock).mockImplementation(async (key: string) => {
+    store.delete(key);
+  });
+  return store;
+}
+
+/** Deixa correr os efeitos assíncronos de mount sem afirmar nada. */
+async function settle() {
+  await act(async () => {
+    await new Promise((r) => setTimeout(r, 50));
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  setupMemoryAsyncStorage();
+  (SecureStore.getItemAsync as jest.Mock).mockResolvedValue(null);
+  (SecureStore.setItemAsync as jest.Mock).mockResolvedValue(undefined);
+  (LocalAuth.hasHardwareAsync as jest.Mock).mockResolvedValue(true);
+  (LocalAuth.isEnrolledAsync as jest.Mock).mockResolvedValue(true);
+  (LocalAuth.authenticateAsync as jest.Mock).mockResolvedValue({ success: false });
+});
+
+describe('LockScreen — Require Passcode after (#611)', () => {
+  it('não pede autenticação quando o último desbloqueio foi dentro do intervalo', async () => {
+    setupMemoryAsyncStorage({
+      [SETTINGS_KEY]: JSON.stringify({ requirePasscodeAfter: '5min' }),
+      [LAST_UNLOCK_KEY]: String(Date.now() - 60_000),
+    });
+
+    const { queryByText } = render(<LockScreen />);
+    await settle();
+
+    expect(LocalAuth.authenticateAsync).not.toHaveBeenCalled();
+    expect(queryByText('Enter Passcode')).toBeNull();
+  });
+
+  it('pede autenticação quando o intervalo já passou', async () => {
+    setupMemoryAsyncStorage({
+      [SETTINGS_KEY]: JSON.stringify({ requirePasscodeAfter: '5min' }),
+      [LAST_UNLOCK_KEY]: String(Date.now() - 6 * 60_000),
+    });
+
+    render(<LockScreen />);
+
+    await waitFor(() => expect(LocalAuth.authenticateAsync).toHaveBeenCalled());
+  });
+
+  it('pede autenticação com "immediately" mesmo com um desbloqueio há um instante', async () => {
+    setupMemoryAsyncStorage({
+      [SETTINGS_KEY]: JSON.stringify({ requirePasscodeAfter: 'immediately' }),
+      [LAST_UNLOCK_KEY]: String(Date.now() - 1_000),
+    });
+
+    render(<LockScreen />);
+
+    await waitFor(() => expect(LocalAuth.authenticateAsync).toHaveBeenCalled());
+  });
+
+  it('pede autenticação num arranque a frio (sem registo de desbloqueio)', async () => {
+    setupMemoryAsyncStorage({
+      [SETTINGS_KEY]: JSON.stringify({ requirePasscodeAfter: '4hours' }),
+    });
+
+    render(<LockScreen />);
+
+    await waitFor(() => expect(LocalAuth.authenticateAsync).toHaveBeenCalled());
+  });
+
+  it('faceIdForUnlock=false salta a biometria e vai directo à passcode', async () => {
+    setupMemoryAsyncStorage({
+      [SETTINGS_KEY]: JSON.stringify({ faceIdForUnlock: false }),
+    });
+
+    const { getByText } = render(<LockScreen />);
+
+    await waitFor(() => expect(getByText('Enter Passcode')).toBeTruthy());
+    expect(LocalAuth.authenticateAsync).not.toHaveBeenCalled();
+  });
+
+  it('biometricUnlock=false (master off) salta a biometria mesmo com faceIdForUnlock=true', async () => {
+    setupMemoryAsyncStorage({
+      [SETTINGS_KEY]: JSON.stringify({ biometricUnlock: false, faceIdForUnlock: true }),
+    });
+
+    const { getByText } = render(<LockScreen />);
+
+    await waitFor(() => expect(getByText('Enter Passcode')).toBeTruthy());
+    expect(LocalAuth.authenticateAsync).not.toHaveBeenCalled();
+  });
+
+  it('registra o instante do desbloqueio para a próxima decisão', async () => {
+    const store = setupMemoryAsyncStorage({
+      [SETTINGS_KEY]: JSON.stringify({ requirePasscodeAfter: '5min' }),
+    });
+    (LocalAuth.authenticateAsync as jest.Mock).mockResolvedValue({ success: true });
+    const onUnlock = jest.fn();
+
+    render(<LockScreen onUnlock={onUnlock} />);
+
+    await waitFor(() => expect(onUnlock).toHaveBeenCalled());
+    await waitFor(() => expect(store.has(LAST_UNLOCK_KEY)).toBe(true));
+    expect(Number(store.get(LAST_UNLOCK_KEY))).toBeGreaterThan(0);
+  });
+
+  it('um valor corrompido em last_unlock_at é tratado como ausente e exige autenticação', async () => {
+    setupMemoryAsyncStorage({
+      [SETTINGS_KEY]: JSON.stringify({ requirePasscodeAfter: '4hours' }),
+      [LAST_UNLOCK_KEY]: 'ontem à tarde',
+    });
+
+    render(<LockScreen />);
+
+    await waitFor(() => expect(LocalAuth.authenticateAsync).toHaveBeenCalled());
+  });
+
+  it('um last_unlock_at no futuro (relógio para trás) exige autenticação', async () => {
+    setupMemoryAsyncStorage({
+      [SETTINGS_KEY]: JSON.stringify({ requirePasscodeAfter: '4hours' }),
+      [LAST_UNLOCK_KEY]: String(Date.now() + 60 * 60_000),
+    });
+
+    render(<LockScreen />);
+
+    await waitFor(() => expect(LocalAuth.authenticateAsync).toHaveBeenCalled());
+  });
+});

--- a/src/store/SettingsStore.tsx
+++ b/src/store/SettingsStore.tsx
@@ -14,6 +14,11 @@ import {
   type CategoryOverrideSettings,
   DEFAULT_CATEGORY_OVERRIDES,
 } from '../utils/categoryOverrides';
+import {
+  type RequirePasscodeAfter,
+  DEFAULT_REQUIRE_PASSCODE_AFTER,
+  normalizeRequirePasscodeAfter,
+} from '../utils/passcodePolicy';
 
 const STORAGE_KEY = '@iostoandroid/settings';
 
@@ -70,6 +75,18 @@ export interface SettingsState {
   boldText: boolean;
   showLockScreen: boolean;
   biometricUnlock: boolean;
+  /**
+   * iOS «Face ID & Passcode → iPhone Unlock»: usar biometria para desbloquear o
+   * launcher. Sub-opção de `biometricUnlock`, que continua a ser o master
+   * on/off — com o master desligado esta não tem efeito nenhum.
+   */
+  faceIdForUnlock: boolean;
+  /**
+   * iOS «Face ID & Passcode → Require Passcode»: quanto tempo depois do último
+   * desbloqueio é que voltar ao ecrã de bloqueio exige autenticação. O default
+   * 'immediately' reproduz o comportamento anterior a #611.
+   */
+  requirePasscodeAfter: RequirePasscodeAfter;
   showSearchLabel: boolean;
   automaticUpdates: boolean;
   updateAvailable: boolean;
@@ -188,6 +205,8 @@ export const DEFAULT_SETTINGS: SettingsState = {
   boldText: false,
   showLockScreen: true,
   biometricUnlock: true,
+  faceIdForUnlock: true,
+  requirePasscodeAfter: DEFAULT_REQUIRE_PASSCODE_AFTER,
   showSearchLabel: true,
   automaticUpdates: true,
   updateAvailable: false,
@@ -261,6 +280,9 @@ export function SettingsProvider({
             // uma máscara indefinida, por isso normaliza-se na leitura.
             iconShape: normalizeIconShape(parsed?.iconShape),
             iconShapeExponent: clampIconShapeExponent(parsed?.iconShapeExponent),
+            // Um valor corrompido aqui decidiria se a passcode é exigida ou
+            // não, por isso normaliza-se na leitura para o mais restritivo.
+            requirePasscodeAfter: normalizeRequirePasscodeAfter(parsed?.requirePasscodeAfter),
           }));
         } catch { /* ignore */ }
       }

--- a/src/utils/__tests__/passcodePolicy.test.ts
+++ b/src/utils/__tests__/passcodePolicy.test.ts
@@ -1,0 +1,72 @@
+import {
+  DEFAULT_REQUIRE_PASSCODE_AFTER,
+  REQUIRE_PASSCODE_DELAY_MS,
+  REQUIRE_PASSCODE_LABELS,
+  REQUIRE_PASSCODE_OPTIONS,
+  isPasscodeRequired,
+  normalizeRequirePasscodeAfter,
+} from '../passcodePolicy';
+
+// #611 — «Require Passcode after» (iOS «Face ID & Passcode → Require Passcode»).
+// Estes testes chamam a função exportada real, não uma cópia da fórmula.
+
+const MIN = 60_000;
+
+describe('passcodePolicy — normalizeRequirePasscodeAfter', () => {
+  it('aceita todas as opções expostas na UI', () => {
+    for (const option of REQUIRE_PASSCODE_OPTIONS) {
+      expect(normalizeRequirePasscodeAfter(option)).toBe(option);
+    }
+  });
+
+  it('cai no default para valores ausentes, corrompidos ou de outro tipo', () => {
+    for (const bad of [undefined, null, '', '10min', 'IMMEDIATELY', 5, {}, []]) {
+      expect(normalizeRequirePasscodeAfter(bad)).toBe(DEFAULT_REQUIRE_PASSCODE_AFTER);
+    }
+  });
+
+  it('tem um rótulo e uma tolerância para cada opção, sem sobras', () => {
+    expect(Object.keys(REQUIRE_PASSCODE_DELAY_MS).sort()).toEqual([...REQUIRE_PASSCODE_OPTIONS].sort());
+    expect(Object.keys(REQUIRE_PASSCODE_LABELS).sort()).toEqual([...REQUIRE_PASSCODE_OPTIONS].sort());
+  });
+});
+
+describe('passcodePolicy — isPasscodeRequired', () => {
+  it("'immediately' exige sempre, mesmo com um desbloqueio há um instante", () => {
+    expect(isPasscodeRequired('immediately', 1_000_000, 1_000_001)).toBe(true);
+    expect(isPasscodeRequired('immediately', 1_000_000, 1_000_000)).toBe(true);
+  });
+
+  it('não exige dentro do intervalo escolhido', () => {
+    const last = 1_000_000;
+    expect(isPasscodeRequired('5min', last, last + 4 * MIN)).toBe(false);
+    expect(isPasscodeRequired('1hour', last, last + 59 * MIN)).toBe(false);
+    expect(isPasscodeRequired('4hours', last, last + 239 * MIN)).toBe(false);
+  });
+
+  it('exige exactamente no limite e depois dele (limite, limite ±1ms)', () => {
+    const last = 1_000_000;
+    expect(isPasscodeRequired('5min', last, last + 5 * MIN - 1)).toBe(false);
+    expect(isPasscodeRequired('5min', last, last + 5 * MIN)).toBe(true);
+    expect(isPasscodeRequired('5min', last, last + 5 * MIN + 1)).toBe(true);
+  });
+
+  it('exige quando nunca houve desbloqueio (arranque a frio)', () => {
+    expect(isPasscodeRequired('4hours', null, 1_000_000)).toBe(true);
+    expect(isPasscodeRequired('4hours', Number.NaN, 1_000_000)).toBe(true);
+  });
+
+  it('exige quando o relógio andou para trás (elapsed negativo)', () => {
+    expect(isPasscodeRequired('4hours', 2_000_000, 1_000_000)).toBe(true);
+  });
+
+  it('exige com uma opção inválida — o default é o mais restritivo', () => {
+    const last = 1_000_000;
+    expect(isPasscodeRequired('42years', last, last + 1)).toBe(true);
+    expect(isPasscodeRequired(undefined, last, last + 1)).toBe(true);
+  });
+
+  it('trata valores de tempo absurdamente grandes sem deixar de exigir', () => {
+    expect(isPasscodeRequired('4hours', 0, Number.MAX_SAFE_INTEGER)).toBe(true);
+  });
+});

--- a/src/utils/passcodePolicy.ts
+++ b/src/utils/passcodePolicy.ts
@@ -1,0 +1,84 @@
+/**
+ * Política de «Require Passcode» (#611), o equivalente ao iOS
+ * «Face ID & Passcode → Require Passcode».
+ *
+ * O iOS não exige a passcode em cada acordar do ecrã: exige-a apenas quando
+ * passou mais do que o intervalo escolhido desde o último desbloqueio
+ * bem-sucedido. Dentro desse intervalo o ecrã de bloqueio continua a aparecer,
+ * mas o swipe-up basta — não há prompt de biometria nem teclado de passcode.
+ */
+
+export type RequirePasscodeAfter =
+  | 'immediately'
+  | '1min'
+  | '5min'
+  | '15min'
+  | '1hour'
+  | '4hours';
+
+/** Tolerância, em ms, de cada opção. 'immediately' é zero por definição. */
+export const REQUIRE_PASSCODE_DELAY_MS: Record<RequirePasscodeAfter, number> = {
+  immediately: 0,
+  '1min': 60_000,
+  '5min': 5 * 60_000,
+  '15min': 15 * 60_000,
+  '1hour': 60 * 60_000,
+  '4hours': 4 * 60 * 60_000,
+};
+
+/** Rótulos como aparecem no iOS, na ordem do action sheet. */
+export const REQUIRE_PASSCODE_LABELS: Record<RequirePasscodeAfter, string> = {
+  immediately: 'Immediately',
+  '1min': 'After 1 minute',
+  '5min': 'After 5 minutes',
+  '15min': 'After 15 minutes',
+  '1hour': 'After 1 hour',
+  '4hours': 'After 4 hours',
+};
+
+export const REQUIRE_PASSCODE_OPTIONS: RequirePasscodeAfter[] = [
+  'immediately',
+  '1min',
+  '5min',
+  '15min',
+  '1hour',
+  '4hours',
+];
+
+export const DEFAULT_REQUIRE_PASSCODE_AFTER: RequirePasscodeAfter = 'immediately';
+
+/**
+ * Normaliza um valor lido do AsyncStorage. Um valor corrompido ou de uma versão
+ * futura não pode virar uma tolerância indefinida (que o `Number` tornaria
+ * `NaN` e a comparação abaixo tornaria «nunca exigir passcode»), por isso cai
+ * no default mais restritivo.
+ */
+export function normalizeRequirePasscodeAfter(value: unknown): RequirePasscodeAfter {
+  return typeof value === 'string' && value in REQUIRE_PASSCODE_DELAY_MS
+    ? (value as RequirePasscodeAfter)
+    : DEFAULT_REQUIRE_PASSCODE_AFTER;
+}
+
+/**
+ * Decide se o desbloqueio exige autenticação.
+ *
+ * @param option    a opção escolhida pelo utilizador (valores inválidos caem no default)
+ * @param lastUnlockAt epoch ms do último desbloqueio, ou null quando nunca houve
+ *                     um (arranque a frio) — nesse caso exige-se sempre.
+ * @param now       epoch ms actual.
+ */
+export function isPasscodeRequired(
+  option: unknown,
+  lastUnlockAt: number | null,
+  now: number,
+): boolean {
+  const resolved = normalizeRequirePasscodeAfter(option);
+  const delay = REQUIRE_PASSCODE_DELAY_MS[resolved];
+  if (delay === 0) return true;
+  if (lastUnlockAt === null || !Number.isFinite(lastUnlockAt)) return true;
+  const elapsed = now - lastUnlockAt;
+  // Relógio para trás (NTP, mudança manual de hora) daria um `elapsed` negativo
+  // e adiaria a passcode indefinidamente — trata-se como «não confiável».
+  if (elapsed < 0) return true;
+  return elapsed >= delay;
+}


### PR DESCRIPTION
## Resumo

feat/611: Face ID & Passcode — faceIdForUnlock + requirePasscodeAfter nas Settings e respeitados no LockScreen

## Causa raiz

Não é um defeito de regressão: é funcionalidade em falta, e o issue descreve-a corretamente. Mas a investigação encontrou **dois mecanismos** que o issue não previu e sem os quais o wiring não funcionaria:

1. `src/screens/LockScreen.tsx:590` — o efeito de mount chamava `triggerBiometric()` sem condição nenhuma, e sem esperar pelo `isReady` do `SettingsStore`. O `SettingsProvider` só aplica o blob do `AsyncStorage` depois de uma leitura assíncrona (`src/store/SettingsStore.tsx:251-269`), por isso qualquer decisão tomada no primeiro render lê **defaults**, não as escolhas do utilizador. Sem gate no `isReady`, o `requirePasscodeAfter` persistido nunca teria efeito — o ecrã pediria sempre autenticação. Foi assim que se comportou empiricamente: os testes que ligam `faceIdForUnlock: false` no armazenamento continuavam a ver `authenticateAsync` chamado.

2. `src/screens/LockScreen.tsx:542` (antes) — `const LocalAuth = await import('expo-local-authentication')` dentro de um `try/catch`. Sob o Jest (CommonJS) o `import()` dinâmico lança `ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING_FLAG`, o `catch` engolia-o, e `triggerBiometric` era um **no-op permanente em todos os testes** — exactamente o mesmo defeito que já estava documentado e corrigido no `SettingsStore.tsx:279-288`. Sem trocar por `require()`, nenhum teste podia observar a decisão de biometria.

A lógica de decisão em si não existia em `main`: `grep faceIdForUnlock|requirePasscodeAfter` em `origin/main` → 0 resultados, confirmado antes de alegar passo vermelho.

## O que mudou

**`src/utils/passcodePolicy.ts`** (novo) — a política, isolada e testável sem montar UI:
- `REQUIRE_PASSCODE_DELAY_MS` / `REQUIRE_PASSCODE_LABELS` / `REQUIRE_PASSCODE_OPTIONS` para as seis opções do iOS.
- `normalizeRequirePasscodeAfter(value)`: um valor corrompido cai no default mais restritivo (`immediately`) em vez de virar `NaN`, o que tornaria a comparação sempre falsa e desactivaria a passcode.
- `isPasscodeRequired(option, lastUnlockAt, now)`: `true` para `immediately`, para `lastUnlockAt` ausente/não finito (arranque a frio) e para `elapsed` negativo (relógio para trás); caso contrário `elapsed >= delay`.

**`src/store/SettingsStore.tsx`** — acrescenta `faceIdForUnlock: boolean` (default `true`) e `requirePasscodeAfter: RequirePasscodeAfter` (default `'immediately'`) ao `SettingsState` e ao `DEFAULT_SETTINGS`, e normaliza `requirePasscodeAfter` na leitura do `AsyncStorage`, ao lado do que já se fazia para `iconShape`.

**`src/screens/LauncherSettingsScreen.tsx`** — na secção Lock Screen, depois de "Biometric Unlock": um `CupertinoSwitch` "Face ID for Unlock" e um `CupertinoListTile` "Require Passcode" que mostra o rótulo actual e abre um `CupertinoActionSheet` com as seis opções (padrão idêntico ao picker "New Apps Go To" já no ficheiro).

**`src/screens/LockScreen.tsx`** — o efeito de mount passa a: esperar por `settingsReady`; ler `@iostoandroid/last_unlock_at`; não pedir nada quando `isPasscodeRequired` é `false`; ir directo à passcode quando `biometricUnlock` ou `faceIdForUnlock` estão desligados; e só então chamar a biometria. `handleUnlock` grava o instante do desbloqueio nessa chave, que é o que alimenta a decisão seguinte. O `await import` de `expo-local-authentication` passou a `require()`.

## Porque assim

- **A política num util, não inline no componente.** Fronteiras de tempo, relógio para trás e valores corrompidos são testáveis directamente na função exportada; testá-los só através do ecrã exigiria montar a árvore inteira por cada caso. O teste do ecrã continua a existir e exercita o componente real — não há reimplementação da fórmula dentro dos testes.
- **`immediately` como default** preserva exactamente o comportamento anterior a #611: quem não toca na opção não vê mudança nenhuma de segurança.
- **Fail-closed em todo o caminho de erro.** Valor corrompido, `AsyncStorage` a lançar, `lastUnlockAt` ausente ou no futuro → exige autenticação. A alternativa (`?? 0`, ou tratar o inválido como «passou muito tempo») abriria o desbloqueio silenciosamente, que é o tipo de defeito invisível a evitar num caminho de autenticação.
- **`biometricUnlock` fica master.** Descartei fundir os dois num só enum (`off | fingerprint | faceId`): mudaria o significado de uma chave já persistida no dispositivo dos utilizadores, e o issue pede explicitamente que o master se mantenha.
- **Gate no `isReady`, não `gateFirstRender`.** Bloquear o render do ecrã de bloqueio até o storage chegar daria um flash de ecrã vazio; adiar só a *decisão* mantém o relógio e as notificações a aparecer de imediato.

## Critérios de aceitação

- [x] Toggle "Face ID for Unlock" na secção Lock Screen, default `true` — teste `mostra "Face ID for Unlock" ligado por omissão` lê o `accessibilityState.checked` do switch real.
- [x] Picker "Require Passcode" com as seis opções (Immediately → After 4 hours) — teste `o picker oferece as seis opções do iOS`.
- [x] `requirePasscodeAfter` respeitado no `LockScreen`: não exige passcode antes do intervalo — teste `não pede autenticação quando o último desbloqueio foi dentro do intervalo` (`authenticateAsync` não chamado, sem overlay "Enter Passcode"); e exige depois dele — teste `pede autenticação quando o intervalo já passou`.
- [x] `biometricUnlock` mantém-se master on/off — teste `"Biometric Unlock" continua a ser o master on/off`: desligá-lo persiste `biometricUnlock:false` e **não** altera o toggle do Face ID; e `biometricUnlock=false (master off) salta a biometria mesmo com faceIdForUnlock=true`.
- [x] Persistem entre arranques — teste `lê o valor persistido de um arranque anterior em vez do default` (blob pré-existente com `requirePasscodeAfter:'1hour'` + `faceIdForUnlock:false` reflete-se na UI) e `desligar "Face ID for Unlock" persiste faceIdForUnlock=false` (afirma sobre o blob escrito, não sobre «houve uma escrita»).
- [x] Testes cobrem ambos, em `src/screens/__tests__/` — dois ficheiros novos (Settings e LockScreen) mais o util.
- [x] **O que NÃO devia mudar:** o comportamento por omissão do desbloqueio. Com os defaults (`immediately`), o teste `pede autenticação com "immediately" mesmo com um desbloqueio há um instante` confirma que se continua a exigir sempre. Os restantes 24 testes do `LockScreen.test.tsx` e as suites de settings pré-existentes continuam no mesmo estado (ver baseline abaixo) — nenhum foi apagado nem marcado `.skip`.

## Testes

**Passo vermelho** — testes escritos, produção ainda não mexida (`git stash push` só dos ficheiros de produção). Primeiro a suite das Settings, antes de qualquer alteração de produção:

```
  ● LauncherSettingsScreen — Face ID & Passcode (#611) › "Biometric Unlock" continua a ser o master on/off e mantém-se independente do Face ID

      146 |     // O inverso do fix: desligar o master não desliga o Face ID toggle.
      147 |     expect(
    > 148 |       within(getByLabelText('Face ID for Unlock')).getByRole('switch').props.accessibilityState.checked,
          |              ^
      149 |     ).toBe(true);

      at Object.getByLabelText (src/screens/__tests__/LauncherSettingsScreen.faceIdPasscode.test.tsx:148:14)

Test Suites: 1 failed, 1 total
Tests:       8 failed, 8 total
```

E o sanity-check final, com as três alterações de produção revertidas por `git stash` e os testes mantidos:

```
$ git stash push -- src/store/SettingsStore.tsx src/screens/LauncherSettingsScreen.tsx src/screens/LockScreen.tsx
$ npx jest src/screens/__tests__/LauncherSettingsScreen.faceIdPasscode.test.tsx src/screens/__tests__/LockScreen.requirePasscode.test.tsx

  ● LockScreen — Require Passcode after (#611) › um last_unlock_at no futuro (relógio para trás) exige autenticação

    expect(jest.fn()).toHaveBeenCalled()

    Expected number of calls: >= 1
    Received number of calls:    0

      156 |     render(<LockScreen />);
      157 |
    > 158 |     await waitFor(() => expect(LocalAuth.authenticateAsync).toHaveBeenCalled());
          |                  ^

      at Object.<anonymous> (src/screens/__tests__/LockScreen.requirePasscode.test.tsx:158:18)

Test Suites: 2 failed, 2 total
Tests:       15 failed, 2 passed, 17 total
```

(Os 2 que passam sem o fix são os que afirmam que a autenticação **é** exigida com `immediately`/arranque a frio — comportamento que `main` já tinha porque exigia sempre. Estão lá de propósito, como o inverso do fix.)

`git stash pop` feito; com o fix restaurado: `Test Suites: 3 passed, Tests: 27 passed, 27 total`.

**Casos cobertos** além do caminho felizal:
- **Fronteiras:** limite exacto do intervalo, limite −1 ms e limite +1 ms (`5min`); 0 (`immediately`); o máximo (`4hours`, e `Number.MAX_SAFE_INTEGER` como `now`).
- **Vazio e ausente:** sem registo de desbloqueio (arranque a frio), `undefined`/`null` como opção.
- **Inválido e hostil:** `'10min'`, `'IMMEDIATELY'`, número, objecto e array como opção; `'ontem à tarde'` gravado em `last_unlock_at`; `'depois-do-almoço'` gravado em `requirePasscodeAfter` (a UI cai em "Immediately"); `NaN` como `lastUnlockAt`.
- **Ordem/relógio:** `lastUnlockAt` no futuro (NTP ou mudança manual de hora) — exige autenticação em vez de a adiar indefinidamente.
- **Assíncrono:** o teste do gate `isReady` é o caso «o `AsyncStorage` devolve depois do primeiro render» — sem ele o ecrã decidia com defaults; o efeito tem `cancelled` para não tocar em estado depois de desmontar.
- **O inverso do fix:** desligar o master não altera o Face ID; `immediately` continua a exigir sempre; a opção persistida de um arranque anterior é lida em vez do default.

**Verificações** (worktree, com LINHA DE BASE de `main` = 12 falhas em 6 suites):
- `npm run lint`: `✖ 2 problems (0 errors, 2 warnings)` — os dois warnings são pré-existentes (`BridgeErrorReporting.test.tsx`, `ClockScreen.tsx`), 0 erros.
- `npx tsc --noEmit`: limpo, exit 0. Nenhum `any` novo.
- `npm test -- --maxWorkers=2`: `Test Suites: 5 failed, 162 passed, 167 total` / `Tests: 11 failed, 1602 passed, 1613 total`. **11 falhas contra 12 no baseline, e o conjunto é um subconjunto estrito dele** — `FoldersStore` (2), `LockScreen` (3: flashlight/camera/numpad), `SettingsScreen` (1), `WeatherScreen` (2), `withLauncherIntent` (3). A falha do baseline `AppLibraryContent — hide app (#606)` passou a verde. Nenhuma falha nova. Os 27 testes deste trabalho passam todos.

## Testes

27 testes novos passam (3 suites). Suite completa: 1602 passaram, 11 falharam, 167 suites — baseline de main era 12 falhas, e as 11 são subconjunto dele (nenhuma nova)

## Linked Issue

Fixes #611