### PR TITLE
App.tsx: adiciona .catch à leitura de '@iostoandroid/onboarding_done' para não ficar ecrã em branco (#714)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -198,9 +198,18 @@ function AppContent() {
   }, []);
 
   useEffect(() => {
-    AsyncStorage.getItem('@iostoandroid/onboarding_done').then(val => {
-      setShowOnboarding(val !== 'true');
-    });
+    AsyncStorage.getItem('@iostoandroid/onboarding_done')
+      .then(val => {
+        setShowOnboarding(val !== 'true');
+      })
+      .catch(() => {
+        // Leitura falhou (BD corrompido, erro de permissão, escrita concorrente
+        // no arranque). Sem este .catch, showOnboarding ficaria null para sempre
+        // e AppContent devolveria null em App.tsx:296 — ecrã em branco que
+        // bloqueia o launcher E a App Library. Em caso de erro, mostramos o
+        // launcher (first-run/returning user continuam inalterados).
+        setShowOnboarding(false);
+      });
   }, []);
 
   useEffect(() => {

--- a/src/__tests__/App.onboardingGate.test.tsx
+++ b/src/__tests__/App.onboardingGate.test.tsx
@@ -1,0 +1,224 @@
+/**
+ * Tests for the onboarding gate in App.tsx (#714, parte de #676).
+ *
+ * Gate de onboarding (App.tsx:200-204) lê `@iostoandroid/onboarding_done`.
+ * Sem `.catch`, se `getItem` rejeitar `showOnboarding` fica `null` para sempre
+ * e `AppContent` devolve `null` em App.tsx:296 — ecrã em branco permanente que
+ * bloqueia o launcher E a App Library.
+ *
+ * Red step (before fix): getItem a rejeitar → showOnboarding fica null →
+ *   TAB_NAVIGATOR_MOUNTED nunca aparece (o teste "reject" falha).
+ * Green step (after fix): .catch(() => setShowOnboarding(false)) → launcher
+ *   monta mesmo com erro de leitura.
+ */
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react-native';
+
+// ── AsyncStorage: getItem controlável por teste ──
+// Prefixo `mock` (case-insensitive) permitido dentro de jest.mock factory.
+const mockGetItem = jest.fn();
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    getItem: (...args: unknown[]) => mockGetItem(...args),
+    setItem: jest.fn(() => Promise.resolve()),
+    removeItem: jest.fn(() => Promise.resolve()),
+  },
+}));
+
+// Fontes carregam logo (gate em App.tsx:295). Sem isto, App devolve null no
+// gate de fontes e o teste não exercita o gate de onboarding.
+jest.mock('expo-font', () => ({
+  useFonts: () => [true, null],
+}));
+
+// expo-notifications: o OnboardingScreen importa-o no topo; sem mock dá
+// "Cannot find native module 'ExpoNotificationChannelManager'".
+jest.mock('expo-notifications', () => ({
+  __esModule: true,
+  getNotificationChannelsAsync: jest.fn(() => Promise.resolve([])),
+  setNotificationChannelAsync: jest.fn(() => Promise.resolve()),
+  scheduleNotificationAsync: jest.fn(() => Promise.resolve('id')),
+  cancelScheduledNotificationAsync: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock('expo-linear-gradient', () => ({
+  LinearGradient: ({ children }: { children: React.ReactNode }) => children as React.ReactElement,
+}));
+
+// Re-mock do módulo nativo — mock COMPLETO porque a AppsStore (montada por
+// AppContent) chama getInstalledApps / getIconCacheSizeBytes / etc.
+jest.mock('../../modules/launcher-module/src', () => ({
+  __esModule: true,
+  addNotificationListener: jest.fn(() => jest.fn()),
+  onBridgeError: jest.fn(() => jest.fn()),
+  default: {
+    getInstalledApps: jest.fn(() => Promise.resolve([])),
+    launchApp: jest.fn(() => Promise.resolve(true)),
+    getAppIcon: jest.fn(() => Promise.resolve('')),
+    isDefaultLauncher: jest.fn(() => Promise.resolve(false)),
+    getProcessStartAgeMs: jest.fn(() => Promise.resolve(-1)),
+    openLauncherSettings: jest.fn(() => Promise.resolve(true)),
+    getWifiInfo: jest.fn(() => Promise.resolve({ enabled: true, ssid: 'TestWiFi', rssi: -50, ip: '192.168.1.100' })),
+    setWifiEnabled: jest.fn(() => Promise.resolve(true)),
+    getWifiNetworks: jest.fn(() => Promise.resolve([])),
+    getBluetoothInfo: jest.fn(() => Promise.resolve({ enabled: false, name: '', address: '', pairedDevices: [] })),
+    setBluetoothEnabled: jest.fn(() => Promise.resolve(true)),
+    getStorageInfo: jest.fn(() => Promise.resolve({ totalGB: '128.0', usedGB: '64.0', freeGB: '64.0', usedPercentage: 50 })),
+    getRecentMessages: jest.fn(() => Promise.resolve([])),
+    getVolume: jest.fn(() => Promise.resolve(0.5)),
+    setVolume: jest.fn(() => Promise.resolve(true)),
+    openSystemSettings: jest.fn(() => Promise.resolve(true)),
+    getNetworkInfo: jest.fn(() => Promise.resolve({ isConnected: true, isWifi: true, isCellular: false, isVpn: false })),
+    setFlashlight: jest.fn(() => Promise.resolve(true)),
+    isFlashlightOn: jest.fn(() => Promise.resolve(false)),
+    getCallLog: jest.fn(() => Promise.resolve([])),
+    makeCall: jest.fn(() => Promise.resolve(true)),
+    getNotifications: jest.fn(() => Promise.resolve([])),
+    clearNotification: jest.fn(() => Promise.resolve(true)),
+    clearAllNotifications: jest.fn(() => Promise.resolve(true)),
+    isNotificationAccessGranted: jest.fn(() => Promise.resolve(false)),
+    openNotificationAccessSettings: jest.fn(() => Promise.resolve(true)),
+    sendSms: jest.fn(() => Promise.resolve(true)),
+    requestAllPermissions: jest.fn(() => Promise.resolve(true)),
+    checkPermissions: jest.fn(() => Promise.resolve({})),
+    getCalendarEvents: jest.fn(() => Promise.resolve([])),
+    getNowPlaying: jest.fn(() => Promise.resolve({ title: '', artist: '', album: '', isPlaying: false, packageName: '' })),
+    uninstallApp: jest.fn(() => Promise.resolve(true)),
+    getIconCacheSizeBytes: jest.fn(() => Promise.resolve(0)),
+  },
+}));
+
+// TabNavigator stub — marcador para saber que o conteúdo principal montou.
+jest.mock('../navigation/TabNavigator', () => ({
+  TabNavigator: () => {
+    const R = jest.requireActual<typeof import('react')>('react');
+    const { Text } = jest.requireActual<typeof import('react-native')>('react-native');
+    return R.createElement(Text, null, 'TAB_NAVIGATOR_MOUNTED');
+  },
+}));
+
+// LockScreen auto-desbloqueia para o conteúdo (TabNavigator) ser alcançável.
+jest.mock('../screens/LockScreen', () => {
+  const R = jest.requireActual<typeof import('react')>('react');
+  return {
+    LockScreen: ({ onUnlock }: { onUnlock: () => void }) => {
+      R.useEffect(() => { onUnlock(); }, [onUnlock]);
+      return null;
+    },
+  };
+});
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: jest.fn(), goBack: jest.fn(), canGoBack: jest.fn(() => false), getParent: () => ({ navigate: jest.fn() }) }),
+  useRoute: () => ({ params: {} }),
+  NavigationContainer: ({ children }: { children: React.ReactNode }) => children as React.ReactElement,
+  useNavigationContainerRef: () => ({ current: null, navigate: jest.fn(), isReady: () => true }),
+}));
+
+jest.mock('../components/GestureHost', () => ({
+  GestureHost: ({ children }: { children: React.ReactNode }) => children as React.ReactElement,
+}));
+jest.mock('../components/HomeIndicator', () => ({ HomeIndicator: () => null }));
+jest.mock('../components/QuickSwitchHomeBar', () => ({ QuickSwitchHomeBar: () => null }));
+jest.mock('../store/AssistiveTouchStore', () => ({
+  AssistiveTouchProvider: ({ children }: { children: React.ReactNode }) => children as React.ReactElement,
+  useAssistiveTouch: () => ({ reachabilityActive: false, setReachabilityActive: jest.fn() }),
+}));
+jest.mock('../components/AssistiveTouch', () => ({ AssistiveTouch: () => null }));
+
+// @expo/vector-icons (Ionicons) usado pelo OnboardingScreen — sob o wrapper do
+// App (GestureHandlerRootView etc.) o Icon nativo rebenta e desmonta a árvore.
+// Stub simples para podermos exercitar o path do OnboardingScreen via App.
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: ({ name, ...props }: { name: string;[k: string]: unknown }) => {
+    const R = jest.requireActual<typeof import('react')>('react');
+    const { Text } = jest.requireActual<typeof import('react-native')>('react-native');
+    return R.createElement(Text, props, String(name));
+  },
+}));
+
+// SettingsProvider / ThemeProvider têm gateFirstRender=default(true): retornam
+// null até lerem o AsyncStorage, e ao resolverem desmontam/remontam a árvore —
+// o que faz o OnboardingScreen (montado quando showOnboarding=true) rebentar
+// com "node on an unmounted component". Desligamos o gate (igual ao test-utils)
+// para podermos exercitar o path do OnboardingScreen via App.
+jest.mock('../store/SettingsStore', () => {
+  const R = jest.requireActual<typeof import('react')>('react');
+  const Actual = jest.requireActual<typeof import('../store/SettingsStore')>('../store/SettingsStore');
+  return {
+    ...Actual,
+    SettingsProvider: (props: { children: React.ReactNode }) =>
+      R.createElement(Actual.SettingsProvider, { ...props, gateFirstRender: false }),
+  };
+});
+jest.mock('../theme/ThemeContext', () => {
+  const R = jest.requireActual<typeof import('react')>('react');
+  const Actual = jest.requireActual<typeof import('../theme/ThemeContext')>('../theme/ThemeContext');
+  return {
+    ...Actual,
+    ThemeProvider: (props: { children: React.ReactNode }) =>
+      R.createElement(Actual.ThemeProvider, { ...props, gateFirstRender: false }),
+  };
+});
+
+// ── Import App after all jest.mock calls ──
+import App from '../../App';
+
+describe('App — onboarding gate (#714)', () => {
+  beforeEach(() => {
+    mockGetItem.mockReset();
+    // Default: qualquer chave (SettingsStore, loadAlarms, etc.) resolve null;
+    // só a chave de onboarding é controlada por cada teste abaixo.
+    // Sem isto, o mock retornaria `undefined` e loadAlarms/.filter rebentaria.
+    mockGetItem.mockImplementation((key: string) =>
+      key === '@iostoandroid/onboarding_done'
+        ? Promise.resolve('true')
+        : Promise.resolve(null),
+    );
+  });
+
+  it('monta o launcher (não ecrã em branco) quando getItem rejeita', async () => {
+    mockGetItem.mockImplementation((key: string) =>
+      key === '@iostoandroid/onboarding_done'
+        ? Promise.reject(new Error('AsyncStorage corrompido'))
+        : Promise.resolve(null),
+    );
+    render(<App />);
+
+    await waitFor(() => screen.getByText('TAB_NAVIGATOR_MOUNTED'), { timeout: 4000 });
+  });
+
+  it('mostra o OnboardingScreen (first-run) quando getItem resolve null', async () => {
+    mockGetItem.mockImplementation((key: string) =>
+      key === '@iostoandroid/onboarding_done'
+        ? Promise.resolve(null)
+        : Promise.resolve(null),
+    );
+    render(<App />);
+
+    await waitFor(() => screen.getByText(/Welcome to/i), { timeout: 4000 });
+  });
+
+  it('monta o launcher quando getItem resolve "true" (returning user)', async () => {
+    mockGetItem.mockImplementation((key: string) =>
+      key === '@iostoandroid/onboarding_done'
+        ? Promise.resolve('true')
+        : Promise.resolve(null),
+    );
+    render(<App />);
+
+    await waitFor(() => screen.getByText('TAB_NAVIGATOR_MOUNTED'), { timeout: 4000 });
+  });
+
+  it('fronteira: valor não-"true" (ex.: "false") mostra o OnboardingScreen', async () => {
+    mockGetItem.mockImplementation((key: string) =>
+      key === '@iostoandroid/onboarding_done'
+        ? Promise.resolve('false')
+        : Promise.resolve(null),
+    );
+    render(<App />);
+
+    await waitFor(() => screen.getByText(/Welcome to/i), { timeout: 4000 });
+  });
+});


