### PR TITLE
Extract backup/restore AsyncStorage logic into src/services/BackupSnapshot.ts (behavior-preserving refactor) (#269)

### DIFF
--- a/src/screens/settings/BackupRestoreScreen.tsx
+++ b/src/screens/settings/BackupRestoreScreen.tsx
@@ -21,45 +21,7 @@ import {
   useAlert,
 } from '../../components';
 import type { AppNavigationProp } from '../../navigation/types';
-
-// Explicit allow-list derived from SettingsStore.tsx, ThemeContext.tsx, and
-// each settings screen that writes its own AsyncStorage keys.
-// Intentionally excludes non-settings data: messages, notes, contacts, reminders,
-// home layout, Spotlight history, and any future non-settings keys.
-const EXPORTABLE_KEYS = [
-  // Main settings blob (SettingsStore)
-  '@iostoandroid/settings',
-  // ThemeContext — display mode, accent colour, high-contrast
-  '@iostoandroid/theme_preference',
-  '@iostoandroid/accent_color',
-  '@iostoandroid/high_contrast',
-  // AccessibilityScreen — text scale, bold, reduce motion
-  '@iostoandroid/a11y_textscale',
-  '@iostoandroid/a11y_bold',
-  '@iostoandroid/a11y_reduce_motion',
-  // DisplayBrightnessScreen — night shift preference
-  '@iostoandroid/night_shift',
-  // KeyboardScreen — keyboard preferences
-  '@iostoandroid/kbd_autocap',
-  '@iostoandroid/kbd_autocorrect',
-  '@iostoandroid/kbd_clicks',
-  '@iostoandroid/kbd_predictive',
-  // CellularScreen — cellular and data-roaming preferences
-  '@iostoandroid/cellular_data',
-  '@iostoandroid/data_roaming',
-  // DateTimeScreen — timezone preference
-  '@iostoandroid/timezone',
-  // LanguageRegionScreen — locale preferences
-  '@iostoandroid/language',
-  '@iostoandroid/region',
-  // SoundsHapticsScreen — ringtone and text-tone labels
-  '@iostoandroid/ringtone',
-  '@iostoandroid/text_tone',
-  // WallpaperScreen — custom wallpaper URI
-  '@iostoandroid/custom_wallpaper',
-] as const;
-
-const EXPORTABLE_SET = new Set<string>(EXPORTABLE_KEYS);
+import { createSnapshot, applySnapshot } from '../../services/BackupSnapshot';
 
 export function BackupRestoreScreen({ navigation }: { navigation: AppNavigationProp }) {
   const { theme, typography, spacing } = useTheme();
@@ -78,12 +40,8 @@ export function BackupRestoreScreen({ navigation }: { navigation: AppNavigationP
   const doExport = useCallback(async () => {
     try {
       setBusy(true);
-      const entries = await AsyncStorage.getMany([...EXPORTABLE_KEYS]);
-      const backup: Record<string, string> = {};
-      for (const [k, v] of Object.entries(entries)) {
-        if (v !== null) backup[k] = v;
-      }
-      const json = JSON.stringify(backup, null, 2);
+      const snapshot = await createSnapshot();
+      const json = JSON.stringify(snapshot, null, 2);
       await Clipboard.setStringAsync(json);
       const now = new Date().toLocaleString();
       setLastBackupTime(now);
@@ -107,16 +65,7 @@ export function BackupRestoreScreen({ navigation }: { navigation: AppNavigationP
     try {
       setImporting(true);
       const data = JSON.parse(importText.trim());
-      if (typeof data !== 'object' || Array.isArray(data)) {
-        throw new Error('Expected a JSON object');
-      }
-      const filtered: Record<string, string> = {};
-      for (const [k, v] of Object.entries(data)) {
-        if (EXPORTABLE_SET.has(k)) {
-          filtered[k] = String(v);
-        }
-      }
-      await AsyncStorage.setMany(filtered);
+      await applySnapshot(data);
       setShowImportModal(false);
       setImportText('');
       alert('Restored', 'Settings imported successfully. Restart the app to apply all changes.');

--- a/src/services/BackupSnapshot.ts
+++ b/src/services/BackupSnapshot.ts
@@ -1,0 +1,77 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+// Explicit allow-list derived from SettingsStore.tsx, ThemeContext.tsx, and
+// each settings screen that writes its own AsyncStorage keys.
+// Intentionally excludes non-settings data: messages, notes, contacts, reminders,
+// home layout, Spotlight history, and any future non-settings keys.
+// Shared by BackupRestoreScreen (clipboard backup/restore) so the snapshot
+// contract can be reused by the cloud-backup path (#126) without duplicating
+// this logic.
+export const EXPORTABLE_KEYS = [
+  // Main settings blob (SettingsStore)
+  '@iostoandroid/settings',
+  // ThemeContext — display mode, accent colour, high-contrast
+  '@iostoandroid/theme_preference',
+  '@iostoandroid/accent_color',
+  '@iostoandroid/high_contrast',
+  // AccessibilityScreen — text scale, bold, reduce motion
+  '@iostoandroid/a11y_textscale',
+  '@iostoandroid/a11y_bold',
+  '@iostoandroid/a11y_reduce_motion',
+  // DisplayBrightnessScreen — night shift preference
+  '@iostoandroid/night_shift',
+  // KeyboardScreen — keyboard preferences
+  '@iostoandroid/kbd_autocap',
+  '@iostoandroid/kbd_autocorrect',
+  '@iostoandroid/kbd_clicks',
+  '@iostoandroid/kbd_predictive',
+  // CellularScreen — cellular and data-roaming preferences
+  '@iostoandroid/cellular_data',
+  '@iostoandroid/data_roaming',
+  // DateTimeScreen — timezone preference
+  '@iostoandroid/timezone',
+  // LanguageRegionScreen — locale preferences
+  '@iostoandroid/language',
+  '@iostoandroid/region',
+  // SoundsHapticsScreen — ringtone and text-tone labels
+  '@iostoandroid/ringtone',
+  '@iostoandroid/text_tone',
+  // WallpaperScreen — custom wallpaper URI
+  '@iostoandroid/custom_wallpaper',
+] as const;
+
+const EXPORTABLE_SET = new Set<string>(EXPORTABLE_KEYS);
+
+export type BackupSnapshot = Record<string, string>;
+
+/**
+ * Reads every allow-listed AsyncStorage key via getMany() and returns a
+ * Record<string,string> of the present values, skipping null entries.
+ * Same behaviour as the former BackupRestoreScreen.handleExport body.
+ */
+export async function createSnapshot(): Promise<BackupSnapshot> {
+  const entries = await AsyncStorage.getMany([...EXPORTABLE_KEYS]);
+  const backup: BackupSnapshot = {};
+  for (const [k, v] of Object.entries(entries)) {
+    if (v !== null) backup[k] = v;
+  }
+  return backup;
+}
+
+/**
+ * Applies a previously created snapshot: rejects non-object input (primitives,
+ * arrays, and null) and writes only allow-listed keys via AsyncStorage.setMany.
+ * Values are coerced to strings (matching the former import behaviour).
+ */
+export async function applySnapshot(data: unknown): Promise<void> {
+  if (typeof data !== 'object' || data === null || Array.isArray(data)) {
+    throw new Error('Expected a JSON object');
+  }
+  const filtered: BackupSnapshot = {};
+  for (const [k, v] of Object.entries(data as Record<string, unknown>)) {
+    if (EXPORTABLE_SET.has(k)) {
+      filtered[k] = String(v);
+    }
+  }
+  await AsyncStorage.setMany(filtered);
+}

--- a/src/services/__tests__/BackupSnapshot.test.ts
+++ b/src/services/__tests__/BackupSnapshot.test.ts
@@ -1,0 +1,157 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { createSnapshot, applySnapshot } from '../BackupSnapshot';
+
+// Isolate this suite from the global jest.setup.js AsyncStorage mock, which only
+// stubs getItem/setItem/removeItem. We own getMany/setMany here.
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(() => Promise.resolve(null)),
+    setItem: jest.fn(() => Promise.resolve()),
+    removeItem: jest.fn(() => Promise.resolve()),
+    getMany: jest.fn(),
+    setMany: jest.fn(),
+  },
+}));
+
+// In-memory backing store so getMany/setMany behave like the real storage.
+function setupAsyncStorage(initial: Record<string, string> = {}) {
+  const store = new Map<string, string>(Object.entries(initial));
+  (AsyncStorage.getMany as jest.Mock).mockImplementation(
+    async (keys: string[]): Promise<Record<string, string | null>> => {
+      const out: Record<string, string | null> = {};
+      for (const k of keys) out[k] = store.has(k) ? store.get(k)! : null;
+      return out;
+    },
+  );
+  (AsyncStorage.setMany as jest.Mock).mockImplementation(
+    async (entries: Record<string, string>): Promise<void> => {
+      for (const [k, v] of Object.entries(entries)) store.set(k, v);
+    },
+  );
+  return store;
+}
+
+beforeEach(() => {
+  // Clear any call history leaked from other suites sharing this worker's
+  // AsyncStorage module instance, then re-arm getMany/setMany implementations.
+  (AsyncStorage.getMany as jest.Mock).mockClear?.();
+  (AsyncStorage.setMany as jest.Mock).mockClear?.();
+  setupAsyncStorage();
+});
+
+const EXPORTABLE_KEYS = [
+  '@iostoandroid/settings',
+  '@iostoandroid/theme_preference',
+  '@iostoandroid/accent_color',
+  '@iostoandroid/high_contrast',
+  '@iostoandroid/a11y_textscale',
+  '@iostoandroid/a11y_bold',
+  '@iostoandroid/a11y_reduce_motion',
+  '@iostoandroid/night_shift',
+  '@iostoandroid/kbd_autocap',
+  '@iostoandroid/kbd_autocorrect',
+  '@iostoandroid/kbd_clicks',
+  '@iostoandroid/kbd_predictive',
+  '@iostoandroid/cellular_data',
+  '@iostoandroid/data_roaming',
+  '@iostoandroid/timezone',
+  '@iostoandroid/language',
+  '@iostoandroid/region',
+  '@iostoandroid/ringtone',
+  '@iostoandroid/text_tone',
+  '@iostoandroid/custom_wallpaper',
+] as const;
+
+describe('createSnapshot', () => {
+  it('returns a Record<string,string> of all EXPORTABLE_KEYS values present in storage', async () => {
+    setupAsyncStorage({
+      '@iostoandroid/settings': '{"vibration":true}',
+      '@iostoandroid/theme_preference': 'dark',
+      '@iostoandroid/language': 'pt',
+    });
+
+    const snapshot = await createSnapshot();
+
+    expect(snapshot).toEqual({
+      '@iostoandroid/settings': '{"vibration":true}',
+      '@iostoandroid/theme_preference': 'dark',
+      '@iostoandroid/language': 'pt',
+    });
+    // It only fetched the allow-listed keys, exactly once.
+    expect(AsyncStorage.getMany).toHaveBeenCalledTimes(1);
+    expect(AsyncStorage.getMany).toHaveBeenCalledWith([...EXPORTABLE_KEYS]);
+  });
+
+  it('skips null entries so they do not appear in the snapshot', async () => {
+    setupAsyncStorage({
+      '@iostoandroid/settings': '{"vibration":true}',
+      // @iostoandroid/theme_preference is absent → getMany returns null for it.
+    });
+
+    const snapshot = await createSnapshot();
+
+    expect(snapshot).toEqual({
+      '@iostoandroid/settings': '{"vibration":true}',
+    });
+    expect(Object.keys(snapshot)).not.toContain('@iostoandroid/theme_preference');
+  });
+
+  it('returns an empty object when no allow-listed key is present', async () => {
+    setupAsyncStorage({
+      '@iostoandroid/sms_messages': 'should-not-appear',
+    });
+
+    const snapshot = await createSnapshot();
+
+    expect(snapshot).toEqual({});
+  });
+});
+
+describe('applySnapshot', () => {
+  it('writes only allow-listed keys via AsyncStorage.setMany', async () => {
+    const data = {
+      '@iostoandroid/settings': '{"vibration":false}',
+      '@iostoandroid/sms_messages': 'injected', // non-settings, must be filtered out
+    };
+
+    await applySnapshot(data);
+
+    expect(AsyncStorage.setMany).toHaveBeenCalledTimes(1);
+    const written = (AsyncStorage.setMany as jest.Mock).mock.calls[0][0];
+    expect(written).toEqual({
+      '@iostoandroid/settings': '{"vibration":false}',
+    });
+    expect(written['@iostoandroid/sms_messages']).toBeUndefined();
+  });
+
+  it('rejects array input with an error', async () => {
+    await expect(applySnapshot([1, 2, 3])).rejects.toThrow();
+    expect(AsyncStorage.setMany).not.toHaveBeenCalled();
+  });
+
+  it('rejects a primitive (non-object) input with an error', async () => {
+    await expect(applySnapshot('not-an-object')).rejects.toThrow();
+    expect(AsyncStorage.setMany).not.toHaveBeenCalled();
+
+    await expect(applySnapshot(42)).rejects.toThrow();
+    expect(AsyncStorage.setMany).not.toHaveBeenCalled();
+  });
+
+  it('rejects null input (typeof object but not a usable record)', async () => {
+    await expect(applySnapshot(null)).rejects.toThrow();
+    expect(AsyncStorage.setMany).not.toHaveBeenCalled();
+  });
+
+  it('coerces non-string values to strings before writing', async () => {
+    const data = {
+      '@iostoandroid/language': 'pt',
+      '@iostoandroid/high_contrast': true as unknown, // stored as boolean upstream edge case
+    };
+    await applySnapshot(data as Record<string, unknown>);
+
+    const written = (AsyncStorage.setMany as jest.Mock).mock.calls[0][0];
+    expect(written['@iostoandroid/high_contrast']).toBe('true');
+    expect(typeof written['@iostoandroid/high_contrast']).toBe('string');
+  });
+});


### PR DESCRIPTION
## Resumo

Extract backup/restore AsyncStorage logic into src/services/BackupSnapshot.ts (behavior-preserving refactor)

## Causa raiz

O issue descrevia mal o código actual. O `BackupRestoreScreen.tsx` **não** inline-iza `getAllKeys()` + loop como o issue afirma (linhas 39‑58 / 60‑84 do issue). O código real (introduzido em `3aa8eea`, issue #397) usa uma **allow‑list explícita `EXPORTABLE_KEYS`** e `AsyncStorage.getMany([...EXPORTABLE_KEYS])` no export, e filtra por `EXPORTABLE_SET` no import — para impedir que chaves não‑settings (SMS, notas, contactos, etc.) saiam no backup ou entrem por import. O `getMany` da biblioteca devolve `Record<string,string|null>` (confirmado em `node_modules/@react-native-async-storage/async-storage/lib/typescript/AsyncStorage.d.ts:35`), pelo que o `Object.entries(entries)` do código actual está correcto. Regra do pipeline: o código ganha. Preservei o comportamento real (allow‑list), não o que o issue descrevia.

Além disso o issue dizia que `BackupRestoreScreen.test.tsx` "none exists today" — mas **já existe e está tracked em `origin/main`** (com o guard de regressão allow‑list). Não o apaguei nem quebrei; continua a passar.

## O que mudou

- **`src/services/BackupSnapshot.ts`** (novo): exporta `EXPORTABLE_KEYS` (a allow‑list, movida do ecrã), `BackupSnapshot = Record<string,string>`, `createSnapshot()` (lê `getMany([...EXPORTABLE_KEYS])`, salta `null`, devolve o record) e `applySnapshot(data)` (rejeita `null`/array/primitivo com `Expected a JSON object`, filtra por `EXPORTABLE_SET`, coerce valores com `String`, e chama `AsyncStorage.setMany`). Comportamento idêntico ao antigo corpo dos callbacks do ecrã.
- **`src/screens/settings/BackupRestoreScreen.tsx`** (modificado): `doExport` passa a chamar `createSnapshot()` + `Clipboard.setStringAsync(JSON.stringify(snapshot, null, 2))`; `handleImportConfirm` passa a `JSON.parse` e `applySnapshot(data)`. A allow‑list e a lógica saíram do ecrã. `AsyncStorage` mantém‑se importado porque `handleReset` ainda usa `AsyncStorage.clear()`. Alert copy, error handling e disclosure dialog ficam inalterados.
- **`src/services/__tests__/BackupSnapshot.test.ts`** (novo): testes de unidade do serviço (ver abaixo).

NÃO mexido: `BackupRestoreScreen.test.tsx` (já existia em main; mantido, continua verde).

## Porque assim

- Refactor puramente behavior‑preserving (critério do issue): nenhuma mudança de comportamento visível. A allow‑list foi movida para o serviço (única fonte de verdade) em vez de duplicada, para o caminho cloud (#126) reutilizar o mesmo contrato.
- O `getMany`/`setMany` não está no mock global de `jest.setup.js` (que só stuba `getItem/setItem/removeItem`), por isso o teste do serviço faz o seu próprio `jest.mock` do módulo e re‑arma as implementações em `beforeEach`, com `mockClear()` para não herdar call history de outros suites que partilham a mesma instância de módulo no worker. Sem isto, os asserts de "reject" falhavam por contaminação de `setMany` chamado noutro ficheiro.

## Critérios de aceitação

- [x] `BackupSnapshot.ts` exporta `createSnapshot()` devolvendo `Record<string,string>` de todas as chaves allow‑list (saltando `null`) e `applySnapshot(data)` que rejeita input não‑objecto/array e chama `AsyncStorage.setMany` — coberto pelos testes de serviço.
- [x] `handleExport`/`handleImportConfirm` chamam estas funções em vez de inline‑izar a lógica AsyncStorage/JSON — diff do ecrã (-55/+4 linhas).
- [x] Clipboard "Export Settings"/"Import Settings" continua igual (mesma alert copy, mesmo error handling, mesmo JSON para um dado estado) — garantido pelo `BackupRestoreScreen.test.tsx` existente (exports only settings keys / import ignores keys outside allow‑list) que continua a passar.
- [x] Novos testes cobrem: `createSnapshot` com múltiplas chaves, `createSnapshot` saltando `null`, `applySnapshot` com objecto válido, `applySnapshot` a rejeitar array, `applySnapshot` a rejeitar primitivo — todos presentes.
- [x] `npm test` sem falhas novas: 23 falham agora vs 25 na baseline; as 23 são subconjunto das 6 suites já vermelhas (SiriScreen, WeatherScreen, SettingsScreen, LockScreen, FoldersStore, withLauncherIntent) — nenhuma em ficheiros que toquei. Os 3 nomes que parecem "novos" são renomes da baseline no `SiriScreen.test.tsx` actual (ex.: `does not throw when launchApp rejects` → `does not throw when launchApp rejects (real app)`), confirmados no ficheiro.

## Testes

- **Passo vermelho (TDD):** escrevi `src/services/__tests__/BackupSnapshot.test.ts` ANTES de criar o serviço. O suite nem correu — falhou por o módulo não existir (prova de que o teste está ligado ao novo módulo):

```
FAIL Android src/services/__tests__/BackupSnapshot.test.ts
  ● Test suite failed to run

    Cannot find module '../BackupSnapshot' from 'src/services/__tests__/BackupSnapshot.test.ts'

      1 | import AsyncStorage from '@react-native-async-storage/async-storage';
      > 2 | import { createSnapshot, applySnapshot } from '../BackupSnapshot';
        | ^

      at Resolver._throwModNotFoundError (.../jest-resolve/build/resolver.js:427:11)
      at Object.require (src/services/__tests__/BackupSnapshot.test.ts:2:1)

Test Suites: 1 failed, 1 total
Tests:       0 total
```

- **Sanity‑check (revert do fix):** quebrei o guard em `applySnapshot` (`if (false)` em vez do `typeof`/array check) mantendo os testes, corri, e 2 testes de rejeição falharam (prova de que testam o comportamento real); depois restaurei:

```
Test Suites: 1 failed, 1 total
Tests:       2 failed, 6 passed, 8 total
    ✕ rejects array input with an error
    ✕ rejects a primitive (non-object) input with an error
```

- **Casos cobertos além do caminho feliz:** fronteiras/vazio (`createSnapshot` com zero chaves allow‑list presentes → `{}`; `getMany` devolve `null` para chave ausente → omitida); inválido/hostil (`applySnapshot` rejeita array, primitivo `string`/`number`, e `null`); coerção (`applySnapshot` converte valor booleano para `'true'` via `String`). O `BackupRestoreScreen.test.tsx` pré‑existente cobre o inverso do fix (export/import não deixam escapar chaves fora da allow‑list, ex.: SMS/notas).

- **Resultado das verificações obrigatórias:**
  - `npm run lint` → 0 erros (7 warnings pré‑existentes em ficheiros não meus: `SiriScreen.tsx`, `SettingsStore.tsx`, etc.).
  - `npx tsc --noEmit` → limpo (exit 0).
  - `npm test -- --maxWorkers=2` → 23 falharam, 1845 passaram, 1868 total (vs 25/1764 na baseline). Nenhuma falha nova em ficheiros tocados; todas as 23 são subconjunto das 6 suites já vermelhas.

## Testes

1845 passaram, 23 falharam (6 suites) — subconjunto das 25/1764 da baseline; 0 falhas novas nos ficheiros tocados. (Meus testes: 8/8 no serviço + 4/4 no ecrã.)

## Linked Issue

Fixes #269