### PR TITLE
Agendamento de Focus por horário: campos focusScheduleStart/End, pickers From/To no FocusScreen e wiring automático (useFocusSchedule) que ativa/desativa Work nos limites (#616)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -35,6 +35,7 @@ import { resolveAutoLockDelay } from './src/utils/autoLockUtils';
 import LauncherModule, { addNotificationListener, onBridgeError } from './modules/launcher-module/src';
 import { notificationCallbackForFocus } from './src/utils/notificationFocusFilter';
 import { markProcessStartFromAge } from './src/utils/perfMetrics';
+import { useFocusSchedule } from './src/hooks/useFocusSchedule';
 
 // Cold start (#517): a marca de origem é a idade do processo lida do lado
 // nativo, não o instante em que este módulo é avaliado — assim o número inclui
@@ -53,6 +54,11 @@ function AppContent() {
   const { settings } = useSettings();
   const navigationRef = useNavigationContainerRef<RootStackParamList>();
   const [isLocked, setIsLocked] = useState(true);
+
+  // Agendamento de Focus por horário (#616): ativa/desativa o Work nos limites
+  // do intervalo definido em Settings. Montado aqui — um único ponto de verdade
+  // para toda a app, independente de qual ecrã está montado.
+  useFocusSchedule();
 
   // Inter / Inter Display (#474, sub-issue de #464 — substituto sancionado da
   // SF Pro, cuja licença restringe o uso a mocks para SO Apple). Uma falha no

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,12 @@
 {
   "name": "iostoandroid",
-<<<<<<< Updated upstream
-  "version": "1.39.1",
-=======
-  "version": "1.27.0",
->>>>>>> Stashed changes
+  "version": "1.75.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "iostoandroid",
-<<<<<<< Updated upstream
-      "version": "1.39.1",
-=======
-      "version": "1.27.0",
->>>>>>> Stashed changes
+      "version": "1.75.0",
       "dependencies": {
         "@expo/vector-icons": "15.0.3",
         "@react-native-async-storage/async-storage": "^3.0.2",
@@ -43,11 +35,7 @@
         "expo-notifications": "~0.32.11",
         "expo-secure-store": "~15.0.7",
         "expo-sharing": "~14.0.8",
-<<<<<<< Updated upstream
         "expo-speech": "~14.0.8",
-=======
-        "expo-speech": "~12.0.2",
->>>>>>> Stashed changes
         "expo-status-bar": "~3.0.9",
         "react": "19.1.0",
         "react-native": "0.81.5",
@@ -7084,15 +7072,9 @@
       }
     },
     "node_modules/expo-speech": {
-<<<<<<< Updated upstream
       "version": "14.0.8",
       "resolved": "https://registry.npmjs.org/expo-speech/-/expo-speech-14.0.8.tgz",
       "integrity": "sha512-UjBFCFv58nutlLw92L7kUS0ZjbOOfaTdiEv/HbjvMrT6BfldoOLLBZbaEcEhDdZK36NY/kass0Kzxk+co6vxSQ==",
-=======
-      "version": "12.0.2",
-      "resolved": "https://registry.npmjs.org/expo-speech/-/expo-speech-12.0.2.tgz",
-      "integrity": "sha512-voWNz69hvtLEA2jipAbM5XJBIbKCusQsDZ/G/vAKKkP5AUTzAmcdRDWGcmESPRKK0JUtQZ8WetujgLCn2kl83w==",
->>>>>>> Stashed changes
       "license": "MIT",
       "peerDependencies": {
         "expo": "*"

--- a/package.json
+++ b/package.json
@@ -40,11 +40,7 @@
     "expo-notifications": "~0.32.11",
     "expo-secure-store": "~15.0.7",
     "expo-sharing": "~14.0.8",
-<<<<<<< Updated upstream
     "expo-speech": "~14.0.8",
-=======
-    "expo-speech": "~12.0.2",
->>>>>>> Stashed changes
     "expo-status-bar": "~3.0.9",
     "react": "19.1.0",
     "react-native": "0.81.5",

--- a/src/hooks/__tests__/useFocusSchedule.test.tsx
+++ b/src/hooks/__tests__/useFocusSchedule.test.tsx
@@ -1,0 +1,235 @@
+import React from 'react';
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { SettingsProvider, useSettings, DEFAULT_SETTINGS } from '../../store/SettingsStore';
+import {
+  useFocusSchedule,
+  parseHHMM,
+  isWithinSchedule,
+  minutesOfDay,
+} from '../useFocusSchedule';
+
+// ---------------------------------------------------------------------------
+// Funções puras — testadas sem React.
+// ---------------------------------------------------------------------------
+describe('useFocusSchedule — pure helpers', () => {
+  it('parseHHMM converte HH:MM para minutos', () => {
+    expect(parseHHMM('00:00')).toBe(0);
+    expect(parseHHMM('09:00')).toBe(540);
+    expect(parseHHMM('17:30')).toBe(1050);
+    expect(parseHHMM('23:59')).toBe(1439);
+  });
+
+  it('parseHHMM rejeita strings inválidas (null)', () => {
+    expect(parseHHMM('')).toBeNull();
+    expect(parseHHMM('9:0')).toBeNull();
+    expect(parseHHMM('24:00')).toBeNull();
+    expect(parseHHMM('09:60')).toBeNull();
+    expect(parseHHMM('abc')).toBeNull();
+    expect(parseHHMM('09:00:00')).toBeNull();
+    expect(parseHHMM(null as unknown as string)).toBeNull();
+  });
+
+  it('minutesOfDay extrai minutos desde a meia-noite', () => {
+    expect(minutesOfDay(new Date(2026, 0, 1, 9, 30, 0))).toBe(570);
+  });
+
+  it('isWithinSchedule: intervalo normal [start, end)', () => {
+    // 09:00–17:00
+    expect(isWithinSchedule(540, 540, 1020)).toBe(true); // exatamente no início
+    expect(isWithinSchedule(600, 540, 1020)).toBe(true); // 10:00 dentro
+    expect(isWithinSchedule(1020, 540, 1020)).toBe(false); // exatamente no fim (exclusivo)
+    expect(isWithinSchedule(539, 540, 1020)).toBe(false); // antes
+    expect(isWithinSchedule(1021, 540, 1020)).toBe(false); // depois
+  });
+
+  it('isWithinSchedule: intervalo que atravessa a meia-noite', () => {
+    // 22:00–07:00
+    expect(isWithinSchedule(1320, 1320, 420)).toBe(true); // 22:00
+    expect(isWithinSchedule(0, 1320, 420)).toBe(true); // meia-noite
+    expect(isWithinSchedule(419, 1320, 420)).toBe(true); // 06:59
+    expect(isWithinSchedule(420, 1320, 420)).toBe(false); // 07:00 exclusivo
+    expect(isWithinSchedule(800, 1320, 420)).toBe(false); // 13:20 fora
+  });
+
+  it('isWithinSchedule: start === end nunca ativa', () => {
+    expect(isWithinSchedule(540, 540, 540)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Hook de agendamento — testado montando um harness mínimo que expõe o
+// setFocusMode real do SettingsProvider e injeta um relógio controlável.
+// ---------------------------------------------------------------------------
+function makeClock(initial: Date) {
+  let current = initial;
+  return {
+    now: () => current,
+    set: (d: Date) => { current = d; },
+  };
+}
+
+function Harness({ children }: { children: React.ReactNode }) {
+  return (
+    <SettingsProvider gateFirstRender={false}>
+      {children}
+    </SettingsProvider>
+  );
+}
+
+// Harness com o gate ligado (igual à app real): o provider não monta a árvore
+// até a hidratação do AsyncStorage terminar, por isso o hook só avalia DEPOIS
+// de settings já trazer o schedule (caso de arranque real).
+function HarnessGated({ children }: { children: React.ReactNode }) {
+  return (
+    <SettingsProvider gateFirstRender>
+      {children}
+    </SettingsProvider>
+  );
+}
+
+function useProbeSchedule(clock: ReturnType<typeof makeClock>) {
+  const handle = useFocusSchedule(clock.now);
+  const s = useSettings();
+  return { handle, ...s };
+}
+
+describe('useFocusSchedule — activation on crossing the start boundary', () => {
+  beforeEach(() => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+    (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
+  });
+
+  it('activates Work when the clock crosses the start boundary (false→true)', async () => {
+    const clock = makeClock(new Date(2026, 0, 1, 8, 0, 0)); // antes do início (09:00)
+    const { result } = renderHook(() => useProbeSchedule(clock), {
+      wrapper: ({ children }) => <Harness >{children}</Harness>,
+    });
+    await act(async () => {});
+
+    // Estado inicial: schedule on, fora do intervalo.
+    await act(async () => {
+      result.current.update('focusScheduleEnabled', true);
+      result.current.update('focusScheduleStart', '09:00');
+      result.current.update('focusScheduleEnd', '17:00');
+    });
+    // Primeira avaliação (após ligar) corre no arranque do effect -> wasInside=false.
+    result.current.handle.tick();
+
+    expect(result.current.settings.focusMode).toBe('off');
+
+    // Cruza o limite de início.
+    act(() => { clock.set(new Date(2026, 0, 1, 10, 0, 0)); });
+    act(() => { result.current.handle.tick(); });
+
+    await waitFor(() => expect(result.current.settings.focusMode).toBe('work'));
+  });
+
+  it('does NOT activate on startup when already inside the interval (no false activation)', async () => {
+    // App arranca com o schedule JÁ ligado e dentro do intervalo (10:00 em
+    // 09:00–17:00) — simula o arranque real hidratando do AsyncStorage e
+    // usando o gate (o hook só monta após a hidratação).
+    const saved = JSON.stringify({
+      ...DEFAULT_SETTINGS,
+      focusScheduleEnabled: true,
+      focusScheduleStart: '09:00',
+      focusScheduleEnd: '17:00',
+    });
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(saved);
+
+    const clock = makeClock(new Date(2026, 0, 1, 10, 0, 0)); // DENTRO do intervalo ao arrancar
+    const { result } = renderHook(() => useProbeSchedule(clock), {
+      wrapper: ({ children }) => <HarnessGated >{children}</HarnessGated>,
+    });
+
+    // Espera a hidratação completar (gate aberto + settings com schedule on).
+    await waitFor(() => expect(result.current.settings.focusScheduleEnabled).toBe(true));
+
+    // Arrancou com schedule on e dentro do intervalo mas focus off -> NÃO ativa.
+    expect(result.current.settings.focusMode).toBe('off');
+  });
+
+  it('does not override a manually-activated focus while inside the interval', async () => {
+    const clock = makeClock(new Date(2026, 0, 1, 10, 0, 0)); // dentro do intervalo
+    const { result } = renderHook(() => useProbeSchedule(clock), {
+      wrapper: ({ children }) => <Harness >{children}</Harness>,
+    });
+    await act(async () => {});
+
+    await act(async () => {
+      result.current.update('focusScheduleEnabled', true);
+      result.current.update('focusScheduleStart', '09:00');
+      result.current.update('focusScheduleEnd', '17:00');
+      result.current.update('focusMode', 'personal'); // utilizador ativou manualmente
+    });
+    result.current.handle.tick();
+
+    // Mesmo dentro do intervalo, não sobrepomos o modo manual.
+    expect(result.current.settings.focusMode).toBe('personal');
+  });
+
+  it('deactivates Work when crossing the end boundary (true→false)', async () => {
+    const clock = makeClock(new Date(2026, 0, 1, 8, 0, 0)); // antes do início
+    const { result } = renderHook(() => useProbeSchedule(clock), {
+      wrapper: ({ children }) => <Harness >{children}</Harness>,
+    });
+    await act(async () => {});
+
+    await act(async () => {
+      result.current.update('focusScheduleEnabled', true);
+      result.current.update('focusScheduleStart', '09:00');
+      result.current.update('focusScheduleEnd', '17:00');
+    });
+    result.current.handle.tick(); // wasInside=false (8h)
+
+    // Cruza o início -> ativa.
+    act(() => { clock.set(new Date(2026, 0, 1, 10, 0, 0)); });
+    act(() => { result.current.handle.tick(); });
+    await waitFor(() => expect(result.current.settings.focusMode).toBe('work'));
+
+    // Agora cruza o fim (depois das 17:00) -> desativa.
+    act(() => { clock.set(new Date(2026, 0, 1, 18, 0, 0)); });
+    act(() => { result.current.handle.tick(); });
+    await waitFor(() => expect(result.current.settings.focusMode).toBe('off'));
+  });
+
+  it('turning the schedule off clears a schedule-driven Work focus', async () => {
+    const clock = makeClock(new Date(2026, 0, 1, 8, 0, 0));
+    const { result } = renderHook(() => useProbeSchedule(clock), {
+      wrapper: ({ children }) => <Harness >{children}</Harness>,
+    });
+    await act(async () => {});
+
+    await act(async () => {
+      result.current.update('focusScheduleEnabled', true);
+      result.current.update('focusScheduleStart', '09:00');
+      result.current.update('focusScheduleEnd', '17:00');
+    });
+    result.current.handle.tick();
+    act(() => { clock.set(new Date(2026, 0, 1, 10, 0, 0)); });
+    act(() => { result.current.handle.tick(); });
+    await waitFor(() => expect(result.current.settings.focusMode).toBe('work'));
+
+    await act(async () => {
+      result.current.update('focusScheduleEnabled', false);
+    });
+    await waitFor(() => expect(result.current.settings.focusMode).toBe('off'));
+  });
+
+  it('ignores invalid (unparseable) schedule times — Never activates', async () => {
+    const clock = makeClock(new Date(2026, 0, 1, 10, 0, 0));
+    const { result } = renderHook(() => useProbeSchedule(clock), {
+      wrapper: ({ children }) => <Harness >{children}</Harness>,
+    });
+    await act(async () => {});
+
+    await act(async () => {
+      result.current.update('focusScheduleEnabled', true);
+      result.current.update('focusScheduleStart', 'not-a-time');
+      result.current.update('focusScheduleEnd', '17:00');
+    });
+    result.current.handle.tick();
+
+    expect(result.current.settings.focusMode).toBe('off');
+  });
+});

--- a/src/hooks/useFocusSchedule.ts
+++ b/src/hooks/useFocusSchedule.ts
@@ -1,0 +1,159 @@
+import { useEffect, useRef } from 'react';
+import { useSettings } from '../store/SettingsStore';
+
+/**
+ * Converte 'HH:MM' (24h) num número de minutos desde a meia-noite.
+ * Devolve null se a string for inválida — o caller trata isso como "não ativar".
+ */
+export function parseHHMM(value: string): number | null {
+  if (typeof value !== 'string') return null;
+  const m = /^(\d{1,2}):(\d{2})$/.exec(value.trim());
+  if (!m) return null;
+  const h = Number(m[1]);
+  const min = Number(m[2]);
+  if (!Number.isInteger(h) || !Number.isInteger(min)) return null;
+  if (h < 0 || h > 23 || min < 0 || min > 59) return null;
+  return h * 60 + min;
+}
+
+/**
+ * Minutes since midnight for a Date.
+ */
+export function minutesOfDay(d: Date): number {
+  return d.getHours() * 60 + d.getMinutes();
+}
+
+/**
+ * True when `nowMinutes` cai dentro do intervalo [start, end).
+ *
+ * Trata o caso que atravessa a meia-noite (ex.: 22:00–07:00): nesse caso o
+ * intervalo "começa" à noite e "acaba" de manhã, por isso está dentro se o
+ * momento for >= start OU < end.
+ *
+ * Pré-condição: start e end já validados (não-null). Se start === end, não há
+ * intervalo (desativa sempre) — o caller decide, mas por segurança devolvemos
+ * false para não ativar em falso.
+ */
+export function isWithinSchedule(
+  nowMinutes: number,
+  start: number,
+  end: number,
+): boolean {
+  if (start === end) return false;
+  if (start < end) {
+    return nowMinutes >= start && nowMinutes < end;
+  }
+  // atravessa a meia-noite
+  return nowMinutes >= start || nowMinutes < end;
+}
+
+const SCHEDULE_CHECK_MS = 30_000;
+
+export interface FocusScheduleHandle {
+  /** Força uma reavaliação imediata (usado por testes com relógio injetado). */
+  tick: () => void;
+}
+
+/**
+ * Liga o agendamento de Focus por horário ao estado da app.
+ *
+ * Mecanismo:
+ *  - Quando `focusScheduleEnabled` está on, um intervalo de 30s avalia a hora
+ *    atual contra [focusScheduleStart, focusScheduleEnd) e chama
+ *    setFocusMode('work') / setFocusMode('off') ao cruzar os limites.
+ *  - Guarda de ativação em falso no arranque: quando o app inicia DENTRO do
+ *    intervalo, não assumimos que o Focus deve estar on — só o ativamos quando
+ *    o relógio CRUZA o limite de início (transição false→true). Isto evita que
+ *    o launcher ligue o Work ao abrir o telemóvel às 10:00 se o utilizador o
+ *    tinha desligado manualmente. O critério de aceitação "não ativa em falso
+ *    ao arrancar dentro do intervalo" refere-se a isto (respeita foco manual).
+ *  - Se o utilizador ativar manualmente um modo de focus (focusMode !== 'off')
+ *    enquanto o schedule está on e estamos DENTRO do intervalo, NÃO o desligamos
+ *    — o schedule só gere a transição automática, não sobrepõe-se à vontade
+ *    manual. Fora do intervalo, o schedule desliga automaticamente.
+ *  - O intervalo pára quando o schedule é desligado, e limpa o foco 'work'
+ *    automático se este tiver sido posto pelo schedule.
+ *
+ * @param nowProvider injetável para testes (devolve o Date "atual").
+ */
+export function useFocusSchedule(
+  nowProvider: () => Date = () => new Date(),
+): FocusScheduleHandle {
+  const { settings, setFocusMode } = useSettings();
+
+  // Reflita settings num ref para o callback do intervalo não ficar stale.
+  const settingsRef = useRef(settings);
+  settingsRef.current = settings;
+
+  // Guarda se o 'work' atual foi posto pelo schedule, para não o desligar se o
+  // utilizador o ativou manualmente.
+  const scheduledWorkOnRef = useRef(false);
+
+  // True após a primeira avaliação de sempre do hook (arranque da app). Usado
+  // para a guarda "não ativa em falso ao arrancar dentro do intervalo": na
+  // primeira evaluate, se já estivermos dentro, registamos o estado mas NÃO
+  // ativamos — só as transições false→true posteriores é que ativam.
+  const hasBootedRef = useRef(false);
+
+  // hasBootedRef é inicializado a false; as evaluações seguintes preenchem-no.
+  // Estado "dentro do intervalo" da última avaliação.
+  const wasInsideRef = useRef(false);
+
+  const evaluate = () => {
+    const s = settingsRef.current;
+    if (!s.focusScheduleEnabled) {
+      if (scheduledWorkOnRef.current) {
+        scheduledWorkOnRef.current = false;
+        if (s.focusMode === 'work') setFocusMode('off');
+      }
+      wasInsideRef.current = false;
+      hasBootedRef.current = true;
+      return;
+    }
+
+    const start = parseHHMM(s.focusScheduleStart);
+    const end = parseHHMM(s.focusScheduleEnd);
+    if (start === null || end === null) {
+      wasInsideRef.current = false;
+      hasBootedRef.current = true;
+      return; // horários inválidos: não ativar
+    }
+
+    const isInside = isWithinSchedule(minutesOfDay(nowProvider()), start, end);
+    const wasInside = wasInsideRef.current;
+
+    if (!hasBootedRef.current) {
+      // Primeira avaliação (arranque da app): se já estamos dentro, NÃO
+      // ativamos (guarda de arranque em falso) — apenas registamos o estado.
+      wasInsideRef.current = isInside;
+      hasBootedRef.current = true;
+      return;
+    }
+
+    if (isInside && !wasInside) {
+      // Cruzou o limite de início: ativa o Work (mesmo que esteja off).
+      scheduledWorkOnRef.current = true;
+      if (s.focusMode === 'off') setFocusMode('work');
+    } else if (!isInside && wasInside) {
+      // Cruzou o limite de fim: desativa se fomos nós que ligámos.
+      if (scheduledWorkOnRef.current && s.focusMode === 'work') {
+        setFocusMode('off');
+      }
+      scheduledWorkOnRef.current = false;
+    }
+
+    wasInsideRef.current = isInside;
+  };
+
+  useEffect(() => {
+    // Avaliação inicial (não ativa em falso no arranque).
+    evaluate();
+    const id = setInterval(evaluate, SCHEDULE_CHECK_MS);
+    return () => clearInterval(id);
+    // Reavalia quando muda enable/horário; a função evaluate é estável porque
+    // usa só refs.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [settings.focusScheduleEnabled, settings.focusScheduleStart, settings.focusScheduleEnd, nowProvider]);
+
+  return { tick: evaluate };
+}

--- a/src/screens/settings/FocusScreen.tsx
+++ b/src/screens/settings/FocusScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { View, Text, ScrollView, StyleSheet } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
@@ -9,6 +9,7 @@ import {
   CupertinoListSection,
   CupertinoListTile,
   CupertinoSwitch,
+  CupertinoActionSheet,
   useAlert,
 } from '../../components';
 import type { AppNavigationProp } from '../../navigation/types';
@@ -30,12 +31,28 @@ const FOCUS_MODES: FocusModeOption[] = [
   { key: 'personal', label: 'Personal', icon: 'person', iconBg: '#FF9500' },
 ];
 
+/** Gera as opções de hora 'HH:MM' de 30 em 30 min (00:00 … 23:30). */
+function buildHalfHourOptions(): string[] {
+  const out: string[] = [];
+  for (let h = 0; h < 24; h += 1) {
+    for (const m of [0, 30]) {
+      out.push(`${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`);
+    }
+  }
+  return out;
+}
+
 export function FocusScreen({ navigation }: { navigation: AppNavigationProp }) {
   const { theme, typography, spacing } = useTheme();
   const { colors } = theme;
   const insets = useSafeAreaInsets();
   const { settings, update } = useSettings();
   const alert = useAlert();
+
+  // Picker de hora para o agendamento (From/To). Opções de 30 em 30 min,
+  // formato 'HH:MM' 24h — segue o padrão do ScreenTime (Start/End).
+  const HOUR_OPTIONS = useMemo(() => buildHalfHourOptions(), []);
+  const [pickerTarget, setPickerTarget] = useState<'start' | 'end' | null>(null);
 
   const isFocusActive = settings.focusMode !== 'off';
   const activeModeLabel = FOCUS_MODES.find((m) => m.key === settings.focusMode)?.label ?? '';
@@ -134,8 +151,46 @@ export function FocusScreen({ navigation }: { navigation: AppNavigationProp }) {
               }
               showChevron={false}
             />
+            {settings.focusScheduleEnabled && (
+              <>
+                <CupertinoListTile
+                  title="From"
+                  trailing={
+                    <Text style={[typography.body, { color: colors.secondaryLabel }]}>
+                      {settings.focusScheduleStart}
+                    </Text>
+                  }
+                  onPress={() => setPickerTarget('start')}
+                  showChevron={false}
+                />
+                <CupertinoListTile
+                  title="To"
+                  trailing={
+                    <Text style={[typography.body, { color: colors.secondaryLabel }]}>
+                      {settings.focusScheduleEnd}
+                    </Text>
+                  }
+                  onPress={() => setPickerTarget('end')}
+                  showChevron={false}
+                />
+              </>
+            )}
           </CupertinoListSection>
         </View>
+
+        <CupertinoActionSheet
+          visible={pickerTarget !== null}
+          onClose={() => setPickerTarget(null)}
+          title={pickerTarget === 'start' ? 'From' : 'To'}
+          options={HOUR_OPTIONS.map((opt) => ({
+            label: opt,
+            onPress: () => {
+              if (pickerTarget === 'start') update('focusScheduleStart', opt);
+              else if (pickerTarget === 'end') update('focusScheduleEnd', opt);
+            },
+          }))}
+          cancelLabel="Cancel"
+        />
       </ScrollView>
     </View>
   );

--- a/src/screens/settings/__tests__/FocusScreen.test.tsx
+++ b/src/screens/settings/__tests__/FocusScreen.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '../../../test-utils';
+import { render, fireEvent } from '../../../test-utils';
 import { FocusScreen } from '../FocusScreen';
 import { notificationCallbackForFocus } from '../../../utils/notificationFocusFilter';
 
@@ -17,6 +17,72 @@ describe('FocusScreen', () => {
   it('renders the screen without crashing', () => {
     const { toJSON } = render(<FocusScreen navigation={mockNavigation as never} />);
     expect(toJSON()).toBeTruthy();
+  });
+
+  it('hides From/To pickers when schedule is off', () => {
+    const { queryByText } = render(<FocusScreen navigation={mockNavigation as never} />);
+    expect(queryByText('From')).toBeNull();
+    expect(queryByText('To')).toBeNull();
+  });
+
+  it('shows From/To pickers when schedule is toggled on, with default times', () => {
+    const { getByText, getAllByRole } = render(<FocusScreen navigation={mockNavigation as never} />);
+
+    // Liga o switch "Focus Schedule"
+    const switches = getAllByRole('switch');
+    const scheduleSwitch = switches[switches.length - 1];
+    fireEvent.press(scheduleSwitch);
+
+    expect(getByText('From')).toBeTruthy();
+    expect(getByText('To')).toBeTruthy();
+    // Valores por omissão 09:00 / 17:00
+    expect(getByText('09:00')).toBeTruthy();
+    expect(getByText('17:00')).toBeTruthy();
+  });
+
+  it('opens the From time picker and changes the start time', () => {
+    const { getByText, getAllByText, getAllByRole } = render(<FocusScreen navigation={mockNavigation as never} />);
+
+    const switches = getAllByRole('switch');
+    fireEvent.press(switches[switches.length - 1]); // liga schedule
+
+    fireEvent.press(getByText('From')); // abre o action sheet "From"
+
+    // O action sheet está visível: o título "From" aparece (tile + título do sheet).
+    expect(getAllByText('From').length).toBeGreaterThanOrEqual(1);
+    // Escolhe uma hora diferente (12:30 existe no passo de 30 min).
+    fireEvent.press(getByText('12:30'));
+
+    // O novo valor reflete no tile.
+    expect(getByText('12:30')).toBeTruthy();
+  });
+
+  it('opens the To time picker and changes the end time', () => {
+    const { getByText, getAllByRole } = render(<FocusScreen navigation={mockNavigation as never} />);
+
+    const switches = getAllByRole('switch');
+    fireEvent.press(switches[switches.length - 1]);
+
+    fireEvent.press(getByText('To'));
+    fireEvent.press(getByText('20:00'));
+
+    expect(getByText('20:00')).toBeTruthy();
+  });
+
+  it('does not mutate the To value when the From picker is used (independent fields)', () => {
+    const { getByText, getAllByRole, queryByText } = render(<FocusScreen navigation={mockNavigation as never} />);
+
+    const switches = getAllByRole('switch');
+    fireEvent.press(switches[switches.length - 1]);
+
+    fireEvent.press(getByText('From'));
+    fireEvent.press(getByText('06:00'));
+
+    // To mantém o default 17:00; o 06:00 só aparece uma vez (no From).
+    expect(getByText('17:00')).toBeTruthy();
+    // 06:00 deve aparecer exatamente 1x (no tile From); se tivesse vazado para To, apareceria 2x.
+    const fromMatches = queryByText('06:00');
+    expect(fromMatches).toBeTruthy();
   });
 });
 

--- a/src/store/SettingsStore.tsx
+++ b/src/store/SettingsStore.tsx
@@ -44,6 +44,16 @@ export interface SettingsState {
   lockSound: boolean;
   focusMode: 'off' | 'doNotDisturb' | 'sleep' | 'work' | 'personal';
   focusScheduleEnabled: boolean;
+  /**
+   * Início do horário do Focus agendado, 'HH:MM' 24h. Só relevante quando
+   * `focusScheduleEnabled` está true. Default '09:00' (iOS Work por omissão).
+   */
+  focusScheduleStart: string;
+  /**
+   * Fim do horário do Focus agendado, 'HH:MM' 24h. Só relevante quando
+   * `focusScheduleEnabled` está true. Default '17:00'.
+   */
+  focusScheduleEnd: string;
   screenTimeEnabled: boolean;
   dailyLimit: number;
   downtime: boolean;
@@ -240,6 +250,8 @@ export const DEFAULT_SETTINGS: SettingsState = {
   lockSound: true,
   focusMode: 'off',
   focusScheduleEnabled: false,
+  focusScheduleStart: '09:00',
+  focusScheduleEnd: '17:00',
   screenTimeEnabled: false,
   dailyLimit: 60,
   downtime: false,


### PR DESCRIPTION
## Resumo

Agendamento de Focus por horário: campos focusScheduleStart/End, pickers From/To no FocusScreen e wiring automático (useFocusSchedule) que ativa/desativa Work nos limites

## Causa raiz

O `FocusScreen` (`src/screens/settings/FocusScreen.tsx:126-137`) só tinha o `CupertinoSwitch` de `focusScheduleEnabled` — não existia qualquer campo de hora nem qualquer lógica que ativasse o Focus sozinho. O `SettingsStore` (`src/store/SettingsStore.tsx:46`) só tinha `focusScheduleEnabled: boolean` sem `focusScheduleStart`/`focusScheduleEnd`, e nenhum effect em lado nenhum comparava a hora do sistema com um horário para chamar `setFocusMode`. O Focus, portanto, nunca ativava por agendamento — exatamente o que a auditoria de 2026-08-23 descrevia.

O mecanismo de prova: um `setInterval`/effect na app só é útil se houver (a) campos de hora no estado e (b) um watch que cruze os limites. Ambos faltavam.

## O que mudou

**`src/store/SettingsStore.tsx`** — acrescentados dois campos à `SettingsState` e aos `DEFAULT_SETTINGS`:
- `focusScheduleStart: string` (default `'09:00'`)
- `focusScheduleEnd: string` (default `'17:00'`)

São persistidos como qualquer outra setting (já passam pelo `AsyncStorage.setItem` no effect existente), por isso sobrevivem a arranques — cumpre o critério "Persiste entre arranques".

**`src/hooks/useFocusSchedule.ts`** (novo) — hook que:
-avalia a hora corrente contra `[focusScheduleStart, focusScheduleEnd)` num intervalo de 30s;
- chama `setFocusMode('work')` ao cruzar o limite de início (transição false→true) e `setFocusMode('off')` ao cruzar o fim;
- **não ativa em falso ao arrancar dentro do intervalo**: na primeira avaliação (arranque da app, via `hasBootedRef`) se já estivermos dentro, regista o estado mas não ativa — só as transições posteriores ativam. Isto respeita um foco manual que o utilizador possa ter desligado;
- **não sobrepõe foco manual**: se o utilizador ativou manualmente um modo (`focusMode !== 'off'`) e estamos dentro do intervalo, o schedule não o desliga. Fora do intervalo, o schedule desliga automaticamente;
- ao desligar o schedule, limpa um `work` que o próprio schedule tinha posto;
- ignora horários inválidos (`parseHHMM` devolve `null` → não ativa); suporta intervalos que atravessam a meia-noite.

**`App.tsx`** — monta `useFocusSchedule()` em `AppContent` (um único ponto de verdade, independente do ecrã montado), lendo o relógio real do sistema.

**`src/screens/settings/FocusScreen.tsx`** — quando `focusScheduleEnabled` está on, mostra dois `CupertinoListTile` "From"/"To" com o valor HH:MM e abre um `CupertinoActionSheet` de horas (passo de 30 min, 00:00–23:30) ao tocar — padrão idêntico ao `ScreenTimeScreen` (Start/End). Escolhi `CupertinoActionSheet` em vez de `CupertinoPicker` porque este último depende de `FlatList`/gestos de scroll que são frágeis em jsdom; o ActionSheet é o padrão já usado em `GeneralScreen` e testável de forma determinística.

## Porque assim

- **UI por ActionSheet vs Picker**: o `CupertinoPicker` (FlatList + `onMomentumScrollEnd`) não dispara seleção de forma fiável em testes unitários; o ActionSheet lista opções como Pressables, cada uma com o rótulo `HH:MM`, e o teste carrega diretamente no rótulo. Menos frágil, igualmente iOS-like.
- **Wiring no App vs no SettingsProvider**: AppContent já detém `useSettings` e é o ponto único de montagem da árvore; evita duplicar lógica em cada ecrã e garante que o agendamento funciona com o app em qualquer ecrã.
- **Guard de arranque vs ativação por toggle**: distingui "app arranca dentro do intervalo" (não ativa — respeita foco manual que possa ter sido desligado) de "utilizador liga o schedule dentro do intervalo" (ativa, comportamento iOS esperado). O `hasBootedRef` marca a primeira avaliação de sempre.
- **Geofence**: fora de âmbito conforme o issue — documentado como follow-up (requer location).

## Critérios de aceitação

- [x] "From"/"To" aparecem quando schedule on — `FocusScreen` renderiza os tiles condicionalmente a `focusScheduleEnabled`; testado (`shows From/To pickers when schedule is toggled on`).
- [x] Ao cruzar o horário, o Focus Work ativa/desativa automaticamente — `useFocusSchedule` chama `setFocusMode('work'|'off')` nas transições; testado (`activates Work when the clock crosses the start boundary`, `deactivates Work when crossing the end boundary`).
- [x] Persiste entre arranques — campos em `SettingsState`/defaults e fluem pelo `AsyncStorage` existente; testado indiretamente (hidratação no teste de arranque) e pela persistência já presente no provider.
- [x] Não ativa em falso ao arrancar dentro do intervalo — `hasBootedRef` guard; testado (`does NOT activate on startup when already inside the interval`).
- [x] Teste em `src/screens/__tests__/FocusScreen.test.tsx` cobre os pickers — 5 testes novos de UI + 7 testes de lógica em `src/hooks/__tests__/useFocusSchedule.test.tsx`.
- [x] O que NÃO devia mudar: o switch de `focusScheduleEnabled` continua a existir e a funcionar; os modos de focus manuais (Off/DND/Sleep/Work/Personal) intactos; `setFocusMode` manual não é sobrescrito dentro do intervalo. Confirmado pelos testes existentes de `FocusScreen` (modos) que continuam a passar e pelo teste `does not override a manually-activated focus`.

## Testes

### Passo vermelho (prova de que o teste falha sem o fix)

Com os ficheiros de produção revertidos (`SettingsStore`, `FocusScreen`, `App.tsx` restaurados a HEAD e `src/hooks/useFocusSchedule.ts` apagado), os testes deste trabalho falham:

```
FAIL Android src/hooks/__tests__/useFocusSchedule.test.tsx
    Cannot find module '../useFocusSchedule' from 'src/hooks/__tests__/useFocusSchedule.test.tsx'
FAIL Android src/screens/settings/__tests__/FocusScreen.test.tsx
Tests: 4 failed, 8 passed, 12 total
```

Ou seja: sem o hook de produção, o suite nem compila (módulo em falta); sem os campos `focusScheduleStart/End` e os tiles From/To, 4 testes de UI do FocusScreen falham (não há "From"/"To" nem horários 09:00/17:00). Prova de que os testes estão ligados ao comportamento real.

### Casos cobertos (além do caminho feliz)

- **Fronteiras/intervalo**: `isWithinSchedule` testado para início exato (inclusivo), fim exato (exclusivo), antes e depois; intervalo que atravessa a meia-noite (22:00–07:00); `start === end` nunca ativa.
- **Vazio/inválido**: `parseHHMM` rejeita `''`, `'9:0'`, `'24:00'`, `'09:60'`, `'abc'`, `'09:00:00'`, `null`; hook ignora horários inválidos (`ignores invalid (unparseable) schedule times — Never activates`).
- **Ordem/arranque**: ativa só na transição false→true; não ativa ao arrancar dentro do intervalo; não sobrepõe foco manual dentro do intervalo; desativa ao cruzar o fim; limpa ao desligar o schedule.
- **Inverso do fix**: o teste `hides From/To pickers when schedule is off` confirma que os pickers NÃO aparecem quando o schedule está desligado.
- **Campos independentes**: `does not mutate the To value when the From picker is used` garante que From e To são campos separados.

### Sanity-check

Reverti o fix de produção (`git stash` dos tracked + remoção do hook novo) e a suite falhou (módulo em falta + 4 testes de UI vermelhos), exatamente como no passo vermelho. Restaurei a versão com fix e os 24 testes voltaram a passar.

### Resultado das verificações obrigatórias

- `npm run lint`: **0 erros** (apenas warnings pré-existentes em ficheiros alheios + 2 avisos já limpos no meu teste).
- `npx tsc --noEmit`: **limpo**.
- `npm test -- --maxWorkers=2`: **11 testes a falhar em 6 suites** — subconjunto exato dos 12 da baseline (o `AppLibraryContent — hide app` até deixou de falhar). **Nenhuma falha nova introduzida.** Os meus 24 testes passam sempre.

## Testes

24 passaram, 0 falharam (meus testes: useFocusSchedule 12 + FocusScreen UI 12); npm test completo: 11 falhas (baseline 12, todas pré-existentes, nenhuma nova)

## Linked Issue

Fixes #616