### PR DESCRIPTION
## Resumo

App.tsx: adiciona .catch à leitura de '@iostoandroid/onboarding_done' para não ficar ecrã em branco

## Causa raiz

A gate de onboarding em `App.tsx:200-204` lê `AsyncStorage.getItem('@iostoandroid/onboarding_done')` e só trata o caso de sucesso (`.then`). Se `getItem` rejeitar — BD corrompido, erro de permissão, escrita concorrente no arranque, todos cenários reais em RN — a promise fica sem handler. `setShowOnboarding` nunca é chamado, logo `showOnboarding` fica `null` para sempre. O `AppContent` devolve `null` em `App.tsx:296` (`if (showOnboarding === null) return null;`) — ecrã em branco **permanente** que bloqueia o launcher E a App Library (ambos montam a partir daí).

O issue estava correto quanto ao mecanismo e ao fix. A linha exata hoje é `App.tsx:200-204` (o issue citava 200-204 também), conferido por leitura direta do ficheiro. Não havia `.catch`.

## O que mudou

- `App.tsx` — o `useEffect` da gate de onboarding passou a encadear um `.catch(() => setShowOnboarding(false))`. Em caso de erro de leitura, mostra-se o launcher (em vez de ecrã em branco). First-run (`null`) e returning user (`'true'`) continuam a ser tratados pelo `.then` exatamente como antes; o `.catch` só dispara no reject. Nenhuma outra linha de `App.tsx` foi tocada.

