### PR TITLE
fix/689: App Library não cai no ecrã do Android quando o blob de apps recentes está corrompido (normaliza @iostoandroid/recent_apps na leitura) (#689)

### DIFF
--- a/src/screens/__tests__/AppLibraryContent.malformedRecents.test.tsx
+++ b/src/screens/__tests__/AppLibraryContent.malformedRecents.test.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { render, waitFor } from '../../test-utils';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import launcherModule from '../../../modules/launcher-module/src';
+import { AppLibraryContent } from '../AppLibraryScreen';
+
+// #689 — a App Library é a última página do pager da home (montada inline em
+// LauncherHomeScreen). As strips "Recently Added"/"Suggestions" ordenam
+// `recentApps` com `b.launchedAt - a.launchedAt` e resolvem
+// `r.packageName`. `recentApps` vem de um blob do AsyncStorage
+// (@iostoandroid/recent_apps) que o AppsStore aceitava desde que fosse um
+// array — sem validar as ENTRADAS. Um blob corrompido (entrada `null`, string,
+// objecto sem packageName/launchedAt) fazia o render rebentar com TypeError e o
+// throw derrubava o launcher inteiro: em vez da App Library aparecia o ecrã
+// inicial do Android. Como o blob é persistido, o crash repetia-se em cada
+// arranque.
+const RECENTS_KEY = '@iostoandroid/recent_apps';
+
+const APPS = [
+  { name: 'Facebook', packageName: 'com.facebook', icon: '', isSystem: false, category: 'social' },
+  { name: 'Spotify', packageName: 'com.spotify', icon: '', isSystem: false, category: 'audio' },
+] as never;
+
+function mockStorage(recents: unknown) {
+  (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) =>
+    key === RECENTS_KEY ? JSON.stringify(recents) : null,
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+  (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
+  (AsyncStorage.removeItem as jest.Mock).mockResolvedValue(undefined);
+  (launcherModule.getInstalledApps as jest.Mock).mockResolvedValue(APPS);
+  (launcherModule.isDefaultLauncher as jest.Mock).mockResolvedValue(false);
+});
+
+describe('AppLibraryContent — blob de recentes corrompido não derruba a App Library (#689)', () => {
+  it.each([
+    ['uma entrada null', [null, { packageName: 'com.facebook', launchedAt: 2 }]],
+    ['uma entrada string', ['com.facebook', { packageName: 'com.spotify', launchedAt: 2 }]],
+    ['uma entrada sem launchedAt', [{ packageName: 'com.facebook' }]],
+    ['launchedAt não numérico', [{ packageName: 'com.facebook', launchedAt: 'ontem' }]],
+    ['packageName não string', [{ packageName: 42, launchedAt: 1 }]],
+    ['uma entrada aninhada em array', [[{ packageName: 'com.facebook', launchedAt: 1 }]]],
+  ])('renderiza a grelha com %s no blob de recentes', async (_label, recents) => {
+    mockStorage(recents);
+    const utils = render(<AppLibraryContent />);
+    await waitFor(() => expect(utils.getByText('Categories')).toBeTruthy());
+    expect(utils.getAllByText('Facebook').length).toBeGreaterThan(0);
+  });
+
+  it('blob de recentes vazio: a grelha renderiza e as strips caem no fallback alfabético', async () => {
+    mockStorage([]);
+    const utils = render(<AppLibraryContent />);
+    await waitFor(() => expect(utils.getByText('Categories')).toBeTruthy());
+    expect(utils.getAllByText('Facebook').length).toBeGreaterThan(0);
+  });
+
+  it('o inverso do fix: entradas VÁLIDAS continuam a alimentar "Recently Added"', async () => {
+    mockStorage([
+      { packageName: 'com.spotify', launchedAt: 100 },
+      { packageName: 'com.facebook', launchedAt: 50 },
+    ]);
+    const utils = render(<AppLibraryContent />);
+    await waitFor(() => expect(utils.getByText('Recently Added')).toBeTruthy());
+    // Spotify (o mais recente) aparece na strip, logo há mais do que uma
+    // ocorrência do seu nome (strip + categoria).
+    await waitFor(() => expect(utils.getAllByText('Spotify').length).toBeGreaterThan(1));
+  });
+
+  it('entradas válidas misturadas com lixo: as válidas sobrevivem à filtragem', async () => {
+    mockStorage([null, { packageName: 'com.spotify', launchedAt: 100 }, 'lixo']);
+    const utils = render(<AppLibraryContent />);
+    await waitFor(() => expect(utils.getByText('Recently Added')).toBeTruthy());
+    await waitFor(() => expect(utils.getAllByText('Spotify').length).toBeGreaterThan(1));
+  });
+});

--- a/src/store/AppsStore.tsx
+++ b/src/store/AppsStore.tsx
@@ -39,6 +39,38 @@ export interface RecentApp {
   launchedAt: number; // epoch ms
 }
 
+/**
+ * Normaliza o blob persistido de apps recentes (@iostoandroid/recent_apps).
+ *
+ * O blob era aceite desde que fosse um array, sem validar as ENTRADAS. Uma
+ * entrada corrompida (`null`, string, objecto sem `packageName`/`launchedAt`,
+ * array aninhado) chegava intacta aos consumidores, e a App Library — que é a
+ * última página do pager da home — faz `r.packageName` e ordena por
+ * `b.launchedAt - a.launchedAt` no render: uma entrada `null` rebentava com
+ * TypeError e o throw derrubava o launcher inteiro, mostrando o ecrã inicial do
+ * Android (#689). Como o blob é persistido, o crash repetia-se em cada arranque.
+ *
+ * Regras: só objectos com `packageName` string não-vazia e `launchedAt` numérico
+ * finito sobrevivem; o resto é descartado silenciosamente (é lixo de uma build
+ * anterior, não informação recuperável). Duplicados por packageName são
+ * colapsados na primeira ocorrência, como faz `addToRecents`.
+ */
+export function normalizeRecentApps(raw: unknown): RecentApp[] {
+  if (!Array.isArray(raw)) return [];
+  const seen = new Set<string>();
+  const out: RecentApp[] = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) continue;
+    const { packageName, launchedAt } = entry as { packageName?: unknown; launchedAt?: unknown };
+    if (typeof packageName !== 'string' || packageName === '') continue;
+    if (typeof launchedAt !== 'number' || !Number.isFinite(launchedAt)) continue;
+    if (seen.has(packageName)) continue;
+    seen.add(packageName);
+    out.push({ packageName, launchedAt });
+  }
+  return out.slice(0, MAX_RECENTS);
+}
+
 // Dynamic import to avoid crashing the module on non-Android. Falls back to a
 // synchronous require when dynamic import() is unavailable (e.g. Jest's VM
 // without --experimental-vm-modules) so moduleNameMapper mocks still apply in tests.
