### PR TITLE
App Library não acessível: índice de apps em cache (apps_index) sem name/packageName rebentava o pager da home (última página = App Library) → ecrã inicial do Android (#704)

### DIFF
--- a/src/store/AppsStore.tsx
+++ b/src/store/AppsStore.tsx
@@ -380,7 +380,29 @@ export function AppsProvider({
     if (cachedIndexRaw) {
       try {
         const parsed = JSON.parse(cachedIndexRaw);
-        if (Array.isArray(parsed)) cachedApps = parsed;
+        if (Array.isArray(parsed)) {
+          // O blob vem do AsyncStorage (não confiável: build anterior, cache
+          // truncado, entrada parcial). A ponte nativa normaliza a SAÍDA
+          // (`withCategory`/`dedupeByPackageName`), mas aqui lemos o cache
+          // PERSISTIDO, que contorna essa normalização. Sem isto, uma entrada
+          // sem `packageName` (chave de React / duplicados) ou sem `name`
+          // (que o appsIndexReducer ordena em `.sort(byName)`) chega ao vivo
+          // `allApps`, e como a AppLibraryContent é a última página do pager
+          // da home, o throw derrubava o launcher → ecrã inicial do Android
+          // (#704). Replicamos a normalização da ponte para o cache.
+          const seen = new Set<string>();
+          const clean = parsed
+            .filter((e): e is Record<string, unknown> => !!e && typeof e === 'object' && !Array.isArray(e))
+            .filter((e) => typeof e.packageName === 'string' && e.packageName !== '' && !seen.has(e.packageName) && (seen.add(e.packageName), true))
+            .filter((e) => typeof e.name === 'string')
+            .map((e) => ({
+              name: e.name as string,
+              packageName: e.packageName as string,
+              icon: typeof e.icon === 'string' ? e.icon : '',
+              isSystem: typeof e.isSystem === 'boolean' ? e.isSystem : false,
+            }));
+          cachedApps = clean.length > 0 ? clean : null;
+        }
       } catch (e) { logger.warn('AppsStore', 'failed to parse cached apps index', e); }
     }
 

--- a/src/store/__tests__/AppsStore.test.tsx
+++ b/src/store/__tests__/AppsStore.test.tsx
@@ -117,6 +117,77 @@ describe('AppsStore — paints from the cached apps index without waiting for th
   });
 });
 
