### PR TITLE
fix/674: clampWallpaperIndex preserva o sentinel custom (6) e cobre store + render com testes de fronteira (#674)

### DIFF
--- a/src/screens/LauncherHomeScreen.tsx
+++ b/src/screens/LauncherHomeScreen.tsx
@@ -51,7 +51,7 @@ import {
 } from '../components';
 import type { BannerNotification } from '../components';
 import type { RootStackParamList } from '../navigation/types';
-import { WALLPAPERS, darkenHex } from '../utils/wallpapers';
+import { WALLPAPERS, darkenHex, clampWallpaperIndex } from '../utils/wallpapers';
 import { withAutoLockSuppressed } from '../utils/permissions';
 import { ControlCenterOverlay } from '../components/ControlCenterOverlay';
 import { NotificationCenterOverlay } from '../components/NotificationCenterOverlay';
@@ -1286,8 +1286,11 @@ export function LauncherHomeScreen() {
   }
 
   // Wallpaper gradient
-  const wallpaperColor =
-    WALLPAPERS[Math.min(settings.wallpaperIndex, WALLPAPERS.length - 1)] as string;
+  // clampWallpaperIndex saneia settings.wallpaperIndex (lido de AsyncStorage,
+  // fonte não confiável — #674): um blob corrompido com índice não-numérico
+  // daria WALLPAPERS[NaN] === undefined e faria darkenHex rebentar no render.
+  const wallpaperIndex = clampWallpaperIndex(settings.wallpaperIndex);
+  const wallpaperColor = WALLPAPERS[wallpaperIndex] as string;
   const wallpaperDark = darkenHex(wallpaperColor, 0.28);
 
   const WallpaperContent =

--- a/src/screens/LauncherHomeScreen.tsx
+++ b/src/screens/LauncherHomeScreen.tsx
@@ -51,7 +51,12 @@ import {
 } from '../components';
 import type { BannerNotification } from '../components';
 import type { RootStackParamList } from '../navigation/types';
-import { WALLPAPERS, darkenHex, clampWallpaperIndex } from '../utils/wallpapers';
+import {
+  darkenHex,
+  clampWallpaperIndex,
+  wallpaperColorFor,
+  CUSTOM_WALLPAPER_INDEX,
+} from '../utils/wallpapers';
 import { withAutoLockSuppressed } from '../utils/permissions';
 import { ControlCenterOverlay } from '../components/ControlCenterOverlay';
 import { NotificationCenterOverlay } from '../components/NotificationCenterOverlay';
@@ -700,7 +705,7 @@ export function NonAndroidFallback() {
   const { settings } = useSettings();
   const device = useDevice();
 
-  const wallpaper = WALLPAPERS[Math.min(settings.wallpaperIndex, WALLPAPERS.length - 1)] as string;
+  const wallpaper = wallpaperColorFor(settings.wallpaperIndex);
   const wallpaperDark = darkenHex(wallpaper, 0.25);
 
   return (
@@ -1315,12 +1320,13 @@ export function LauncherHomeScreen() {
   // fonte não confiável — #674): um blob corrompido com índice não-numérico
   // daria WALLPAPERS[NaN] === undefined e faria darkenHex rebentar no render.
   const wallpaperIndex = clampWallpaperIndex(settings.wallpaperIndex);
-  const wallpaperColor = WALLPAPERS[wallpaperIndex] as string;
+  const wallpaperColor = wallpaperColorFor(wallpaperIndex);
   const wallpaperDark = darkenHex(wallpaperColor, 0.28);
 
   const WallpaperContent =
-    settings.wallpaperIndex === 6 && customWallpaperUri ? (
+    wallpaperIndex === CUSTOM_WALLPAPER_INDEX && customWallpaperUri ? (
       <ImageBackground
+        testID="wallpaper-custom-image"
         source={{ uri: customWallpaperUri }}
         style={StyleSheet.absoluteFillObject}
         resizeMode="cover"

--- a/src/screens/__tests__/LauncherHomeScreen.wallpaperIndex.test.tsx
+++ b/src/screens/__tests__/LauncherHomeScreen.wallpaperIndex.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, waitFor } from '../../test-utils';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as AppsStore from '../../store/AppsStore';
 import * as SettingsStore from '../../store/SettingsStore';
 import { LauncherHomeScreen } from '../LauncherHomeScreen';
@@ -82,5 +83,49 @@ describe('LauncherHomeScreen — wallpaperIndex inválido (#674)', () => {
   it('darkenHex não rebenta com input inválido (undef/NaN)', () => {
     expect(() => darkenHex(undefined as unknown as string, 0.28)).not.toThrow();
     expect(() => darkenHex(NaN as unknown as string, 0.28)).not.toThrow();
+  });
+});
+
+// Retrabalho #674: o saneamento não pode destruir o wallpaper personalizado.
+// wallpaperIndex === 6 é o sentinel de custom (WallpaperScreen grava 6), por
+// isso o clamp tem de o preservar e a home tem de continuar a pintar a imagem.
+describe('LauncherHomeScreen — wallpaper personalizado (índice 6)', () => {
+  beforeEach(() => {
+    mockApps();
+    (AsyncStorage.getItem as jest.Mock).mockImplementation((key: string) =>
+      Promise.resolve(key === '@iostoandroid/custom_wallpaper' ? 'file:///custom.jpg' : null),
+    );
+  });
+  afterEach(() => { jest.restoreAllMocks(); });
+
+  it('renderiza o ImageBackground custom quando wallpaperIndex === 6', async () => {
+    withSettings({ wallpaperIndex: 6 });
+    const utils = render(<LauncherHomeScreen />);
+    await waitFor(() => {
+      expect(utils.getByTestId('wallpaper-custom-image')).toBeTruthy();
+    }, { timeout: 3000 });
+  });
+
+  it('mantém o custom mesmo com o índice em string "6" (blob legado)', async () => {
+    withSettings({ wallpaperIndex: '6' as unknown as number });
+    const utils = render(<LauncherHomeScreen />);
+    await waitFor(() => {
+      expect(utils.getByTestId('wallpaper-custom-image')).toBeTruthy();
+    }, { timeout: 3000 });
+  });
+
+  it('o inverso do fix: índice de cor (2) NÃO mostra a imagem custom', async () => {
+    withSettings({ wallpaperIndex: 2 });
+    const utils = render(<LauncherHomeScreen />);
+    await waitFor(() => expect(utils.getByTestId('wallpaper-layer')).toBeTruthy(), { timeout: 3000 });
+    expect(utils.queryByTestId('wallpaper-custom-image')).toBeNull();
+  });
+
+  it('índice 6 sem imagem guardada cai no gradiente, sem rebentar', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+    withSettings({ wallpaperIndex: 6 });
+    const utils = render(<LauncherHomeScreen />);
+    await waitFor(() => expect(utils.getByTestId('wallpaper-layer')).toBeTruthy(), { timeout: 3000 });
+    expect(utils.queryByTestId('wallpaper-custom-image')).toBeNull();
   });
 });

--- a/src/screens/__tests__/LauncherHomeScreen.wallpaperIndex.test.tsx
+++ b/src/screens/__tests__/LauncherHomeScreen.wallpaperIndex.test.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { render, waitFor } from '../../test-utils';
+import * as AppsStore from '../../store/AppsStore';
+import * as SettingsStore from '../../store/SettingsStore';
+import { LauncherHomeScreen } from '../LauncherHomeScreen';
+import { darkenHex } from '../../utils/wallpapers';
+
+// issue #674: home renderiza em branco (RGB 250,250,250, só LogBox) em runtime
+// Android. Causa raiz: `settings.wallpaperIndex` é lido do AsyncStorage (blob
+// JSON não confiável de versões antigas) e NÃO é saneado no SettingsStore —
+// ao contrário de `iconShape`/`whitePointLevel`/`focusPageVisibility` (que são
+// normalizados na leitura, SettingsStore.tsx:414-424). Se o blob tiver um
+// `wallpaperIndex` não-numérico/inválido, então:
+//   WALLPAPERS[Math.min(settings.wallpaperIndex, WALLPAPERS.length-1)]
+//     → WALLPAPERS[NaN] → undefined
+//   darkenHex(undefined) → undefined.replace('#','') → TypeError DURANTE O RENDER.
+// O throw é apanhado pelo ErrorBoundary; em build de preview não há redbox,
+// dá ecrã branco. É específico da home porque o gradiente do wallpaper só é
+// calculado aqui.
+//
+// RED: com wallpaperIndex inválido a home NÃO deve rebentar — tem de renderizar
+// o conteúdo (wallpaper-layer + Search) como faria com um índice válido.
+// Forçamos o valor exato que o SettingsStore (sem saneamento) produziria a
+// partir de um blob corrompido, espiando useSettings.
+function withSettings(overrides: Partial<SettingsStore.SettingsState>) {
+  jest.spyOn(SettingsStore, 'useSettings').mockReturnValue({
+    settings: { ...SettingsStore.DEFAULT_SETTINGS, ...overrides },
+    update: jest.fn(),
+    updateMany: jest.fn(),
+    reset: jest.fn(),
+    syncFromDevice: jest.fn(() => Promise.resolve()),
+    isReady: true,
+    activeFocusMode: null,
+    setFocusMode: jest.fn(),
+  } as unknown as ReturnType<typeof SettingsStore.useSettings>);
+}
+
+function mockApps(overrides: Record<string, unknown> = {}) {
+  jest.spyOn(AppsStore, 'useApps').mockReturnValue({
+    apps: [], homeApps: [], dockApps: [], nonDockApps: [], recentPackages: [], recentApps: [],
+    isLoading: false, refreshApps: jest.fn(() => Promise.resolve()), launchApp: jest.fn(() => Promise.resolve(true)),
+    addToHome: jest.fn(), removeFromHome: jest.fn(), addToDock: jest.fn(), removeFromDock: jest.fn(),
+    removeFromRecents: jest.fn(), clearRecents: jest.fn(), isDefaultLauncher: true,
+    openLauncherSettings: jest.fn(() => Promise.resolve()), hiddenApps: [], visibleApps: [],
+    hideApp: jest.fn(), unhideApp: jest.fn(), iconCacheSizeBytes: 0, isRebuildingIconCache: false,
+    iconCacheRebuildProgress: null, rebuildIconCache: jest.fn(() => Promise.resolve()),
+    ...overrides,
+  } as ReturnType<typeof AppsStore.useApps>);
+}
+
+describe('LauncherHomeScreen — wallpaperIndex inválido (#674)', () => {
+  beforeEach(() => { mockApps(); });
+  afterEach(() => { jest.restoreAllMocks(); });
+
+  it('renderiza conteúdo quando wallpaperIndex é string não-numérica', async () => {
+    withSettings({ wallpaperIndex: 'not-a-number' as unknown as number });
+    const utils = render(<LauncherHomeScreen />);
+    await waitFor(() => {
+      expect(utils.getByTestId('wallpaper-layer')).toBeTruthy();
+      expect(utils.getByText('Search')).toBeTruthy();
+    }, { timeout: 3000 });
+  });
+
+  it('renderiza conteúdo quando wallpaperIndex é NaN', async () => {
+    withSettings({ wallpaperIndex: NaN });
+    const utils = render(<LauncherHomeScreen />);
+    await waitFor(() => {
+      expect(utils.getByTestId('wallpaper-layer')).toBeTruthy();
+      expect(utils.getByText('Search')).toBeTruthy();
+    }, { timeout: 3000 });
+  });
+
+  it('renderiza conteúdo com wallpaperIndex numérico fora de gama (clampa)', async () => {
+    withSettings({ wallpaperIndex: 999 });
+    const utils = render(<LauncherHomeScreen />);
+    await waitFor(() => {
+      expect(utils.getByTestId('wallpaper-layer')).toBeTruthy();
+      expect(utils.getByText('Search')).toBeTruthy();
+    }, { timeout: 3000 });
+  });
+
+  it('darkenHex não rebenta com input inválido (undef/NaN)', () => {
+    expect(() => darkenHex(undefined as unknown as string, 0.28)).not.toThrow();
+    expect(() => darkenHex(NaN as unknown as string, 0.28)).not.toThrow();
+  });
+});

--- a/src/store/SettingsStore.tsx
+++ b/src/store/SettingsStore.tsx
@@ -18,6 +18,7 @@ import {
   type RequirePasscodeAfter,
   DEFAULT_REQUIRE_PASSCODE_AFTER,
 } from '../utils/passcodePolicy';
+import { clampWallpaperIndex } from '../utils/wallpapers';
 import { clampWhitePointLevel } from '../utils/whitePoint';
 import {
   normalizeFocusPageVisibility,
@@ -422,6 +423,12 @@ export function SettingsProvider({
             // valores não-array) faria o filtro esconder páginas ao acaso ou
             // rebentar no `.includes`, por isso normaliza-se na leitura.
             focusPageVisibility: normalizeFocusPageVisibility(parsed?.focusPageVisibility),
+            // wallpaperIndex (#674) indexa WALLPAPERS no render da home; um
+            // valor corrompido (string, NaN, fora de gama) daria
+            // WALLPAPERS[NaN] === undefined e faria darkenHex rebentar no
+            // render → ecrã branco. Saneia-se na leitura, à semelhança dos
+            // campos acima.
+            wallpaperIndex: clampWallpaperIndex(parsed?.wallpaperIndex),
           }));
         } catch { /* ignore */ }
       }

--- a/src/store/__tests__/SettingsStore.wallpaperIndex.test.tsx
+++ b/src/store/__tests__/SettingsStore.wallpaperIndex.test.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { Text } from 'react-native';
+import { render, waitFor } from '@testing-library/react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { SettingsProvider, useSettings } from '../SettingsStore';
+import { clampWallpaperIndex, WALLPAPERS } from '../../utils/wallpapers';
+
+// issue #674 (retrabalho): o saneamento de `wallpaperIndex` na hidratação do
+// AsyncStorage tem de aceitar 6 como valor VÁLIDO — é o sentinel de wallpaper
+// personalizado (WallpaperScreen.tsx:112/127/195 gravam 6; a home só mostra o
+// ImageBackground custom em LauncherHomeScreen.tsx:1322 se o índice for === 6).
+// Clampá-lo a WALLPAPERS.length-1 = 5 apagava silenciosamente a escolha do
+// utilizador no relançamento seguinte.
+
+/** Expõe o wallpaperIndex hidratado como texto, para assertar no que pintou. */
+function Probe() {
+  const { settings, isReady } = useSettings();
+  return <Text>{`ready=${isReady} idx=${String(settings.wallpaperIndex)}`}</Text>;
+}
+
+function renderWithStored(blob: unknown) {
+  (AsyncStorage.getItem as jest.Mock).mockImplementation((key: string) =>
+    Promise.resolve(key === '@iostoandroid/settings' ? JSON.stringify(blob) : null),
+  );
+  return render(
+    <SettingsProvider gateFirstRender={false}>
+      <Probe />
+    </SettingsProvider>,
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+  (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
+});
+
+describe('clampWallpaperIndex (#674)', () => {
+  it('preserva 6 (sentinel de wallpaper personalizado)', () => {
+    expect(clampWallpaperIndex(6)).toBe(6);
+  });
+
+  it('preserva todos os índices de cor válidos e o limite ±1', () => {
+    WALLPAPERS.forEach((_, i) => expect(clampWallpaperIndex(i)).toBe(i));
+    expect(clampWallpaperIndex(5)).toBe(5);
+    expect(clampWallpaperIndex(7)).toBe(6);
+    expect(clampWallpaperIndex(Number.MAX_SAFE_INTEGER)).toBe(6);
+  });
+
+  it('saneia não-finito, negativo, vazio e não-numérico para 0', () => {
+    expect(clampWallpaperIndex(NaN)).toBe(0);
+    expect(clampWallpaperIndex(-1)).toBe(0);
+    expect(clampWallpaperIndex(-999)).toBe(0);
+    expect(clampWallpaperIndex(Infinity)).toBe(6);
+    expect(clampWallpaperIndex(-Infinity)).toBe(0);
+    expect(clampWallpaperIndex('não-um-número')).toBe(0);
+    expect(clampWallpaperIndex(undefined)).toBe(0);
+    expect(clampWallpaperIndex(null)).toBe(0);
+    expect(clampWallpaperIndex({})).toBe(0);
+    expect(clampWallpaperIndex([])).toBe(0);
+  });
+
+  it('aceita numérico em string e trunca fracções', () => {
+    expect(clampWallpaperIndex('3')).toBe(3);
+    expect(clampWallpaperIndex('6')).toBe(6);
+    expect(clampWallpaperIndex(2.9)).toBe(2);
+    expect(clampWallpaperIndex(6.9)).toBe(6);
+  });
+});
+
+describe('SettingsProvider — hidratação de wallpaperIndex (#674)', () => {
+  it('mantém wallpaperIndex=6 (custom) na hidratação, sem clampar para 5', async () => {
+    const utils = renderWithStored({ wallpaperIndex: 6 });
+    await waitFor(() => expect(utils.getByText('ready=true idx=6')).toBeTruthy());
+  });
+
+  it('saneia wallpaperIndex string não-numérica para 0', async () => {
+    const utils = renderWithStored({ wallpaperIndex: 'roxo' });
+    await waitFor(() => expect(utils.getByText('ready=true idx=0')).toBeTruthy());
+  });
+
+  it('saneia wallpaperIndex negativo para 0', async () => {
+    const utils = renderWithStored({ wallpaperIndex: -3 });
+    await waitFor(() => expect(utils.getByText('ready=true idx=0')).toBeTruthy());
+  });
+
+  it('clampa wallpaperIndex acima do domínio para 6', async () => {
+    const utils = renderWithStored({ wallpaperIndex: 999 });
+    await waitFor(() => expect(utils.getByText('ready=true idx=6')).toBeTruthy());
+  });
+
+  it('usa 0 quando o campo está totalmente ausente do blob', async () => {
+    const utils = renderWithStored({ volume: 0.4 });
+    await waitFor(() => expect(utils.getByText('ready=true idx=0')).toBeTruthy());
+  });
+});

--- a/src/utils/wallpapers.ts
+++ b/src/utils/wallpapers.ts
@@ -14,11 +14,31 @@ export const NAMED_WALLPAPERS: readonly NamedWallpaper[] = [
 
 export const WALLPAPERS: readonly string[] = NAMED_WALLPAPERS.map((w) => w.color);
 
+/**
+ * Normaliza um índice de wallpaper lido de fonte não confiável (AsyncStorage,
+ * settings legados de versões antigas). Devolve 0 para não-inteiro / negativo e
+ * clampa ao intervalo válido [0, WALLPAPERS.length - 1].
+ *
+ * Sem isto, um `wallpaperIndex` corrompido (string, NaN, fora de gama) passaria
+ * a `WALLPAPERS[Math.min(index, len-1)] === undefined` e `darkenHex(undefined)`
+ * rebentava DURANTE O RENDER da home (#674) — ecrã branco em runtime.
+ */
+export function clampWallpaperIndex(index: unknown): number {
+  const n = typeof index === 'number' ? index : Number(index);
+  if (!Number.isFinite(n) || n < 0) return 0;
+  return Math.min(Math.floor(n), WALLPAPERS.length - 1);
+}
+
 /** Darken a hex colour by `amount` (0–1) to build a gradient end stop. */
 export function darkenHex(hex: string, amount: number): string {
-  const num = parseInt(hex.replace('#', ''), 16);
-  const r = Math.max(0, (num >> 16) - Math.round(255 * amount));
-  const g = Math.max(0, ((num >> 8) & 0xff) - Math.round(255 * amount));
-  const b = Math.max(0, (num & 0xff) - Math.round(255 * amount));
+  // Defesa em profundidade: nunca rebenta com input inválido (issue #674).
+  // Um `wallpaperColor` undefined/NaN não deve derrubar o render da home.
+  const safe = typeof hex === 'string' && hex.length > 0 ? hex : WALLPAPERS[0];
+  const clean = safe.startsWith('#') ? safe.slice(1) : safe;
+  const num = parseInt(clean, 16);
+  const valid = Number.isFinite(num) ? num : 0x667eea; // fallback Lavender
+  const r = Math.max(0, (valid >> 16) - Math.round(255 * amount));
+  const g = Math.max(0, ((valid >> 8) & 0xff) - Math.round(255 * amount));
+  const b = Math.max(0, (valid & 0xff) - Math.round(255 * amount));
   return `#${r.toString(16).padStart(2, '0')}${g.toString(16).padStart(2, '0')}${b.toString(16).padStart(2, '0')}`;
 }

--- a/src/utils/wallpapers.ts
+++ b/src/utils/wallpapers.ts
@@ -15,9 +15,19 @@ export const NAMED_WALLPAPERS: readonly NamedWallpaper[] = [
 export const WALLPAPERS: readonly string[] = NAMED_WALLPAPERS.map((w) => w.color);
 
 /**
+ * Índice sentinel de wallpaper personalizado (imagem escolhida pelo utilizador).
+ * Não indexa WALLPAPERS: `WallpaperScreen` grava 6 e a home mostra o
+ * ImageBackground guardado em '@iostoandroid/custom_wallpaper'. O domínio válido
+ * de `settings.wallpaperIndex` é portanto [0, 6].
+ */
+export const CUSTOM_WALLPAPER_INDEX = 6;
+
+/**
  * Normaliza um índice de wallpaper lido de fonte não confiável (AsyncStorage,
- * settings legados de versões antigas). Devolve 0 para não-inteiro / negativo e
- * clampa ao intervalo válido [0, WALLPAPERS.length - 1].
+ * settings legados de versões antigas). Devolve 0 para NaN / não-numérico /
+ * negativo e clampa ao domínio válido [0, CUSTOM_WALLPAPER_INDEX] — 6 é
+ * preservado porque é o sentinel de wallpaper personalizado, não um valor fora
+ * de gama.
  *
  * Sem isto, um `wallpaperIndex` corrompido (string, NaN, fora de gama) passaria
  * a `WALLPAPERS[Math.min(index, len-1)] === undefined` e `darkenHex(undefined)`
@@ -25,8 +35,18 @@ export const WALLPAPERS: readonly string[] = NAMED_WALLPAPERS.map((w) => w.color
  */
 export function clampWallpaperIndex(index: unknown): number {
   const n = typeof index === 'number' ? index : Number(index);
-  if (!Number.isFinite(n) || n < 0) return 0;
-  return Math.min(Math.floor(n), WALLPAPERS.length - 1);
+  if (Number.isNaN(n)) return 0;
+  return Math.min(Math.max(Math.floor(n), 0), CUSTOM_WALLPAPER_INDEX);
+}
+
+/**
+ * Cor de gradiente a usar para um `wallpaperIndex` qualquer. O sentinel custom
+ * (6) não tem cor própria — cai na primeira cor, que só é pintada quando não
+ * existe imagem personalizada guardada.
+ */
+export function wallpaperColorFor(index: unknown): string {
+  const i = clampWallpaperIndex(index);
+  return (WALLPAPERS[Math.min(i, WALLPAPERS.length - 1)] ?? WALLPAPERS[0]) as string;
 }
 
 /** Darken a hex colour by `amount` (0–1) to build a gradient end stop. */


### PR DESCRIPTION
## Resumo

fix/674: clampWallpaperIndex preserva o sentinel custom (6) e cobre store + render com testes de fronteira

## Causa raiz

Duas causas, encadeadas.

1. **Original (#674, já no branch):** `settings.wallpaperIndex` é hidratado do blob JSON do AsyncStorage em `src/store/SettingsStore.tsx:439` sem saneamento (ao contrário de `iconShape`, `whitePointLevel`, `focusPageVisibility`, `categoryOverrides`, todos normalizados nas linhas 416-433). Com um valor corrompido (string, NaN), `WALLPAPERS[NaN] === undefined` e `darkenHex(undefined)` fazia `undefined.replace(...)` **durante o render** da home → árvore vazia → ecrã branco. É específico da home porque o gradiente só é calculado ali.

2. **Regressão introduzida pela primeira correcção (o que a review bloqueou):** o `clampWallpaperIndex` clampava a `WALLPAPERS.length - 1 = 5`, mas o domínio real de `wallpaperIndex` é **0..6** — `6` é o *sentinel* de wallpaper personalizado, gravado em `src/screens/settings/WallpaperScreen.tsx:112,127,195` e lido em `src/screens/LauncherHomeScreen.tsx:1327`. O clamp convertia silenciosamente 6 → 5 na hidratação, apagando a imagem escolhida pelo utilizador no relançamento seguinte.

## O que mudou

- **src/utils/wallpapers.ts** — nova constante exportada `CUSTOM_WALLPAPER_INDEX = 6` a documentar o sentinel. `clampWallpaperIndex` passa a clampar ao domínio `[0, 6]` em vez de `[0, WALLPAPERS.length-1]`: `NaN`/não-numérico → 0, negativo e `-Infinity` → 0, `>6` e `Infinity` → 6, fracções truncadas, **6 preservado**. Nova função `wallpaperColorFor(index)` que devolve sempre uma cor de gradiente válida para qualquer índice do domínio (o sentinel 6 não indexa `WALLPAPERS`, cai na primeira cor). `darkenHex` mantém o endurecimento anterior.
- **src/screens/LauncherHomeScreen.tsx** — o render da home usa `wallpaperColorFor(wallpaperIndex)` em vez de indexar `WALLPAPERS` à mão, e o teste do custom passa a ser `wallpaperIndex === CUSTOM_WALLPAPER_INDEX` (índice já saneado) em vez de `settings.wallpaperIndex === 6` (valor bruto) — assim `'6'` de um blob legado também funciona. `NonAndroidFallback` (linha ~705) tinha o mesmo `WALLPAPERS[Math.min(settings.wallpaperIndex, len-1)]` sem saneamento (mesma classe de defeito, apontada no raio de impacto da review anterior) e passa também por `wallpaperColorFor`. `testID="wallpaper-custom-image"` no `ImageBackground` para o custom ser observável em teste.
- **src/store/SettingsStore.tsx** — inalterado nesta ronda; mantém o conflito de merge resolvido (clamp de `wallpaperIndex` #674 + `normalizeCategoryOverrides` #688) e a chamada de saneamento na leitura (linha 439), que agora herda o domínio 0..6.
- **src/store/__tests__/SettingsStore.wallpaperIndex.test.tsx** (novo) — testa o clamp do store, que era exactamente o buraco apontado: monta o `SettingsProvider` real com blob do AsyncStorage e assere o estado hidratado.
- **src/screens/__tests__/LauncherHomeScreen.wallpaperIndex.test.tsx** — acrescenta o describe do wallpaper personalizado.

## Porque assim

A alternativa era manter o clamp em 5 e tratar o 6 fora do clamp (um `if (index === 6) return 6` no chamador). Descartada: espalhava o conhecimento do sentinel por três ficheiros e o `SettingsStore` continuaria a poder destruir o valor. Codificar o domínio real (`[0, CUSTOM_WALLPAPER_INDEX]`) num sítio, com constante nomeada, mantém store e render de acordo. `wallpaperColorFor` existe para que nenhum chamador volte a indexar `WALLPAPERS` cru — a origem do `undefined`. Sem `any` novo, sem `try/catch` a tapar nada: o saneamento é explícito e testado.

## Critérios de aceitação

- [x] `clampWallpaperIndex(6) === 6` — teste `preserva 6 (sentinel de wallpaper personalizado)`.
- [x] `clampWallpaperIndex` devolve 0 para `NaN`, `-1`, `-999`, `-Infinity`, `'não-um-número'`, `undefined`, `null`, `{}`, `[]`; 6 para `7`, `Infinity`, `MAX_SAFE_INTEGER`; preserva 0..5; aceita `'3'`/`'6'`; trunca `2.9`→2 e `6.9`→6.
- [x] O store NÃO clampa 6 na hidratação — `mantém wallpaperIndex=6 (custom) na hidratação, sem clampar para 5` monta o `SettingsProvider` real com `{"wallpaperIndex":6}` no AsyncStorage e lê `idx=6`.
- [x] O store saneia blob inválido — string não-numérica → 0, negativo → 0, 999 → 6, campo ausente → 0.
- [x] Com `wallpaperIndex=6` e `@iostoandroid/custom_wallpaper` presente, a home renderiza o `ImageBackground` custom (`wallpaper-custom-image`). Também com `'6'` em string.
- [x] **Inverso do fix:** com índice de cor (2) a imagem custom NÃO aparece (`queryByTestId(...)` é `null`) e o gradiente continua a pintar.
- [x] **Vazio/ausente:** índice 6 sem imagem guardada (AsyncStorage devolve `null`) cai no gradiente sem rebentar.
- [x] **Não mudou:** `WALLPAPERS`/`NAMED_WALLPAPERS` intactos; `WallpaperScreen` e `LockScreen` não foram tocados; nenhum teste alheio apagado ou `.skip`; snapshots 6/6 a passar (nenhum actualizado).

## Testes

- **Passo vermelho** (fix de `clampWallpaperIndex`/render ainda não feito, testes novos já escritos):

```
FAIL Android src/store/__tests__/SettingsStore.wallpaperIndex.test.tsx
  clampWallpaperIndex (#674)
    ✕ preserva 6 (sentinel de wallpaper personalizado) (3 ms)
    ✕ preserva todos os índices de cor válidos e o limite ±1 (1 ms)
    ✕ saneia não-finito, negativo, vazio e não-numérico para 0
    ✕ aceita numérico em string e trunca fracções
  SettingsProvider — hidratação de wallpaperIndex (#674)
    ✕ mantém wallpaperIndex=6 (custom) na hidratação, sem clampar para 5 (1058 ms)
    ✓ saneia wallpaperIndex string não-numérica para 0 (52 ms)
    ✓ saneia wallpaperIndex negativo para 0 (51 ms)
    ✕ clampa wallpaperIndex acima do domínio para 6 (1002 ms)
    ✓ usa 0 quando o campo está totalmente ausente do blob (53 ms)

  ● clampWallpaperIndex (#674) › preserva 6 (sentinel de wallpaper personalizado)

    expect(received).toBe(expected) // Object.is equality

    Expected: 6
    Received: 5

      38 | describe('clampWallpaperIndex (#674)', () => {
      39 |   it('preserva 6 (sentinel de wallpaper personalizado)', () => {
    > 40 |     expect(clampWallpaperIndex(6)).toBe(6);
         |                                    ^

      at Object.toBe (src/store/__tests__/SettingsStore.wallpaperIndex.test.tsx:40:36)

  ● SettingsProvider — hidratação de wallpaperIndex (#674) › mantém wallpaperIndex=6 (custom) na hidratação, sem clampar para 5

    Unable to find an element with text: ready=true idx=6

    <Text>
      ready=true idx=5
    </Text>

      73 |     const utils = renderWithStored({ wallpaperIndex: 6 });
    > 74 |     await waitFor(() => expect(utils.getByText('ready=true idx=6')).toBeTruthy());
         |                  ^

      at Object.<anonymous> (src/store/__tests__/SettingsStore.wallpaperIndex.test.tsx:74:18)

Test Suites: 1 failed, 1 total
Tests:       6 failed, 3 passed, 9 total
```

  Nota: o `idx=5` recebido é a prova directa da regressão apontada pela review — o store convertia o sentinel custom em cor Dark.

- **Casos cobertos** além do caminho felizim: fronteiras (0, 5, 6, 7, `MAX_SAFE_INTEGER`, ±`Infinity`), vazio/ausente (campo em falta no blob, AsyncStorage a devolver `null` na leitura do custom wallpaper), inválido/hostil (string, objecto, array, `null`, `undefined`, negativos, fracções), tipos legados (`'6'` em string, como um blob antigo gravaria), e **o inverso do fix** (índice de cor não mostra a imagem custom; índice 6 sem imagem não força `ImageBackground`). Cada teste falha por razão distinta: os do `clampWallpaperIndex` no domínio puro, os do `SettingsProvider` na hidratação, os do `LauncherHomeScreen` na árvore renderizada.

- **Sanity-check:** `git stash push -- src/utils/wallpapers.ts src/screens/LauncherHomeScreen.tsx src/store/SettingsStore.tsx` (mantendo os testes) → as duas suites correm **8 falhados / 9 passados / 17 total**; `git stash pop` → **17 passados / 17 total**. Sem o código de produção os testes falham; estão ligados ao comportamento.

- `npm run lint` → **0 erros, 7 warnings** (idênticos à baseline; nenhum nos ficheiros tocados).
- `npx tsc --noEmit` → limpo.
- `npm test -- --maxWorkers=2` → **25 failed / 1799 passed / 1824 total, 6 de 190 suites**. As 25 falhas são exactamente as da baseline (FoldersStore 2, LockScreen 3, SettingsScreen 1, SiriScreen 14, WeatherScreen 2, withLauncherIntent 3) — nenhuma nova, nenhuma em ficheiro tocado. Snapshots 6/6 a passar, nenhum actualizado.

## Testes

25 falharam (todas da baseline), 1799 passaram, 1824 total, 190 suites; os 17 testes dedicados a #674 passam

## Linked Issue

Fixes #674