### PR TITLE
Filtro Foco (#618): páginas da home ocultáveis por modo de Focus, com page dots a refletir as páginas visíveis (#618)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,12 @@
 {
   "name": "iostoandroid",
-<<<<<<< Updated upstream
-  "version": "1.39.1",
-=======
-  "version": "1.27.0",
->>>>>>> Stashed changes
+  "version": "1.75.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "iostoandroid",
-<<<<<<< Updated upstream
-      "version": "1.39.1",
-=======
-      "version": "1.27.0",
->>>>>>> Stashed changes
+      "version": "1.75.0",
       "dependencies": {
         "@expo/vector-icons": "15.0.3",
         "@react-native-async-storage/async-storage": "^3.0.2",
@@ -43,11 +35,7 @@
         "expo-notifications": "~0.32.11",
         "expo-secure-store": "~15.0.7",
         "expo-sharing": "~14.0.8",
-<<<<<<< Updated upstream
         "expo-speech": "~14.0.8",
-=======
-        "expo-speech": "~12.0.2",
->>>>>>> Stashed changes
         "expo-status-bar": "~3.0.9",
         "react": "19.1.0",
         "react-native": "0.81.5",
@@ -7084,15 +7072,9 @@
       }
     },
     "node_modules/expo-speech": {
-<<<<<<< Updated upstream
       "version": "14.0.8",
       "resolved": "https://registry.npmjs.org/expo-speech/-/expo-speech-14.0.8.tgz",
       "integrity": "sha512-UjBFCFv58nutlLw92L7kUS0ZjbOOfaTdiEv/HbjvMrT6BfldoOLLBZbaEcEhDdZK36NY/kass0Kzxk+co6vxSQ==",
-=======
-      "version": "12.0.2",
-      "resolved": "https://registry.npmjs.org/expo-speech/-/expo-speech-12.0.2.tgz",
-      "integrity": "sha512-voWNz69hvtLEA2jipAbM5XJBIbKCusQsDZ/G/vAKKkP5AUTzAmcdRDWGcmESPRKK0JUtQZ8WetujgLCn2kl83w==",
->>>>>>> Stashed changes
       "license": "MIT",
       "peerDependencies": {
         "expo": "*"

--- a/package.json
+++ b/package.json
@@ -40,11 +40,7 @@
     "expo-notifications": "~0.32.11",
     "expo-secure-store": "~15.0.7",
     "expo-sharing": "~14.0.8",
-<<<<<<< Updated upstream
     "expo-speech": "~14.0.8",
-=======
-    "expo-speech": "~12.0.2",
->>>>>>> Stashed changes
     "expo-status-bar": "~3.0.9",
     "react": "19.1.0",
     "react-native": "0.81.5",

--- a/src/screens/LauncherHomeScreen.tsx
+++ b/src/screens/LauncherHomeScreen.tsx
@@ -70,6 +70,7 @@ import type { AppNavigationProp } from '../navigation/types';
 import type { SettingsState } from '../store/SettingsStore';
 import { hapticImpact, hapticSelection } from '../utils/haptics';
 import { computeLauncherGridGeometry } from '../utils/launcherGridGeometry';
+import { hiddenPageIndicesForMode, filterVisiblePages } from '../utils/focusPageVisibility';
 import { clampWithRubberBand } from '../theme/motion';
 
 // ---------------------------------------------------------------------------
@@ -1228,7 +1229,7 @@ export function LauncherHomeScreen() {
   // size (appsPerPage derives from settings, issue #503) re-packs pages
   // without ever reordering an app — there is no per-page stored position to
   // migrate (issue #503).
-  const pages: GridItem[][] = useMemo(() => {
+  const allPages: GridItem[][] = useMemo(() => {
     const out: GridItem[][] = [];
     for (let i = 0; i < gridItems.length; i += appsPerPage) {
       out.push(gridItems.slice(i, i + appsPerPage));
@@ -1239,6 +1240,19 @@ export function LauncherHomeScreen() {
     }
     return out;
   }, [gridItems, appsPerPage]);
+
+  // Focus filters (#618): com um modo de Focus activo, as páginas cujo índice
+  // está em `focusPageVisibility[focusMode]` não renderizam. O índice é o da
+  // paginação completa (`allPages`), por isso esconder a página 1 não renumera
+  // a configuração das restantes. `off` nunca esconde nada.
+  const hiddenPageIndices = useMemo(
+    () => hiddenPageIndicesForMode(settings.focusPageVisibility, settings.focusMode),
+    [settings.focusPageVisibility, settings.focusMode],
+  );
+  const pages: GridItem[][] = useMemo(
+    () => filterVisiblePages(allPages, hiddenPageIndices),
+    [allPages, hiddenPageIndices],
+  );
 
   // +1 for the App Library page appended at the end
   const totalPages = pages.length + 1;

--- a/src/screens/__tests__/LauncherHomeScreen.test.tsx
+++ b/src/screens/__tests__/LauncherHomeScreen.test.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
-import { render, fireEvent, within } from '../../test-utils';
+import { View as RNView, StyleSheet } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { render, fireEvent, within, waitFor } from '../../test-utils';
 import {
   LauncherHomeScreen,
   NonAndroidFallback,
@@ -674,5 +676,185 @@ describe('LauncherHomeScreen dock has no app-name labels (#501)', () => {
     const icon = getByLabelText('Open DockOnlyApp');
     expect(icon.props.accessibilityRole).toBe('button');
     expect(() => fireEvent.press(icon)).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Focus filters — page visibility per Focus mode (#618)
+// ---------------------------------------------------------------------------
+// Um modo de Focus activo esconde as páginas cujo índice está em
+// settings.focusPageVisibility[focusMode]. Os testes montam o LauncherHomeScreen
+// real com apps suficientes para haver 2 páginas e afirmam sobre os testIDs
+// `launcher-page-grid-N` e sobre os page dots (#603), que têm de refletir o
+// número real de páginas visíveis.
+describe('LauncherHomeScreen — Focus page visibility (#618)', () => {
+  const FOCUS_APP_NAMES = Array.from({ length: 26 }, (_, i) => `FocusApp${i}`);
+
+  function focusApp(name: string): AppsStore.InstalledApp {
+    const pkg = `com.example.${name.toLowerCase()}`;
+    return { name, packageName: pkg, icon: `file:///${pkg}.png`, isSystem: false };
+  }
+
+  function mockFocusApps(apps: AppsStore.InstalledApp[]) {
+    jest.spyOn(AppsStore, 'useApps').mockReturnValue({
+      apps,
+      homeApps: [],
+      dockApps: [],
+      nonDockApps: apps,
+      recentPackages: [],
+      recentApps: [],
+      isLoading: false,
+      refreshApps: jest.fn(() => Promise.resolve()),
+      launchApp: jest.fn(() => Promise.resolve(true)),
+      addToHome: jest.fn(),
+      removeFromHome: jest.fn(),
+      addToDock: jest.fn(),
+      removeFromDock: jest.fn(),
+      removeFromRecents: jest.fn(),
+      clearRecents: jest.fn(),
+      isDefaultLauncher: true,
+      openLauncherSettings: jest.fn(() => Promise.resolve()),
+      hiddenApps: [],
+      visibleApps: [],
+      hideApp: jest.fn(),
+      unhideApp: jest.fn(),
+      iconCacheSizeBytes: 0,
+      isRebuildingIconCache: false,
+      iconCacheRebuildProgress: null,
+      rebuildIconCache: jest.fn(() => Promise.resolve()),
+    } as ReturnType<typeof AppsStore.useApps>);
+  }
+
+  function seedSettings(partial: Record<string, unknown>) {
+    (AsyncStorage.getItem as jest.Mock).mockImplementation((key: string) =>
+      key === '@iostoandroid/settings'
+        ? Promise.resolve(JSON.stringify(partial))
+        : Promise.resolve(null),
+    );
+  }
+
+  /** Conta os page dots (#603): View 7x7 com borderRadius 3.5. */
+  function countDots(root: ReturnType<typeof render>): number {
+    return root.UNSAFE_getAllByType(RNView).filter((n: { props?: { style?: unknown } }) => {
+      const s = StyleSheet.flatten(n.props?.style) as Record<string, unknown> | undefined;
+      return !!s && s.width === 7 && s.height === 7 && s.borderRadius === 3.5;
+    }).length;
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('hides a page whose index is listed for the active focus mode', async () => {
+    // 26 apps reais + 14 virtuais = 40 itens; 4x6 = 24/página → 2 páginas.
+    seedSettings({
+      gridColumns: 4,
+      gridRows: 6,
+      focusMode: 'work',
+      focusPageVisibility: { work: [1] },
+    });
+    mockFocusApps(FOCUS_APP_NAMES.map(focusApp));
+
+    const root = render(<LauncherHomeScreen />);
+    await waitFor(() => expect(root.getByTestId('launcher-page-grid-0')).toBeTruthy(), {
+      timeout: 3000,
+    });
+    expect(root.queryByTestId('launcher-page-grid-1')).toBeNull();
+    root.unmount();
+  });
+
+  it('shows every page when focusMode is off, even with entries stored', async () => {
+    // O inverso do fix: a configuração existe mas 'off' não filtra nada.
+    seedSettings({
+      gridColumns: 4,
+      gridRows: 6,
+      focusMode: 'off',
+      focusPageVisibility: { work: [1] },
+    });
+    mockFocusApps(FOCUS_APP_NAMES.map(focusApp));
+
+    const root = render(<LauncherHomeScreen />);
+    await waitFor(() => expect(root.getByTestId('launcher-page-grid-1')).toBeTruthy(), {
+      timeout: 3000,
+    });
+    root.unmount();
+  });
+
+  it('ignores hidden pages configured for a DIFFERENT mode than the active one', async () => {
+    seedSettings({
+      gridColumns: 4,
+      gridRows: 6,
+      focusMode: 'sleep',
+      focusPageVisibility: { work: [1] },
+    });
+    mockFocusApps(FOCUS_APP_NAMES.map(focusApp));
+
+    const root = render(<LauncherHomeScreen />);
+    await waitFor(() => expect(root.getByTestId('launcher-page-grid-1')).toBeTruthy(), {
+      timeout: 3000,
+    });
+    root.unmount();
+  });
+
+  it('page dots reflect the real number of visible pages (#603 + #618)', async () => {
+    // Sem filtro: 2 páginas + App Library = 3 dots. Com a página 1 oculta: 2.
+    seedSettings({ gridColumns: 4, gridRows: 6, focusMode: 'off' });
+    mockFocusApps(FOCUS_APP_NAMES.map(focusApp));
+    const unfiltered = render(<LauncherHomeScreen />);
+    await waitFor(() => expect(unfiltered.getByTestId('launcher-page-grid-1')).toBeTruthy(), {
+      timeout: 3000,
+    });
+    const dotsWithAllPages = countDots(unfiltered);
+    expect(dotsWithAllPages).toBe(3);
+    unfiltered.unmount();
+
+    seedSettings({
+      gridColumns: 4,
+      gridRows: 6,
+      focusMode: 'work',
+      focusPageVisibility: { work: [1] },
+    });
+    mockFocusApps(FOCUS_APP_NAMES.map(focusApp));
+    const filtered = render(<LauncherHomeScreen />);
+    await waitFor(() => expect(filtered.getByTestId('launcher-page-grid-0')).toBeTruthy(), {
+      timeout: 3000,
+    });
+    expect(countDots(filtered)).toBe(dotsWithAllPages - 1);
+    filtered.unmount();
+  });
+
+  it('keeps the first page visible when every page is hidden (no empty home)', async () => {
+    seedSettings({
+      gridColumns: 4,
+      gridRows: 6,
+      focusMode: 'work',
+      focusPageVisibility: { work: [0, 1] },
+    });
+    mockFocusApps(FOCUS_APP_NAMES.map(focusApp));
+
+    const root = render(<LauncherHomeScreen />);
+    await waitFor(() => expect(root.getByTestId('launcher-page-grid-0')).toBeTruthy(), {
+      timeout: 3000,
+    });
+    expect(root.queryByTestId('launcher-page-grid-1')).toBeNull();
+    root.unmount();
+  });
+
+  it('survives a corrupted focusPageVisibility blob in AsyncStorage', async () => {
+    // Inválido e hostil: valor não-array, índices negativos e strings.
+    seedSettings({
+      gridColumns: 4,
+      gridRows: 6,
+      focusMode: 'work',
+      focusPageVisibility: { work: [-1, 'x', 1.5], sleep: 'nope' },
+    });
+    mockFocusApps(FOCUS_APP_NAMES.map(focusApp));
+
+    const root = render(<LauncherHomeScreen />);
+    // Nenhum índice válido → nada é escondido, e nada rebenta.
+    await waitFor(() => expect(root.getByTestId('launcher-page-grid-1')).toBeTruthy(), {
+      timeout: 3000,
+    });
+    root.unmount();
   });
 });

--- a/src/screens/settings/FocusScreen.tsx
+++ b/src/screens/settings/FocusScreen.tsx
@@ -1,17 +1,27 @@
-import React, { useCallback } from 'react';
-import { View, Text, ScrollView, StyleSheet } from 'react-native';
+import React, { useCallback, useMemo, useState } from 'react';
+import { View, Text, ScrollView, StyleSheet, Dimensions } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
 import { useTheme } from '../../theme/ThemeContext';
 import { useSettings } from '../../store/SettingsStore';
+import { useApps } from '../../store/AppsStore';
+import { useFolders } from '../../store/FoldersStore';
+import { computeLauncherGridGeometry } from '../../utils/launcherGridGeometry';
+import {
+  hiddenPageIndicesForMode,
+  toggleHiddenPage,
+  homePageCount,
+} from '../../utils/focusPageVisibility';
 import {
   CupertinoNavigationBar,
   CupertinoListSection,
   CupertinoListTile,
   CupertinoSwitch,
+  CupertinoActionSheet,
   useAlert,
 } from '../../components';
 import type { AppNavigationProp } from '../../navigation/types';
+import { BUILT_IN_APPS } from '../LauncherHomeScreen';
 
 type FocusMode = 'off' | 'doNotDisturb' | 'sleep' | 'work' | 'personal';
 
@@ -30,15 +40,64 @@ const FOCUS_MODES: FocusModeOption[] = [
   { key: 'personal', label: 'Personal', icon: 'person', iconBg: '#FF9500' },
 ];
 
+/** Ícones virtuais que o launcher injecta sempre na grelha (ver LauncherHomeScreen.gridItems). */
+const BUILT_IN_APP_COUNT = Object.keys(BUILT_IN_APPS).length;
+
 export function FocusScreen({ navigation }: { navigation: AppNavigationProp }) {
   const { theme, typography, spacing } = useTheme();
   const { colors } = theme;
   const insets = useSafeAreaInsets();
   const { settings, update } = useSettings();
+  const { nonDockApps } = useApps();
+  const { folders } = useFolders();
   const alert = useAlert();
 
   const isFocusActive = settings.focusMode !== 'off';
   const activeModeLabel = FOCUS_MODES.find((m) => m.key === settings.focusMode)?.label ?? '';
+
+  // Hidden Pages (#618): o multiselect precisa de saber quantas páginas a home
+  // tem. A contagem replica a do launcher — apps virtuais (BUILT_IN_APPS) +
+  // pastas + apps reais fora do dock, em blocos de `cols * gridRows` — através
+  // da mesma `computeLauncherGridGeometry`, para não divergir da paginação real.
+  const [pagePickerMode, setPagePickerMode] = useState<FocusMode | null>(null);
+
+  const pageCount = useMemo(() => {
+    const geometry = computeLauncherGridGeometry(
+      Dimensions.get('window').width,
+      settings.gridColumns,
+      settings.iconSizeScale,
+    );
+    const appsPerPage = geometry.cols * settings.gridRows;
+    const appsInFolders = new Set(folders.flatMap((f) => f.apps));
+    const realApps = nonDockApps.filter((a) => !appsInFolders.has(a.packageName)).length;
+    const itemCount = BUILT_IN_APP_COUNT + folders.length + realApps;
+    return homePageCount(itemCount, appsPerPage);
+  }, [folders, nonDockApps, settings.gridColumns, settings.gridRows, settings.iconSizeScale]);
+
+  const hiddenSummary = useCallback(
+    (mode: FocusMode) => {
+      const hidden = hiddenPageIndicesForMode(settings.focusPageVisibility, mode);
+      if (mode === 'off') return 'All pages';
+      return hidden.length === 0 ? 'None' : `${hidden.length} hidden`;
+    },
+    [settings.focusPageVisibility],
+  );
+
+  const handleToggleHiddenPage = useCallback(
+    (mode: FocusMode, pageIndex: number) => {
+      update('focusPageVisibility', toggleHiddenPage(settings.focusPageVisibility, mode, pageIndex));
+    },
+    [settings.focusPageVisibility, update],
+  );
+
+  const pagePickerOptions = useMemo(() => {
+    if (!pagePickerMode) return [];
+    const hidden = hiddenPageIndicesForMode(settings.focusPageVisibility, pagePickerMode);
+    return Array.from({ length: pageCount }, (_, index) => ({
+      label: `${hidden.includes(index) ? '✓ ' : ''}Page ${index + 1}`,
+      onPress: () => handleToggleHiddenPage(pagePickerMode, index),
+    }));
+  }, [pagePickerMode, pageCount, settings.focusPageVisibility, handleToggleHiddenPage]);
 
   const handleSelectMode = useCallback((mode: FocusModeOption) => {
     const wasActive = settings.focusMode !== 'off';
@@ -121,6 +180,27 @@ export function FocusScreen({ navigation }: { navigation: AppNavigationProp }) {
           </CupertinoListSection>
         </View>
 
+        {/* Hidden Pages per mode (#618) */}
+        <View style={{ paddingHorizontal: spacing.md }}>
+          <CupertinoListSection
+            header="Hidden Pages"
+            footer="While a Focus mode is on, the home-screen pages you pick here are hidden. Off always shows every page."
+          >
+            {FOCUS_MODES.filter((mode) => mode.key !== 'off').map((mode) => (
+              <CupertinoListTile
+                key={`hidden-pages-${mode.key}`}
+                title={`${mode.label} — Hidden Pages`}
+                trailing={
+                  <Text style={[typography.body, { color: colors.secondaryLabel }]}>
+                    {hiddenSummary(mode.key)}
+                  </Text>
+                }
+                onPress={() => setPagePickerMode(mode.key)}
+              />
+            ))}
+          </CupertinoListSection>
+        </View>
+
         {/* Focus Schedule section */}
         <View style={{ paddingHorizontal: spacing.md }}>
           <CupertinoListSection header="Focus Schedule">
@@ -137,6 +217,21 @@ export function FocusScreen({ navigation }: { navigation: AppNavigationProp }) {
           </CupertinoListSection>
         </View>
       </ScrollView>
+
+      {/* Multiselect das páginas ocultas (#618). O CupertinoActionSheet fecha
+          após cada opção (chama sempre onClose depois do onPress), por isso a
+          selecção múltipla faz-se um toque por página: cada linha mostra ✓
+          quando a página já está oculta e o toque alterna esse estado. Padrão do
+          LanguageRegionScreen; não se alterou o componente partilhado para não
+          mexer nos outros ecrãs que dele dependem. */}
+      <CupertinoActionSheet
+        visible={pagePickerMode !== null}
+        onClose={() => setPagePickerMode(null)}
+        title="Hidden Pages"
+        message="Pages hidden while this Focus mode is on."
+        options={pagePickerOptions}
+        cancelLabel="Done"
+      />
     </View>
   );
 }

--- a/src/screens/settings/__tests__/FocusScreen.test.tsx
+++ b/src/screens/settings/__tests__/FocusScreen.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { render } from '../../../test-utils';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { render, fireEvent, waitFor } from '../../../test-utils';
 import { FocusScreen } from '../FocusScreen';
 import { notificationCallbackForFocus } from '../../../utils/notificationFocusFilter';
 
@@ -80,5 +81,85 @@ describe('notificationCallbackForFocus — focus mode suppression', () => {
     notificationCallbackForFocus(undefined, seenIds, focusModeRef, setBanner);
 
     expect(setBanner).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Hidden Pages per Focus mode (#618)
+// ---------------------------------------------------------------------------
+// Monta o FocusScreen real: abre o multiselect de um modo, alterna uma página e
+// verifica que a escolha vai para o AsyncStorage (persiste entre arranques) e
+// que o resumo da linha muda. O modo 'off' não tem linha nenhuma — não filtra.
+describe('FocusScreen — Hidden Pages (#618)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+  });
+
+  it('renders one Hidden Pages row per mode, and none for Off', () => {
+    const { getByText, queryByText } = render(
+      <FocusScreen navigation={mockNavigation as never} />,
+    );
+    expect(getByText('Work — Hidden Pages')).toBeTruthy();
+    expect(getByText('Sleep — Hidden Pages')).toBeTruthy();
+    expect(getByText('Do Not Disturb — Hidden Pages')).toBeTruthy();
+    expect(getByText('Personal — Hidden Pages')).toBeTruthy();
+    expect(queryByText('Off — Hidden Pages')).toBeNull();
+  });
+
+  it('shows "None" until a page is hidden, then the count', async () => {
+    const { getByText, getAllByText } = render(
+      <FocusScreen navigation={mockNavigation as never} />,
+    );
+    expect(getAllByText('None').length).toBeGreaterThan(0);
+
+    fireEvent.press(getByText('Work — Hidden Pages'));
+    fireEvent.press(getByText('Page 1'));
+
+    await waitFor(() => expect(getByText('1 hidden')).toBeTruthy());
+  });
+
+  it('persists focusPageVisibility to AsyncStorage (survives a restart)', async () => {
+    const { getByText } = render(<FocusScreen navigation={mockNavigation as never} />);
+
+    fireEvent.press(getByText('Work — Hidden Pages'));
+    fireEvent.press(getByText('Page 1'));
+
+    await waitFor(() => {
+      const write = (AsyncStorage.setItem as jest.Mock).mock.calls
+        .filter(([key]) => key === '@iostoandroid/settings')
+        .pop();
+      expect(write).toBeTruthy();
+      expect(JSON.parse(write![1] as string).focusPageVisibility).toEqual({ work: [0] });
+    });
+  });
+
+  it('un-hides the page when the same row is tapped twice (double tap is a no-op)', async () => {
+    const { getByText, getAllByText } = render(
+      <FocusScreen navigation={mockNavigation as never} />,
+    );
+
+    fireEvent.press(getByText('Work — Hidden Pages'));
+    fireEvent.press(getByText('Page 1'));
+    await waitFor(() => expect(getByText('1 hidden')).toBeTruthy());
+
+    fireEvent.press(getByText('Work — Hidden Pages'));
+    fireEvent.press(getByText('✓ Page 1'));
+
+    await waitFor(() => expect(getAllByText('None').length).toBeGreaterThan(0));
+  });
+
+  it('keeps each mode independent — hiding a Work page leaves Sleep untouched', async () => {
+    const { getByText } = render(<FocusScreen navigation={mockNavigation as never} />);
+
+    fireEvent.press(getByText('Work — Hidden Pages'));
+    fireEvent.press(getByText('Page 1'));
+
+    await waitFor(() => {
+      const write = (AsyncStorage.setItem as jest.Mock).mock.calls
+        .filter(([key]) => key === '@iostoandroid/settings')
+        .pop();
+      expect(JSON.parse(write![1] as string).focusPageVisibility.sleep).toBeUndefined();
+    });
   });
 });

--- a/src/store/SettingsStore.tsx
+++ b/src/store/SettingsStore.tsx
@@ -19,6 +19,10 @@ import {
   DEFAULT_REQUIRE_PASSCODE_AFTER,
 } from '../utils/passcodePolicy';
 import { clampWhitePointLevel } from '../utils/whitePoint';
+import {
+  normalizeFocusPageVisibility,
+  type FocusPageVisibility,
+} from '../utils/focusPageVisibility';
 
 const STORAGE_KEY = '@iostoandroid/settings';
 
@@ -44,6 +48,12 @@ export interface SettingsState {
   lockSound: boolean;
   focusMode: 'off' | 'doNotDisturb' | 'sleep' | 'work' | 'personal';
   focusScheduleEnabled: boolean;
+  /**
+   * Focus filters (#618): por modo de Focus, os índices das páginas da home que
+   * ficam ocultas enquanto esse modo está activo. `off` nunca esconde nada.
+   * Default `{}` — sem entradas, todas as páginas continuam visíveis.
+   */
+  focusPageVisibility: FocusPageVisibility;
   screenTimeEnabled: boolean;
   dailyLimit: number;
   downtime: boolean;
@@ -248,6 +258,7 @@ export const DEFAULT_SETTINGS: SettingsState = {
   lockSound: true,
   focusMode: 'off',
   focusScheduleEnabled: false,
+  focusPageVisibility: {},
   screenTimeEnabled: false,
   dailyLimit: 60,
   downtime: false,
@@ -370,6 +381,11 @@ export function SettingsProvider({
             // corrompido (NaN, fora da gama) faria um overlay com opacidade
             // inválida, por isso normaliza-se na leitura.
             whitePointLevel: clampWhitePointLevel(parsed?.whitePointLevel),
+            // focusPageVisibility (#618) decide se páginas inteiras da home
+            // renderizam; um blob corrompido (índices negativos, strings,
+            // valores não-array) faria o filtro esconder páginas ao acaso ou
+            // rebentar no `.includes`, por isso normaliza-se na leitura.
+            focusPageVisibility: normalizeFocusPageVisibility(parsed?.focusPageVisibility),
           }));
         } catch { /* ignore */ }
       }

--- a/src/utils/__tests__/focusPageVisibility.test.ts
+++ b/src/utils/__tests__/focusPageVisibility.test.ts
@@ -1,0 +1,125 @@
+import {
+  normalizeFocusPageVisibility,
+  hiddenPageIndicesForMode,
+  filterVisiblePages,
+  toggleHiddenPage,
+  homePageCount,
+} from '../focusPageVisibility';
+
+// Focus filters (#618) — helpers puros. Exercitam as funções exportadas reais
+// (nada é reimplementado aqui): o LauncherHomeScreen e o FocusScreen consomem
+// exactamente estas.
+
+describe('normalizeFocusPageVisibility', () => {
+  it('devolve {} para valores que não são objectos', () => {
+    expect(normalizeFocusPageVisibility(undefined)).toEqual({});
+    expect(normalizeFocusPageVisibility(null)).toEqual({});
+    expect(normalizeFocusPageVisibility(42)).toEqual({});
+    expect(normalizeFocusPageVisibility('work')).toEqual({});
+    expect(normalizeFocusPageVisibility([1, 2])).toEqual({});
+  });
+
+  it('mantém índices inteiros e aceita strings decimais', () => {
+    expect(normalizeFocusPageVisibility({ work: [2, '0'] })).toEqual({ work: [0, 2] });
+  });
+
+  it('descarta negativos, não-inteiros, NaN, vazios e duplicados', () => {
+    expect(
+      normalizeFocusPageVisibility({ work: [-1, 1.5, NaN, '', 'abc', 3, 3, null] }),
+    ).toEqual({ work: [3] });
+  });
+
+  it('descarta modos cujo valor não é array', () => {
+    expect(normalizeFocusPageVisibility({ work: 'nope', sleep: [1] })).toEqual({ sleep: [1] });
+  });
+
+  it('mantém 0 (fronteira: a primeira página é um índice válido)', () => {
+    expect(normalizeFocusPageVisibility({ work: [0] })).toEqual({ work: [0] });
+  });
+});
+
+describe('hiddenPageIndicesForMode', () => {
+  it('devolve [] para o modo off mesmo com entradas guardadas', () => {
+    expect(hiddenPageIndicesForMode({ off: [0, 1], work: [1] }, 'off')).toEqual([]);
+  });
+
+  it('devolve [] para modo desconhecido, vazio ou mapa ausente', () => {
+    expect(hiddenPageIndicesForMode({ work: [1] }, 'sleep')).toEqual([]);
+    expect(hiddenPageIndicesForMode({ work: [1] }, '')).toEqual([]);
+    expect(hiddenPageIndicesForMode(undefined, 'work')).toEqual([]);
+    expect(hiddenPageIndicesForMode(null, 'work')).toEqual([]);
+  });
+
+  it('devolve os índices do modo activo', () => {
+    expect(hiddenPageIndicesForMode({ work: [0, 2] }, 'work')).toEqual([0, 2]);
+  });
+});
+
+describe('filterVisiblePages', () => {
+  it('devolve a mesma referência quando não há nada oculto', () => {
+    const pages = [['a'], ['b']];
+    expect(filterVisiblePages(pages, [])).toBe(pages);
+  });
+
+  it('remove só as páginas listadas', () => {
+    expect(filterVisiblePages(['p0', 'p1', 'p2'], [1])).toEqual(['p0', 'p2']);
+  });
+
+  it('ignora índices fora do intervalo', () => {
+    expect(filterVisiblePages(['p0'], [7])).toEqual(['p0']);
+  });
+
+  it('mantém a primeira página quando todas estão ocultas', () => {
+    expect(filterVisiblePages(['p0', 'p1'], [0, 1])).toEqual(['p0']);
+  });
+
+  it('lida com lista de páginas vazia', () => {
+    expect(filterVisiblePages([], [0])).toEqual([]);
+  });
+});
+
+describe('toggleHiddenPage', () => {
+  it('adiciona um índice ausente e ordena', () => {
+    expect(toggleHiddenPage({ work: [2] }, 'work', 0)).toEqual({ work: [0, 2] });
+  });
+
+  it('remove um índice já presente (duplo toque volta ao estado inicial)', () => {
+    const once = toggleHiddenPage({}, 'work', 1);
+    expect(once).toEqual({ work: [1] });
+    expect(toggleHiddenPage(once, 'work', 1)).toEqual({ work: [] });
+  });
+
+  it('não muta o mapa recebido', () => {
+    const before = { work: [1] };
+    toggleHiddenPage(before, 'work', 2);
+    expect(before).toEqual({ work: [1] });
+  });
+
+  it('não toca noutros modos', () => {
+    expect(toggleHiddenPage({ sleep: [0] }, 'work', 1)).toEqual({ sleep: [0], work: [1] });
+  });
+
+  it('ignora índices inválidos', () => {
+    expect(toggleHiddenPage({}, 'work', -1)).toEqual({});
+    expect(toggleHiddenPage({}, 'work', 1.5)).toEqual({});
+  });
+});
+
+describe('homePageCount', () => {
+  it('nunca devolve menos de 1', () => {
+    expect(homePageCount(0, 24)).toBe(1);
+    expect(homePageCount(-5, 24)).toBe(1);
+  });
+
+  it('arredonda para cima nos limites exactos e ±1', () => {
+    expect(homePageCount(24, 24)).toBe(1);
+    expect(homePageCount(25, 24)).toBe(2);
+    expect(homePageCount(23, 24)).toBe(1);
+  });
+
+  it('protege contra appsPerPage inválido', () => {
+    expect(homePageCount(40, 0)).toBe(1);
+    expect(homePageCount(40, -3)).toBe(1);
+    expect(homePageCount(40, NaN)).toBe(1);
+  });
+});

--- a/src/utils/focusPageVisibility.ts
+++ b/src/utils/focusPageVisibility.ts
@@ -1,0 +1,105 @@
+/**
+ * Focus filters — page visibility per Focus mode (issue #618, filho de #617).
+ *
+ * Um Modo de Foco pode esconder páginas inteiras da home (ex.: «Work» esconde a
+ * página de lazer). O mapa vive em `settings.focusPageVisibility` e é
+ * `modo -> índices de páginas ocultas`. O modo 'off' nunca esconde nada, mesmo
+ * que exista uma entrada para ele no armazenamento — «off» significa
+ * literalmente sem filtro.
+ *
+ * O AsyncStorage é um blob JSON escrito por versões anteriores da app, por isso
+ * tudo o que sai dele é tratado como não confiável: `normalizeFocusPageVisibility`
+ * é o único ponto que converte esse blob na forma canónica.
+ */
+
+/** Mapa canónico: chave = modo de Focus, valor = índices de página ocultos. */
+export type FocusPageVisibility = Record<string, number[]>;
+
+/**
+ * Normaliza o valor lido do AsyncStorage para `Record<string, number[]>`.
+ *
+ * Aceita índices como número ou como string decimal (o issue propôs `string[]`;
+ * ambas as formas são aceites na leitura para não perder configurações escritas
+ * por qualquer das leituras). Descarta: não-objectos, arrays no topo, valores
+ * que não sejam array, índices negativos, não inteiros, NaN e duplicados.
+ */
+export function normalizeFocusPageVisibility(raw: unknown): FocusPageVisibility {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return {};
+  const out: FocusPageVisibility = {};
+  for (const [mode, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (!Array.isArray(value)) continue;
+    const seen = new Set<number>();
+    for (const entry of value) {
+      const n =
+        typeof entry === 'number'
+          ? entry
+          : typeof entry === 'string' && entry.trim() !== ''
+          ? Number(entry)
+          : NaN;
+      if (!Number.isInteger(n) || n < 0) continue;
+      seen.add(n);
+    }
+    out[mode] = Array.from(seen).sort((a, b) => a - b);
+  }
+  return out;
+}
+
+/**
+ * Índices ocultos para o modo activo. 'off' (ou modo vazio/desconhecido)
+ * devolve sempre uma lista vazia: todas as páginas ficam visíveis.
+ */
+export function hiddenPageIndicesForMode(
+  visibility: FocusPageVisibility | undefined | null,
+  mode: string | undefined | null,
+): number[] {
+  if (!visibility || !mode || mode === 'off') return [];
+  const hidden = visibility[mode];
+  return Array.isArray(hidden) ? hidden : [];
+}
+
+/**
+ * Filtra as páginas escondidas pelo modo activo.
+ *
+ * Devolve sempre pelo menos uma página: se o utilizador esconder todas as
+ * páginas de um modo, o pager ficaria sem conteúdo antes da App Library e o
+ * clamp de `currentPage` passaria a operar sobre 1 página só — preferimos
+ * manter a primeira página visível a apresentar uma home vazia (decisão menos
+ * destrutiva, registada no PR).
+ */
+export function filterVisiblePages<T>(pages: T[], hiddenIndices: number[]): T[] {
+  if (hiddenIndices.length === 0) return pages;
+  const hidden = new Set(hiddenIndices);
+  const kept = pages.filter((_, index) => !hidden.has(index));
+  if (kept.length === 0 && pages.length > 0) return [pages[0] as T];
+  return kept;
+}
+
+/**
+ * Alterna um índice de página na lista oculta de um modo, devolvendo um mapa
+ * novo (nunca muta o anterior — o estado do store é comparado por referência).
+ * Índices inválidos (negativos, não inteiros) são ignorados.
+ */
+export function toggleHiddenPage(
+  visibility: FocusPageVisibility | undefined | null,
+  mode: string,
+  index: number,
+): FocusPageVisibility {
+  const base: FocusPageVisibility = { ...(visibility ?? {}) };
+  if (!Number.isInteger(index) || index < 0) return base;
+  const current = Array.isArray(base[mode]) ? base[mode] : [];
+  const next = current.includes(index)
+    ? current.filter((i) => i !== index)
+    : [...current, index].sort((a, b) => a - b);
+  base[mode] = next;
+  return base;
+}
+
+/**
+ * Número de páginas da home para `itemCount` ícones a `appsPerPage` por página.
+ * Nunca menos de 1 (a home tem sempre uma página, tal como `LauncherHomeScreen`
+ * garante). `appsPerPage <= 0` também devolve 1 em vez de dividir por zero.
+ */
+export function homePageCount(itemCount: number, appsPerPage: number): number {
+  if (!Number.isFinite(itemCount) || !Number.isFinite(appsPerPage) || appsPerPage <= 0) return 1;
+  return Math.max(1, Math.ceil(Math.max(0, itemCount) / appsPerPage));
+}


### PR DESCRIPTION
## Resumo

Filtro Foco (#618): páginas da home ocultáveis por modo de Focus, com page dots a refletir as páginas visíveis

## Causa raiz

Não é um bug — é uma funcionalidade que não existia. A paginação da home é puramente
derivada do número de itens: `src/screens/LauncherHomeScreen.tsx:1231-1241` corta
`gridItems` em blocos de `appsPerPage` e `:1244` faz `totalPages = pages.length + 1`.
Nada no caminho de render consultava `settings.focusMode` — a única leitura do modo de
Focus no ecrã era o ícone da lua na status bar (`:1585`). Logo, com «Work» activo a home
renderizava exactamente as mesmas páginas que com Focus desligado, e os page dots (#603,
`:1712`, alimentados por `totalPages`) contavam-nas todas.

O issue estava certo na proposta mas errado em dois detalhes, e o código ganhou:
- propôs `Record<string, string[]>` (índices como strings). Guardar índices como string
  obriga a converter em cada comparação e permite `"01"`/`"1"` a designar a mesma página.
  O tipo canónico é `Record<string, number[]>`; a normalização de leitura **aceita**
  strings decimais para não perder configurações escritas por essa leitura.
- apontou `:1286`/`:1338` como o sítio a filtrar (dentro do `AppIcon`/página). Filtrar aí
  esconderia ícones, não páginas, e deixaria `totalPages` inalterado — os dots continuariam
  a contar a página oculta. O filtro tem de ser sobre o array `pages`, antes de `totalPages`.

## O que mudou

**`src/utils/focusPageVisibility.ts`** (novo) — helpers puros do filtro:
`normalizeFocusPageVisibility` (blob do AsyncStorage → `Record<string, number[]>`,
descartando negativos, não-inteiros, NaN, valores não-array e duplicados),
`hiddenPageIndicesForMode` (devolve `[]` para `off`/modo desconhecido/mapa ausente),
`filterVisiblePages` (remove por índice; devolve a mesma referência quando não há filtro),
`toggleHiddenPage` (alterna sem mutar) e `homePageCount` (contagem de páginas, mínimo 1,
protegida contra `appsPerPage <= 0`).

**`src/store/SettingsStore.tsx`** — novo campo `focusPageVisibility: FocusPageVisibility`
no `SettingsState`, default `{}` em `DEFAULT_SETTINGS`, e normalização na hidratação do
AsyncStorage (junto de `iconShape`/`whitePointLevel`, que já seguiam este padrão). Persiste
pelo `setItem` já existente, logo sobrevive a reinícios.

**`src/screens/LauncherHomeScreen.tsx`** — o memo da paginação passou a chamar-se
`allPages`; um novo memo `pages` aplica `filterVisiblePages(allPages, hiddenPageIndices)`,
com `hiddenPageIndices` derivado de `focusPageVisibility` + `focusMode`. Como `totalPages`
continua a ser `pages.length + 1`, os page dots, o clamp de `currentPage` e o `handleScroll`
passam automaticamente a operar sobre as páginas visíveis. Nenhum outro sítio foi tocado.

**`src/screens/settings/FocusScreen.tsx`** — nova secção `Hidden Pages` com um
`CupertinoListTile` por modo (excepto `Off`, que nunca filtra), trailing a mostrar `None` ou
`N hidden`, e um `CupertinoActionSheet` com uma linha por página (`Page N`, prefixada com ✓
quando oculta) que alterna o estado. A contagem de páginas usa a mesma
`computeLauncherGridGeometry` do launcher para não divergir da paginação real.

## Porque assim

- **Filtrar `pages`, não ícones.** É o único ponto por onde passam simultaneamente o render
  do pager e `totalPages`; um filtro a jusante (nos `AppIcon`) deixaria os dots a mentir,
  que é explicitamente um dos critérios de aceitação.
- **Índices sobre a paginação completa (`allPages`).** Esconder a página 1 não renumera a
  configuração das restantes — se os índices fossem relativos à lista já filtrada, esconder
  uma página mudaria o significado de todas as outras entradas.
- **Helpers num módulo próprio.** Deixa a lógica testável sem montar o ecrã e é o mesmo
  código consumido pelo launcher e pelo ecrã de settings (uma só definição de «off não
  filtra»). Alternativa descartada: inline no `LauncherHomeScreen`, que obrigaria o
  FocusScreen a duplicar a regra.
- **Normalizar na leitura em vez de na escrita.** O AsyncStorage já tem blobs escritos por
  versões anteriores; validar no ponto de entrada é o padrão que o store já usa e evita um
  `?.`/`?? []` defensivo espalhado pelo render.
- **Decisão de produto registada:** se o utilizador esconder *todas* as páginas de um modo,
  `filterVisiblePages` mantém a primeira visível em vez de apresentar uma home vazia antes
  da App Library. É a leitura menos destrutiva; a alternativa (home sem páginas) deixaria o
  utilizador sem forma óbvia de voltar atrás.
- **O `CupertinoActionSheet` partilhado não foi alterado.** Ele fecha após cada opção; a
  selecção múltipla faz-se um toque por página (reabrindo a folha), tal como o
  `LanguageRegionScreen`. Mudar o componente afectaria todos os ecrãs que dele dependem —
  fora do âmbito deste issue.

## Critérios de aceitação

- [x] **Páginas ocultas por modo não renderizam** — `focusMode: 'work'` +
      `focusPageVisibility: { work: [1] }` → `launcher-page-grid-1` deixa de existir
      (`queryByTestId(...) === null`) e `launcher-page-grid-0` continua lá.
- [x] **`off` mostra todas** — com a mesma configuração guardada mas `focusMode: 'off'`,
      `launcher-page-grid-1` renderiza. `hiddenPageIndicesForMode` devolve `[]` para `off`
      mesmo que exista uma entrada `off` no mapa.
- [x] **Persiste entre arranques** — o teste do FocusScreen lê o payload real escrito em
      `AsyncStorage.setItem('@iostoandroid/settings', ...)` e confirma
      `focusPageVisibility === { work: [0] }`; a hidratação normaliza-o de volta no arranque.
- [x] **Page dots (#603) refletem o número real de páginas visíveis** — 2 páginas + App
      Library = 3 dots sem filtro; com a página 1 oculta, exactamente 2 (contados pelo estilo
      real do dot: 7x7, raio 3.5).
- [x] **Teste em `src/screens/__tests__/LauncherHomeScreen.test.tsx` cobre o filtro** — 6
      testes novos nesse ficheiro, a montar o `LauncherHomeScreen` real.
- [x] **NÃO devia mudar: a paginação sem Focus activo.** Confirmado — `filterVisiblePages`
      devolve a *mesma referência* quando não há índices ocultos (teste `toBe`), logo a
      memoização a jusante (`AppIcon`/`FolderIcon`, #518) não é invalidada. As 38 asserções
      pré-existentes do `LauncherHomeScreen.test.tsx` e as 3 do `pageDotsToggle` continuam a
      passar.
- [x] **NÃO devia mudar: os modos entre si.** Configurar `work` não afecta `sleep` — testado
      no util (`toggleHiddenPage` não toca noutros modos) e no ecrã (o payload persistido não
      cria chave `sleep`).
- [x] **NÃO devia mudar: o ecrã de Focus existente.** Os 2 testes de render e os 5 de
      `notificationCallbackForFocus` continuam a passar; a linha de `Off` não foi adicionada.

## Testes

**Passo vermelho — `LauncherHomeScreen.test.tsx` com o fix de produção revertido**
(`git stash push -u -- src/screens/LauncherHomeScreen.tsx src/store/SettingsStore.tsx src/screens/settings/FocusScreen.tsx src/utils/focusPageVisibility.ts`):

```
  ● LauncherHomeScreen — Focus page visibility (#618) › page dots reflect the real number of visible pages (#603 + #618)

    expect(received).toBe(expected) // Object.is equality

    Expected: 2
    Received: 3

      820 |       timeout: 3000,
      821 |     });
    > 822 |     expect(countDots(filtered)).toBe(dotsWithAllPages - 1);
          |                                 ^
      823 |     filtered.unmount();

  ● LauncherHomeScreen — Focus page visibility (#618) › keeps the first page visible when every page is hidden (no empty home)

    expect(received).toBeNull()

    Received: {"_fiber": {... "elementType": "View", ... "type": "View" ...}}

      837 |       timeout: 3000,
      838 |     });
    > 839 |     expect(root.queryByTestId('launcher-page-grid-1')).toBeNull();
          |                                                        ^
      840 |     root.unmount();

    ✕ hides a page whose index is listed for the active focus mode (1958 ms)
    ✕ page dots reflect the real number of visible pages (#603 + #618) (113 ms)
    ✕ keeps the first page visible when every page is hidden (no empty home) (2046 ms)

Test Suites: 1 failed, 1 total
Tests:       3 failed, 41 passed, 44 total
```

Com o fix aplicado (`git stash pop`): `Tests: 44 passed, 44 total`.

Passo vermelho dos outros dois ficheiros, com o mesmo stash:

```
Cannot find module '../focusPageVisibility' from 'src/utils/__tests__/focusPageVisibility.test.ts'
Test Suites: 2 failed, 2 total
Tests:       5 failed, 7 passed, 12 total
```

(as 5 falhas do `FocusScreen.test.tsx` são as asserções sobre as linhas `Hidden Pages` e o
payload persistido, que sem o fix não existem; a falha do util é o módulo ausente — dito
explicitamente porque «módulo não existe» *não* é, por si, prova de comportamento: a prova
do comportamento está no bloco do `LauncherHomeScreen` acima, que monta a unidade real.)

**Casos cobertos além do caminho feliz:**
- *Fronteiras* — `homePageCount` em 24/25/23 itens a 24 por página; índice `0` (primeira
  página) aceite pela normalização; `appsPerPage` 0 / negativo / NaN.
- *Vazio e ausente* — mapa `undefined`/`null`, modo `''`, lista de páginas vazia, modo sem
  entrada, `focusPageVisibility` ausente do blob guardado.
- *Inválido e hostil* — blob com `{ work: [-1, 'x', 1.5], sleep: 'nope' }` renderizado no
  ecrã real: nada é escondido e nada rebenta; `normalizeFocusPageVisibility` com número,
  string, array no topo e `null` no lugar do objecto.
- *Ordem e repetição* — duplo toque na mesma página no FocusScreen volta a `None` (o duplo
  toque é um defeito recorrente neste repositório); `toggleHiddenPage` chamado duas vezes
  devolve `[]`; confirmado que não muta o mapa de entrada.
- *O inverso do fix* — `off` mostra todas as páginas *apesar* de existirem entradas
  guardadas; um modo activo diferente do configurado (`sleep` activo, `work` configurado)
  não esconde nada; a linha `Off — Hidden Pages` não é renderizada.
- *Degenerado* — todas as páginas ocultas mantém a primeira (a decisão de produto acima é
  testada, não só documentada).

**Sanity-check (fix revertido, testes mantidos):**
```
Test Suites: 3 failed, 3 total
Tests:       8 failed, 48 passed, 56 total     <- sem o fix
Test Suites: 3 passed, 3 total
Tests:       77 passed, 77 total               <- com o fix restaurado
```

**Verificações:**
- `npm run lint`: `✖ 2 problems (0 errors, 2 warnings)` — os 2 warnings são pré-existentes
  (`BridgeErrorReporting.test.tsx`, `ClockScreen.tsx`), nenhum nos ficheiros tocados. 0 erros,
  igual à baseline.
- `npx tsc --noEmit`: limpo, sem output. Nenhum `any` novo.
- `npm test -- --maxWorkers=2`: `Tests: 11 failed, 1726 passed, 1737 total` /
  `Test Suites: 5 failed, 175 passed, 180 total` / `Snapshots: 6 passed`. Baseline: 12 falhas
  em 6 suites. As 11 falhas são todas da lista de baseline (`FoldersStore` x2, `LockScreen` x3,
  `SettingsScreen` x1, `WeatherScreen` x2, `withLauncherIntent` x3) — **zero falhas novas**, e
  a `AppLibraryContent.hideApp` da baseline até passou. Nenhum snapshot mudou; nenhum teste
  alheio foi apagado ou posto em `.skip`.

## Testes

77 passaram, 0 falharam nos 3 ficheiros do trabalho; suite completa 1726 passaram / 11 falharam (todas de baseline, 0 novas), 180 suites

## Linked Issue

Fixes #618