### PR TITLE
AssistiveTouch 'Home' acção navega para o HomeMain dentro da app (não foge para o launcher do sistema) — mesmo defeito da #697, deixado por resolver aqui (#707) (#707)

### DIFF
--- a/src/components/AssistiveTouch.tsx
+++ b/src/components/AssistiveTouch.tsx
@@ -49,6 +49,38 @@ export const MENU_GEOMETRY = {
   maxItems: 6,
 } as const;
 
+// ─── Home-commit decision (shared by the `home` action) ──────────────────────
+// Kept as a small pure unit so the in-app-vs-native ordering can be tested
+// without mounting Reanimated/RN or invoking the broken dynamic import in the
+// test environment. See issue #707 (and #697 for the HomeIndicator twin).
+//
+// FIX (issue #707): the in-app HomeMain is tried FIRST. Native goHome()
+// (ACTION_MAIN + CATEGORY_HOME) is only the last-resort escape hatch when
+// in-app navigation is unavailable. The old code tried goHome() first and only
+// fell back to HomeMain, so on a device where this app is NOT the device's
+// default launcher, goHome() surfaced the system launcher's home screen
+// instead of the iOS-style grid — exactly the "Android home screen instead of
+// the Calendar UI" frame QA captured on the Calendar screen.
+export async function commitHomeNavigation(args: {
+  navigate: (route: string) => void;
+  goHome: () => Promise<boolean>;
+}): Promise<void> {
+  // Stay inside the app: the user expects the iOS-style grid, not the device's
+  // system launcher. goHome() is only a last-resort escape hatch.
+  try {
+    args.navigate('HomeMain');
+    return;
+  } catch {
+    /* fall through to native goHome */
+  }
+  try {
+    const ok = await args.goHome();
+    if (ok) return;
+  } catch {
+    /* best effort */
+  }
+}
+
 // ─── Menu item catalog ──────────────────────────────────────────────────────
 
 interface MenuItemDef {
@@ -242,14 +274,18 @@ export function AssistiveTouch({ navigationRef }: AssistiveTouchProps) {
           openMenu();
           break;
         case 'home':
-          if (Platform.OS === 'android') {
-            try {
-              const mod = (await import('../../modules/launcher-module/src')).default;
-              const ok = await mod.goHome();
-              if (ok) return;
-            } catch { /* fall through */ }
-          }
-          navigate('HomeMain');
+          await commitHomeNavigation({
+            navigate,
+            goHome: async () => {
+              if (Platform.OS !== 'android') return false;
+              try {
+                const mod = (await import('../../modules/launcher-module/src')).default;
+                return await mod.goHome();
+              } catch {
+                return false;
+              }
+            },
+          });
           break;
         case 'multitask':        navigate('Multitask'); break;
         case 'notifications':    navigate('NotificationCenter'); break;

--- a/src/components/__tests__/AssistiveTouch.home.test.tsx
+++ b/src/components/__tests__/AssistiveTouch.home.test.tsx
@@ -1,0 +1,180 @@
+import React, { useEffect } from 'react';
+import { act, render, fireEvent } from '../../test-utils';
+import { AssistiveTouch, commitHomeNavigation } from '../AssistiveTouch';
+import { AssistiveTouchProvider, useAssistiveTouch } from '../../store/AssistiveTouchStore';
+import type { NavigationContainerRefWithCurrent } from '@react-navigation/native';
+import type { RootStackParamList } from '../../navigation/types';
+
+// #707: the AssistiveTouch radial menu's "Home" item must navigate back into
+// the app's own home (HomeMain) and NOT bail out to the Android system launcher
+// via the native goHome() call. This is the SAME defect class as #697 (which
+// was fixed in HomeIndicator.doHome) but left here: the old code tried the
+// native goHome() FIRST and only fell back to navigate('HomeMain'). On a device
+// where this app is NOT the default launcher, goHome() (ACTION_MAIN +
+// CATEGORY_HOME) surfaces the system launcher's home screen — exactly the
+// "Android home screen instead of the Calendar UI" frame the QA harness
+// captured on the Calendar screen (the bug is global; Calendar was just where
+// it was reproduced).
+//
+// The fix lives in the `home` action's decision, extracted into the pure unit
+// `commitHomeNavigation`: navigate to HomeMain (the in-app iOS-style grid)
+// FIRST; native goHome() is only the last-resort escape hatch when navigation
+// fails.
+//
+// NOTE on testability: the component reaches goHome() through a dynamic
+// `import()` of the launcher module, which throws in the jest environment
+// ("A dynamic import callback was invoked without --experimental-vm-modules"),
+// so that path cannot be exercised through the rendered component. That is
+// precisely why #697's twin bug was invisible here. The ordering decision is
+// therefore unit-tested on the REAL `commitHomeNavigation` helper (which the
+// component delegates to) with an injected goHome, AND the component is driven
+// end-to-end to confirm it still lands on the in-app HomeMain.
+
+const mockNavigate = jest.fn();
+const mockGoHome = jest.fn(() => Promise.resolve(true));
+
+// Re-mock gesture-handler so the single-tap that opens the menu keeps its
+// onEnd handler (jest.setup.js discards every callback).
+const mockTapRecords: Array<{ numberOfTaps: number; onEnd: (e: unknown, success: boolean) => void }> = [];
+
+jest.mock('react-native-gesture-handler', () => {
+  const chain = (record: Record<string, unknown>) => {
+    const g: Record<string, unknown> = {};
+    g.numberOfTaps = (n: number) => { record.numberOfTaps = n; return g; };
+    g.minDuration = (n: number) => { record.minDuration = n; return g; };
+    g.maxDuration = (n: number) => { record.maxDuration = n; return g; };
+    ['minDistance', 'maxPointers', 'minPointers', 'enabled', 'hitSlop',
+      'simultaneousWithExternalGesture', 'withRef', 'activeOffsetX',
+      'activeOffsetY', 'failOffsetX', 'failOffsetY', 'averageTouches',
+    ].forEach((m) => { g[m] = () => g; });
+    g.onBegin = (fn: unknown) => { record.onBegin = fn; return g; };
+    g.onStart = (fn: unknown) => { record.onStart = fn; return g; };
+    g.onUpdate = (fn: unknown) => { record.onUpdate = fn; return g; };
+    g.onChange = (fn: unknown) => { record.onChange = fn; return g; };
+    g.onEnd = (fn: unknown) => { record.onEnd = fn; return g; };
+    g.onFinalize = (fn: unknown) => { record.onFinalize = fn; return g; };
+    return g;
+  };
+  const tap = () => {
+    const record = { numberOfTaps: 0, maxDuration: 0 };
+    mockTapRecords.push(record as never);
+    return chain(record);
+  };
+  return {
+    GestureHandlerRootView: 'View',
+    GestureDetector: 'View',
+    Gesture: {
+      Pan: () => chain({}),
+      Tap: tap,
+      LongPress: () => chain({}),
+      Fling: () => chain({}),
+      Exclusive: (...gs: unknown[]) => gs[0],
+      Simultaneous: (...gs: unknown[]) => gs[0],
+      Race: (...gs: unknown[]) => gs[0],
+    },
+    Swipeable: 'View',
+    DrawerLayout: 'View',
+    State: {},
+    PanGestureHandler: 'View',
+    TapGestureHandler: 'View',
+    FlatList: 'FlatList',
+    ScrollView: 'ScrollView',
+  };
+});
+
+// ── Harness ─────────────────────────────────────────────────────────────────
+
+function EnableAssistiveTouch() {
+  const { update } = useAssistiveTouch();
+  useEffect(() => {
+    update({ enabled: true });
+  }, [update]);
+  return null;
+}
+
+function makeNavigationRef() {
+  return {
+    isReady: () => true,
+    getCurrentRoute: () => ({ name: 'Calendar', key: 'calendar', params: undefined }),
+    addListener: jest.fn(() => () => {}),
+    navigate: mockNavigate,
+  } as unknown as NavigationContainerRefWithCurrent<RootStackParamList>;
+}
+
+function renderAssistiveTouch(navigationRef = makeNavigationRef()) {
+  return render(
+    <AssistiveTouchProvider>
+      <EnableAssistiveTouch />
+      <AssistiveTouch navigationRef={navigationRef} />
+    </AssistiveTouchProvider>,
+  );
+}
+
+const lastSingleTap = () => {
+  for (let i = mockTapRecords.length - 1; i >= 0; i--) {
+    if (mockTapRecords[i].numberOfTaps === 1) return mockTapRecords[i];
+  }
+  throw new Error('no single-tap gesture captured');
+};
+
+/** Simulates a successful tap on the floating button → openMenu(). */
+const openMenu = () => {
+  act(() => {
+    lastSingleTap().onEnd({}, true);
+  });
+};
+
+const advance = (ms: number) => {
+  act(() => {
+    jest.advanceTimersByTime(ms);
+  });
+};
+
+describe('commitHomeNavigation must prefer the in-app HomeMain (#707)', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+    mockGoHome.mockClear();
+  });
+
+  it('navigates to HomeMain and does NOT call native goHome when goHome would succeed', async () => {
+    await commitHomeNavigation({ navigate: mockNavigate, goHome: mockGoHome });
+
+    expect(mockNavigate).toHaveBeenCalledWith('HomeMain');
+    // The native escape hatch must never be tried when in-app navigation works.
+    expect(mockGoHome).not.toHaveBeenCalled();
+  });
+
+  it('falls back to native goHome only when in-app navigation throws', async () => {
+    const throwingNavigate = jest.fn(() => { throw new Error('no navigator'); });
+
+    await commitHomeNavigation({ navigate: throwingNavigate, goHome: mockGoHome });
+
+    expect(mockGoHome).toHaveBeenCalledTimes(1);
+    expect(throwingNavigate).toHaveBeenCalledWith('HomeMain');
+  });
+});
+
+describe('AssistiveTouch Home item stays inside the app (#707)', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockTapRecords.length = 0;
+    mockNavigate.mockClear();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('tapping the Home menu item lands on the in-app HomeMain', async () => {
+    const { getByLabelText } = renderAssistiveTouch();
+    openMenu();
+    advance(150); // let the menu fully-open timer settle
+
+    fireEvent.press(getByLabelText('Home'));
+
+    // Flush the microtasks runAction('home') awaits (no setTimeout in that path).
+    await act(async () => { await Promise.resolve(); });
+
+    expect(mockNavigate).toHaveBeenCalledWith('HomeMain');
+  });
+});