@@ -250,15 +282,29 @@ export function AppsProvider({
           const parsed = JSON.parse(raw);
           if (Array.isArray(parsed)) {
             if (parsed.length > 0 && typeof parsed[0] === 'string') {
-              // Legacy format: migrate string[] to RecentApp[]
-              const migrated: RecentApp[] = (parsed as string[]).map((pkg, i) => ({
-                packageName: pkg,
-                launchedAt: Date.now() - i * 60000,
-              }));
+              // Legacy format: migrate string[] to RecentApp[]. Só as entradas
+              // que são de facto strings não-vazias — um array misto
+              // (legacy parcialmente reescrito) produzia `packageName:
+              // undefined` e voltava a alimentar o crash da App Library (#689).
+              const migrated: RecentApp[] = (parsed as unknown[])
+                .filter((pkg): pkg is string => typeof pkg === 'string' && pkg !== '')
+                .map((pkg, i) => ({
+                  packageName: pkg,
+                  launchedAt: Date.now() - i * 60000,
+                }));
               setRecentApps(migrated);
               AsyncStorage.setItem(RECENTS_KEY, JSON.stringify(migrated));
             } else {
-              setRecentApps(parsed as RecentApp[]);
+              // Blob no formato actual: valida entrada a entrada. Uma entrada
+              // corrompida derrubava o launcher inteiro no render da App
+              // Library (#689).
+              const normalized = normalizeRecentApps(parsed);
+              setRecentApps(normalized);
+              if (normalized.length !== parsed.length) {
+                // Reescreve o blob saneado para que o arranque seguinte não
+                // volte a pagar a filtragem nem herde o lixo.
+                AsyncStorage.setItem(RECENTS_KEY, JSON.stringify(normalized));
+              }
             }
           }
         } catch (e) { logger.warn('AppsStore', 'failed to parse recent apps', e); }

--- a/src/store/__tests__/AppsStore.normalizeRecentApps.test.ts
+++ b/src/store/__tests__/AppsStore.normalizeRecentApps.test.ts
@@ -1,0 +1,87 @@
+import { normalizeRecentApps } from '../AppsStore';
+
+// #689 — fronteiras e casos hostis do blob persistido de apps recentes.
+// A App Library (última página do pager da home) consome estas entradas no
+// render; qualquer coisa que não seja {packageName: string, launchedAt: number}
+// tem de ser descartada antes de chegar lá.
+describe('normalizeRecentApps (#689)', () => {
+  it('devolve [] para valores que não são array', () => {
+    expect(normalizeRecentApps(null)).toEqual([]);
+    expect(normalizeRecentApps(undefined)).toEqual([]);
+    expect(normalizeRecentApps('com.facebook')).toEqual([]);
+    expect(normalizeRecentApps(42)).toEqual([]);
+    expect(normalizeRecentApps({ packageName: 'com.facebook', launchedAt: 1 })).toEqual([]);
+  });
+
+  it('devolve [] para um array vazio', () => {
+    expect(normalizeRecentApps([])).toEqual([]);
+  });
+
+  it('descarta entradas não-objecto e objectos com campos do tipo errado', () => {
+    expect(
+      normalizeRecentApps([
+        null,
+        undefined,
+        'com.facebook',
+        7,
+        [],
+        [{ packageName: 'com.facebook', launchedAt: 1 }],
+        { packageName: '', launchedAt: 1 },
+        { packageName: 'com.a', launchedAt: 'ontem' },
+        { packageName: 'com.b', launchedAt: NaN },
+        { packageName: 'com.c', launchedAt: Infinity },
+        { packageName: 'com.d' },
+        { launchedAt: 1 },
+        { packageName: 42, launchedAt: 1 },
+      ]),
+    ).toEqual([]);
+  });
+
+  it('mantém as entradas válidas pela ordem original', () => {
+    expect(
+      normalizeRecentApps([
+        { packageName: 'com.a', launchedAt: 2 },
+        'lixo',
+        { packageName: 'com.b', launchedAt: 1 },
+      ]),
+    ).toEqual([
+      { packageName: 'com.a', launchedAt: 2 },
+      { packageName: 'com.b', launchedAt: 1 },
+    ]);
+  });
+
+  it('aceita launchedAt 0 e negativo (relógio do sistema atrasado não é lixo)', () => {
+    expect(normalizeRecentApps([{ packageName: 'com.a', launchedAt: 0 }])).toEqual([
+      { packageName: 'com.a', launchedAt: 0 },
+    ]);
+    expect(normalizeRecentApps([{ packageName: 'com.b', launchedAt: -1 }])).toEqual([
+      { packageName: 'com.b', launchedAt: -1 },
+    ]);
+  });
+
+  it('colapsa duplicados por packageName na primeira ocorrência', () => {
+    expect(
+      normalizeRecentApps([
+        { packageName: 'com.a', launchedAt: 5 },
+        { packageName: 'com.a', launchedAt: 1 },
+      ]),
+    ).toEqual([{ packageName: 'com.a', launchedAt: 5 }]);
+  });
+
+  it('trunca no máximo de recentes (8), mesmo com lixo intercalado', () => {
+    const raw: unknown[] = [];
+    for (let i = 0; i < 20; i++) {
+      raw.push(null, { packageName: `com.app${i}`, launchedAt: i });
+    }
+    const out = normalizeRecentApps(raw);
+    expect(out).toHaveLength(8);
+    expect(out[0]).toEqual({ packageName: 'com.app0', launchedAt: 0 });
+    expect(out[7]).toEqual({ packageName: 'com.app7', launchedAt: 7 });
+  });
+
+  it('ignora campos extra sem os propagar', () => {
+    expect(
+      normalizeRecentApps([{ packageName: 'com.a', launchedAt: 1, bogus: 'x' }]),
+    ).toEqual([{ packageName: 'com.a', launchedAt: 1 }]);
+  });
+});


### PR DESCRIPTION
## Resumo

fix/689: App Library não cai no ecrã do Android quando o blob de apps recentes está corrompido (normaliza @iostoandroid/recent_apps na leitura)

## Causa raiz

O issue diz "App Library frame shows Android system home screen instead of iOS App Library" e o corpo está vazio ("## What is wrong" sem texto). O sintoma descrito — cair no ecrã inicial do Android em vez da App Library — é, neste projecto, sempre o mesmo mecanismo: a `AppLibraryContent` é montada **inline como última página do pager da home** (`src/screens/LauncherHomeScreen.tsx:1753`), por isso qualquer throw no seu render derruba o launcher inteiro e o Android volta ao launcher do sistema. Os fixes issue 688 (categoryOverrides) e #699 (`app.name` ausente) fecharam duas dessas fontes; ficou aberta uma terceira, no mesmo padrão exacto e com a mesma consequência.

A fonte que faltava é o blob persistido de apps recentes, `@iostoandroid/recent_apps`:

- `src/store/AppsStore.tsx:279-296` (antes do fix) aceitava o blob **desde que fosse um array**, e fazia `setRecentApps(parsed as RecentApp[])` — um `as` que valida zero coisas em runtime. As **entradas** nunca eram verificadas.
- A `AppLibraryContent` consome essas entradas directamente no render: `src/screens/AppLibraryScreen.tsx:648-651` faz `[...recentApps].sort((a, b) => b.launchedAt - a.launchedAt).map(r => visibleApps.find(a => a.packageName === r.packageName))`, e `AppLibraryScreen.tsx:666-670` repete-o para as Suggestions.
- Uma entrada `null` no blob (ou qualquer não-objecto) faz `b.launchedAt` rebentar com `TypeError: Cannot read property 'launchedAt' of null` **durante o render**. O throw sobe pela árvore, derruba o `AppsProvider`/launcher, e o utilizador vê o ecrã inicial do Android — sem nenhuma pista de que a causa está no AsyncStorage.
- Como o blob é **persistido**, o crash é determinístico e repete-se em cada arranque até a app ser limpa. É exactamente a assinatura de #688/#699: "a App Library mostra o ecrã do Android".

Correcção onde a #688 já pôs a defesa do irmão (normalizar na leitura), não com um `?.` no consumidor.

## O que mudou

**`src/store/AppsStore.tsx`**
- Nova função exportada `normalizeRecentApps(raw: unknown): RecentApp[]`: devolve `[]` para tudo o que não é array e, para arrays, aceita apenas entradas que sejam objectos (não-array) com `packageName` string não-vazia e `launchedAt` numérico finito. Duplicados por `packageName` colapsam na primeira ocorrência (como `addToRecents` faz), e o resultado é truncado em `MAX_RECENTS` (8), a mesma fronteira que a escrita já respeita.
- O carregamento do blob (`useEffect` dos recentes) passa a chamar `normalizeRecentApps(parsed)` em vez de `parsed as RecentApp[]`, e reescreve o blob saneado quando descartou entradas — para que o arranque seguinte não volte a herdar o lixo.
- O ramo de migração do formato legado (`string[]`) passa a filtrar entradas que sejam de facto strings não-vazias antes de mapear. Um array misto (legado parcialmente reescrito) produzia `{ packageName: undefined }`, que alimentava o mesmo crash pelo outro caminho.

**`src/store/__tests__/AppsStore.normalizeRecentApps.test.ts`** (novo) — unidade da função exportada.

**`src/screens/__tests__/AppLibraryContent.malformedRecents.test.tsx`** (novo) — integração: monta a `AppLibraryContent` real com o blob corrompido no AsyncStorage mockado.

## Porque assim

- **Sanear na leitura, não no consumidor.** É o padrão já estabelecido neste repositório para blobs não confiáveis do AsyncStorage: `normalizeCategoryOverrides` (#688), `normalizeFocusPageVisibility` (#618), `clampWallpaperIndex` (#674) — todos em `SettingsStore.tsx:406-440`. Um `?? 0` ou `?.` nos comparadores da App Library taparia o crash mas deixaria entradas inválidas a circular por `MultitaskScreen` e `QuickSwitchHomeBar`, que também leem `recentApps`.
- **Descartar, não reparar.** Uma entrada sem `packageName` utilizável não é informação recuperável; inventar um `launchedAt` daria ordenação arbitrária nas strips. Descartada, a strip cai no fallback alfabético que já existe.
- **Reescrever o blob saneado**: alternativa descartada era só filtrar em memória. Persistir corta o lixo de vez, e é uma escrita só no arranque em que houve corrupção.
- **`MAX_RECENTS` na normalização**: a escrita já trunca em 8; um blob escrito por outra versão podia trazer 200 entradas e as strips passariam a resolver 200 `find()` por render. Repor a fronteira na leitura mantém o invariante nos dois sentidos.
- Alternativa descartada: pôr a normalização em `src/utils/`. Ficou junto ao `RecentApp` e ao `MAX_RECENTS` que ela usa, no único ficheiro que lê o blob.

## Critérios de aceitação

- [x] **Um blob de recentes com uma entrada `null` não derruba a App Library**: teste de integração monta `AppLibraryContent` com `[null, {...}]` e o header "Categories" renderiza. Antes falhava com "Unable to find node on an unmounted component" (a árvore tinha morrido).
- [x] **Nem string, objecto sem `launchedAt`, `launchedAt` não numérico, `packageName` não string, nem entrada aninhada em array**: 6 variantes cobertas por `it.each`.
- [x] **O inverso do fix: entradas válidas continuam a alimentar "Recently Added"** — teste confirma que com `[{com.spotify, 100}, {com.facebook, 50}]` o header "Recently Added" aparece e "Spotify" ocorre mais de uma vez (strip + categoria). Sem isto, um `normalizeRecentApps` que devolvesse sempre `[]` passaria todos os outros testes.
- [x] **Válidas misturadas com lixo: as válidas sobrevivem** — `[null, {com.spotify,100}, 'lixo']` continua a produzir a strip com Spotify.
- [x] **`launchedAt: 0` e negativo são aceites** (relógio do sistema atrasado é estado legítimo, não corrupção) — verificado na unidade.
- [x] **A fronteira `MAX_RECENTS` (8) é respeitada** — 20 entradas válidas com lixo intercalado devolvem exactamente 8, a começar na primeira.
- [x] **O que NÃO devia mudar:** nenhum ficheiro fora de `src/store/AppsStore.tsx` foi tocado em produção. `AppLibraryScreen.tsx`, `LauncherHomeScreen.tsx`, `MultitaskScreen.tsx` e `QuickSwitchHomeBar.tsx` ficaram intactos; a forma de `RecentApp` e a assinatura de `recentApps` no contexto não mudaram, por isso os consumidores não precisaram de alteração. Confirmado por `git status --porcelain`, que lista só o `AppsStore.tsx` modificado e os dois testes novos.
- [x] **Sem regressão na suite:** 25 falhas antes e depois, as mesmas 6 suites da LINHA DE BASE.
- [x] **Nenhum `any` novo, nenhum `as` a calar o compilador**: `normalizeRecentApps` recebe `unknown` e estreita por verificações de runtime; `npx tsc --noEmit` limpo.

## Testes

**Passo vermelho** — `git stash push -- src/store/AppsStore.tsx` (tira só o fix, deixa os testes), output real do jest:

```
● AppLibraryContent — blob de recentes corrompido não derruba a App Library (#689) › renderiza a grelha com uma entrada null no blob de recentes

    Unable to find node on an unmounted component.
      49 |     const utils = render(<AppLibraryContent />);
      50 |     await waitFor(() => expect(utils.getByText('Categories')).toBeTruthy());
    > 51 |     expect(utils.getAllByText('Facebook').length).toBeGreaterThan(0);
         |                  ^
      52 |   });

● AppLibraryContent — blob de recentes corrompido não derruba a App Library (#689) › entradas válidas misturadas com lixo: as válidas sobrevivem à filtragem

    Unable to find node on an unmounted component.
      74 |     mockStorage([null, { packageName: 'com.spotify', launchedAt: 100 }, 'lixo']);
      75 |     const utils = render(<AppLibraryContent />);
    > 76 |     await waitFor(() => expect(utils.getByText('Recently Added')).toBeTruthy());
         |                  ^
      77 |     await waitFor(() => expect(utils.getAllByText('Spotify').length).toBeGreaterThan(1));

Test Suites: 1 failed, 1 total
Tests:       2 failed, 7 passed, 9 total
```

("Unable to find node on an unmounted component" é como o `@testing-library/react-native` reporta uma árvore que morreu a meio do render — o mesmo mecanismo do crash em produção. A suite unitária de `normalizeRecentApps` falha em bloco no passo vermelho porque a função não existe em `main`.)

Com o fix aplicado:

```
Test Suites: 1 passed, 1 total
Tests:       9 passed, 9 total   (AppLibraryContent.malformedRecents)
Tests:       8 passed, 8 total   (AppsStore.normalizeRecentApps)
```

**Casos cobertos além do caminho feliz:**
- *Vazio e ausente*: `null`, `undefined`, array vazio, entrada sem `packageName`, entrada sem `launchedAt`.
- *Inválido e hostil*: string/número/objecto onde se espera array; string, número, array e objecto malformado como entrada; `packageName` numérico; `launchedAt` string, `NaN`, `Infinity`.
- *Fronteiras*: `launchedAt` 0 e negativo (aceites de propósito); 20 entradas → truncadas em 8 (o limite exacto do `MAX_RECENTS`, verificando a primeira e a oitava).
- *Repetição*: duplicados do mesmo `packageName` colapsam na primeira ocorrência.
- *O inverso do fix*: dois testes garantem que a normalização **não** esvazia a strip quando os dados são bons — sem eles, um fix trivial `return []` passaria tudo.
- *Campos extra*: não são propagados, para que o blob reescrito seja canónico.

**Sanity-check** — fix de produção revertido com `git stash push -- src/store/AppsStore.tsx`, mantendo os testes, suite completa corrida:

```
Test Suites: 8 failed, 186 passed, 194 total
Tests:       35 failed, 1815 passed, 1850 total
```

Restaurado com `git stash pop`, suite completa novamente:

```
Test Suites: 6 failed, 188 passed, 194 total
Tests:       25 failed, 1825 passed, 1850 total
```

35 → 25 falhas: as 10 falhas extra são exactamente os testes novos, o que prova que estão ligados ao código de produção.

**Verificações:**
- `npm run lint`: `✖ 7 problems (0 errors, 7 warnings)` — 0 erros, igual à LINHA DE BASE (avisos pré-existentes de `no-unused-vars` noutros ficheiros).
- `npx tsc --noEmit`: limpo.
- `npm test -- --maxWorkers=2`: **25 falhados, 1825 passados, 1850 total; 6 de 194 suites falhadas** — idêntico à LINHA DE BASE (25 falhas em 6 suites, causadas pelo gate `firstSyncDone` do SettingsStore). Nenhuma falha nova; nenhuma das suites falhadas toca `AppsStore.tsx`.

## Testes

1825 passaram, 25 falharam (baseline: 25), 194 suites — testes novos: 17 passaram (9 integração + 8 unidade)

## Linked Issue

Fixes #689