### PR TITLE
BluetoothScreen: override local do tipo de dispositivo (Speaker/Headphones/Car Stereo/Other) via CupertinoActionSheet, persistido por device.address (#615)

### DIFF
--- a/src/screens/settings/BluetoothScreen.tsx
+++ b/src/screens/settings/BluetoothScreen.tsx
@@ -4,11 +4,13 @@ import { Ionicons } from '@expo/vector-icons';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTheme } from '../../theme/ThemeContext';
 import { useDevice } from '../../store/DeviceStore';
+import { useSettings } from '../../store/SettingsStore';
 import {
   CupertinoNavigationBar,
   CupertinoListSection,
   CupertinoListTile,
   CupertinoSwitch,
+  CupertinoActionSheet,
   useAlert,
 } from '../../components';
 import type { AppNavigationProp } from '../../navigation/types';
@@ -29,7 +31,7 @@ interface DiscoveredDevice {
   bondState: number;
 }
 
-function getDeviceIcon(type: number): keyof typeof Ionicons.glyphMap {
+export function getDeviceIcon(type: number): keyof typeof Ionicons.glyphMap {
   switch (type) {
     case 1:
       return 'laptop-outline';
@@ -37,6 +39,10 @@ function getDeviceIcon(type: number): keyof typeof Ionicons.glyphMap {
       return 'phone-portrait-outline';
     case 7:
       return 'headset-outline';
+    case 8:
+      return 'volume-high-outline';
+    case 9:
+      return 'car-sport-outline';
     default:
       return 'bluetooth';
   }
@@ -45,6 +51,10 @@ function getDeviceIcon(type: number): keyof typeof Ionicons.glyphMap {
 function getDeviceIconBackground(type: number, accentColor: string): string {
   switch (type) {
     case 7:
+      return '#FF9500';
+    case 8:
+      return '#FF9500';
+    case 9:
       return '#FF9500';
     case 1:
       return '#5856D6';
@@ -55,16 +65,55 @@ function getDeviceIconBackground(type: number, accentColor: string): string {
   }
 }
 
+/**
+ * User-overridable device type (issue #615). The native layer reports a raw
+ * `device.type`; the user may relabel a paired device as speaker / headphones /
+ * car / other. This only affects the local UI (icon + intent) — Android's real
+ * Headphone Safety is handled by the OS, not this launcher.
+ */
+export type BluetoothDeviceType = 'speaker' | 'headphones' | 'car' | 'other';
+
+/**
+ * Maps the user-overridden type to the Ionicons glyph + native `device.type`
+ * integer the existing `getDeviceIcon`/`getDeviceIconBackground` already know
+ * how to render. Keeping the override in native-type space means the rest of
+ * the screen (paired + discovered tiles) renders the override for free.
+ */
+const DEVICE_TYPE_TO_NATIVE: Record<BluetoothDeviceType, number> = {
+  speaker: 8,
+  headphones: 7,
+  car: 9,
+  other: 0,
+};
+
+const DEVICE_TYPE_OPTIONS: { label: string; value: BluetoothDeviceType }[] = [
+  { label: 'Speaker', value: 'speaker' },
+  { label: 'Headphones', value: 'headphones' },
+  { label: 'Car Stereo', value: 'car' },
+  { label: 'Other', value: 'other' },
+];
+
+/** Resolve the icon type for a device: override wins over the raw native type. */
+export function getIconTypeForDevice(
+  device: { address: string; type: number },
+  overrides: Record<string, BluetoothDeviceType>,
+): number {
+  const override = overrides[device.address];
+  return override ? DEVICE_TYPE_TO_NATIVE[override] : device.type ?? 0;
+}
+
 export function BluetoothScreen({ navigation }: { navigation: AppNavigationProp }) {
   const { theme, typography, spacing } = useTheme();
   const { colors } = theme;
   const insets = useSafeAreaInsets();
   const { bluetooth, bluetoothError, toggleBluetooth, refresh } = useDevice();
+  const { settings, update } = useSettings();
   const alert = useAlert();
 
   const [discovered, setDiscovered] = useState<DiscoveredDevice[]>([]);
   const [scanning, setScanning] = useState(false);
   const [pairingAddress, setPairingAddress] = useState<string | null>(null);
+  const [typePickerAddress, setTypePickerAddress] = useState<string | null>(null);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const pairedAddresses = new Set(bluetooth.pairedDevices.map((d) => d.address));
@@ -141,6 +190,22 @@ export function BluetoothScreen({ navigation }: { navigation: AppNavigationProp 
       alert('Unpair Failed', 'Could not unpair this device.');
     }
   }, [alert, refresh]);
+
+  // Opens the device-type picker (the iOS "i" override) for a paired device.
+  const openTypePicker = useCallback((address: string) => {
+    setTypePickerAddress(address);
+  }, []);
+
+  // Persists the chosen device type override keyed by device.address (#615).
+  const handleSetType = useCallback((value: BluetoothDeviceType) => {
+    const address = typePickerAddress;
+    setTypePickerAddress(null);
+    if (!address) return;
+    update('bluetoothDeviceTypes', {
+      ...settings.bluetoothDeviceTypes,
+      [address]: value,
+    });
+  }, [typePickerAddress, settings.bluetoothDeviceTypes, update]);
 
   useEffect(() => {
     if (bluetooth.enabled) {
@@ -234,7 +299,7 @@ export function BluetoothScreen({ navigation }: { navigation: AppNavigationProp 
               <CupertinoListSection header="My Devices">
                 {bluetooth.pairedDevices.length > 0 ? (
                   bluetooth.pairedDevices.map((device) => {
-                    const deviceType = device.type ?? 0;
+                    const deviceType = getIconTypeForDevice(device, settings.bluetoothDeviceTypes);
                     return (
                       <CupertinoListTile
                         key={device.address}
@@ -252,7 +317,8 @@ export function BluetoothScreen({ navigation }: { navigation: AppNavigationProp 
                             </Text>
                           </Pressable>
                         }
-                        showChevron={false}
+                        onPress={() => openTypePicker(device.address)}
+                        showChevron
                       />
                     );
                   })
@@ -324,6 +390,17 @@ export function BluetoothScreen({ navigation }: { navigation: AppNavigationProp 
             <Text style={[typography.footnote, styles.footer, { color: colors.secondaryLabel }]}>
               When pairing, Android may show a passkey confirmation dialog — this is required for security.
             </Text>
+
+            <CupertinoActionSheet
+              visible={typePickerAddress !== null}
+              onClose={() => setTypePickerAddress(null)}
+              title={typePickerAddress ? `Device Type — ${typePickerAddress}` : 'Device Type'}
+              options={DEVICE_TYPE_OPTIONS.map((option) => ({
+                label: option.label,
+                onPress: () => handleSetType(option.value),
+              }))}
+              cancelLabel="Cancel"
+            />
 
             {scanning && (
               <View style={styles.stopScanRow}>

--- a/src/screens/settings/__tests__/BluetoothScreen.test.tsx
+++ b/src/screens/settings/__tests__/BluetoothScreen.test.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
-import { render } from '../../../test-utils';
+import { render, fireEvent } from '../../../test-utils';
 import { BluetoothScreen } from '../BluetoothScreen';
+import Ionicons from '@expo/vector-icons/Ionicons';
+
+// Minimal shape of a rendered Ionicons host element we inspect for the icon name.
+type IconInstance = { props: { name?: string } };
 
 const mockNavigation = { navigate: jest.fn(), goBack: jest.fn() } as any; // eslint-disable-line @typescript-eslint/no-explicit-any
 
@@ -19,6 +23,32 @@ const baseDeviceValue = {
   refresh: jest.fn(),
 };
 
+// A paired device with a generic (type 0) native type — the override must be
+// able to relabel it as a speaker/headphones/car without touching the native type.
+const pairedDevice = {
+  name: 'My BT Speaker',
+  address: 'AA:BB:CC:DD:EE:FF',
+  type: 0,
+  rssi: -50,
+  bondState: 12,
+};
+
+function renderWithPaired() {
+  mockUseDevice.mockReturnValue({
+    ...baseDeviceValue,
+    bluetooth: { enabled: true, name: 'Phone', address: '11:22:33', pairedDevices: [pairedDevice] },
+  });
+  return render(<BluetoothScreen navigation={mockNavigation} />);
+}
+
+function deviceTypeIcons(result: ReturnType<typeof render>) {
+  // The paired-device tile's leading Ionicons carries the resolved icon name.
+  // Exclude the trailing chevron glyph that every tappable tile also renders.
+  return result.UNSAFE_getAllByType(Ionicons)
+    .map((el: IconInstance) => el.props.name as string)
+    .filter((name: string) => name && name !== 'chevron-forward');
+}
+
 describe('BluetoothScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -31,7 +61,6 @@ describe('BluetoothScreen', () => {
   });
 
   it('shows error tile when bluetoothError is true', () => {
-    // Red: before fix, bluetoothError did not exist. After fix, error tile appears.
     mockUseDevice.mockReturnValue({ ...baseDeviceValue, bluetoothError: true });
     const { getByText } = render(<BluetoothScreen navigation={mockNavigation} />);
     expect(getByText(/Could not load Bluetooth status/i)).toBeTruthy();
@@ -41,5 +70,64 @@ describe('BluetoothScreen', () => {
     mockUseDevice.mockReturnValue({ ...baseDeviceValue, bluetoothError: false });
     const { queryByText } = render(<BluetoothScreen navigation={mockNavigation} />);
     expect(queryByText(/Could not load Bluetooth status/i)).toBeNull();
+  });
+
+  it('opens the device-type picker when tapping a paired device', () => {
+    const { getByText } = renderWithPaired();
+    fireEvent.press(getByText('My BT Speaker'));
+    // The action sheet surfaces the four iOS device-type choices.
+    expect(getByText('Speaker')).toBeTruthy();
+    expect(getByText('Headphones')).toBeTruthy();
+    expect(getByText('Car Stereo')).toBeTruthy();
+    expect(getByText('Other')).toBeTruthy();
+  });
+
+  it('does not open the picker when tapping the Forget button', () => {
+    const { getByText, queryByText } = renderWithPaired();
+    fireEvent.press(getByText(/Forget/i));
+    expect(queryByText('Speaker')).toBeNull();
+  });
+
+  it('persists the chosen device type keyed by address and updates the icon', () => {
+    const result = renderWithPaired();
+    const { getByText } = result;
+    const before = deviceTypeIcons(result);
+    // Default generic type 0 → 'bluetooth' glyph.
+    expect(before).toContain('bluetooth');
+
+    fireEvent.press(getByText('My BT Speaker'));
+    fireEvent.press(getByText('Speaker'));
+
+    // After choosing "Speaker", the tile icon must reflect the override.
+    const after = deviceTypeIcons(result);
+    expect(after).toContain('volume-high-outline');
+    expect(after).not.toContain('bluetooth');
+  });
+
+  it('keeps the native type when no override is set', () => {
+    mockUseDevice.mockReturnValue({
+      ...baseDeviceValue,
+      bluetooth: {
+        enabled: true,
+        name: 'Phone',
+        address: '11:22:33',
+        pairedDevices: [{ ...pairedDevice, type: 7 }],
+      },
+    });
+    const result = render(<BluetoothScreen navigation={mockNavigation} />);
+    const names = result.UNSAFE_getAllByType(Ionicons).map((el: IconInstance) => el.props.name as string);
+    // type 7 is a headset → headset-outline, untouched by any override.
+    expect(names).toContain('headset-outline');
+  });
+
+  it('restores the override after re-opening the picker', () => {
+    const result = renderWithPaired();
+    const { getByText } = result;
+    fireEvent.press(getByText('My BT Speaker'));
+    fireEvent.press(getByText('Car Stereo'));
+    // Reopen and confirm the previous choice is still applied (icon reflects override).
+    fireEvent.press(getByText('My BT Speaker'));
+    const after = deviceTypeIcons(result);
+    expect(after).toContain('car-sport-outline');
   });
 });

--- a/src/store/SettingsStore.tsx
+++ b/src/store/SettingsStore.tsx
@@ -216,6 +216,15 @@ export interface SettingsState {
    * "Dark until 7:00 PM".
    */
   darkModeDarkUntil: string;
+  /**
+   * Override local do tipo de dispositivo Bluetooth, por endereço (issue #615).
+   * O native devolve o tipo real (`device.type`), mas o utilizador pode
+   * sobrepô-lo no "i" de cada dispositivo emparelhado (Coluna / Auscultadores /
+   * Rádio do Carro / Outro) — isto calibra o ícone e a intenção de uso. É um
+   * override puramente visual/local; o Headphone Safety real é do SO Android.
+   * Chaveado por `device.address` (estável), nunca pelo nome exibido.
+   */
+  bluetoothDeviceTypes: Record<string, 'speaker' | 'headphones' | 'car' | 'other'>;
 }
 
 export const DEFAULT_SETTINGS: SettingsState = {
@@ -302,6 +311,7 @@ export const DEFAULT_SETTINGS: SettingsState = {
   darkModeAutomatic: false,
   darkModeLightUntil: '07:00',
   darkModeDarkUntil: '19:00',
+  bluetoothDeviceTypes: {},
 };
 
 interface SettingsContextValue {


### PR DESCRIPTION
## Resumo

BluetoothScreen: override local do tipo de dispositivo (Speaker/Headphones/Car Stereo/Other) via CupertinoActionSheet, persistido por device.address

## Causa raiz

O `BluetoothScreen` só lia `device.type` (native) e mostrava o ícone, mas não havia qualquer via para o utilizador definir/sobrepor o tipo — o issue está correcto quanto a isso. Faltava (1) estado para guardar o override e (2) um picker acionável ao tocar num dispositivo emparelhado.

Nota sobre o issue: aponta `src/store/Settings.tsx` como local do estado, mas esse ficheiro **não existe** — o store de settings é `src/store/SettingsStore.tsx` (confirmado por `ls`/grep). O código ganha: implementei o campo em `SettingsStore.tsx`. O componente `CupertinoActionSheet` referido no issue **existe** em `src/components/` (e já é usado em `LauncherSettingsScreen`), portanto foi reutilizado tal como sugerido.

## O que mudou

- **`src/store/SettingsStore.tsx`**: adicionado `bluetoothDeviceTypes: Record<string, 'speaker' | 'headphones' | 'car' | 'other'>` à `SettingsState` e ao `DEFAULT_SETTINGS` (`{}`). Chaveado por `device.address` (estável), nunca pelo nome exibido. Persiste via o `update`/AsyncStorage já existente — sem lógica nova de storage.
- **`src/screens/settings/BluetoothScreen.tsx`**:
  - Novo `export type BluetoothDeviceType` e mapa `DEVICE_TYPE_TO_NATIVE` (speaker→8, headphones→7, car→9, other→0) que traduz o override para o espaço de `device.type` nativo, para que `getDeviceIcon`/`getDeviceIconBackground` o rendam de graça.
  - `getIconTypeForDevice(device, overrides)` — override ganha ao tipo nativo. O tile emparelhado agora usa isto em vez de `device.type ?? 0`.
  ️  `getDeviceIcon`/`getDeviceIconBackground` ganharam os casos 8 (volume-high-outline) e 9 (car-sport-outline) para que os novos tipos tenham ícone e cor corretos. **Sem isto o override gravava mas o ícone continuava `bluetooth`** — foi a causa real de o teste inicial falhar ao afirmar o ícone.
  - Estado `typePickerAddress` + `openTypePicker(address)` + `handleSetType(value)` (grava em `bluetoothDeviceTypes[address]`).
  - O tile emparelhado passou a ter `onPress={() => openTypePicker(device.address)}` e `showChevron` (antes `showChevron={false}`), abrindo o `CupertinoActionSheet` "Device Type" (Speaker / Headphones / Car Stereo / Other). O botão "Forget" (Pressable aninhado) continua a desemparelhar e NÃO abre o picker (verificado: Pressable aninhado dispara só o filho).
  - `getDeviceIcon`/`getIconTypeForDevice` exportados para permitir testes unitários.

## Porque assim

- **Override em espaço de `device.type`**: em vez de bifurcar a renderização do ícone por tipo override vs nativo, mapeio o override para um inteiro e reuso `getDeviceIcon`. Menos código de renderização duplicado e o ícone fica consistente em telas emparelhadas/descobertas.
- **`CupertinoActionSheet` em vez de `CupertinoPicker`/`Alert`**: é o padrão iOS do "i" (igual ao usado em `LauncherSettingsScreen` para New Apps/Require Passcode) e o issue pede explicitamente esse componente.
- **`Record` por `address`**: endereço BT é estável; o nome pode mudar. Seguido o mesmo princípio dos `categoryOverrides` do store.
- Descartado: escrever no native module (exigiria bridge Kotlin + permissões) — o issue diz claramente que é override visual/local e que o Headphone Safety real é do SO Android. Documentado no PR.

## Critérios de aceitação

- [x] Toque num dispositivo emparelhado abre picker de tipo — teste `opens the device-type picker when tapping a paired device` (afirma Speaker/Headphones/Car Stereo/Other).
- [x] Escolha persiste por `device.address` — teste `persists the chosen device type keyed by address and updates the icon` + `restores the override after re-opening the picker`.
- [x] Ícone reflete o tipo escolhido (`getDeviceIcon`) — teste afirma `volume-high-outline` após Speaker e `car-sport-outline` após Car Stereo; `keeps the native type when no override is set` confirma que type 7 nativo (headset-outline) não é tocado sem override.
- [x] Sem quebrar unpair/pair existente — `handleUnpair`/`doPair`/`handlePair` intocados; o teste `does not open the picker when tapping the Forget button` confirma que o Forget continua a desemparelhar e não abre o picker.
- [x] Teste em `src/screens/__tests__/` cobre o override — `BluetoothScreen.test.tsx` (8 testes, todos passam).
- [x] O que NÃO devia mudar: o resto do ecrã (toggle, erro, scan, descobertos, Forget) e os stores alheios. Confirmado: lint/tsc limpos e as únicas suites a falhar na suite completa são as 5 da baseline (ver abaixo), nenhuma em ficheiro que toquei.

## Testes

- **Passo vermelho** (fix revertido via `git stash` dos 2 ficheiros de produção, só o teste fica):
  ```
  Test Suites: 1 failed, 1 total
  Tests:       3 failed, 5 passed, 8 total

    ● BluetoothScreen › opens the device-type picker when tapping a paired device
      Unable to find an element with text: Speaker

    ● BluetoothScreen › persists the chosen device type keyed by address and updates the icon
      Expected value: "volume-high-outline"
      Received array: [...]   (ícone continua 'bluetooth')

    ● BluetoothScreen › restores the override after re-opening the picker
      Expected value: "car-sport-outline"
      Received array: ["bluetooth"]
  ```
  Com o fix: `Tests: 8 passed, 8 total`.

- **Casos cobertos** além do caminho feliz:
  - Fronteira/vazio: dispositivo com `type: 0` (genérico) sem override → ícone `bluetooth` por defeito (`before` no teste de persistência).
  - Inválido/ausente: `keeps the native type when no override is set` — type nativo 7 mantém `headset-outline` (o override não corrompe o tipo real quando não há escolha).
  - Ordem/repetição: `restores the override after re-opening the picker` — reabrir e confirmar que a escolha anterior persiste.
  - O inverso do fix: `does not open the picker when tapping the Forget button` — o botão de unpair não dispara o picker (separação da acção destrutiva vs override).
  - Não há async no caminho do picker (estado síncrono + update de settings), mas o `handleSetType` protege contra `typePickerAddress === null` (não grava se o picker fechou sem endereço).

- **Sanity-check**: reverti os 2 ficheiros de produção (`git stash`), a suite do `BluetoothScreen` caiu para 3 falhados; restaurei (`git stash pop`) e voltou a 8/8. Prova de que os testes estão ligados ao comportamento.

- **Resultado das verificações obrigatórias** (worktree, contra a baseline de `main` que já tinha 12 falhas/6 suites):
  - `npm run lint`: 0 erros (apenas 2 warnings pré-existentes em ficheiros que não toquei: `ClockScreen.tsx`, `BridgeErrorReporting.test.tsx`).
  - `npx tsc --noEmit`: limpo (exit 0).
  - `npm test -- --maxWorkers=2`: **11 falharam**, 1687 passaram (vs 12/1586 na baseline). As 11 falhas pertencem às **mesmas 5 suites da baseline** (FoldersStore, LockScreen, SettingsScreen, WeatherScreen, withLauncherIntent) — nenhuma falha nova em ficheiro que toquei; o `BluetoothScreen` passa 8/8. Critério de regressão cumprido (não piorou; até reduziu 1 falha em relação à baseline).

## Testes

BluetoothScreen: 8 passaram, 0 falharam (suite própria). Suite completa: 11 falharam, 1687 passaram, 178 suites — as falhas são as 5 suites da baseline, nenhuma nova.

## Linked Issue

Fixes #615