### PR TITLE
fix(deps): pin expo-speech to ~12.0.2 for Expo SDK 54

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "iostoandroid",
-  "version": "1.77.0",
+  "version": "1.78.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "iostoandroid",
-      "version": "1.77.0",
+      "version": "1.78.2",
       "dependencies": {
         "@expo/vector-icons": "15.0.3",
         "@react-native-async-storage/async-storage": "^3.0.2",
@@ -35,7 +35,7 @@
         "expo-notifications": "~0.32.11",
         "expo-secure-store": "~15.0.7",
         "expo-sharing": "~14.0.8",
-        "expo-speech": "~14.0.8",
+        "expo-speech": "~12.0.2",
         "expo-status-bar": "~3.0.9",
         "react": "19.1.0",
         "react-native": "0.81.5",
@@ -7072,9 +7072,9 @@
       }
     },
     "node_modules/expo-speech": {
-      "version": "14.0.8",
-      "resolved": "https://registry.npmjs.org/expo-speech/-/expo-speech-14.0.8.tgz",
-      "integrity": "sha512-UjBFCFv58nutlLw92L7kUS0ZjbOOfaTdiEv/HbjvMrT6BfldoOLLBZbaEcEhDdZK36NY/kass0Kzxk+co6vxSQ==",
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/expo-speech/-/expo-speech-12.0.2.tgz",
+      "integrity": "sha512-voWNz69hvtLEA2jipAbM5XJBIbKCusQsDZ/G/vAKKkP5AUTzAmcdRDWGcmESPRKK0JUtQZ8WetujgLCn2kl83w==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "expo-notifications": "~0.32.11",
     "expo-secure-store": "~15.0.7",
     "expo-sharing": "~14.0.8",
-    "expo-speech": "~14.0.8",
+    "expo-speech": "~12.0.2",
     "expo-status-bar": "~3.0.9",
     "react": "19.1.0",
     "react-native": "0.81.5",


### PR DESCRIPTION
Merge-conflict resolution wrongly bumped expo-speech to ~14.0.8 (an SDK 55 package). Under SDK 54 (expo 54.0.33 / expo-modules-core 3.0.29) the 14.x native module fails to register, so `requireNativeModule('ExpoSpeech')` throws `Cannot find native module` at runtime — RedBox on app load.

Reverts to ~12.0.2 (the version the feat/siri commit added), matching Expo SDK 54. The native SpeechModule registers as `ExpoSpeech` (android/src/main/java/expo/modules/speech/SpeechModule.kt:23), so TTS resolves once the build links 12.0.2.

Verified: node_modules + package-lock + package.json all resolve to 12.0.2; `npx tsc --noEmit` clean.