### PR TITLE
feat/270: encriptação de backups com passphrase (PBKDF2 + AES-256-CBC) em src/services/BackupEncryption.ts (#270)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "iostoandroid",
-  "version": "1.78.2",
+  "version": "1.79.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "iostoandroid",
-      "version": "1.78.2",
+      "version": "1.79.1",
       "dependencies": {
         "@expo/vector-icons": "15.0.3",
         "@react-native-async-storage/async-storage": "^3.0.2",
         "@react-navigation/bottom-tabs": "^7.15.9",
         "@react-navigation/native": "^7.2.2",
         "@react-navigation/native-stack": "^7.14.10",
+        "crypto-js": "^4.2.0",
         "decimal.js": "^10.4.3",
         "expo": "~54.0.33",
         "expo-asset": "~12.0.12",
@@ -47,6 +48,7 @@
       },
       "devDependencies": {
         "@testing-library/react-native": "^13.3.3",
+        "@types/crypto-js": "^4.2.2",
         "@types/jest": "^29.5.0",
         "@types/react": "~19.1.0",
         "@typescript-eslint/eslint-plugin": "^8.58.0",
@@ -3665,6 +3667,13 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/crypto-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@types/crypto-js/-/crypto-js-4.2.2.tgz",
+      "integrity": "sha512-sDOLlVbHhXpAUAL0YHDUUwDZf3iN4Bwi4W6a0W0b+QcAezUbRtH4FVb+9J4h+XFPW7l/gQ9F8qC7P+Ec4k8QVQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
@@ -5551,6 +5560,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "deprecated": "Active development of CryptoJS has been discontinued. This library is no longer maintained.",
+      "license": "MIT"
     },
     "node_modules/cssom": {
       "version": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@react-navigation/bottom-tabs": "^7.15.9",
     "@react-navigation/native": "^7.2.2",
     "@react-navigation/native-stack": "^7.14.10",
+    "crypto-js": "^4.2.0",
     "decimal.js": "^10.4.3",
     "expo": "~54.0.33",
     "expo-asset": "~12.0.12",
@@ -52,6 +53,7 @@
   },
   "devDependencies": {
     "@testing-library/react-native": "^13.3.3",
+    "@types/crypto-js": "^4.2.2",
     "@types/jest": "^29.5.0",
     "@types/react": "~19.1.0",
     "@typescript-eslint/eslint-plugin": "^8.58.0",

--- a/src/services/BackupEncryption.ts
+++ b/src/services/BackupEncryption.ts
@@ -1,0 +1,168 @@
+import CryptoJS from 'crypto-js';
+
+/**
+ * A backup payload as produced by the settings export path: a flat map of
+ * AsyncStorage key -> serialised value.
+ */
+export type BackupSnapshot = Record<string, string>;
+
+/**
+ * Envelope produced by {@link encryptSnapshot}. Contains only public material:
+ * the salt and IV needed to re-derive the key, and the ciphertext. The
+ * passphrase is never part of this object and is never persisted anywhere.
+ */
+export interface EncryptedBackup {
+  version: 1;
+  /** base64, 16 random bytes, fresh on every encryption call */
+  salt: string;
+  /** base64, 16 random bytes, fresh on every encryption call */
+  iv: string;
+  /** base64 AES-256-CBC ciphertext */
+  ciphertext: string;
+}
+
+/** Thrown for a wrong passphrase or a structurally invalid envelope. */
+export class BackupDecryptError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'BackupDecryptError';
+  }
+}
+
+const CURRENT_VERSION = 1;
+const SALT_BYTES = 16;
+const IV_BYTES = 16;
+const KEY_SIZE_WORDS = 256 / 32;
+/**
+ * PBKDF2 rounds. crypto-js is pure JS and roughly 100x slower than a native
+ * implementation, so this is a deliberate compromise between a usable UI
+ * (~70ms per derivation on a laptop) and brute-force cost. It is recorded here
+ * rather than in the envelope because v1 pins it; a future version bump would
+ * carry its own iteration count.
+ */
+const PBKDF2_ITERATIONS = 10000;
+
+/**
+ * Magic marker wrapped into the plaintext before encryption. AES-CBC gives no
+ * authentication, so a wrong passphrase would otherwise decrypt to garbage
+ * that may accidentally parse. Checking this marker after decryption makes a
+ * wrong passphrase a deterministic, detectable failure instead of silent
+ * corruption.
+ */
+const PLAINTEXT_MAGIC = 'iostoandroid-backup-v1';
+
+interface Envelope {
+  magic: string;
+  data: BackupSnapshot;
+}
+
+function deriveKey(passphrase: string, salt: CryptoJS.lib.WordArray): CryptoJS.lib.WordArray {
+  return CryptoJS.PBKDF2(passphrase, salt, {
+    keySize: KEY_SIZE_WORDS,
+    iterations: PBKDF2_ITERATIONS,
+    hasher: CryptoJS.algo.SHA256,
+  });
+}
+
+export function encryptSnapshot(snapshot: BackupSnapshot, passphrase: string): EncryptedBackup {
+  const salt = CryptoJS.lib.WordArray.random(SALT_BYTES);
+  const iv = CryptoJS.lib.WordArray.random(IV_BYTES);
+  const key = deriveKey(passphrase, salt);
+
+  const envelope: Envelope = { magic: PLAINTEXT_MAGIC, data: snapshot };
+  const encrypted = CryptoJS.AES.encrypt(JSON.stringify(envelope), key, {
+    iv,
+    mode: CryptoJS.mode.CBC,
+    padding: CryptoJS.pad.Pkcs7,
+  });
+
+  return {
+    version: CURRENT_VERSION,
+    salt: CryptoJS.enc.Base64.stringify(salt),
+    iv: CryptoJS.enc.Base64.stringify(iv),
+    ciphertext: encrypted.ciphertext.toString(CryptoJS.enc.Base64),
+  };
+}
+
+function parseBase64 (value: string, expectedBytes: number | null, field: string): CryptoJS.lib.WordArray {
+  let parsed: CryptoJS.lib.WordArray;
+  try {
+    parsed = CryptoJS.enc.Base64.parse(value);
+  } catch {
+    throw new BackupDecryptError(`Malformed backup: ${field} is not valid base64`);
+  }
+  if (parsed.sigBytes <= 0) {
+    throw new BackupDecryptError(`Malformed backup: ${field} is empty`);
+  }
+  if (expectedBytes !== null && parsed.sigBytes !== expectedBytes) {
+    throw new BackupDecryptError(
+      `Malformed backup: ${field} must be ${expectedBytes} bytes, got ${parsed.sigBytes}`
+    );
+  }
+  return parsed;
+}
+
+function isStringMap(value: unknown): value is BackupSnapshot {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+  return Object.values(value as Record<string, unknown>).every((v) => typeof v === 'string');
+}
+
+export function decryptSnapshot(blob: EncryptedBackup, passphrase: string): BackupSnapshot {
+  // Structural validation happens before any crypto work, so a malformed
+  // envelope fails fast instead of being fed to the cipher.
+  if (typeof blob !== 'object' || blob === null || Array.isArray(blob)) {
+    throw new BackupDecryptError('Malformed backup: expected an object');
+  }
+  const candidate = blob as unknown as Record<string, unknown>;
+  if (candidate.version !== CURRENT_VERSION) {
+    throw new BackupDecryptError(`Unsupported backup version: ${String(candidate.version)}`);
+  }
+  for (const field of ['salt', 'iv', 'ciphertext'] as const) {
+    if (typeof candidate[field] !== 'string' || candidate[field] === '') {
+      throw new BackupDecryptError(`Malformed backup: missing or invalid "${field}"`);
+    }
+  }
+
+  const salt = parseBase64(candidate.salt as string, SALT_BYTES, 'salt');
+  const iv = parseBase64(candidate.iv as string, IV_BYTES, 'iv');
+  const ciphertext = parseBase64(candidate.ciphertext as string, null, 'ciphertext');
+  if (ciphertext.sigBytes % IV_BYTES !== 0) {
+    throw new BackupDecryptError('Malformed backup: ciphertext length is not a block multiple');
+  }
+
+  const key = deriveKey(passphrase, salt);
+
+  let plaintext: string;
+  try {
+    const decrypted = CryptoJS.AES.decrypt(
+      CryptoJS.lib.CipherParams.create({ ciphertext }),
+      key,
+      { iv, mode: CryptoJS.mode.CBC, padding: CryptoJS.pad.Pkcs7 }
+    );
+    plaintext = decrypted.toString(CryptoJS.enc.Utf8);
+  } catch {
+    // A wrong key almost always yields invalid padding or invalid UTF-8 here.
+    throw new BackupDecryptError('Could not decrypt backup: wrong passphrase or corrupt data');
+  }
+
+  let envelope: unknown;
+  try {
+    envelope = JSON.parse(plaintext);
+  } catch {
+    throw new BackupDecryptError('Could not decrypt backup: wrong passphrase or corrupt data');
+  }
+
+  if (
+    typeof envelope !== 'object' ||
+    envelope === null ||
+    (envelope as Envelope).magic !== PLAINTEXT_MAGIC
+  ) {
+    throw new BackupDecryptError('Could not decrypt backup: wrong passphrase or corrupt data');
+  }
+
+  const data = (envelope as Envelope).data;
+  if (!isStringMap(data)) {
+    throw new BackupDecryptError('Malformed backup: payload is not a string map');
+  }
+  return data;
+}

