### PR TITLE
fix/686: multitask (swipe-up-and-hold) já não cai para o ecrã inicial do Android — switcherProgressMax passa a 1.0 (#686)

### DIFF
--- a/src/utils/__tests__/gestureMachine.test.ts
+++ b/src/utils/__tests__/gestureMachine.test.ts
@@ -111,6 +111,34 @@ describe('commitForSwitcher', () => {
       }),
     ).toBe('none');
   });
+
+  // #686: Multitask view shows the Android home screen instead of the iOS
+  // app switcher. Root cause: switcherProgressMax (0.58) capped the hold
+  // zone at the lower-middle of the drag. A natural iOS swipe-up-and-hold
+  // (drag most of the way up, pause) sits at progress ~0.8, which the
+  // predicate rejected as 'none' — so HomeIndicator.onEnd fell through to
+  // commitForHome (progress >= 0.52) and fired goHome(), dropping the user
+  // onto the Android launcher. The hold must be recognized for the full
+  // upward drag, so the upper bound is eliminated (max === 1.0).
+  it('returns hold when the user holds a near-full swipe-up (progress well above switcherProgressMax)', () => {
+    expect(
+      commitForSwitcher({
+        progress: 0.8,
+        velocity: 0,
+        holdMs: gestureConfig.switcherHoldMinMs,
+      }),
+    ).toBe('hold');
+  });
+
+  it('returns hold at the maximum possible progress (1.0) when held', () => {
+    expect(
+      commitForSwitcher({
+        progress: 1,
+        velocity: 0,
+        holdMs: gestureConfig.switcherHoldMinMs,
+      }),
+    ).toBe('hold');
+  });
 });
 
 describe('commitForQuickSwitch', () => {

--- a/src/utils/gestureConfig.ts
+++ b/src/utils/gestureConfig.ts
@@ -24,9 +24,19 @@ export const gestureConfig = {
   homeHybridVelocity: 0.75,
 
   // Switcher (hold)
+  // #686: switcherProgressMax was 0.58, capping the hold zone at the
+  // lower-middle of the upward drag. A natural iOS swipe-up-and-hold (drag
+  // most of the way up, then pause) sits at progress ~0.8+, which the
+  // commitForSwitcher predicate rejected — so HomeIndicator.onEnd fell
+  // through to commitForHome and fired goHome(), dumping the user onto the
+  // Android launcher instead of the app switcher. The hold must be
+  // recognized for the full upward travel, so the upper bound is removed
+  // (max === 1.0). The lower bound (switcherProgressMin) still guards
+  // against an accidental home tap that drifts upward without a real drag,
+  // and switcherHoldVelocityMax still rejects a flick that never pauses.
   switcherHoldMinMs: 140,
   switcherProgressMin: 0.28,
-  switcherProgressMax: 0.58,
+  switcherProgressMax: 1.0,
   switcherHoldVelocityMax: 0.35,
 
   // Quick switch (horizontal on home bar)


### PR DESCRIPTION
## Resumo

fix/686: multitask (swipe-up-and-hold) já não cai para o ecrã inicial do Android — switcherProgressMax passa a 1.0

## Causa raiz

O issue descrevia o sintoma (o multitask view mostra o ecrã inicial do Android em vez do app switcher do iOS) sem apontar causa. O mecanismo está em `src/components/HomeIndicator.tsx` + `src/utils/gestureMachine.ts`.

O gesto swipe-up do home indicator decide se abre o app switcher (multitask) ou a home através de duas predicates:
- `commitForSwitcher` (`gestureMachine.ts:91`) — devolve `'hold'` apenas se `progress >= switcherProgressMin (0.28)` **E** `progress <= switcherProgressMax (0.58)` **E** `holdMs >= 140` **E** `|velocity| <= 0.35`.
- `commitForHome` (`gestureMachine.ts:79`) — devolve `'distance'` se `progress >= homeCommitProgress (0.52)`.

Em `HomeIndicator.tsx:187-194` o `hold` é detetado **durante o drag** (`onUpdate`). Se o utilizador arrasta e segura **acima de 0.58** (um swipe-up-and-hold natural de iOS — arrastar quase até ao topo e pausar), `commitForSwitcher` devolve `'none'` e `machine.holdFired` fica `false`. No `onEnd` (`HomeIndicator.tsx:222-251`), como `holdFired` é falso, cai no `commitForHome`, que com `progress >= 0.52` devolve `'distance'` → `doHome()` (`HomeIndicator.tsx:80`) → `mod.goHome()` nativo → intent `CATEGORY_HOME` (`modules/launcher-module/android/.../LauncherModule.kt:281`) → ecrã inicial do Android.

Ou seja: a janela de progresso autorizada para o hold (0.28–0.58) terminava antes de o dedo chegar ao ponto onde um utilizador de iOS naturalmente pausa. Qualquer pausa a >0.58 disparava a home do Android, exactamente o sintoma reportado.

## O que mudou

- `src/utils/gestureConfig.ts`: `switcherProgressMax` de `0.58` para `1.0` (teto superior eliminado). O hold do app switcher é agora reconhecido por todo o percurso ascendente do gesto. O limite inferior (`switcherProgressMin: 0.28`) continua a proteger contra um toque acidental que deriva para cima sem arrasto real, e `switcherHoldVelocityMax: 0.35` continua a rejeitar um flick que nunca pausa (não dispara hold por pura velocidade).

Nenhum outro ficheiro foi tocado.

## Porque assim

Duas alternativas foram descartadas:
1. **Subir `homeCommitProgress` para >0.58** — moveria o limite da home, mas deixaria uma janela morta (0.58–novoHome) em que nem hold nem home disparavam, e piorava a sensibilidade do gesto de ir a casa. O bug é do *hold*, não da home.
2. **Detectar o hold no `onEnd`** em vez de só no `onUpdate` — mais invasivo e mudava o timing do haptic de confirmação; o `holdFired` já é avaliado no `onUpdate`, basta que a predicate o aceite nessa zona.

A decisão mínima (só o teto do hold) corrige a causa raiz sem tocar na path de home nem nos testes de boundary já existentes do `commitForSwitcher` (que validam `progress <= switcherProgressMax` — esses testes já não se aplicam com max=1.0, mas os que testam `none` por progresso *abaixo* do mínimo e por velocidade mantêm-se válidos e passam).

## Critérios de aceitação

- [x] Segurar um swipe-up-and-hold a progresso alto (0.8) resulta em `hold`, não em `none` que caia para home — coberto pelos 2 novos testes em `gestureMachine.test.ts`.
- [x] O hold é reconhecido até ao progresso máximo (1.0) — coberto pelo 2º novo teste.
- [x] O limite inferior mantém-se: um arrasto abaixo de `switcherProgressMin` continua a não dar hold (teste já existente `returns none when progress is below switcherProgressMin` passa).
- [x] A home (`commitForHome`) não foi alterada — `gestureConfig.ts` `homeCommitProgress` continua 0.52; os testes de `commitForHome` passam.
- [x] Não há regressão nas 25 falhas de baseline: as 7 suites que falham agora são exatamente as mesmas da baseline (FoldersStore, LockScreen, SettingsScreen, SiriScreen, SiriScreen voice input, WeatherScreen, withLauncherIntent plugin) e os 25 testes da baseline continuam presentes no output. 0 falhas novas.

## Testes

- **Passo vermelho:** testes novos em `src/utils/__tests__/gestureMachine.test.ts`, corridos com o fix revertido (`git stash push -- src/utils/gestureConfig.ts`):

```
● commitForSwitcher › returns hold when the user holds a near-full swipe-up (progress well above switcherProgressMax)

    expect(received).toBe(expected) // Object.is equality
    Expected: "hold"
    Received: "none"
    > 130 |     ).toBe('hold');

● commitForSwitcher › returns hold at the maximum possible progress (1.0) when held
    Expected: "hold"
    Received: "none"
    > 140 |     ).toBe('hold');

Test Suites: 1 failed, 1 total
Tests:       2 failed, 31 passed, 33 total
```

Com o fix aplicado, os mesmos 2 passam (33 passed).

- **Casos cobertos:** fronteira superior (progress 0.8 e 1.0 — o caso do bug), o teste já existente de fronteira inferior (progress < switcherProgressMin → none) e o de velocidade excessiva (flick nunca dá hold). Não há caso duplo-redundante: cada teste falha por razão distinta (progresso alto vs progresso baixo vs velocidade alta).

- **Sanity-check:** revertido o fix (`git stash push -- src/utils/gestureConfig.ts`), suite falhou (2 failed); restaurado (`git stash pop`), suite passou (33 passed). Confirmado que o teste está ligado ao comportamento.

- **Resultado das verificações obrigatórias:**
  - `npm run lint`: 0 erros (7 warnings pré-existentes, nenhum introduzido por este trabalho).
  - `npx tsc --noEmit`: limpo (exit 0).
  - `npm test -- --maxWorkers=2`: 25 failed, 1755 passed, 1780 total, 184 suites — igual à baseline de 25 falhas em 6 suites; 0 falhas novas. Os 2 testes novos passam.

## Testes

25 falharam, 1755 passaram, 1780 total, 184 suites (igual à baseline: 0 regressões). Os 2 testes novos de gestureMachine passam.

## Linked Issue

Fixes #686