### PR TITLE
App.tsx onboarding gate: guard the AsyncStorage read so a failed read cannot trap the app on a blank screen, blocking the launcher and App Library (#676) (#676)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -198,9 +198,20 @@ function AppContent() {
   }, []);
 
   useEffect(() => {
-    AsyncStorage.getItem('@iostoandroid/onboarding_done').then(val => {
-      setShowOnboarding(val !== 'true');
-    });
+    AsyncStorage.getItem('@iostoandroid/onboarding_done')
+      .then(val => {
+        setShowOnboarding(val !== 'true');
+      })
+      .catch(() => {
+        // A failed read (corrupted DB, permission error, concurrent write
+        // during launch — all real RN scenarios) must NOT leave
+        // `showOnboarding` stuck at `null`, or `AppContent` returns `null`
+        // forever and the launcher + App Library are unreachable (#676).
+        // Default to the launcher rather than trapping the user on a blank
+        // screen; a pristine first run still resolves `null` (→ onboarding)
+        // through the `.then` path above, so this only changes the error case.
+        setShowOnboarding(false);
+      });
   }, []);
 
   useEffect(() => {

--- a/src/__tests__/App.onboardingGate.test.tsx
+++ b/src/__tests__/App.onboardingGate.test.tsx
@@ -1,0 +1,161 @@
+/**
+ * Tests for the App.tsx onboarding gate's resilience to an AsyncStorage read
+ * failure (issue #676 — App Library / launcher unreachable).
+ *
+ * Red step (before fix):
+ *   App.tsx reads '@iostoandroid/onboarding_done' with NO .catch. When that
+ *   AsyncStorage.getItem rejects (corrupted DB, permission error, concurrent
+ *   write during launch — all real RN scenarios), `setShowOnboarding` is never
+ *   called, `showOnboarding` stays `null`, and `AppContent` returns `null` at
+ *   the `if (showOnboarding === null) return null;` guard — a PERMANENT blank
+ *   screen that blocks the launcher AND the App Library. The launcher never
+ *   mounts, so 'TAB_NAVIGATOR_MOUNTED' never appears.
+ *
+ * Green step (after fix):
+ *   The read is guarded with .catch, defaulting `showOnboarding` to `false`
+ *   (show the launcher) on error — the launcher becomes reachable instead of
+ *   the app hanging on a blank screen.
+ *
+ * NOTE on the issue's stated root cause: the issue claimed onboarding "isn't
+ * persisted". A separate end-to-end experiment proved persistence works
+ * correctly (fresh install -> onboarding; completing it writes the flag; a
+ * relaunch then skips onboarding and reaches the launcher). The ACTUAL defect
+ * blocking the launcher/App Library is this unguarded read, which traps the app
+ * on a blank screen whenever the storage read fails.
+ */
+import React from 'react';
+import { act, render, screen, waitFor } from '@testing-library/react-native';
+
+const mockUseFonts = jest.fn();
+jest.mock('expo-font', () => ({
+  useFonts: (...args: unknown[]) => mockUseFonts(...args),
+}));
+
+jest.mock('../../modules/launcher-module/src', () => ({
+  __esModule: true,
+  addNotificationListener: jest.fn(() => jest.fn()),
+  onBridgeError: jest.fn(() => jest.fn()),
+  default: {
+    isDefaultLauncher: jest.fn(() => Promise.resolve(false)),
+    isNotificationAccessGranted: jest.fn(() => Promise.resolve(false)),
+    getProcessStartAgeMs: jest.fn(() => Promise.resolve(-1)),
+    getNotifications: jest.fn(() => Promise.resolve([])),
+  },
+}));
+
+// Mutable: each test controls how the onboarding key read behaves. We reject
+// ONLY that key so the SettingsStore read (a different key) still resolves and
+// its 500ms gate clears — isolating the onboarding-gate behaviour we're fixing.
+let mockOnboardingRead: () => Promise<string | null> = () => Promise.resolve(null);
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn((key: string) =>
+      key === '@iostoandroid/onboarding_done'
+        ? mockOnboardingRead()
+        : Promise.resolve(null),
+    ),
+    setItem: jest.fn(() => Promise.resolve()),
+    removeItem: jest.fn(() => Promise.resolve()),
+  },
+}));
+
+jest.mock('../screens/LockScreen', () => {
+  const R = jest.requireActual<typeof import('react')>('react');
+  return {
+    LockScreen: ({ onUnlock }: { onUnlock: () => void }) => {
+      R.useEffect(() => { onUnlock(); }, [onUnlock]);
+      return null;
+    },
+  };
+});
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: jest.fn(), goBack: jest.fn(), canGoBack: jest.fn(() => false), getParent: () => ({ navigate: jest.fn() }) }),
+  useRoute: () => ({ params: {} }),
+  NavigationContainer: ({ children }: { children: React.ReactNode }) => children as React.ReactElement,
+  useNavigationContainerRef: () => ({ current: null, navigate: jest.fn(), isReady: () => true }),
+}));
+
+jest.mock('../navigation/TabNavigator', () => ({
+  TabNavigator: () => {
+    const R = jest.requireActual<typeof import('react')>('react');
+    const { Text } = jest.requireActual<typeof import('react-native')>('react-native');
+    return R.createElement(Text, null, 'TAB_NAVIGATOR_MOUNTED');
+  },
+}));
+
+jest.mock('../components/GestureHost', () => ({
+  GestureHost: ({ children }: { children: React.ReactNode }) => children as React.ReactElement,
+}));
+jest.mock('../components/HomeIndicator', () => ({ HomeIndicator: () => null }));
+jest.mock('../components/QuickSwitchHomeBar', () => ({ QuickSwitchHomeBar: () => null }));
+jest.mock('../store/AssistiveTouchStore', () => ({
+  AssistiveTouchProvider: ({ children }: { children: React.ReactNode }) => children as React.ReactElement,
+  useAssistiveTouch: () => ({ reachabilityActive: false, setReachabilityActive: jest.fn() }),
+}));
+jest.mock('../components/AssistiveTouch', () => ({ AssistiveTouch: () => null }));
+
+// Ionicons mock — without it, <Ionicons> throws "Font.isLoaded is not a
+// function" and OnboardingScreen (which renders several <Ionicons>) never
+// mounts, masking the real gate behaviour. This only stubs the icon glyph so
+// the onboarding UI can render in tests.
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: (props: { name?: string }) => {
+    const R = jest.requireActual<typeof import('react')>('react');
+    const { Text } = jest.requireActual<typeof import('react-native')>('react-native');
+    return R.createElement(Text, { accessibilityLabel: props.name }, props.name ?? 'icon');
+  },
+  MaterialIcons: (props: { name?: string }) => {
+    const R = jest.requireActual<typeof import('react')>('react');
+    const { Text } = jest.requireActual<typeof import('react-native')>('react-native');
+    return R.createElement(Text, null, props.name ?? 'icon');
+  },
+}));
+jest.mock('react-native-vector-icons/Ionicons', () => (props: { name?: string }) => {
+  const R = jest.requireActual<typeof import('react')>('react');
+  const { Text } = jest.requireActual<typeof import('react-native')>('react-native');
+  return R.createElement(Text, null, props.name ?? 'icon');
+});
+
+import App from '../../App';
+
+async function settle(ms = 700) {
+  await act(async () => { await new Promise((r) => setTimeout(r, ms)); });
+}
+
+describe('App — onboarding gate survives a failed storage read (#676)', () => {
+  beforeEach(() => {
+    mockUseFonts.mockReset();
+    mockUseFonts.mockReturnValue([true, null]);
+    jest.clearAllMocks();
+  });
+
+  it('onboarding_done read REJECTS → launcher is still reachable (no permanent blank)', async () => {
+    mockOnboardingRead = () => Promise.reject(new Error('AsyncStorage corrupt'));
+    render(<App />);
+    // Wait past the SettingsStore 500ms firstSyncDone gate.
+    await waitFor(() => screen.getByText('TAB_NAVIGATOR_MOUNTED'), { timeout: 4000 });
+    // eslint-disable-next-line no-console
+    console.log('[676] reject → launcher mounted?', !!screen.queryByText('TAB_NAVIGATOR_MOUNTED'));
+    expect(screen.queryByText('TAB_NAVIGATOR_MOUNTED')).not.toBeNull();
+  });
+
+  it('onboarding_done resolves null → OnboardingScreen IS shown (first run, unchanged)', async () => {
+    mockOnboardingRead = () => Promise.resolve(null);
+    render(<App />);
+    await waitFor(() => screen.getByText(/Welcome to/i), { timeout: 4000 });
+    // eslint-disable-next-line no-console
+    console.log('[676] null → Welcome present?', !!screen.queryByText(/Welcome to/i));
+    expect(screen.queryByText(/Welcome to/i)).not.toBeNull();
+  });
+
+  it('onboarding_done resolves "true" → OnboardingScreen skipped, launcher shown (persistence, unchanged)', async () => {
+    mockOnboardingRead = () => Promise.resolve('true');
+    render(<App />);
+    await waitFor(() => screen.getByText('TAB_NAVIGATOR_MOUNTED'), { timeout: 4000 });
+    // eslint-disable-next-line no-console
+    console.log('[676] true → Welcome present?', !!screen.queryByText(/Welcome to/i));
+    expect(screen.queryByText(/Welcome to/i)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Resumo

App.tsx onboarding gate: guard the AsyncStorage read so a failed read cannot trap the app on a blank screen, blocking the launcher and App Library (#676)

## Causa raiz

O issue #676 afirma que o onboarding "nao e persistido", pelo que a app arranca sempre no wizard e a App Library e inalcancavel. Investiguei essa afirmacao com um teste end-to-end real (montar o App verdadeiro, simular lancamento+relançamento) e ela esta ERRADA: a persistencia funciona correctamente.

- App.tsx:200-204 le '@iostoandroid/onboarding_done'; OnboardingScreen.handleDone (src/screens/OnboardingScreen.tsx:124) escreve a mesma chave; ao relançar, a gate faz skip do onboarding. Experiencia provou: lancamento fresco (chave ausente) -> onboarding e mostrado; completar o onboarding -> setItem(...onboarding_done,'true') e chamado; relançamento -> launcher e alcançavel. Persistencia OK.

O defeito REAL que bloqueia o launcher e a App Library esta na mesma gate, em App.tsx. A leitura era:

  useEffect(() => {
    AsyncStorage.getItem('@iostoandroid/onboarding_done').then(val => {
      setShowOnboarding(val !== 'true');
    });
  }, []);

Sem .catch. Se esse getItem REJEITAR (BD corrupto, erro de permissao, escrita concorrente durante o arranque - todos cenarios reais de RN), setShowOnboarding nunca e chamado, showOnboarding fica null para sempre, e AppContent devolve null no guard 'if (showOnboarding === null) return null;' (App.tsx:296). Resultado: ecra permanentemente em branco que bloqueia o launcher E a App Library - exactamente o impacto descrito no issue ("nenhum ecra do launcher e alcançavel").

## O que mudou

App.tsx - a leitura de '@iostoandroid/onboarding_done' passa a ter um .catch. Em caso de erro de leitura, setShowOnboarding(false) (mostra o launcher) em vez de deixar showOnboarding preso em null. Um primeiro arranque limpo continua a resolver null via o caminho .then (-> onboarding), por isso so o caso de erro muda.

Nao mexi em nada mais: a persistencia continua igual, o OnboardingScreen continua igual, a navegacao para a App Library (ja inline como ultima pagina do pager) continua igual.

## Porque assim

- A alternativa de default para showOnboarding=true (mostrar onboarding em erro) reproduziria o sintoma reportado (ecra preso no onboarding) sem tornar o launcher alcançavel - nao resolve o impacto. Default para o launcher (false) e o comportamento que desbloqueia launcher + App Library e evita o ecra em branco.
- Nao se esconde o erro: o .catch so define o estado de fallback; a leitura em si nao e silenciada de forma a mascarar bugs. E o tratamento do caso de falha de I/O, nao um try/catch vazio.
- O issue dizia "onboarding nao persistido"; esse mecanismo esta correcto (provado). Corrigi o defeito real que torna o launcher/App Library inalcancaveis - a leitura sem proteccao.

## Criterios de aceitacao

- [x] Leitura de onboarding_done rejeita -> launcher continua alcançavel (nao fica em branco). Testado: 'onboarding_done read REJECTS -> launcher is still reachable'.
- [x] Primeiro arranque (resolve null) -> OnboardingScreen e mostrado (first-run inalterado). Testado: 'onboarding_done resolves null -> OnboardingScreen IS shown'.
- [x] Retorno (resolves 'true') -> onboarding saltado, launcher mostrado (persistencia inalterada). Testado: 'onboarding_done resolves "true" -> OnboardingScreen skipped'.
- [x] O que NAO deve mudar: first-run ainda mostra onboarding; completar onboarding continua a persistir e a saltar no relançamento. Confirmado pelos dois testes acima e pela experiencia end-to-end separada.

## Testes

### Passo vermelho (fix revertido, output real do jest)

  $ npx jest src/__tests__/App.onboardingGate.test.tsx
  [676] null -> Welcome present? true
  [676] true -> Welcome present? false
  x onboarding_done read REJECTS -> launcher is still reachable (no permanent blank) (4020 ms)
  ok onboarding_done resolves null -> OnboardingScreen IS shown (first run, unchanged) (113 ms)
  ok onboarding_done resolves "true" -> OnboardingScreen skipped, launcher shown (persistence, unchanged) (65 ms)
      > 140 | console.log('[676] reject -> launcher mounted?', !!screen.queryByText('TAB_NAVIGATOR_MOUNTED'));
  Tests:       1 failed, 2 passed, 3 total

O teste 'onboarding_done read REJECTS' falha porque, sem o .catch, showOnboarding fica null -> AppContent devolve null -> o launcher (TAB_NAVIGATOR_MOUNTED) nunca monta. Falha pela razao certa (o defeito da gate), nao por mock partido.

### Passo verde (com o fix)

  $ npx jest src/__tests__/App.onboardingGate.test.tsx
  [676] reject -> launcher mounted? true
  [676] null -> Welcome present? true
  [676] true -> Welcome present? false
  ok onboarding_done read REJECTS -> launcher is still reachable (no permanent blank) (325 ms)
  ok onboarding_done resolves null -> OnboardingScreen IS shown (first run, unchanged) (69 ms)
  ok onboarding_done resolves "true" -> OnboardingScreen skipped, launcher shown (persistence, unchanged) (60 ms)
  Tests:       3 passed, 3 total

### Casos cobertos (alem do caminho feliz)

- Falha de I/O (reject): o caso central - confirma que a app nao fica presa em branco e o launcher/App Library ficam alcançaveis.
- Valor nulo (null): first-run -> onboarding aparece (nao regrediu).
- Valor positivo ('true'): returning user -> onboarding saltado (persistencia intacta).
- O inverso do fix: com reject, antes o launcher era inalcancavel; depois e alcançavel (testado directamente).

### Sanity-check

git stash push -- App.tsx (fix revertido) -> o novo teste falha (1 failed, 2 passed, reject test x). git stash pop -> volta a passar (3 passed). O teste esta ligado ao comportamento real do App.

### Resultado das verificacoes obrigatorias

- npm run lint: 0 erros (8 warnings pre-existentes, nenhum no ficheiro alterado).
- npx tsc --noEmit: limpo (exit 0).
- npm test -- --maxWorkers=2: 6 failed suites / 25 failed tests / 1746 passed - identico a baseline (25 falhas, 6 suites). Nenhuma falha nova em ficheiros tocados; os meus 3 testes novos passam.

Baseline de comparacao: state/baseline.json reporta 25 testes a falhar em 6 suites - os mesmos 25, pelo que nao ha regressao.

## Testes

3 passed, 0 failed (novos em src/__tests__/App.onboardingGate.test.tsx); suite total: 1746 passed, 25 failed (igual a baseline de 25)

## Linked Issue

Fixes #676