### PR TITLE
App Library: placeholder da barra de pesquisa corrigido de 'App Library' para 'Search' (#677)

### DIFF
--- a/src/screens/AppLibraryScreen.tsx
+++ b/src/screens/AppLibraryScreen.tsx
@@ -653,7 +653,7 @@ export function AppLibraryContent() {
         <CupertinoSearchBar
           value={query}
           onChangeText={setQuery}
-          placeholder="App Library"
+          placeholder="Search"
           autoFocus={false}
         />
       </View>

--- a/src/screens/__tests__/AppLibraryContent.hideApp.test.tsx
+++ b/src/screens/__tests__/AppLibraryContent.hideApp.test.tsx
@@ -58,7 +58,7 @@ describe('AppLibraryContent — hide app (#606)', () => {
     // Ausente das listas browsable.
     expect(queryAllByText('Facebook')).toHaveLength(0);
 
-    fireEvent.changeText(getByPlaceholderText('App Library'), 'face');
+    fireEvent.changeText(getByPlaceholderText('Search'), 'face');
     await waitFor(() => expect(getAllByText('Facebook').length).toBeGreaterThan(0));
 
     // A linha da procura é um pressable de lançamento — a app escondida continua

--- a/src/screens/__tests__/AppLibraryScreen.test.tsx
+++ b/src/screens/__tests__/AppLibraryScreen.test.tsx
@@ -18,21 +18,29 @@ describe('AppLibraryScreen', () => {
 
   it('shows the App Library search input', () => {
     const { getByPlaceholderText } = render(<AppLibraryScreen navigation={nav} />);
-    expect(getByPlaceholderText('App Library')).toBeTruthy();
+    // iOS App Library search bar always shows the "Search" placeholder.
+    expect(getByPlaceholderText('Search')).toBeTruthy();
   });
 
   it('typing activates search results view without crashing', () => {
     const { getByPlaceholderText } = render(<AppLibraryScreen navigation={nav} />);
-    fireEvent.changeText(getByPlaceholderText('App Library'), 'Settings');
+    fireEvent.changeText(getByPlaceholderText('Search'), 'Settings');
     // Re-query after state update — no crash is the assertion
-    expect(getByPlaceholderText('App Library')).toBeTruthy();
+    expect(getByPlaceholderText('Search')).toBeTruthy();
   });
 
   it('clearing search returns to category view without crashing', () => {
     const { getByPlaceholderText } = render(<AppLibraryScreen navigation={nav} />);
-    fireEvent.changeText(getByPlaceholderText('App Library'), 'foo');
-    fireEvent.changeText(getByPlaceholderText('App Library'), '');
-    expect(getByPlaceholderText('App Library')).toBeTruthy();
+    fireEvent.changeText(getByPlaceholderText('Search'), 'foo');
+    fireEvent.changeText(getByPlaceholderText('Search'), '');
+    expect(getByPlaceholderText('Search')).toBeTruthy();
+  });
+
+  it('search bar placeholder is "Search", never the screen title "App Library" (#677)', () => {
+    const { getByPlaceholderText } = render(<AppLibraryScreen navigation={nav} />);
+    // O placeholder NÃO deve ser o título do ecrã.
+    expect(() => getByPlaceholderText('App Library')).toThrow();
+    expect(getByPlaceholderText('Search')).toBeTruthy();
   });
 });
 
@@ -125,7 +133,8 @@ describe('AppLibraryContent — toggle Show Suggestions (#602)', () => {
     expect(queryByText('Suggestions')).toBeNull();
     // O que NÃO deve mudar:
     expect(getByText('Categories')).toBeTruthy();
-    expect(getByPlaceholderText('App Library')).toBeTruthy();
+    // iOS App Library search bar always shows the "Search" placeholder.
+    expect(getByPlaceholderText('Search')).toBeTruthy();
   });
 
   it('Show Suggestions = false não quebra a pesquisa nem as categorias', async () => {
@@ -133,9 +142,9 @@ describe('AppLibraryContent — toggle Show Suggestions (#602)', () => {
       settings: { appLibraryShowSuggestions: false },
     });
     await waitFor(() => expect(queryByText('Recently Added')).toBeNull());
-    fireEvent.changeText(getByPlaceholderText('App Library'), 'Face');
+    fireEvent.changeText(getByPlaceholderText('Search'), 'Face');
     // A pesquisa ativa e continua a mostrar resultados (Facebook) sem crash.
-    await waitFor(() => expect(getByPlaceholderText('App Library')).toBeTruthy());
+    await waitFor(() => expect(getByPlaceholderText('Search')).toBeTruthy());
   });
 });
 

--- a/src/screens/__tests__/AppStoreScreen.test.tsx
+++ b/src/screens/__tests__/AppStoreScreen.test.tsx
@@ -511,6 +511,6 @@ describe('AppLibraryScreen entry point to the App Store', () => {
     fireEvent.press(getByLabelText('Back'));
     expect(mockGoBack).toHaveBeenCalled();
     expect(getByText('App Library')).toBeTruthy();
-    expect(getByPlaceholderText('App Library')).toBeTruthy();
+    expect(getByPlaceholderText('Search')).toBeTruthy();
   });
 });