## Porque assim

O issue sugeria `setShowOnboarding(false)` no erro e foi o que implementei: é o comportamento menos destrutivo — em falha de leitura é preferível mostrar o launcher funcional do que prender o utilizador num ecrã em branco sem saída. Alternativas descartadas:
- `setShowOnboarding(true)` (mostrar onboarding no erro): pior UX e obriga o utilizador a repetir o fluxo de first-run só porque a leitura falhou.
- `try/catch` vazio / `?? 0` / `as any`: esconderiam o erro sem resolução — exatamente o que o pipeline proíbe.

O `.catch` não mascara valores válidos: `null` e `'true'`/`'false'` continuam a fluir pelo `.then`. Só o reject é desviado.

## Critérios de aceitação

- [x] `getItem` a rejeitar → launcher monta (não fica ecrã em branco). Teste `monta o launcher (não ecrã em branco) quando getItem rejeita` → `TAB_NAVIGATOR_MOUNTED` aparece.
- [x] `getItem` a resolver `null` → OnboardingScreen mostrado (first-run inalterado). Teste `mostra o OnboardingScreen (first-run) quando getItem resolve null` → `Welcome to` aparece.
- [x] `getItem` a resolver `'true'` → launcher mostrado (persistência inalterada). Teste `monta o launcher quando getItem resolve "true" (returning user)` → `TAB_NAVIGATOR_MOUNTED` aparece.
- [x] Nenhuma regressão nas suites existentes. Suite completa: 25 falhas / 1782 testes, exatamente o baseline documentado (25/182). `comm -23 <agora> <baseline>` devolve vazio → zero falhas novas fora do baseline.
- [x] O que NÃO devia mudar: first-run e returning user continuam idênticos (cobertos pelos dois testes acima que passavam JÁ ANTES do fix, confirmando ausência de regressão no caminho feliz); o launcher continua a montar em `'true'`; o onboarding continua a montar em `null`/`'false'`.

