### PR TITLE
fix/685: Notification center não rebenta com notificações sem packageName (causa do ecrã em branco) (#685)

### DIFF
--- a/src/screens/NotificationCenterScreen.tsx
+++ b/src/screens/NotificationCenterScreen.tsx
@@ -216,16 +216,28 @@ export function NotificationCenterScreen() {
   const groups: NotificationGroup[] = React.useMemo(() => {
     const map = new Map<string, NotificationGroup>();
     for (const notif of notifications) {
-      if (!map.has(notif.packageName)) {
-        const appInfo = apps.find(a => a.packageName === notif.packageName);
-        map.set(notif.packageName, {
-          packageName: notif.packageName,
-          appName: appInfo?.name ?? notif.packageName.split('.').pop() ?? notif.packageName,
+      // The native bridge (modules/launcher-module/src) deliberately passes
+      // through notifications whose packageName is missing/non-string
+      // (dedupeByPackageName keeps malformed native data instead of coercing it).
+      // A bare `notif.packageName.split('.')` here would throw on `undefined`/
+      // `null` and take down the entire screen, which the app-wide ErrorBoundary
+      // then replaces with a near-white fallback — the "blank white, no content"
+      // reported for the notification center. Key such entries under a stable,
+      // per-notification id and label them "Unknown" instead of crashing.
+      const pkg = typeof notif.packageName === 'string' ? notif.packageName : '';
+      const groupKey = pkg || `unknown:${notif.key}`;
+      if (!map.has(groupKey)) {
+        const appInfo = pkg
+          ? apps.find(a => a.packageName === pkg)
+          : undefined;
+        map.set(groupKey, {
+          packageName: pkg,
+          appName: appInfo?.name ?? (pkg ? pkg.split('.').pop() ?? pkg : 'Unknown'),
           appIcon: appInfo?.icon ?? '',
           notifications: [],
         });
       }
-      map.get(notif.packageName)!.notifications.push(notif);
+      map.get(groupKey)!.notifications.push(notif);
     }
     return Array.from(map.values());
   }, [notifications, apps]);
@@ -308,7 +320,8 @@ export function NotificationCenterScreen() {
                       const isRead = readIds.has(notif.key);
                       const isExpanded = expandedNotifKey === notif.key;
                       const isReplying = replyingKey === notif.key;
-                      const isMessageApp = notif.packageName.includes('message') || notif.packageName.includes('sms') || notif.packageName.includes('whatsapp') || notif.packageName.includes('telegram') || notif.packageName.includes('signal');
+                      const isMessageApp = typeof notif.packageName === 'string'
+                        && (notif.packageName.includes('message') || notif.packageName.includes('sms') || notif.packageName.includes('whatsapp') || notif.packageName.includes('telegram') || notif.packageName.includes('signal'));
                       return (
                         <CupertinoSwipeableRow
                           key={notif.key}

--- a/src/screens/__tests__/NotificationCenterMalformed.test.tsx
+++ b/src/screens/__tests__/NotificationCenterMalformed.test.tsx
@@ -1,0 +1,128 @@
+import React from 'react';
+import { render, waitFor } from '../../test-utils';
+import { Text } from 'react-native';
+import { NotificationCenterScreen } from '../NotificationCenterScreen';
+import launcherModule from '../../../modules/launcher-module/src';
+
+/**
+ * The native bridge (modules/launcher-module/src/index.ts) deliberately PASSES
+ * THROUGH notifications whose `packageName` is missing/non-string — see
+ * `dedupeByPackageName`, which keeps malformed native data instead of coercing
+ * it. Those malformed entries reach `getNotifications()` and then this screen.
+ *
+ * The screen used to group notifications with `notif.packageName.split('.')`
+ * (NotificationCenterScreen.tsx ~line 223) and test message-app membership with
+ * `notif.packageName.includes(...)` (~line 311). With `packageName === undefined`
+ * (or any non-string) both throw during render, taking down the whole screen —
+ * which the app-wide ErrorBoundary then replaces with a near-white fallback.
+ * That is the "blank white, no content" reported for the notification center.
+ *
+ * These tests exercise the REAL grouping/mapping path (the same useMemo the
+ * screen runs), not a reimplementation, by mounting the real component and
+ * feeding it malformed bridge data through the mocked module.
+ */
+
+interface RawNotif {
+  id: string;
+  key: string;
+  packageName?: string | null;
+  title?: string | null;
+  text?: string | null;
+  time?: number | null;
+  isOngoing: boolean;
+}
+
+function makeNotif(over: Partial<RawNotif>): RawNotif {
+  return { id: 'n0', key: 'n0', packageName: 'com.app0', title: 'Title', text: 'Body', time: Date.now(), isOngoing: false, ...over };
+}
+
+// Probe boundary: captures a render-time crash and renders it as a detectable
+// text node (so the test can assert the screen did NOT crash, instead of relying
+// on the app-wide ErrorBoundary silently swallowing it).
+class Probe extends React.Component<{ children: React.ReactNode }, { err: Error | null }> {
+  constructor(props: { children: React.ReactNode }) {
+    super(props);
+    this.state = { err: null };
+  }
+  static getDerivedStateFromError(err: Error) {
+    return { err };
+  }
+  render() {
+    if (this.state.err) {
+      return <Text>{`CRASH:${this.state.err.message}`}</Text>;
+    }
+    return this.props.children as React.ReactElement;
+  }
+}
+
+function grantAccess(notifs: RawNotif[]) {
+  (launcherModule.isNotificationAccessGranted as jest.Mock).mockResolvedValue(true);
+  (launcherModule.getNotifications as jest.Mock).mockResolvedValue(notifs);
+}
+
+describe('NotificationCenterScreen — malformed bridge data (issue #685)', () => {
+  afterEach(() => {
+    (launcherModule.isNotificationAccessGranted as jest.Mock).mockResolvedValue(false);
+    (launcherModule.getNotifications as jest.Mock).mockResolvedValue([]);
+  });
+
+  it('does not crash when a notification has no packageName', async () => {
+    grantAccess([makeNotif({ packageName: undefined })]);
+    const { queryByText, getByText } = render(
+      <Probe>
+        <NotificationCenterScreen />
+      </Probe>,
+    );
+    await waitFor(() => expect(getByText(/, \w+ \d+/)).toBeTruthy(), { timeout: 1500 });
+    expect(queryByText(/^CRASH:/)).toBeNull();
+  });
+
+  it('does not crash when a notification has an empty-string packageName', async () => {
+    grantAccess([makeNotif({ packageName: '' })]);
+    const { queryByText, getByText } = render(
+      <Probe>
+        <NotificationCenterScreen />
+      </Probe>,
+    );
+    await waitFor(() => expect(getByText(/, \w+ \d+/)).toBeTruthy(), { timeout: 1500 });
+    expect(queryByText(/^CRASH:/)).toBeNull();
+  });
+
+  it('does not crash when a notification has a null packageName', async () => {
+    grantAccess([makeNotif({ packageName: null })]);
+    const { queryByText, getByText } = render(
+      <Probe>
+        <NotificationCenterScreen />
+      </Probe>,
+    );
+    await waitFor(() => expect(getByText(/, \w+ \d+/)).toBeTruthy(), { timeout: 1500 });
+    expect(queryByText(/^CRASH:/)).toBeNull();
+  });
+
+  it('still renders well-formed notifications after a malformed one', async () => {
+    grantAccess([
+      makeNotif({ packageName: undefined, key: 'bad', id: 'bad' }),
+      makeNotif({ packageName: 'com.good.app', key: 'good', id: 'good', title: 'Good Title' }),
+    ]);
+    const { queryByText, getByText } = render(
+      <Probe>
+        <NotificationCenterScreen />
+      </Probe>,
+    );
+    // The well-formed notification must still appear — the malformed one must
+    // not take down the whole list.
+    await waitFor(() => expect(getByText('Good Title')).toBeTruthy(), { timeout: 1500 });
+    expect(queryByText(/^CRASH:/)).toBeNull();
+  });
+
+  it('does not crash when a notification is missing title/text/time fields', async () => {
+    grantAccess([{ id: 'n0', key: 'n0', packageName: 'com.app0', isOngoing: false } as RawNotif]);
+    const { queryByText, getByText } = render(
+      <Probe>
+        <NotificationCenterScreen />
+      </Probe>,
+    );
+    await waitFor(() => expect(getByText(/, \w+ \d+/)).toBeTruthy(), { timeout: 1500 });
+    expect(queryByText(/^CRASH:/)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Resumo

fix/685: Notification center não rebenta com notificações sem packageName (causa do ecrã em branco)

## Causa raiz

O issue chegou sem corpo (apenas o título "Notification center renders blank white — Metro loading banner visible, no content"). Não há string literal "Metro loading banner" no código — é a descrição de sintoma de um utilizador a ver o ecrã do centro de notificações completamente branco/sem conteúdo. Investiguei o caminho de render do `NotificationCenterScreen` e encontrei a causa mecânica real.

O ecrã agrupa as notificações vindas da bridge nativa num `useMemo` (`src/screens/NotificationCenterScreen.tsx:216`). Esse agrupamento chamava `notif.packageName.split('.')` para derivar o nome do app, e o mapeamento de cada cartão chamava `notif.packageName.includes(...)` para detetar apps de mensagens (linha 311). Quando uma notificação tem `packageName` ausente/non-string, **ambos lançam `TypeError: Cannot read properties of undefined (reading 'split')` durante o render**, o que derruba o ecrã inteiro. O `ErrorBoundary` da app (`src/components/ErrorBoundary.tsx`) substitui então a árvore por um fallback quase-branco em modo claro → exactamente o "blank white, no content" reportado.

Isto é atingível em produção: o módulo nativo (`modules/launcher-module/src/index.ts:419`, `dedupeByPackageName`) **deixa passar expressamente** notificações sem `packageName` utilizável ("An entry without a usable packageName is malformed native data... collapsing those together would silently drop real apps"). Ou seja, dados malformados da bridge chegam a `getNotifications()` e depois a este ecrã.

## O que mudou

`src/screens/NotificationCenterScreen.tsx` (apenas o ecrã, sem tocar noutros ficheiros):

1. **Agrupamento (`useMemo` ~linha 216):** normaliza `packageName` para string antes de o usar. Se for `undefined`/`null`/non-string, a notificação passa a ser agrupada sob uma chave estável `unknown:<key>` e o appName passa a "Unknown" — em vez de `.split('.')` rebentar. Apps com `packageName` válido mantêm o comportamento anterior (nome real ou `split('.').pop()`).
2. **Deteção de app de mensagem (linha 311):** `isMessageApp` passa a verificar `typeof notif.packageName === 'string'` antes dos `.includes(...)`, devolvendo `false` (sem reply inline) para notificações sem packageName, em vez de lançar.

Nenhuma das duas alterações mascara o erro com `try/catch`/`??`/`as any`: trata o caso em falta como dado legítimo (mostra a notificação sob "Unknown").

## Porque assim

A alternativa de filtrar as notificações malformadas à entrada (descartá-las) esconderia notificações reais — o próprio `dedupeByPackageName` documenta que isso é indesejável. Agrupar sob "Unknown" preserva a notificação visível (o inverso do comportamento atual, que escondia TUDO) e mantém o contrato de não-coerção do módulo nativo. A normalização é feita no ponto de consumo, não na bridge, porque a bridge tem razões válidas para preservar os dados Originais.

## Critérios de aceitação

- [x] O ecrã não rebenta quando uma notificação tem `packageName: undefined` — testado (antes: crash, depois: renderiza).
- [x] O ecrã não rebenta quando `packageName` é `null` — testado.
- [x] O ecrã não rebenta quando `packageName` é `''` (string vazia) — testado (continua a agrupar sob chave vazia, sem crash).
- [x] Uma notificação bem-formada continua a aparecer mesmo quando partilha a lista com uma malformada — testado (`Good Title` renderiza).
- [x] Notificações sem `title`/`text`/`time` também não rebentam — testado.
- [x] **O que NÃO devia mudar:** notificações com `packageName` válido mantêm exatamente o mesmo agrupamento e nome de app (ver teste existente `NotificationCenterScreen.test.tsx`, que continua a passar; o `groupAppName` e os testes de WCAG AA não foram tocados). Confirmado: `npm test` nos testes existentes do ecrã passa a 23/23.

## Testes

- **Passo vermelho:** teste em `src/screens/__tests__/NotificationCenterMalformed.test.tsx`, com o fix **revertido** via `git stash`. Output real do jest (3 de 5 falham pela causa certa):
  ```
  TypeError: Cannot read properties of undefined (reading 'split')
    [message]: "Cannot read properties of undefined (reading 'split')"
  TypeError: Cannot read properties of null (reading 'split')
    [message]: "Cannot read properties of null (reading 'split')"
  ✕ does not crash when a notification has no packageName (236 ms)
  ✕ does not crash when a notification has a null packageName (163 ms)
  ✕ still renders well-formed notifications after a malformed one (1512 ms)
  <Text>CRASH:Cannot read properties of undefined (reading 'split')</Text>
  ```
  Com o fix aplicado, os 5 testes passam.
- **Casos cobertos (para além do caminho feliz):**
  - Vazio/ausente: `packageName` `undefined`, `null`, `''` (3 variações do campo em falta).
  - Campo ausente: notificação sem `title`/`text`/`time` nenhuns.
  - Mistura de dados: uma notificação malformada na mesma lista de uma bem-formada (o defeito típico — uma só entrada podre derrubava a lista toda).
  - Fronteira string: `packageName === ''` (chama `.split` sobre string vazia sem crash; cobre o limite entre "válido" e "ausente").
  - O inverso do fix: apps com `packageName` válido continuam a agrupar/mostrar normalmente (testado pelo `NotificationCenterScreen.test.tsx` existente, não modificado).
- **Sanity-check:** `git stash push` do ficheiro de produção → 3 testes falham com `reading 'split'`; `git stash pop` → 5/5 passam. O teste está ligado ao comportamento, não a uma cópia.
- **Verificações obrigatórias (critério = regressão vs baseline, não perfeição):**
  - `npm run lint`: 0 erros (7 warnings pré-existentes, fora do meu diff).
  - `npx tsc --noEmit`: limpo (exit 0).
  - `npm test -- --maxWorkers=2`: **25 falham, 1753 passam, 178 suites**. Exactamente os mesmos 25 testes que a baseline (FoldersStore, LockScreen, SettingsScreen, SiriScreen×14, WeatherScreen×2, withLauncherIntent plugin×3) — confirmado por comparação de nomes normalizados: **0 falhas novas**, 0 resolvidas. Os meus 5 testes novos passam sempre.

## Testes

25 falharam (baseline), 1753 passaram, 178 suites; os 5 testes novos (NotificationCenterMalformed) passam 100%

## Linked Issue

Fixes #685