--- a/src/services/__tests__/BackupEncryption.test.ts
+++ b/src/services/__tests__/BackupEncryption.test.ts
@@ -1,0 +1,105 @@
+import {
+  encryptSnapshot,
+  decryptSnapshot,
+  BackupDecryptError,
+  type EncryptedBackup,
+  type BackupSnapshot,
+} from '../BackupEncryption';
+
+const snapshot: BackupSnapshot = {
+  '@iostoandroid/settings': JSON.stringify({ darkMode: true, volume: 7 }),
+  '@iostoandroid/accent_color': 'blue',
+};
+
+describe('BackupEncryption', () => {
+  it('round-trips a snapshot with the correct passphrase', () => {
+    const blob = encryptSnapshot(snapshot, 'correct horse');
+    expect(decryptSnapshot(blob, 'correct horse')).toEqual(snapshot);
+  });
+
+  it('round-trips an empty snapshot', () => {
+    const blob = encryptSnapshot({}, 'pw');
+    expect(decryptSnapshot(blob, 'pw')).toEqual({});
+  });
+
+  it('round-trips unicode and empty-string values', () => {
+    const s: BackupSnapshot = { 'k/ç': 'ação — 日本語 🎉', empty: '' };
+    expect(decryptSnapshot(encryptSnapshot(s, 'pw'), 'pw')).toEqual(s);
+  });
+
+  it('uses a fresh random salt and IV on every call', () => {
+    const a = encryptSnapshot(snapshot, 'pw');
+    const b = encryptSnapshot(snapshot, 'pw');
+    expect(a.salt).not.toEqual(b.salt);
+    expect(a.iv).not.toEqual(b.iv);
+    expect(a.ciphertext).not.toEqual(b.ciphertext);
+    // both still decrypt to the same plaintext
+    expect(decryptSnapshot(a, 'pw')).toEqual(snapshot);
+    expect(decryptSnapshot(b, 'pw')).toEqual(snapshot);
+  });
+
+  it('never embeds the passphrase in the encrypted blob', () => {
+    const pass = 'super-secret-passphrase';
+    const blob = encryptSnapshot(snapshot, pass);
+    expect(JSON.stringify(blob)).not.toContain(pass);
+    expect(Object.keys(blob).sort()).toEqual(['ciphertext', 'iv', 'salt', 'version']);
+  });
+
+  it('throws BackupDecryptError on a wrong passphrase', () => {
+    const blob = encryptSnapshot(snapshot, 'right-pw');
+    expect(() => decryptSnapshot(blob, 'wrong-pw')).toThrow(BackupDecryptError);
+  });
+
+  it('throws BackupDecryptError on an empty passphrase mismatch', () => {
+    const blob = encryptSnapshot(snapshot, 'pw');
+    expect(() => decryptSnapshot(blob, '')).toThrow(BackupDecryptError);
+  });
+
+  it.each(['salt', 'iv', 'ciphertext'] as const)(
+    'throws BackupDecryptError when %s is missing',
+    (field) => {
+      const blob = encryptSnapshot(snapshot, 'pw') as unknown as Record<string, unknown>;
+      delete blob[field];
+      expect(() => decryptSnapshot(blob as unknown as EncryptedBackup, 'pw')).toThrow(
+        BackupDecryptError
+      );
+    }
+  );
+
+  it.each([null, undefined, 'string', 42, []])('throws on non-object blob %p', (bad) => {
+    expect(() => decryptSnapshot(bad as unknown as EncryptedBackup, 'pw')).toThrow(
+      BackupDecryptError
+    );
+  });
+
+  it('throws BackupDecryptError on an unsupported version', () => {
+    const blob = { ...encryptSnapshot(snapshot, 'pw'), version: 2 as unknown as 1 };
+    expect(() => decryptSnapshot(blob, 'pw')).toThrow(BackupDecryptError);
+  });
+
+  it('throws BackupDecryptError on non-base64 garbage ciphertext', () => {
+    const blob = { ...encryptSnapshot(snapshot, 'pw'), ciphertext: '!!!not base64!!!' };
+    expect(() => decryptSnapshot(blob, 'pw')).toThrow(BackupDecryptError);
+  });
+
+  it('throws BackupDecryptError when the ciphertext was tampered with', () => {
+    const blob = encryptSnapshot(snapshot, 'pw');
+    const raw = Buffer.from(blob.ciphertext, 'base64');
+    raw[0] ^= 0xff;
+    const tampered: EncryptedBackup = { ...blob, ciphertext: raw.toString('base64') };
+    expect(() => decryptSnapshot(tampered, 'pw')).toThrow(BackupDecryptError);
+  });
+
+  it('throws BackupDecryptError when the salt does not match the one used', () => {
+    const blob = encryptSnapshot(snapshot, 'pw');
+    const other = encryptSnapshot(snapshot, 'pw');
+    expect(() => decryptSnapshot({ ...blob, salt: other.salt }, 'pw')).toThrow(BackupDecryptError);
+  });
+
+  it('is idempotent: encrypting twice in a row leaves the source snapshot untouched', () => {
+    const copy = { ...snapshot };
+    encryptSnapshot(snapshot, 'pw');
+    encryptSnapshot(snapshot, 'pw');
+    expect(snapshot).toEqual(copy);
+  });
+});