## Testes

- **Passo vermelho (fix revertido via `git stash push -- App.tsx`):** output real do jest para o caso reject —

  ```
  FAIL Android src/__tests__/App.onboardingGate.test.tsx
    App — onboarding gate (#714)
      ✕ monta o launcher (não ecrã em branco) quando getItem rejeita (4258 ms)
        Unable to find an element with text: TAB_NAVIGATOR_MOUNTED
  
        at waitFor (src/__tests__/App.onboardingGate.test.tsx:142:18)
  
  Tests:       1 failed, 3 passed, 4 total
  ```

  O teste falha à linha `expect(screen.getByText('TAB_NAVIGATOR_MOUNTED'))` porque `showOnboarding` fica `null` e `AppContent` retorna `null` — ecrã em branco. Os outros 3 casos (`null`, `'true'`, `'false'`) passavam já antes do fix (não dependem do `.catch`).

- **Passo verde (com fix):** `Tests: 4 passed, 4 total`.

- **Casos cobertos além do caminho feliz:**
  - *Fronteira de parsing:* `getItem` resolve `'false'` (valor não-`'true'`) → OnboardingScreen monta. Confirma que só `'true'` curto-circuita; qualquer outro valor (incluindo string inválida) vai para onboarding, não para launcher. Distinto do caso `null` (ausente) — falham por razões conceptuais diferentes (um ausente, um presente-mas-não-true).
  - *Inverso do fix:* o próprio caso reject (com o fix) confirma que o launcher APARECE quando devia, e os casos `null`/`'true'`/`'false'` confirmam que o onboarding/launcher continuam corretos quando a leitura NÃO falha.
  - *Assíncrono:* a leitura é assíncrona; o teste espera pela promise resolver/errar antes de afirmar (via `waitFor` no marcador `TAB_NAVIGATOR_MOUNTED` ou `Welcome to`).

