### PR TITLE
App Library: reduz ícones das faixas Recently Added/Suggestions de 62px para 60px (#678) (#678)

### DIFF
--- a/src/screens/AppLibraryScreen.tsx
+++ b/src/screens/AppLibraryScreen.tsx
@@ -447,7 +447,9 @@ const AppStrip = React.memo(function AppStrip({
 }) {
   const { theme, typography } = useTheme();
   const { colors } = theme;
-  const stripIconSize = 62;
+  // iOS App Library: ícones de faixa horizontal alinhados aos ~60px da grelha
+  // densa (4 por linha). 62px exagerava e forçava scroll horizontal (#678).
+  const stripIconSize = 60;
 
   return (
     <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.stripContent}>

--- a/src/screens/__tests__/AppStripIconSize.test.tsx
+++ b/src/screens/__tests__/AppStripIconSize.test.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { render, waitFor } from '../../test-utils';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import launcherModule from '../../../modules/launcher-module/src';
+import { AppLibraryContent } from '../AppLibraryScreen';
+import { DEFAULT_SETTINGS } from '../../store/SettingsStore';
+
+// Issue #678: as faixas horizontais "Recently Added" e "Suggestions" (AppStrip)
+// renderizavam os ícones com 62px (stripIconSize = 62), exagerado para uma
+// faixa horizontal de 4 ícones — o iOS usa ~60px em grelha densa e mostra os 4
+// de uma vez, sem scroll. O tamanho do ícone é o que o issue pede para corrigir;
+// o stripItem (72px) mantém-se para alojar o label e não forçar scroll.
+//
+// O AppIcon (definido em AppLibraryScreen.tsx) empacota o ícone num <View> com
+// width/height = size; por isso o tamanho do ícone aparece na árvore como a
+// prop `width` desse View (e do Image/View interior). Recolhemos todos os
+// `width` da árvore renderizada e verificamos o valor das faixas.
+
+const BASE_APPS = [
+  { name: 'Messages', packageName: 'com.iostoandroid.messages', icon: '', isSystem: false, category: 'social' },
+  { name: 'Facebook', packageName: 'com.facebook', icon: '', isSystem: false, category: 'social' },
+  { name: 'Spotify', packageName: 'com.spotify', icon: '', isSystem: false, category: 'undefined' },
+  { name: 'Strava', packageName: 'com.strava', icon: '', isSystem: false, category: 'undefined' },
+  { name: 'Maps', packageName: 'com.maps', icon: '', isSystem: false, category: 'undefined' },
+] as never;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+async function renderLibraryWithApps(apps: unknown[]) {
+  const saved = JSON.stringify({ ...DEFAULT_SETTINGS });
+  (AsyncStorage.getItem as jest.Mock).mockImplementation((key: string) =>
+    key === '@iostoandroid/settings' ? Promise.resolve(saved) : Promise.resolve(null),
+  );
+  (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
+  (AsyncStorage.removeItem as jest.Mock).mockResolvedValue(undefined);
+  (launcherModule.getInstalledApps as jest.Mock).mockResolvedValue(apps);
+  (launcherModule.isDefaultLauncher as jest.Mock).mockResolvedValue(false);
+
+  const utils = render(<AppLibraryContent />);
+  // Apps carregam de forma assíncrona a partir do mock do LauncherModule.
+  await waitFor(() => expect(utils.getAllByText('Categories').length).toBeGreaterThan(0));
+  return utils;
+}
+
+// Recolhe todos os valores de `width` presentes nas props `style` da árvore.
+interface JsonNode {
+  children?: JsonNode | JsonNode[];
+  props?: { style?: unknown };
+}
+function collectWidths(node: unknown, acc: number[] = []): number[] {
+  if (!node || typeof node !== 'object') return acc;
+  const n = node as JsonNode;
+  const style = n.props && n.props.style;
+  if (style) {
+    const styles = Array.isArray(style) ? style : [style];
+    for (const s of styles) {
+      if (s && typeof s === 'object' && typeof (s as { width?: unknown }).width === 'number') {
+        acc.push((s as { width: number }).width);
+      }
+    }
+  }
+  const children = n.children;
+  if (children) {
+    const arr = Array.isArray(children) ? children : [children];
+    for (const c of arr) collectWidths(c, acc);
+  }
+  return acc;
+}
+
+describe('AppLibrary AppStrip icon size (#678)', () => {
+  it('ícones das faixas Recently Added/Suggestions renderizam a 60px e não a 62px', async () => {
+    const { toJSON } = await renderLibraryWithApps(BASE_APPS);
+    const widths = collectWidths(toJSON());
+
+    // O valor exagerado de 62px (stripIconSize antigo) não pode existir.
+    expect(widths).not.toContain(62);
+    // O valor alinhado ao iOS (~60px) tem de estar presente — e em quantidade
+    // suficiente para cobrir ambas as faixas (4 ícones cada = 8 contentores de
+    // ícone, contando o View exterior de cada AppIcon).
+    const sixtyCount = widths.filter((w) => w === 60).length;
+    expect(sixtyCount).toBeGreaterThanOrEqual(8);
+  });
+
+  it('faixa com um único app continua a 60px (fronteira: 1 ícone)', async () => {
+    const { toJSON } = await renderLibraryWithApps([BASE_APPS[0]]);
+    const widths = collectWidths(toJSON());
+    expect(widths).not.toContain(62);
+    expect(widths).toContain(60);
+  });
+});


### PR DESCRIPTION
## Resumo

App Library: reduz ícones das faixas Recently Added/Suggestions de 62px para 60px (#678)

## Causa raiz

As faixas horizontais "Recently Added" e "Suggestions" usam o componente `AppStrip`
(`src/screens/AppLibraryScreen.tsx:437`), cujo tamanho de ícone estava hardcoded:
`src/screens/AppLibraryScreen.tsx:450` — `const stripIconSize = 62;`. Esse valor é
passado ao `AppIcon` (definido em `AppLibraryScreen.tsx:133`), que empacota o ícone
num `<View style={{ width: size, height: size }}>` (linha 174). Como 62px é o tamanho
usado na grelha densa de 4-por-linha, numa faixa de apenas 4 ícones fica
desproporcionalmente grande e força scroll horizontal onde o iOS mostra os 4 de uma vez.

Nota sobre o issue: o corpo aponta `AppLibraryScreen.tsx:278` e `stripIconSize` nas
linhas 290-294. Na realidade (código ganha sobre o issue) o `stripIconSize` está nas
linhas 450/464, e a 278 é a `iconGrid` da `CategoryCard` (que NÃO tem esse defeito —
usa `iconSize` derivado do `useWindowDimensions`). O defeito real é o `AppStrip`, não
a `CategoryCard`. Corrigi o `AppStrip`.

## O que mudou

- `src/screens/AppLibraryScreen.tsx`: `stripIconSize` passou de `62` para `60`,
alinhado aos ~60px da grelha densa do iOS App Library. Adicionado comentário a
explicar a razão (evitar scroll horizontal na faixa).
- `src/screens/__tests__/AppStripIconSize.test.tsx` (NOVO): teste que monta o
`AppLibraryContent` real (com apps reais do LauncherModule mockado), recolhe todos
os valores de `width` da árvore renderizada e verifica que (a) `62` não aparece e
(b) `60` aparece em quantidade suficiente para cobrir ambas as faixas.

Não mexeu em `stripItem` (`width: 72`, `AppLibraryScreen.tsx:852`): esse é o
contentor do ícone + label, e mantê-lo dá margem para o texto do label sem
encolher o ícone. O issue pedia especificamente o tamanho do ícone.

## Porque assim

Escolhi 60px (não 56/58) porque o issue afirma explicitamente que o iOS App Library
usa ícones de ~60px — é o valor declarado como referência, e manter a AppIcon com
raio proporcional (`radius = (size / ICON_SIZE) * ICON_RADIUS`, linha 143) garante
que a cantaria continua igual à do resto da App Library (ICON_SIZE=50, ICON_RADIUS=12;
60px dá raio 14.4, coerente com a grid). Alternativa descartada: derivar o tamanho
do `useWindowDimensions` como a CategoryCard faz — desnecessário para uma faixa de
4 ícones fixos e introduziria acoplamento a largura de ecrã sem benefício visível.

## Critérios de aceitação

- [x] Os ícones das faixas Recently Added e Suggestions renderizam a 60px (e não 62px).
  Confirmado pelo teste que inspeciona a árvore real renderizada.
- [x] A grelha de categorias (CategoryCard, `iconSize` por `useWindowDimensions`) NÃO
  mudou — continua a usar o seu cálculo próprio; só o `AppStrip` foi tocado.
- [x] O badge (dot vermelho) da AppIcon continua a funcionar: o `AppIcon` não foi
  alterado, apenas o `size` que lhe é passado no `AppStrip`.
- [x] Sem scroll horizontal forçado por tamanho de ícone exagerado — o `stripItem`
  (72px, com label) mantém-se; a redução é no ícone, não no contentor.
- [x] Nada de `any` novo: o helper de inspeção de árvore usa tipo `JsonNode` explícito.

## Testes

- **Passo vermelho** (fix revertido via `git stash`, teste escrito e a correr sozinho):

```
  ● AppLibrary AppStrip icon size (#678) › ícones das faixas Recently Added/Suggestions renderizam a 60px e não a 62px

    expect(received).not.toContain(expected) // indexOf

    Expected value: not 62
    Received array:     [72, 62, 62, 72, 62, 62, 72, 62, 62, 72, 62, 62, 72, 62, 62, 72, 62, 62, 72, 62, 62, 72, 62, 62, 353, 161.5, 161.5, 161.5, 353, 161.5, 161.5, 161.5, 353, 161.5, 161.5, 161.5, 161.5, 161.5, 161.5, 353, 161.5, 161.5, 161.5]

      69 |
      70 |     // O valor exagerado de 62px (stripIconSize antigo) não pode existir.
    > 71 |     expect(widths).not.toContain(62);
         |                        ^

  ● AppLibrary AppStrip icon size (#678) › faixa com um único app continua a 60px (fronteira: 1 ícone)

    expect(received).not.toContain(expected) // indexOf

    Expected value: not 62
    Received array:     [72, 62, 62, 72, 62, 62, 353, 161.5, 161.5, 161.5]

      80 |     const { toJSON } = await renderLibraryWithApps([BASE_APPS[0]]);
      81 |     const widths = collectWidths(toJSON());
    > 82 |     expect(widths).not.toContain(62);
         |                        ^
```

  Com o fix aplicado, ambos passam (`Tests: 2 passed`).

- **Casos cobertos:**
  - Caminho feliz: 4 ícones em cada faixa → `62` ausente e `60` presente ≥ 8 vezes.
  - Fronteira (1 ícone): a faixa com um único app continua a 60px e sem 62px —
    garante que o valor não depende de haver 4 ícones.
  - O inverso do fix: o teste afirma explicitamente que `62` NÃO aparece em lado
    nenhum da árvore (o valor exagerado antigo está banido), pelo que um
    regression para 62px seria apanhado.

- **Sanity-check:** reverti o fix (`git stash push -- src/screens/AppLibraryScreen.tsx`),
  corri `npx jest src/screens/__tests__/AppStripIconSize.test.tsx` → `2 failed`, e
  restaurei (`git stash pop`) → `2 passed`. Sem o fix a suite falha; com o fix passa.

- **Resultado das verificações obrigatórias** (worktree `qa/issue-678`, baseado no
  baseline de `main` que já tinha 25/1764 a falhar):
  - `npm run lint`: **0 erros** (7 warnings pré-existentes, fora do diff deste issue).
  - `npx tsc --noEmit`: limpo.
  - `npm test -- --maxWorkers=2`: **25 falharam, 1741 passaram, 1766 no total**
    (soma os meus 2 testes que passam). Os 25 testes a falhar são EXATAMENTE os do
    baseline (`baseline.json`) — nenhuma falha nova em ficheiros que toquei. Os meus
    2 testes passam sempre.

## Testes

25 falharam, 1741 passaram, 1766 no total (meus 2 testes passam; as 25 falhas são as do baseline, sem regressão nova)

## Linked Issue

Fixes #678