+// ─── Regressão: blob apps_index persistido (não confiável) não pode rebentar
+// a leitura do cache (#704) ────────────────────────────────────────────────
+//
+// O `apps_index` vem do AsyncStorage — blob de uma build anterior, truncado ou
+// com entradas parciais. A ponte nativa normaliza a SAÍDA (`withCategory`/
+// `dedupeByPackageName`), mas aqui lemos o cache PERSISTIDO, que contorna essa
+// normalização. Sem saneamento, uma entrada sem `packageName` (chave React /
+// duplicados) ou sem `name` (que o appsIndexReducer ordena em `.sort(byName)`)
+// chegava ao vivo `allApps`; e como a AppLibraryContent é a última página do
+// pager da home, o throw derrubava o launcher e o utilizador via o ecrã
+// inicial do Android em vez da App Library. Exercitamos o caminho REAL:
+// carregamos um blob malformado no AsyncStorage e a leitura tem de pintar só o
+// que é válido, sem lançar.
+describe('AppsStore — apps_index malformado no AsyncStorage não rebenta a leitura (#704)', () => {
+  it('descarta entradas sem name/packageName e mantém as válidas', async () => {
+    const cachedApps = [
+      { packageName: 'com.corrupt.noname', icon: '', isSystem: false }, // sem name
+      null, // não é objeto
+      { name: 'Valid', packageName: 'com.example.valid', icon: '', isSystem: false },
+      { packageName: 'com.dup', name: 'Dup', icon: '' }, // duplicado abaixo
+      { packageName: 'com.dup', name: 'Dup', icon: '' },
+    ];
+    (AsyncStorage.getItem as jest.Mock).mockImplementation((key: string) =>
+      Promise.resolve(key === APPS_INDEX_KEY ? JSON.stringify(cachedApps) : null)
+    );
+    let resolveNative: (apps: unknown[]) => void = () => {};
+    (LauncherModule.getInstalledApps as jest.Mock).mockImplementation(
+      () => new Promise((resolve) => { resolveNative = resolve; })
+    );
+
+    const { result } = renderHook(() => useApps(), { wrapper });
+    // Flush só a leitura do cache (native ainda pending, de propósito).
+    await act(async () => {});
+
+    expect(result.current.isLoading).toBe(false);
+    // Só a entrada válida sobrevive; a sem-name e as não-objeto/duplicadas caem.
+    expect(result.current.apps).toEqual([
+      { name: 'Valid', packageName: 'com.example.valid', icon: '', isSystem: false },
+      { name: 'Dup', packageName: 'com.dup', icon: '', isSystem: false },
+    ]);
+
+    await act(async () => { resolveNative([]); });
+  });
+
+  it('o inverso: um índice só com apps bem-formadas continua a pintar intacto', async () => {
+    const cachedApps = [
+      { name: 'Alpha', packageName: 'com.example.alpha', icon: '', isSystem: false },
+      { name: 'Beta', packageName: 'com.example.beta', icon: '', isSystem: false },
+    ];
+    (AsyncStorage.getItem as jest.Mock).mockImplementation((key: string) =>
+      Promise.resolve(key === APPS_INDEX_KEY ? JSON.stringify(cachedApps) : null)
+    );
+    let resolveNative: (apps: unknown[]) => void = () => {};
+    (LauncherModule.getInstalledApps as jest.Mock).mockImplementation(
+      () => new Promise((resolve) => { resolveNative = resolve; })
+    );
+
+    const { result } = renderHook(() => useApps(), { wrapper });
+    // Flush só a leitura do cache (native ainda pending, de propósito).
+    await act(async () => {});
+
+    expect(result.current.apps).toHaveLength(2);
+    expect(result.current.apps.map((a) => a.packageName)).toEqual([
+      'com.example.alpha',
+      'com.example.beta',
+    ]);
+
+    await act(async () => { resolveNative([]); });
+  });
+});
+
 describe('AppsStore — icon cache (#486: treatment threading, size, manual rebuild)', () => {
   beforeEach(() => {
     (LauncherModule.getIconCacheSizeBytes as jest.Mock).mockResolvedValue(0);

--- a/src/store/__tests__/appsIndexReducer.malformed.test.tsx
+++ b/src/store/__tests__/appsIndexReducer.malformed.test.tsx
@@ -1,0 +1,56 @@
+import { upsertApp, removeApp } from '../appsIndexReducer';
+import type { InstalledApp } from '../AppsStore';
+
+// Regressão: o índice de apps em cache (apps_index, persistido no
+// AsyncStorage) é tratado como NÃO confiável — exatamente como o
+// categoryOverrides o é desde o #688. Um blob de uma build anterior, truncado
+// ou corrompido pode conter entradas que não são objetos, ou objetos sem
+// `name` (o campo que o `withCategory`/`dedupeByPackageName` da ponte nativa
+// normalizam à SAÍDA, mas que chega intacto do cache persistido).
+//
+// O appsIndexReducer ordena o índice INTEIRO em cada evento de
+// instalar/desinstalar (`upsertApp`/`removeApp` → `byName`), e o `loadApps`
+// (AppsStore) lê o blob diretamente para o `allApps`. Como a AppLibraryContent
+// é a ÚLTIMA página do pager da home (montada inline), qualquer throw aqui
+// derruba o render do pager inteiro e o utilizador vê o ecrã inicial do Android
+// em vez da App Library — o sintoma exato do #704.
+//
+// Os irmãos #696/#699/#688 taparam o caminho de RENDER (categorizeApp,
+// AppIcon, categoryOverrides) mas deixaram esta fronteira e o sort do índice
+// por normalizar. Este teste exercita a unidade REAL.
+
+const good = (name: string, pkg: string): InstalledApp => ({
+  name,
+  packageName: pkg,
+  icon: `file:///icons/${pkg}_1.png`,
+  isSystem: false,
+});
+
+// Entrada sem `name` — payload de cache antigo/corrompido.
+const nameless = { packageName: 'com.corrupt.entry', icon: '', isSystem: false } as unknown as InstalledApp;
+
+describe('appsIndexReducer — índice com app sem name não rebenta (#704)', () => {
+  it('upsertApp insere uma app normal num índice que já tem uma app sem name', () => {
+    // O índice em cache já continha a entrada corrompida; chega uma app nova.
+    const next = upsertApp([nameless], good('Zebra', 'com.example.zebra'));
+    // Não pode lançar, e tem de manter ambas as entradas (a boa na posição certa).
+    expect(next).toHaveLength(2);
+    expect(next.some((a) => a.packageName === 'com.example.zebra')).toBe(true);
+    expect(next.some((a) => a.packageName === 'com.corrupt.entry')).toBe(true);
+  });
+
+  it('removeApp remove uma app sem lançar num índice com entrada sem name (e ordena o resto)', () => {
+    // Remove a app boa deixando 2 entradas (a corrompida + outra), para que o
+    // `.sort(byName)` obrigatório no reducer disparado pelo uso interno.
+    const next = removeApp(
+      [nameless, good('Apple', 'com.example.apple'), good('Banana', 'com.example.banana')],
+      'com.example.apple',
+    );
+    expect(next.map((a) => a.packageName)).toEqual(['com.corrupt.entry', 'com.example.banana']);
+  });
+
+  it('o inverso: um índice só com apps bem-formadas continua a ordenar', () => {
+    const next = upsertApp([good('Banana', 'com.example.banana')], good('Apple', 'com.example.apple'));
+    expect(next.map((a) => a.name)).toEqual(['Apple', 'Banana']);
+  });
+});

--- a/src/store/appsIndexReducer.ts
+++ b/src/store/appsIndexReducer.ts
@@ -14,7 +14,13 @@ import type { InstalledApp } from './AppsStore';
  */
 
 function byName(a: InstalledApp, b: InstalledApp): number {
-  return a.name.toLowerCase().localeCompare(b.name.toLowerCase());
+  // `name` pode estar ausente numa entrada do índice em cache (`apps_index`)
+  // lida DIRETAMENTE do AsyncStorage — à espera da ponte nativa, que contorna o
+  // `withCategory`/`dedupeByPackageName` que normalizam a saída nativa. Como a
+  // AppLibraryContent é a última página do pager da home, um throw aqui
+  // derrubava o launcher inteiro e o utilizador via o ecrã inicial do Android
+  // em vez da App Library (#704). Trata-se como string vazia.
+  return (a.name ?? '').toLowerCase().localeCompare((b.name ?? '').toLowerCase());
 }
 
 /** Insert `app`, or replace the existing entry with the same packageName. */


### PR DESCRIPTION
## Resumo

App Library não acessível: índice de apps em cache (apps_index) sem name/packageName rebentava o pager da home (última página = App Library) → ecrã inicial do Android

## Causa raiz

O issue #704 (corpo vazio, só o título) descreve "App Library not accessible: shows Android home screen instead of App Library UI". É o sintoma clássico de a AppLibraryContent (montada inline como **última página** do pager da home, em `LauncherHomeScreen.tsx:1749-1754`) lançar durante o render e derrubar o pager inteiro — o launcher cai e o utilizador vê o ecrã inicial do Android.

Os irmãos #696/#699/#688 já tinham tapado os caminhos de **render** dentro da `AppLibraryScreen` (`categorizeApp`, `AppIcon`, `buildCategorySections`), mas deixaram duas fronteiras por normalizar:

1. **`src/store/appsIndexReducer.ts:17`** — `byName` faz `a.name.toLowerCase().localeCompare(b.name.toLowerCase())` **sem guarda**. O `upsertApp`/`removeApp` ordenam o índice INTEIRO em `.sort(byName)` a cada evento de instalar/desinstalar (`AppsStore.tsx:464-471`, `applyIndex`).
2. **`src/store/AppsStore.tsx` (`loadApps`)** — lê o blob `apps_index` do AsyncStorage e mete-o diretamente em `allApps` (`if (Array.isArray(parsed)) cachedApps = parsed`), **sem validação**. A ponte nativa normaliza a SAÍDA (`withCategory`/`dedupeByPackageName` em `modules/launcher-module/src/index.ts:400-424`), mas aqui lemos o cache **persistido**, que contorna essa normalização.

O `InstalledApp` é tipado com `name`/`packageName` obrigatórios, mas a fronteira nativa é `any` e o cache do AsyncStorage é não confiável (build anterior, cache truncado, entrada parcial). Uma entrada sem `name` no índice em cache — exatamente o cenário "índice em cache antigo" citado nas fix issue 696/#699/#688 — chega ao vivo `allApps` e faz `byName` lançar `TypeError: Cannot read properties of undefined (reading 'toLowerCase')`. Como a grelha da home e a App Library partilham o mesmo `allApps`, o throw derruba o pager.

## O que mudou

- **`src/store/appsIndexReducer.ts`**: `byName` passa a tratar `name` ausente como string vazia (`(a.name ?? '').toLowerCase()...`). É a causa raiz, não um `?.` que esconde — o sort continua a correr e a ordenar; só deixa de lançar numa entrada corrompida.
- **`src/store/AppsStore.tsx`** (`loadApps`): o blob `apps_index` lido do AsyncStorage é agora saneado antes de ir a `allApps` — descarta entradas que não são objetos, sem `packageName` válido (e deduplica por `packageName`), e sem `name` (string). Isto espelha o que #688 fez para `categoryOverrides`: tratar um blob persistido não confiável à entrada, em vez de deixar um throw chegar ao render.
- **`src/store/__tests__/appsIndexReducer.malformed.test.tsx`** (novo) e **`src/store/__tests__/AppsStore.test.tsx`** (regressão acrescentada): cobrem o caminho real.

## Porque assim

- A alternativa de só pôr `?.`/`as any` no render da `AppLibraryScreen` já foi feita nos irmãos e **não cobria** estas duas fronteiras — o crash voltava pelo índice. O saneamento à entrada (`loadApps` + `byName`) é o que garante que dados corrompidos nem chegam ao `allApps`.
- Mantive o saneamento shape-faithful (não invento `category`/`isSystem` a não ser pelos defaults seguros), para não alterar o comportamento de um índice bem-formado (o teste inverso confirma).

## Critérios de aceitação

- [x] O `apps_index` persistido com uma entrada sem `name` não rebenta a leitura do cache (teste `AppsStore — apps_index malformado... › descarta entradas sem name/packageName`).
- [x] `upsertApp`/`removeApp` não lançam quando o índice contém uma app sem `name` (teste `appsIndexReducer.malformed`).
- [x] O inverso: um índice só com apps bem-formadas continua a pintar intacto e a ordenar (testes inversos em ambos os ficheiros).
- [x] Não piorou o baseline: as 25 falhas pré-existentes mantêm-se (SiriScreen/WeatherScreen/SettingsScreen/FoldersStore/LockScreen/withLauncherIntent), nenhuma nas comes do meu diff. `npm run lint` 0 erros; `npx tsc --noEmit` limpo.

## Testes

- **Passo vermelho** (fix revertido via `git stash`, produção só):

```
FAIL Android src/store/__tests__/appsIndexReducer.malformed.test.tsx
  ● appsIndexReducer — índice com app sem name não rebenta (#704)
    › upsertApp insere uma app normal num índice que já tem uma app sem name

    TypeError: Cannot read properties of undefined (reading 'toLowerCase')

      16 | function byName(a: InstalledApp, b: InstalledApp): number {
    > 17 |   return a.name.toLowerCase().localeCompare(b.name.toLowerCase());
         |                                                    ^
      at toLowerCase (src/store/appsIndexReducer.ts:17:52)
      at Array.sort (<anonymous>)
      at sort (src/store/appsIndexReducer.ts:24:27)
      at Object.<anonymous> (src/store/__tests__/appsIndexReducer.malformed.test.tsx:35:27)

Tests: 1 failed, 2 passed, 3 total
```

- **Casos cobertos além do caminho feliz:** fronteiras/vazios (entrada `null`/não-objeto no blob, entrada sem `name`, entrada sem `packageName`); repetição/ordenação (entrada duplicada por `packageName` é deduplicada); o inverso do fix (índice 100% bem-formado continua intacto e ordenado). Cada teste falha por razão diferente: o do reducer falha no `.sort(byName)`; o do `loadApps` falharia ao pintar a entrada corrompida no `allApps` (hoje filtrada).

- **Sanity-check:** reverti o fix de produção (`git stash push -- src/store/appsIndexReducer.ts src/store/AppsStore.tsx`), a suite nova falhou (2 failed, 31 passed), e restaurei (`git stash pop`) — os testes passam só com o fix. Prova de que estão ligados ao comportamento.

- Resultado de `npm run lint`: **0 erros** (7 warnings pré-existentes, nenhuns nos meus ficheiros). `npx tsc --noEmit`: **limpo**. `npm test -- --maxWorkers=2`: **25 falharam, 1815 passaram, 194 suites** — exatamente as 25 falhas de baseline (mesmas 6 suites × 2 plataformas), zero novas nas comes do meu diff.

## Testes

25 falharam (baseline), 1815 passaram, 194 suites — mais 5 testes novos/regressão todos a passar (appsIndexReducer.malformed: 3, AppsStore malformed: 2)

## Linked Issue

Fixes #704