- **Sanity-check:** `git stash push -- App.tsx` (tira o fix) → `npx jest src/__tests__/App.onboardingGate.test.tsx` → 1 failed (`Unable to find an element with text: TAB_NAVIGATOR_MOUNTED`), 3 passed. `git stash pop` (restaura fix) → 4 passed. O teste está ligado ao comportamento real de produção.

- **Resultado das verificações obrigatórias:**
  - `npm run lint`: **0 erros** (7 warnings pré-existentes em ficheiros que não toquei — SiriScreen, SettingsStore, etc. — fora de scope).
  - `npx tsc --noEmit`: limpo (exit 0).
  - `npm test -- --maxWorkers=2`: **25 failed, 1757 passed, 185 suites** (6 failed). Igual ao baseline (25/6). Zero regressões novas.

## Notas

- O ficheiro de teste referenciado no issue (`src/__tests__/App.onboardingGate.test.tsx`) NÃO existia no worktree (nem em `origin/main`); criei-o do zero seguindo o padrão dos testes vizinhos (`App.fonts.test.tsx`, `App.bridgeError.test.tsx`).
- Para montar o `OnboardingScreen` via `App` nos testes de `null`/`'false'`, foi necessário (a) desligar `gateFirstRender` em `SettingsProvider`/`ThemeProvider` (igual ao `src/test-utils.tsx`, senão a árvore desmonta ao hidratar) e (b) stubar `@expo/vector-icons` (Ionicons) e `expo-notifications`/`expo-linear-gradient`, que rebentam sob o wrapper do `App` em ambiente de teste. Estes stubs são apenas de teste e não afetam código de produção.

## Testes

4 passaram, 0 falharam, 1 suite (ficheiro de teste novo); suite completa: 25 falharam (baseline), 1757 passaram, 185 suites — zero regressões novas

## Linked Issue

Fixes #714