### PR DESCRIPTION
## Resumo

feat/270: encriptação de backups com passphrase (PBKDF2 + AES-256-CBC) em src/services/BackupEncryption.ts

## Causa raiz

Não é um bug — é uma capacidade em falta. Confirmei no worktree que **não existia nada de crypto**: `grep -rn 'BackupSnapshot' src` não devolve nada e `package.json` não tinha `crypto-js`, `expo-crypto` nem `react-native-aes-crypto`. O caminho de backup actual (`src/screens/settings/BackupRestoreScreen.tsx:78-96`) serializa as chaves de `EXPORTABLE_KEYS` do AsyncStorage e faz `Clipboard.setStringAsync(json)` **em texto claro**. Qualquer upload futuro (épico #126) enviaria esse JSON tal e qual.

**Onde o issue estava errado:** o issue diz que este trabalho "builds on the `BackupSnapshot` shape from #269 (`Record<string,string>`)" e importa-o de `./BackupSnapshot`. Esse módulo **não existe neste repositório** — #269 não aterrou. O código ganha: exportei `BackupSnapshot = Record<string, string>` do próprio `BackupEncryption.ts`, que é exactamente a forma que o `BackupRestoreScreen` já constrói (`const backup: Record<string, string> = {}`, linha 82). Quando #269 aterrar, o alias pode ser reencaminhado sem alterar a API pública deste ficheiro.

## O que mudou

- **`package.json`** — adiciona `crypto-js@^4.2.0` a `dependencies` e `@types/crypto-js@^4.2.2` a `devDependencies` (os tipos são dev-only, não vão para o bundle). JS puro, sem linking nativo, corre sem alterações sob Jest.
- **`package-lock.json`** — lockfile resultante do `npm install`.
- **`src/services/BackupEncryption.ts`** (novo) — expõe `BackupSnapshot`, `EncryptedBackup`, `BackupDecryptError`, `encryptSnapshot`, `decryptSnapshot`. `encryptSnapshot` gera 16 bytes aleatórios de salt e 16 de IV **por chamada** (`CryptoJS.lib.WordArray.random`), deriva chave de 256 bits com PBKDF2-SHA256 (10 000 iterações) e cifra AES-256-CBC/Pkcs7. O plaintext é envelopado como `{ magic: 'iostoandroid-backup-v1', data: snapshot }`. `decryptSnapshot` valida a estrutura **antes de qualquer trabalho criptográfico** (objecto, `version === 1`, `salt`/`iv`/`ciphertext` strings não vazias, base64 válido, salt e IV com exactamente 16 bytes, ciphertext múltiplo do bloco), deriva a chave, decifra, e só aceita o resultado se o `magic` corresponder e o payload for um mapa string→string. Qualquer desvio lança `BackupDecryptError`.
- **`src/services/__tests__/BackupEncryption.test.ts`** (novo) — 20 testes.

## Porque assim

- **Marcador `magic` no plaintext.** AES-CBC não é autenticado: com a passphrase errada o Pkcs7 às vezes valida por acaso e devolve bytes que podem passar por JSON. Sem verificação de integridade, o critério "nunca devolve dados corrompidos" seria falso em modo probabilístico. O marcador torna a passphrase errada uma falha **determinística**. Descartei HMAC-then-encrypt separado (mais código e mais um campo no envelope para ganho equivalente aqui) e AES-GCM (o `crypto-js` não o suporta).
- **10 000 iterações de PBKDF2.** Medido no host: 100 000 iterações = 1 323 ms, 10 000 = 71 ms. Em JS puro num telemóvel de gama média isto multiplica-se; 10 000 mantém a UI utilizável. Está documentado no ficheiro e ligado ao `version: 1`, para um bump futuro poder aumentar sem quebrar blobs antigos.
- **Sem `any` novo, sem `?.` a tapar casos.** As entradas não fidedignas passam por `Record<string, unknown>` com narrowing explícito; cada ramo inválido lança em vez de degradar.
- **Nada de segredos.** A passphrase é só parâmetro de função: não é logada, não entra no `EncryptedBackup`, não toca o AsyncStorage. Um teste verifica-o (`JSON.stringify(blob)` não contém a passphrase, e as chaves do blob são exactamente `ciphertext`/`iv`/`salt`/`version`).

## Critérios de aceitação

- [x] **Salt e IV frescos por chamada** — teste `uses a fresh random salt and IV on every call`: duas chamadas com input idêntico dão `salt`, `iv` e `ciphertext` diferentes, e ambas decifram para o mesmo snapshot.
- [x] **Round-trip deep-equal** — `decryptSnapshot(encryptSnapshot(s,'pw'),'pw')` iguala `s` (mais snapshot vazio e valores unicode/string vazia).
- [x] **Passphrase errada lança `BackupDecryptError`** — nunca devolve dados parciais; garantido pelo marcador `magic`.
- [x] **Blob sem `salt`/`iv`/`ciphertext` lança antes de parsear** — as verificações estruturais estão acima da derivação da chave em `decryptSnapshot`; teste `it.each` para os três campos.
- [x] **Passphrase nunca em AsyncStorage nem no output** — o ficheiro não importa AsyncStorage (verificável no diff); teste dedicado sobre a serialização do blob.
- [x] **`BackupRestoreScreen` e o export/import por clipboard de #269 intactos** — não toquei nesse ficheiro; `git status --porcelain` mostra apenas `package.json`, `package-lock.json` e `src/services/` novo. A suite `src/screens/settings/__tests__/BackupRestoreScreen.test.tsx` continua a passar.
- [x] **Cobertura pedida** — round-trip, passphrase errada, blob malformado, unicidade de salt/IV: todos presentes.
- [x] **Não regredi a baseline** — 23 falhas em 6 suites, todas na lista da baseline (25 falhas / 6 suites). Nenhuma falha nova.

## Testes

**Passo vermelho** (implementação ingénua com salt/IV fixos e sem validação no lugar, teste inalterado):

```
  ● BackupEncryption › throws BackupDecryptError when the ciphertext was tampered with

    expect(received).toThrow(expected)

    Expected constructor: BackupDecryptError
    Received constructor: Error

    Received message: "Malformed UTF-8 data"

          34 |     key,
          35 |     { iv: FIXED_IV }
        > 36 |   ).toString(CryptoJS.enc.Utf8);
             |     ^
      at toString (src/services/BackupEncryption.ts:36:5)
      at Object.toThrow (src/services/__tests__/BackupEncryption.test.ts:90:51)

  ● BackupEncryption › throws BackupDecryptError when the salt does not match the one used

    expect(received).toThrow(expected)

    Expected constructor: BackupDecryptError

    Received function did not throw

      94 |     const blob = encryptSnapshot(snapshot, 'pw');
      95 |     const other = encryptSnapshot(snapshot, 'pw');
    > 96 |     expect(() => decryptSnapshot({ ...blob, salt: other.salt }, 'pw')).toThrow(BackupDecryptError);
         |                                                                        ^
      at Object.toThrow (src/services/__tests__/BackupEncryption.test.ts:96:72)

Test Suites: 1 failed, 1 total
Tests:       15 failed, 5 passed, 20 total
```

Lista completa dos 15 vermelhos: `uses a fresh random salt and IV on every call`, `throws BackupDecryptError on a wrong passphrase`, `throws BackupDecryptError on an empty passphrase mismatch`, `throws BackupDecryptError when salt is missing`, `... when iv is missing`, `... when ciphertext is missing`, `throws on non-object blob null/undefined/"string"/42/[]`, `... on an unsupported version`, `... on non-base64 garbage ciphertext`, `... when the ciphertext was tampered with`, `... when the salt does not match the one used`.

Nota: `git stash push -- src/services/BackupEncryption.ts` não serve aqui porque o ficheiro é novo e não está indexado (`pathspec did not match any file(s) known to git`), por isso o passo vermelho foi obtido substituindo a implementação real pela ingénua no local, e restaurando depois.

**Casos cobertos além do caminho feliz:**
- *Vazio/ausente*: snapshot `{}`, valor string vazia, `salt`/`iv`/`ciphertext` em falta, blob `null`/`undefined`.
- *Inválido/hostil*: blob que é string, número ou array; base64 lixo; `version: 2`; ciphertext com um byte invertido (tampering); salt de outra chamada colado num blob válido.
- *Repetição*: duas encriptações seguidas do mesmo objecto — verifica unicidade de salt/IV **e** que o snapshot de origem não é mutado.
- *Unicode*: acentos, CJK e emoji sobrevivem ao round-trip (regressão clássica de UTF-8 em crypto-js).
- *O inverso do fix*: os round-trips confirmam que a validação endurecida **não** rejeita blobs legítimos.

**Sanity-check:** substituí a implementação real pela ingénua e corri o teste → `Test Suites: 1 failed`, `Tests: 15 failed, 5 passed, 20 total`. Restaurei a real → `Tests: 20 passed, 20 total`. Os testes estão ligados ao comportamento de produção.

**Verificações:**
- `npm run lint`: `✖ 7 problems (0 errors, 7 warnings)` — 0 erros, iguais à baseline, nenhum nos meus ficheiros.
- `npx tsc --noEmit`: limpo, sem output.
- `npm test -- --maxWorkers=2`: `Test Suites: 6 failed, 191 passed, 197 total` / `Tests: 23 failed, 1857 passed, 1880 total`. As 6 suites vermelhas são exactamente as da baseline (SiriScreen, WeatherScreen, SettingsScreen, FoldersStore, withLauncherIntent, LockScreen) e o total de falhas **desceu** de 25 para 23. Zero falhas novas.
- `npx jest src/services/__tests__/BackupEncryption.test.ts`: 20 passed, 20 total.

## Testes

20 passaram, 0 falharam na suite nova (BackupEncryption); suite completa: 1857 passaram, 23 falharam (todas de baseline: 25 antes), 197 suites

## Linked Issue

Fixes #270