### PR TITLE
App Library: remove cartão branco das categorias — ícones ficam diretamente no fundo (cluster iOS) (#680)

### DIFF
--- a/src/screens/AppLibraryScreen.tsx
+++ b/src/screens/AppLibraryScreen.tsx
@@ -233,14 +233,20 @@ export const CategoryCard = React.memo(function CategoryCard({ title, apps, onPr
   // where an animated style per card would make a page transition's
   // useAnimatedStyle cost grow with the number of categories (the exact
   // invariant #518 protects). The ad hoc 0.8 opacity is gone either way.
+  // iOS App Library categories are NOT closed white cards: a title sits above a
+  // translucent cluster of icons laid directly on the blurred wallpaper. The
+  // category container therefore carries no card background and no rounded
+  // corners (the preset card chrome belongs to list rows / sheets, not here).
+  // Only the width + inset padding are kept; the pressed state is dropped too
+  // because there is no painted surface to darken — the whole card opens the
+  // category anyway, so a pressed backdrop would be pure card chrome.
   return (
     <Pressable
       onPress={onPress}
-      style={({ pressed }) => [
-        styles.categoryCard,
+      style={[
+        styles.categoryCluster,
         {
           width: cardWidth,
-          backgroundColor: pressed ? colors.pressedRowBackground : colors.secondarySystemGroupedBackground,
         },
       ]}
       accessibilityLabel={`${title} category, ${apps.length} app${apps.length !== 1 ? 's' : ''}`}
@@ -864,10 +870,10 @@ const styles = StyleSheet.create({
     gap: 12,
     marginBottom: 16,
   },
-  categoryCard: {
-    borderRadius: 20,
+  categoryCluster: {
+    // No card: iOS lays the icon cluster directly on the wallpaper. Only the
+    // inset padding + column width are kept so the icons don't touch the edges.
     padding: 12,
-    overflow: 'hidden',
   },
   iconGrid: {
     flexDirection: 'row',

--- a/src/screens/__tests__/CategoryCard.test.tsx
+++ b/src/screens/__tests__/CategoryCard.test.tsx
@@ -94,3 +94,51 @@ describe('CategoryCard — quadrant layout', () => {
     expect(onPress).toHaveBeenCalledTimes(1);
   });
 });
+
+// ---------------------------------------------------------------------------
+// iOS-style transparent cluster: App Library categories are NOT white rounded
+// cards. On iOS the category is a title + a cluster of icons sitting directly
+// on the blurred wallpaper, no closed card container. (issue #680)
+// ---------------------------------------------------------------------------
+
+// Collect every style entry applied to the *root* CategoryCard container so we
+// can assert on the card's own box, not on the inner icon grid.
+function rootStyleEntries(json: ReturnType<ReturnType<typeof renderCard>['toJSON']>) {
+  const style = json?.props?.style;
+  if (!style) return [];
+  return Array.isArray(style) ? style : [style];
+}
+
+describe('CategoryCard — iOS-style transparent cluster (no card)', () => {
+  it('does not render a white/rounded card container; icons sit directly on the background', () => {
+    const { toJSON } = renderCard(5);
+    const entries = rootStyleEntries(toJSON());
+    const hasCardBackground = entries.some(
+      (e) => e && typeof e === 'object' && 'backgroundColor' in e,
+    );
+    const hasRoundedCorner = entries.some(
+      (e) => e && typeof e === 'object' && 'borderRadius' in e,
+    );
+    expect(hasCardBackground).toBe(false);
+    expect(hasRoundedCorner).toBe(false);
+  });
+
+  it('keeps the container width + inset padding but drops the card background and corners', () => {
+    const { toJSON } = renderCard(4);
+    const entries = rootStyleEntries(toJSON());
+    const flat = Object.assign({}, ...(entries.filter(Boolean) as object[]));
+    expect((flat as { width?: number }).width).toBe(CARD_WIDTH);
+    expect((flat as { padding?: number }).padding).toBe(12);
+    expect((flat as { backgroundColor?: string }).backgroundColor).toBeUndefined();
+    expect((flat as { borderRadius?: number }).borderRadius).toBeUndefined();
+  });
+
+  it('renders an empty category (0 apps) without a card background', () => {
+    const { getByText, toJSON } = renderCard(0);
+    expect(getByText('0 apps')).toBeTruthy();
+    const entries = rootStyleEntries(toJSON());
+    expect(
+      entries.some((e) => e && typeof e === 'object' && 'backgroundColor' in e),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Resumo

App Library: remove cartão branco das categorias — ícones ficam diretamente no fundo (cluster iOS)

## Causa raiz

O `CategoryCard` (`src/screens/AppLibraryScreen.tsx:237-248`) renderizava um `Pressable` raiz com `styles.categoryCard` (`borderRadius: 20`, `overflow: 'hidden'`) e `backgroundColor: colors.secondarySystemGroupedBackground` — ou seja, um cartão branco arredondado fechado (light `#FFFFFF`, dark `#1C1C1E`) à volta de cada categoria. No iOS a App Library NÃO usa cartões: cada categoria é um título + um aglomerado de ícones translúcido diretamente sobre o wallpaper desfocado. O aspeto de "widget/cartão" era puro card chrome herdado de listas/sheets, não da identidade visual iOS.

Mecanismo em `ficheiro:linha`: `AppLibraryScreen.tsx:240` (`styles.categoryCard`) + `AppLibraryScreen.tsx:243` (`backgroundColor: pressed ? ... : colors.secondarySystemGroupedBackground`) + `AppLibraryScreen.tsx:867` (definição `categoryCard` com `borderRadius`/`overflow`).

## O que mudou

- `src/screens/AppLibraryScreen.tsx` — o container raiz do `CategoryCard` deixou de aplicar fundo nem cantos arredondados. Passou a usar `styles.categoryCluster` (apenas `padding: 12`, sem `borderRadius`/`overflow`/`backgroundColor`). O estado `pressed` foi removido do container porque não há superfície pintada para escurecer (todo o cartão já abre a categoria, logo um backdrop pressed seria puro card chrome). Mantém-se a `width: cardWidth` e o `padding` para os ícones não tocarem nas margens.
- `src/screens/AppLibraryScreen.tsx` — `styles.categoryCard` renomeado para `styles.categoryCluster`, com `borderRadius`/`overflow: 'hidden'` eliminados; sobra só o `padding: 12`.
- `src/screens/__tests__/CategoryCard.test.tsx` — 3 testes novos que garantem que o container raiz não tem `backgroundColor` nem `borderRadius`, mantém `width`/`padding`, e funciona com 0 apps.

## Porque assim

Decisão: remover o cartão do container, não pôr fundo translúcido. O issue pede "aglomerado de ícones translúcido diretamente sobre o wallpaper" — como o `AppLibraryContent` já tem `backgroundColor: colors.systemGroupedBackground` (`:650`) e o ecrã real assenta sobre o wallpaper desfocado, o cluster certo é transparente (deixa passar o fundo do content), não um cartão semi-opaco. Alternativas descartadas: (1) manter `categoryCard` e só tirar o fundo — deixaria `borderRadius`/`overflow` mortos e enganaria qualquer leitura futura; (2) pôr `tertiarySystemFill` translúcido — reintroduziria um cartão, que é exatamente o que o issue rejeita.

## Critérios de aceitação

- [x] O container raiz do `CategoryCard` não tem `backgroundColor` (light nem dark) — testado em `does not render a white/rounded card container` e `renders an empty category (0 apps) without a card background`.
- [x] O container raiz não tem `borderRadius` — testado nos dois primeiros testes do grupo.
- [x] Mantém `width = cardWidth` e `padding = 12` — testado em `keeps the container width + inset padding`.
- [x] O que NÃO devia mudar: layout de ícones/quadrant (3+quadrant a 5+, 4 largos a 4, fronteiras 1/2/3), tapping (large icon → launch; quadrant/title → open category), texto de contagem, e categoria vazia — mantido pela suite existente de 9 testes que continua a passar na íntegra.

## Testes

- **Passo vermelho** (fix revertido via `git stash`, output real do jest):

```
  ● CategoryCard — iOS-style transparent cluster (no card) › does not render a white/rounded card container; icons sit directly on the background
    ...
  ● CategoryCard — iOS-style transparent cluster (no card) › keeps the container width + inset padding but drops the card background and corners
    expect(received).toBeUndefined()
    Received: "#FFFFFF"
      133 |     expect((flat as { backgroundColor?: string }).backgroundColor).toBeUndefined();
          |                                                                    ^
  ● CategoryCard — iOS-style transparent cluster (no card) › renders an empty category (0 apps) without a card background
    Expected: false
    Received: true
      143 |     ).toBe(false);
Tests: 3 failed, 9 passed, 12 total
```

- **Casos cobertos:** fronteira vazia (0 apps) — o cluster transparente tem de continuar a renderizar sem cartão; manutenção de `width`/`padding` (garante que não se perdeu o layout ao tirar o cartão); o inverso do fix (presença de `backgroundColor`/`borderRadius` é rejeitada). Os testes do caminho feliz (quadrant, tapping, contagens) já existiam e foram preservados.

- **Sanity-check:** `git stash` do `AppLibraryScreen.tsx` + correr a suite → `3 failed, 9 passed` (os meus 3 testes falham porque o cartão branco `#FFFFFF`/`borderRadius` voltam). `git stash pop` → `12 passed`. Prova que os testes estão ligados ao comportamento.

- **Verificações:** `npm run lint` → 0 erros (8 warnings pré-existentes noutros ficheiros, não introduzidos por mim); `npx tsc --noEmit` → limpo; `npm test -- --maxWorkers=2` → 25 falharam / 1742 passaram de 1767 (6 suites). As 25 falhas são exatamente as da baseline (`comm -13` entre baseline e current devolveu vazio) — não introduzi nenhuma falha nova. Os meus 3 testes novos passam.

## Testes

12 passaram, 0 falharam no CategoryCard.test.tsx; suite total: 1742 passaram, 25 falharam (baseline), 1767 testes, 182 suites

## Linked Issue

Fixes #680