--- a/src/screens/__tests__/LauncherHomeScreen.pagerMemo.test.tsx
+++ b/src/screens/__tests__/LauncherHomeScreen.pagerMemo.test.tsx
@@ -137,7 +137,7 @@ describe('LauncherHomeScreen: paginação não re-renderiza os AppIcon já monta
     // não é virtualizada ela já está montada — o que prova que avançámos é o
     // efeito de handleScroll (setCurrentPage), verificável indirectamente
     // via o próprio disparo sem excepção e via PageDots (testado abaixo).
-    expect(queryByPlaceholderText('App Library')).toBeTruthy();
+    expect(queryByPlaceholderText('Search')).toBeTruthy();
 
     const pager = getByTestId('launcher-pager');
     expect(() => act(() => {

--- a/src/screens/__tests__/LauncherHomeScreen.test.tsx
+++ b/src/screens/__tests__/LauncherHomeScreen.test.tsx
@@ -483,7 +483,7 @@ describe('LauncherHomeScreen last page is the App Library itself (#434)', () => 
   it('shows the App Library search bar directly on mount, with no tap required', () => {
     mockLoadedApps();
     const { getByPlaceholderText } = render(<LauncherHomeScreen />);
-    expect(getByPlaceholderText('App Library')).toBeTruthy();
+    expect(getByPlaceholderText('Search')).toBeTruthy();
   });
 
   it('shows the Categories section directly, without navigating anywhere first', () => {
@@ -511,7 +511,7 @@ describe('LauncherHomeScreen last page is the App Library itself (#434)', () => 
     // to the search-results view, proving the search bar is wired to real
     // state inside the embedded component, not just visually present.
     expect(getByText('Categories')).toBeTruthy();
-    fireEvent.changeText(getByPlaceholderText('App Library'), 'zzz-no-such-app');
+    fireEvent.changeText(getByPlaceholderText('Search'), 'zzz-no-such-app');
     expect(queryByText('Categories')).toBeNull();
   });
 });

--- a/src/screens/__tests__/SiriSearchVisibility.test.tsx
+++ b/src/screens/__tests__/SiriSearchVisibility.test.tsx
@@ -100,7 +100,7 @@ describe('Siri & Search — visibilidade na App Library (#610)', () => {
     mockStoredSettings({ searchShowInLibrary: false });
     const { getByPlaceholderText, queryAllByText, queryByText } = render(<AppLibraryContent />);
     await waitFor(() => expect(queryByText('Categories')).toBeTruthy());
-    fireEvent.changeText(getByPlaceholderText('App Library'), 'Face');
+    fireEvent.changeText(getByPlaceholderText('Search'), 'Face');
     await waitFor(() => expect(queryAllByText('Facebook')).toHaveLength(0));
   });
 


### PR DESCRIPTION
## Resumo

App Library: placeholder da barra de pesquisa corrigido de 'App Library' para 'Search'

## Causa raiz

O `CupertinoSearchBar` no topo da App Library recebia `placeholder="App Library"` (literal, o título do ecrã) em vez do texto iOS padrão "Search". Mecanismo em `src/screens/AppLibraryScreen.tsx:656` — a props `placeholder` é passada diretamente ao `TextInput` do `CupertinoSearchBar` (`src/components/CupertinoSearchBar.tsx:89`), que a renderiza como placeholder. Como o valor era a string "App Library", o placeholder exibia exatamente essa string.

Nota sobre o issue: o issue aponta `src/screens/AppLibraryScreen.tsx:444`, mas essa linha não contém a search bar — o placeholder errado está na **linha 656**. O código ganha sobre o número da linha do issue. A linha 769 (`title="App Library"` na `CupertinoNavigationBar`) é o **título** do ecrã e está correta — não foi tocada.

## O que mudou

- `src/screens/AppLibraryScreen.tsx:656` — `placeholder="App Library"` → `placeholder="Search"`. É a única linha de produção alterada; o `CupertinoSearchBar` já aceita o placeholder correto via props, por isso nenhuma mudança de componente foi necessária.
- `src/screens/__tests__/AppLibraryScreen.test.tsx` — os testes existentes afirmavam o bug (`getByPlaceholderText('App Library')`); atualizados para `getByPlaceholderText('Search')` e acrescentado um teste de regressão que garante que o placeholder NUNCA é o título do ecrã (`expect(() => getByPlaceholderText('App Library')).toThrow()`).
- `src/screens/__tests__/AppLibraryContent.hideApp.test.tsx`, `AppStoreScreen.test.tsx`, `LauncherHomeScreen.test.tsx`, `LauncherHomeScreen.pagerMemo.test.tsx`, `SiriSearchVisibility.test.tsx` — 7 locais em 5 suites alheias afirmavam o placeholder bug "App Library" (a App Library é renderizada dentro da home, na AppStoreScreen via `AppLibraryScreen`, e na SiriSearchVisibility). Corrigidos para "Search". Nenhuma destas suites estava na baseline vermelha; falhavam todas apenas porque o bug existia.

## Porque assim

A correção é uma única substituição de string literal — o componente `CupertinoSearchBar` já faz o que deve e o seu `placeholder` default é "Search" (`CupertinoSearchBar.tsx:24`); o ecrã estava a sobrepor esse default com o título do ecrã por engano. Não valia a pena nenhuma lógica nova, mock, `as any`, ou guard — seria esconder o defeito. As alternativas descartadas: (a) mudar o `CupertinoSearchBar` para ignorar o placeholder passado — quebraria todos os outros consumidores que usam placeholders legítimos; (b) deixar os testes alheios a afirmar o bug — inaceitável, pois testariam o defeito em vez do comportamento.

## Critérios de aceitação

- [x] A barra de pesquisa da App Library mostra "Search" (não "App Library"). Cumprido: `AppLibraryScreen.tsx:656`. Testado por `AppLibraryScreen.test.tsx › shows the App Library search input` e pelo novo teste de regressão.
- [x] O título do ecrã "App Library" (nav bar) mantém-se inalterado. Cumprido: linha 769 não tocada; `AppStoreScreen.test.tsx › keeps the Back button and centered title untouched` continua a afirmar `getByText('App Library')`.
- [x] A pesquisa continua funcional (escrever filtra, limpar volta às categorias) — testado nos casos nominais e nos testes de hideApp / SiriSearchVisibility.
- [x] O que NÃO devia mudar: nenhuma regressão nas 6 suites da baseline (comprovado abaixo — as mesmas 6 falham, nenhuma nova).

## Testes

- **Passo vermelho:** executado com o fix revertido (`git stash push -- src/screens/AppLibraryScreen.tsx`), o teste `src/screens/__tests__/AppLibraryScreen.test.tsx` falha — prova de que o teste está ligado ao comportamento:

  ```
  $ npx jest src/screens/__tests__/AppLibraryScreen.test.tsx
  ...
      143 |     });
      144 |     await waitFor(() => expect(queryByText('Recently Added')).toBeNull());
    > 145 |     fireEvent.changeText(getByPlaceholderText('Search'), 'Face');
          |                          ^
      146 |     // A pesquisa ativa e continua a mostrar resultados (Facebook) sem crash.
  
    at Object.getByPlaceholderText (src/screens/__tests__/AppLibraryScreen.test.tsx:145:26)
  
  Test Suites: 1 failed, 1 total
  Tests:       6 failed, 5 passed, 11 total
  ```

  (6 falham porque `getByPlaceholderText('Search')` lança — o placeholder ainda era "App Library".)

- **Casos cobertos:**
  - Caminho feliz: a barra aparece com placeholder "Search" (`shows the App Library search input`).
  - O inverso do fix: o placeholder NUNCA é "App Library" — teste novo que afirma `getByPlaceholderText('App Library')` lança (evita regressão ao bug original).
  - Escrita + limpeza: `typing activates search results...` e `clearing search returns to category view...` (sem crash ao transitar entre modos).
  - Render através de cada consumidor: `LauncherHomeScreen`, `AppStoreScreen`, `SiriSearchVisibility`, `AppLibraryContent.hideApp` — todos atualizados para "Search", garantindo que o componente partilhado não divergiu.
  - Fronteiras/repetição: `fireEvent.changeText` duas vezes seguidas (foo → '') em `clearing search`; query sem resultado (`zzz-no-such-app`) em `LauncherHomeScreen.test.tsx`.

- **Sanity-check:** `git stash push -- src/screens/AppLibraryScreen.tsx` → `npx jest src/screens/__tests__/AppLibraryScreen.test.tsx` → **6 failed, 5 passed**; `git stash pop` → **11 passed, 11 total**. Sem o fix a suite falha; com o fix passa.

- **Resultado das verificações obrigatórias:**
  - `npm run lint`: **0 erros** (7 warnings pré-existentes, idênticos à baseline).
  - `npx tsc --noEmit`: limpo (exit 0).
  - `npm test -- --maxWorkers=2`: **25 failed, 1740 passed, 1765 total, 6 failed suites** — idêntico à baseline (25 falhas em 6 suites: withLauncherIntent, LockScreen, SettingsScreen, SiriScreen, WeatherScreen, FoldersStore). Nenhuma falha nova; sem o meu trabalho estas mesmas 6 suites já falhavam (o gate do SettingsStore/AsyncStorage descrito na baseline). Confirmei que as 5 suites que o meu fix fez falhar inicialmente (AppStoreScreen, LauncherHomeScreen, LauncherHomeScreen.pagerMemo, AppLibraryContent.hideApp, SiriSearchVisibility) passam agora todas — eram testes que afirmavam o bug.

## Testes

11 passaram (AppLibraryScreen.test.tsx) + 5 suites alheias corrigidas 100 passaram; full suite: 1740 passaram, 25 falharam (6 suites) = baseline, sem regressão

## Linked Issue

Fixes #677