### PR TITLE
TodayView registado como transparentModal para flutuar sobre a home em vez de a substituir (#712) (#712)

### DIFF
--- a/src/navigation/TabNavigator.tsx
+++ b/src/navigation/TabNavigator.tsx
@@ -150,7 +150,12 @@ export function TabNavigator() {
       <Stack.Screen name="AppStoreDetail" component={AppStoreDetailScreen} options={{ animation: slideAnimation }} />
       <Stack.Screen name="SpotlightSearch" component={SpotlightSearchScreen} options={{ animation: fadeAnimation, presentation: 'transparentModal' }} />
       <Stack.Screen name="Siri" component={SiriScreen} options={{ animation: fadeAnimation, presentation: 'transparentModal' }} />
-      <Stack.Screen name="TodayView" component={TodayViewScreen} options={{ animation: settings.reduceMotion ? 'none' : 'slide_from_left' }} />
+      {/* Today View is a translucent overlay (translucent root + tap-to-dismiss
+          backdrop + swipe-to-dismiss), so it must float over the home, not
+          replace it. Registered as a transparentModal like its overlay siblings
+          (SpotlightSearch, Siri, ControlCenter, NotificationCenter, Multitask) —
+          #712. */}
+      <Stack.Screen name="TodayView" component={TodayViewScreen} options={{ animation: settings.reduceMotion ? 'none' : 'slide_from_left', presentation: 'transparentModal' }} />
       <Stack.Screen name="LauncherSettings" component={LauncherSettingsScreen} options={{ animation: slideAnimation }} />
     </Stack.Navigator>
   );

--- a/src/navigation/__tests__/todayViewPresentation.test.tsx
+++ b/src/navigation/__tests__/todayViewPresentation.test.tsx
@@ -1,0 +1,69 @@
+import fs from 'fs';
+import path from 'path';
+import React from 'react';
+import { render, fireEvent } from '../../test-utils';
+import { TodayViewScreen } from '../../screens/TodayViewScreen';
+import type { AppNavigationProp } from '../../navigation/types';
+
+// #712: "TodayView frame renders home screen instead of widget overlay".
+//
+// Root cause (src/screens/TodayViewScreen.tsx:665-712 + src/navigation/TabNavigator.tsx:153):
+// TodayViewScreen was built as a TRANSLUCENT OVERLAY — styles.root is
+// backgroundColor 'rgba(0,0,0,0.5)', there is a full-screen tap-to-dismiss
+// backdrop (Pressable absoluteFill, accessibilityLabel="Dismiss"), a
+// swipe-to-dismiss gesture, and a GlassSurface blur panel. But it is
+// registered in TabNavigator.tsx as a regular *opaque* pushed Stack.Screen
+// (`slide_from_left`, no presentation prop). Every sibling overlay with the
+// same translucent-overlay contract — SpotlightSearch (line 151), Siri (line
+// 152), ControlCenter (line 93), NotificationCenter (line 94), Multitask
+// (line 95) — is registered with `presentation: 'transparentModal'`. A pushed
+// (opaque) screen replaces the home instead of floating the translucent
+// overlay on top of it, so the widget overlay never shows over the home.
+//
+// The fix is a one-line navigator registration: TodayView must be
+// `presentation: 'transparentModal'` like its siblings.
+//
+// Test 1 below reads the REAL TabNavigator.tsx (the source the app ships, no
+// copy) and asserts the TodayView screen is a transparent modal. This matches
+// the static-analysis convention already used by routeReachability.test.tsx
+// for navigator-level guarantees, and it is the property that actually broke.
+
+const TAB_NAVIGATOR_PATH = path.join(__dirname, '..', 'TabNavigator.tsx');
+
+function screenSource(name: string): string {
+  const source = fs.readFileSync(TAB_NAVIGATOR_PATH, 'utf8');
+  const marker = `<Stack.Screen name="${name}"`;
+  const start = source.indexOf(marker);
+  if (start === -1) throw new Error(`Screen "${name}" not registered in TabNavigator.tsx`);
+  // The screen's options object closes at the first '/>' after its opening tag.
+  const end = source.indexOf('/>', start);
+  return source.slice(start, end + 2);
+}
+
+const mockNavigation = { navigate: jest.fn(), goBack: jest.fn(), push: jest.fn() } as unknown as AppNavigationProp;
+
+describe('TodayView is registered as a translucent overlay (transparentModal) — #712', () => {
+  it('registers TodayView with presentation: transparentModal', () => {
+    const src = screenSource('TodayView');
+    expect(src).toMatch(/presentation:\s*['"]transparentModal['"]/);
+  });
+
+  it('keeps TodayViewScreen itself rendering the overlay contract (backdrop + Dismiss)', () => {
+    // Distinct from the navigator test: mounts the REAL screen and confirms the
+    // overlay it draws is intact (translucent root + a tap-to-dismiss backdrop).
+    // Protects what must NOT change while the navigator registration is fixed.
+    const { getByLabelText } = render(<TodayViewScreen navigation={mockNavigation} />);
+    const dismiss = getByLabelText('Dismiss');
+    expect(dismiss).toBeTruthy();
+    // Tapping Dismiss closes the overlay rather than navigating elsewhere.
+    fireEvent.press(dismiss);
+    expect(mockNavigation.goBack).toHaveBeenCalled();
+  });
+
+  it('does NOT blanket-apply transparentModal to real app screens (Calculator stays opaque)', () => {
+    // Inverse-of-fix guard: the change must be targeted at the overlay, not a
+    // repo-wide switch. A genuine launched app screen must remain an opaque push.
+    const src = screenSource('Calculator');
+    expect(src).not.toMatch(/presentation:\s*['"]transparentModal['"]/);
+  });
+});


### PR DESCRIPTION
## Resumo

TodayView registado como transparentModal para flutuar sobre a home em vez de a substituir (#712)

## Causa raiz

O `TodayViewScreen` foi desenhado como um **overlay translúcido**: `styles.root` é `backgroundColor: 'rgba(0,0,0,0.5)'` (`src/screens/TodayViewScreen.tsx:720-724`), tem um backdrop de ecrã inteiro para fechar ao tocar (`Pressable` `StyleSheet.absoluteFill` com `accessibilityLabel="Dismiss"`, linha 670), um gesto swipe-left para dispensar (linhas 622-658) e um painel com `GlassSurface` blur (linha 675). Ou seja, o ecrã espera ser empilhado *por cima* da home com fundo translúcido.

Mas no navegador (`src/navigation/TabNavigator.tsx:153`) estava registado como um `Stack.Screen` comum, **opaco**, apenas com `animation: 'slide_from_left'` e **sem** `presentation`. Um `Stack.Screen` normal é empurrado (push) e **substitui** a home — logo a home desaparece por baixo e o que se vê é a transição de push, não o widget overlay a flutuar sobre a home. Daí o sintoma do issue: "o frame do TodayView mostra o ecrã de casa em vez do overlay de widgets".

Todos os irmãos com o mesmo contrato de overlay translúcido usam `presentation: 'transparentModal'`: `SpotlightSearch` (linha 151), `Siri` (linha 152), `ControlCenter` (linha 93), `NotificationCenter` (linha 94), `Multitask` (linha 95). O `TodayView` era o único deixado de fora — um desvio de registo da convenção do repo, não um defeito no ecrã em si.

## O que mudou

- `src/navigation/TabNavigator.tsx:153` — adicionado `presentation: 'transparentModal'` à linha `<Stack.Screen name="TodayView" ... />`, ficando idêntico aos overlays irmãos. A animação `slide_from_left` (respeitando `reduceMotion`) foi mantida.
- `src/navigation/__tests__/todayViewPresentation.test.tsx` — novo ficheiro de teste (ver abaixo).

Não se tocou no `TodayViewScreen.tsx`: o ecrã já desenhava o overlay correcto; o defeito era puramente de registo no navegador.

## Porque assim

A causa raiz é de nível de navegador (uma propriedade de `options` em `Stack.Screen`), não de lógica do ecrã. A correção mínima e correcta é registar o ecrã com `presentation: 'transparentModal'`, exactamente como os 5 overlays irmãos. Alternativas descartadas:

- *Mudar o `TodayViewScreen` para fundo opaco* — destruiria o efeito iOS de widget overlay translúcido por cima da home; pioraria o produto para acomodar um registo errado.
- *Usar `animation: 'fade'` em vez de `slide_from_left`* — desnecessário; a animação original já respeita `reduceMotion` e não é a causa. Mantive-a.
- *Qualquer `try/catch`/optional chaining* para "esconder" o problema — não se aplica: não há exceção, há uma escolha de apresentação errada.

## Critérios de aceitação

- [x] O `TodayView` é registado com `presentation: 'transparentModal'` (lê-se o `TabNavigator.tsx` real). Cumprido pelo teste `registers TodayView with presentation: transparentModal`.
- [x] A animação `slide_from_left` / `reduceMotion` é preservada (não se removeu o `animation`). Confirmado: o diff mantém `options={{ animation: settings.reduceMotion ? 'none' : 'slide_from_left', presentation: 'transparentModal' }}`.
- [x] O `TodayViewScreen` continua a desenhar o overlay (root translúcido + backdrop "Dismiss" + swipe-to-dismiss). Cumprido por `keeps TodayViewScreen itself rendering the overlay contract (backdrop + Dismiss)` — monta o ecrã real e confirma o `accessibilityLabel="Dismiss"`, e que carregar nele faz `goBack()` (fecha o overlay, não navega para outro lado).
- [x] A correção é direcionada ao overlay, não um switch global. Cumprido por `does NOT blanket-apply transparentModal to real app screens` — `Calculator` (ecrã de app real) continua sem `transparentModal`.
- [x] O que NÃO devia mudar: nenhum outro `Stack.Screen` foi alterado; o `TodayViewScreen.tsx` não foi tocado. Confirmado por `git status --porcelain` (só `TabNavigator.tsx` + o novo teste).

## Testes

- **Passo vermelho** (fix revertido via `git stash push -- src/navigation/TabNavigator.tsx`, teste escrito, depois restaurado). Output real do jest:

  ```
  FAIL Android src/navigation/__tests__/todayViewPresentation.test.tsx
    TodayView is registered as a translucent overlay (transparentModal) — #712
      ✕ registers TodayView with presentation: transparentModal (2 ms)
      ✓ keeps TodayViewScreen itself rendering the overlay contract (backdrop + Dismiss) (153 ms)
      ✓ does NOT blanket-apply transparentModal to real app screens (Calculator stays opaque) (1 ms)

    ● TodayView is registered as a translucent overlay (transparentModal) — #712 › registers TodayView with presentation: transparentModal

      expect(received).toMatch(expected)

      Expected pattern: /presentation:\s*['"]transparentModal['"]/
      Received string:  "<Stack.Screen name=\"TodayView\" component={TodayViewScreen} options={{ animation: settings.reduceMotion ? 'none' : 'slide_from_left' }} />"

        46 |   it('registers TodayView with presentation: transparentModal', () => {
        47 |     const src = screenSource('TodayView');
      > 48 |     expect(src).toMatch(/presentation:\s*['"]transparentModal['"]/);
            |                 ^
        49 |   });
  ```

  Falha pela razão certa: a linha do expect (48) não encontra `presentation: 'transparentModal'` porque o `TodayView` não o tem. Os outros dois testes (que não dependem do fix) passam no vermelho, isolando a afirmação no registo.

- **Casos cobertos** (além do caminho feliz):
  - *O inverso do fix* — `does NOT blanket-apply transparentModal to real app screens` garante que a correção não se alastra a ecrãs de app reais (Calculator). Um `transparentModal` em `Calculator` seria uma regressão visível noutro sítio.
  - *O que não deve mudar* — `keeps TodayViewScreen itself rendering the overlay contract` monta o ecrã REAL (não uma cópia) e confirma o backdrop "Dismiss" e que o toque o fecha (`goBack`), protegendo a interface do overlay contra futuras alterações acidentais.
  - O teste de registo lê o **verdadeiro** `TabNavigator.tsx` do disco (sem reimplementar a configuração), seguindo a convenção de análise estática já usada em `routeReachability.test.tsx`.

- **Sanity-check:** `git stash push -- src/navigation/TabNavigator.tsx` (fix fora, testes dentro) → `npx jest src/navigation/__tests__/todayViewPresentation.test.tsx` → `1 failed, 2 passed` (o teste do registo falha). `git stash pop` restaura o fix → `3 passed, 3 total`. Sem o fix os testes falham; com o fix passam. Prova de que o teste está ligado ao comportamento.

- **Resultado das verificações obrigatórias** (criterio = regressão vs baseline `857f5a2`: lint 0 erros, tsc limpo, 25/1764 testes a falhar em 6 suites):
  - `npm run lint`: **0 erros** (7 warnings pré-existentes, sem relação com esta mudança).
  ̀  - `npx tsc --noEmit`: limpo (exit 0).
  - `npm test -- --maxWorkers=2`: **23 falharam, 1840 passaram, 197 suites** (vs 25/1764 baseline). O total desceu 2. Os 23 que falham são todos em ficheiros que NÃO toquei (`SiriScreen.test.tsx`, `withLauncherIntent.test.js`, `LockScreen.test.tsx`, `SettingsScreen.test.tsx`, `WeatherScreen.test.tsx`, `FoldersStore.test.tsx`) — correspondem aos testes já na baseline; as entradas que aparecem como "novas" têm títulos alterados por commits entre o SHA da baseline (857f5a2) e o HEAD (c187d9f), não são regressões deste trabalho. Os meus 3 testes passam sempre. Nenhuma falha nova em ficheiro que mexí.

## Testes

23 falharam (baseline 25), 1840 passaram, 197 suites — os meus 3 testes (todayViewPresentation) passam; sem o fix o registo falha (sanity-check ok)

## Linked Issue

Fixes #712