### PR DESCRIPTION
## Resumo

AssistiveTouch 'Home' acção navega para o HomeMain dentro da app (não foge para o launcher do sistema) — mesmo defeito da #697, deixado por resolver aqui (#707)

## Causa raiz

O issue #707 descrevia "Calendar frame shows Android home screen instead of Calendar UI". Ao investigar, o `CalendarScreen` em si está correto — o defeito é **global**, não do ecrã do Calendário. A causa raiz é a ação `'home'` do `AssistiveTouch` (`src/components/AssistiveTouch.tsx:244`): tal como a `HomeIndicator.doHome` antes do fix issue 697, a ação chamava `mod.goHome()` **primeiro** e só recuava para `navigate('HomeMain')`. Em dispositivo onde esta app **não** é o launcher por omissão, `goHome()` dispara `ACTION_MAIN + CATEGORY_HOME` e mostra o *home screen* do sistema Android por cima da app — exatamente o frame "Android home screen instead of the Calendar UI" que o QA capturou (o Calendário foi apenas onde se reproduziu; o item `home` está no `menuItems` por omissão, por isso afeta qualquer ecrã).

O fix issue 697 (commit `c1e4ccf`) só corrigiu `HomeIndicator.doHome`. O caminho gémeo em `AssistiveTouch` ficou por fazer.

Detalhe de testabilidade importante: no ambiente jest, o `import()` dinâmico do módulo launcher lança `TypeError: A dynamic import callback was invoked without --experimental-vm-modules`, por isso o `try { import(); goHome() }` antigo apanhava a exceção em silêncio e caía para `navigate` — o defeito estava **invisível** nos testes. Por isso a decisão de ordem foi extraída para uma unidade pura e testável.

## O que mudou

- `src/components/AssistiveTouch.tsx`:
  - Extraída a decisão de "home" para a função pura `commitHomeNavigation({ navigate, goHome })`. A ordem correta é: **tentar o `navigate('HomeMain')` dentro da app primeiro**; o `goHome()` nativo só é o último recurso quando a navegação dentro da app falha (espelha a `HomeIndicator.doHome` do fix issue 697).
  - O caso `'home'` do `runAction` agora delega em `commitHomeNavigation`, passando um `goHome` que só dispara o `import()` dinâmico em Android e devolve `false` se falhar.
- `src/components/__tests__/AssistiveTouch.home.test.tsx` (novo):
  - Testa a unidade real `commitHomeNavigation` com um `goHome` injetado que resolve `true`: confirma que `navigate('HomeMain')` é chamado e `goHome` **não** é chamado (o caso nominal não pode fugir para o launcher).
  - Testa o inverso do fix: quando `navigate` lança, o `goHome` é o fallback (1 chamada).
  - Teste de integração: carrega no item "Home" do menu radial real e confirma que aterra em `HomeMain`.

## Porque assim

- Espelhar o fix issue 697 (`navigate` primeiro, `goHome` último recurso) é a decisão consistente com o resto da app e com o comportamento iOS esperado (grade estilo-iOS, não o launcher do sistema).
- A extração para `commitHomeNavigation` foi necessária porque o `import()` dinâmico está quebrado no jest (mascara o defeito); uma unidade pura com dependências injetadas torna a ordem testável sem montar Reanimated/RN nem invocar o import quebrado. Não é um reimplementar-da-lógica no ficheiro de teste: o componente delega na mesma função de produção.
- Alternativa descartada: simplesmente inverter a ordem inline sem extrair — continuaria intesticável no jest (o `goHome` via import dinâmico nunca corre), pelo que o teste não conseguiria provar o vermelho.

## Critérios de aceitação

- [x] Tocar em "Home" no menu AssistiveTouch leva ao `HomeMain` dentro da app, nunca ao launcher do sistema. Coberto pelo teste de integração (tapa no item "Home" → `navigate('HomeMain')`).
- [x] Mesmo quando `goHome()` nativo teria sucesso (devolve `true`), a app fica dentro dela própria. Coberto pelo teste unitário `commitHomeNavigation` com `goHome` a resolver `true`.
- [x] O `goHome()` só é usado como último recurso (quando `navigate` lança). Coberto pelo teste "falls back to native goHome only when in-app navigation throws".
- [x] O que NÃO devia mudar: o ecrã Calendar e todos os outros continuam intactos; só a ação `home` do AssistiveTouch foi tocada. Confirmado: `git status` mostra apenas `AssistiveTouch.tsx` (modificado) e o novo teste; nenhum ficheiro de baseline em falha foi tocado.

## Testes

- **Passo vermelho** (output real do jest com a ordem goHome-primeiro, antes do fix):

```
  ● commitHomeNavigation must prefer the in-app HomeMain (#707) › navigates to HomeMain and does NOT call native goHome when goHome would succeed

    expect(jest.fn()).toHaveBeenCalledWith(...expected)
    Expected: "HomeMain"
    Number of calls: 0

      142 |     expect(mockNavigate).toHaveBeenCalledWith('HomeMain');

  ● commitHomeNavigation must prefer the in-app HomeMain (#707) › falls back to native goHome only when in-app navigation throws

    expect(jest.fn()).toHaveBeenCalledWith(...expected)
    Expected: "HomeMain"
    Number of calls: 0

      153 |     expect(throwingNavigate).toHaveBeenCalledWith('HomeMain');

  Test Suites: 1 failed, 1 total
  Tests:       2 failed, 1 passed, 3 total
```

- **Casos cobertos além do caminho feliz:**
  - Inverso do fix: `navigate` lança → `goHome` é o fallback (1 chamada) — prova que o escape nativo não desapareceu, só mudou de ordem.
  - Fronteira de ordem: a decisão navega-em-app-primeiro vs goHome-primeiro é exatamente o que separa vermelho de verde.
  - Integração: o item "Home" do menu radial real (via `fireEvent.press` e gesto de toque mockado) aterra em `HomeMain`, garantindo que a extração não quebrou o caminho real.

- **Sanity-check:** reverti a ordem da helper para goHome-primeiro (mantendo a extração) e os 2 testes unitários falharam (`Tests: 2 failed, 1 passed`); restaurei para navega-em-app-primeiro e os 3 passaram (`Tests: 3 passed`).

- **Verificações:**
  - `npm run lint`: 0 erros (apenas 7 warnings pré-existentes noutros ficheiros).
  - `npx tsc --noEmit`: limpo (exit 0).
  - `npm test -- --maxWorkers=2`: `Tests: 23 failed, 1836 passed, 1859 total` em 6 suites. As 6 suites em falha são **exatamente** as do baseline (`LockScreen`, `SettingsScreen`, `SiriScreen`, `WeatherScreen`, `FoldersStore`, `withLauncherIntent`) — o mesmo defeito conhecido do `SettingsStore`/`AsyncStorage`. **Não há falhas novas** em ficheiros que toquei; os meus testes passam sempre.

## Testes

3 passaram, 0 falharam (AssistiveTouch.home.test.tsx); suite completa: 23 falharam (baseline), 1836 passaram, 1859 total

## Linked Issue

Fixes #707