### PR TITLE
fix/701: App Library e Spotlight abrem o nosso ecrã Photos em vez de lançarem a app Google Photos (aliases dos built-ins resolvidos em todos os pontos de entrada) (#701)

### DIFF
--- a/src/screens/AppLibraryScreen.tsx
+++ b/src/screens/AppLibraryScreen.tsx
@@ -31,6 +31,7 @@ import { CupertinoNavigationBar, CupertinoEmptyState } from '../components';
 import type { AppNavigationProp } from '../navigation/types';
 import type { CupertinoColors } from '../theme/CupertinoTheme';
 import { hapticImpact } from '../utils/haptics';
+import { resolveInternalRoute } from '../utils/builtInAppRoutes';
 
 // ---------------------------------------------------------------------------
 // Category detection
@@ -573,7 +574,7 @@ function SectionHeader({ title, colors }: { title: string; colors: CupertinoColo
 // page of the paginated home screen (LauncherHomeScreen) — see issue #434.
 // Keeping this in one place means the two call sites can't drift apart the
 // way twin overlays did in #384.
-export function AppLibraryContent() {
+export function AppLibraryContent({ navigation }: { navigation?: AppNavigationProp } = {}) {
   const { theme } = useTheme();
   const { colors } = theme;
   // `apps` é a lista completa (usada só pela procura, para que uma app
@@ -687,8 +688,19 @@ export function AppLibraryContent() {
 
   const handleLaunch = useCallback((packageName: string) => {
     hapticImpact(Haptics.ImpactFeedbackStyle.Light).catch(() => {});
+    // #701: a app Android que duplica um built-in (Google Photos, Google Clock,
+    // …) aparece aqui com o MESMO nome do nosso ecrã ("Photos"), por isso tem de
+    // abrir o nosso ecrã, como já acontecia na grelha da home. Sem navigation
+    // (a App Library também é a última página do pager, #434, onde é montada sem
+    // prop) cai-se no lançamento externo em vez de rebentar.
+    const internalRoute = resolveInternalRoute(packageName);
+    if (internalRoute && navigation) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- rotas de built-ins não têm params; os overloads de navigate exigem a spec
+      navigation.navigate(internalRoute as any);
+      return;
+    }
     launchApp(packageName);
-  }, [launchApp]);
+  }, [launchApp, navigation]);
 
   const isSearching = query.trim().length > 0;
 
@@ -835,7 +847,7 @@ export function AppLibraryScreen({ navigation }: { navigation: AppNavigationProp
           </Pressable>
         }
       />
-      <AppLibraryContent />
+      <AppLibraryContent navigation={navigation} />
     </View>
   );
 }

--- a/src/screens/LauncherHomeScreen.tsx
+++ b/src/screens/LauncherHomeScreen.tsx
@@ -148,54 +148,19 @@ export function computePagerRubberBandOffset(
   return clampWithRubberBand(translationX, 0, 0, dimension);
 }
 
-// Built-in app routing: packageName → navigation screen name
-export const BUILT_IN_APPS: Record<string, keyof RootStackParamList> = {
-  'com.iostoandroid.phone': 'Phone',
-  'com.iostoandroid.messages': 'Messages',
-  'com.iostoandroid.contacts': 'Contacts',
-  'com.iostoandroid.settings': 'Settings',
-  'com.iostoandroid.weather': 'Weather',
-  'com.iostoandroid.clock': 'Clock',
-  'com.iostoandroid.camera': 'Camera',
-  'com.iostoandroid.photos': 'Photos',
-  'com.iostoandroid.calendar': 'Calendar',
-  'com.iostoandroid.calculator': 'Calculator',
-  'com.iostoandroid.notes': 'Notes',
-  'com.iostoandroid.reminders': 'Reminders',
-  'com.iostoandroid.mail': 'Mail',
-  'com.iostoandroid.browser': 'Browser',
-};
-
-// Known Android packages that duplicate a built-in app (issue #438).
-//
-// The home screen shows a virtual icon for every entry of BUILT_IN_APPS, which
-// opens the internal iOS-style screen. The real Android app that serves the
-// same function has a different packageName, so it used to pass through the
-// grid filter untouched and render a second icon with the SAME label that
-// launched an external app instead — one "Phone" going to the internal screen,
-// another going to the Google Dialer.
-//
-// Product decision (issue #438, option 1): the Android duplicate is hidden from
-// the home screen grid. This is an explicit alias list, not a heuristic: dialer
-// / messaging package names vary by OEM, so unlisted equivalents are simply not
-// deduped rather than being guessed at. The App Library (AppLibraryScreen) is
-// unaffected and keeps listing everything that is installed.
-export const BUILT_IN_APP_ANDROID_ALIASES: Record<string, readonly string[]> = {
-  'com.iostoandroid.phone': ['com.google.android.dialer', 'com.android.dialer'],
-  'com.iostoandroid.messages': ['com.google.android.apps.messaging', 'com.android.messaging'],
-  'com.iostoandroid.contacts': ['com.google.android.contacts', 'com.android.contacts'],
-  'com.iostoandroid.settings': ['com.android.settings'],
-  'com.iostoandroid.clock': ['com.google.android.deskclock', 'com.android.deskclock'],
-  'com.iostoandroid.camera': ['com.google.android.GoogleCamera', 'com.android.camera2'],
-  'com.iostoandroid.photos': ['com.google.android.apps.photos'],
-  'com.iostoandroid.calendar': ['com.google.android.calendar', 'com.android.calendar'],
-  'com.iostoandroid.calculator': ['com.google.android.calculator', 'com.android.calculator2'],
-};
-
-// Flat set of every Android package that duplicates a built-in app.
-export const BUILT_IN_DUPLICATE_PACKAGES: ReadonlySet<string> = new Set(
-  Object.values(BUILT_IN_APP_ANDROID_ALIASES).flat(),
-);
+// A tabela de routing dos built-ins mudou para src/utils/builtInAppRoutes.ts
+// (#701) para poder ser usada também pela App Library e pelo Spotlight sem
+// criar um ciclo de imports (este ficheiro importa AppLibraryScreen). Re-exporta-se
+// daqui para não quebrar os consumidores existentes.
+export {
+  BUILT_IN_APPS,
+  BUILT_IN_APP_ANDROID_ALIASES,
+  BUILT_IN_DUPLICATE_PACKAGES,
+} from '../utils/builtInAppRoutes';
+import {
+  BUILT_IN_APPS,
+  BUILT_IN_DUPLICATE_PACKAGES,
+} from '../utils/builtInAppRoutes';
 
 // Icon config for virtual (built-in) apps rendered in dock/grid
 export const VIRTUAL_ICON_CONFIG: Record<string, {
@@ -1750,7 +1715,7 @@ export function LauncherHomeScreen() {
           key="app-library"
           style={[styles.page, styles.appLibraryPage, lastPageOverscrollStyle]}
         >
-          <AppLibraryContent />
+          <AppLibraryContent navigation={navigation} />
         </Animated.View>
       </ScrollView>
 

--- a/src/screens/SpotlightSearchScreen.tsx
+++ b/src/screens/SpotlightSearchScreen.tsx
@@ -20,6 +20,7 @@ import { useTheme } from '../theme/ThemeContext';
 import { CupertinoSearchBar } from '../components/CupertinoSearchBar';
 import { CupertinoPressable } from '../components/CupertinoPressable';
 import type { AppNavigationProp, RootStackParamList } from '../navigation/types';
+import { resolveInternalRoute } from '../utils/builtInAppRoutes';
 
 // ---------------------------------------------------------------------------
 // Fuzzy matching
@@ -364,9 +365,18 @@ export function SpotlightSearchScreen({ navigation }: { navigation: AppNavigatio
     setHistory(updatedHistory);
 
     switch (item.type) {
-      case 'app':
-        launchApp(item.app.packageName);
+      case 'app': {
+        // #701: a app Android que duplica um built-in (Google Photos, Google
+        // Clock, …) é listada aqui com o nome do nosso ecrã, por isso resolve-se
+        // primeiro a rota interna — como já fazia a grelha da home.
+        const internalRoute = resolveInternalRoute(item.app.packageName);
+        if (internalRoute) {
+          navigation.navigate(internalRoute as never);
+        } else {
+          launchApp(item.app.packageName);
+        }
         break;
+      }
       case 'contact':
         navigation.navigate('ContactDetail', { contactId: item.contactId });
         break;

--- a/src/screens/__tests__/builtInAliasRouting.test.tsx
+++ b/src/screens/__tests__/builtInAliasRouting.test.tsx
@@ -1,0 +1,179 @@
+import React from 'react';
+import { render, fireEvent, act } from '../../test-utils';
+import * as AppsStore from '../../store/AppsStore';
+import { AppLibraryContent } from '../AppLibraryScreen';
+import { SpotlightSearchScreen } from '../SpotlightSearchScreen';
+import type { AppNavigationProp } from '../../navigation/types';
+
+// #701: tapping "Photos" in the App Library started Google Photos instead of
+// our own photo library. The Android duplicates of our built-ins
+// (BUILT_IN_APP_ANDROID_ALIASES, #438) were only resolved to an internal route
+// by the home grid; the App Library and Spotlight called launchApp() for every
+// row, so the real Google package went out through the Android intent — and the
+// row's label is "Photos", so the user has no way to tell them apart.
+//
+// These tests mount the REAL screens and press the REAL rows; only the apps
+// store is mocked (same pattern as LauncherHomeScreen.entryPoints.test.tsx),
+// because the routing decision under test lives in the screens.
+
+const GOOGLE_PHOTOS: AppsStore.InstalledApp = {
+  name: 'Photos', packageName: 'com.google.android.apps.photos', icon: '', isSystem: false,
+};
+const GOOGLE_CLOCK: AppsStore.InstalledApp = {
+  name: 'Clock', packageName: 'com.google.android.deskclock', icon: '', isSystem: false,
+};
+const SPOTIFY: AppsStore.InstalledApp = {
+  name: 'Spotify', packageName: 'com.spotify', icon: '', isSystem: false,
+};
+
+const ALL_APPS = [GOOGLE_PHOTOS, GOOGLE_CLOCK, SPOTIFY];
+
+const mockLaunchApp = jest.fn(() => Promise.resolve(true));
+
+function mockApps(apps: AppsStore.InstalledApp[] = ALL_APPS) {
+  jest.spyOn(AppsStore, 'useApps').mockReturnValue({
+    apps,
+    homeApps: [],
+    dockApps: [],
+    nonDockApps: apps,
+    libraryOnlyApps: [],
+    hiddenApps: [],
+    visibleApps: apps,
+    recentPackages: [],
+    recentApps: [],
+    isLoading: false,
+    refreshApps: jest.fn(() => Promise.resolve()),
+    launchApp: mockLaunchApp,
+    addToHome: jest.fn(),
+    removeFromHome: jest.fn(),
+    hideApp: jest.fn(),
+    unhideApp: jest.fn(),
+    addToDock: jest.fn(),
+    removeFromDock: jest.fn(),
+    removeFromRecents: jest.fn(),
+    clearRecents: jest.fn(),
+    isDefaultLauncher: true,
+    openLauncherSettings: jest.fn(() => Promise.resolve()),
+    iconCacheSizeBytes: 0,
+    isRebuildingIconCache: false,
+    iconCacheRebuildProgress: null,
+    rebuildIconCache: jest.fn(() => Promise.resolve()),
+  } as unknown as ReturnType<typeof AppsStore.useApps>);
+}
+
+function makeNav() {
+  return { navigate: jest.fn(), goBack: jest.fn(), push: jest.fn() } as unknown as AppNavigationProp;
+}
+
+beforeEach(() => {
+  mockLaunchApp.mockClear();
+  mockApps();
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('App Library — Android duplicates of built-ins open our screen (#701)', () => {
+  function renderLibrary(nav: AppNavigationProp, query: string) {
+    const utils = render(<AppLibraryContent navigation={nav} />);
+    fireEvent.changeText(utils.getByPlaceholderText('Search'), query);
+    return utils;
+  }
+
+  function pressRow(utils: ReturnType<typeof render>, name: string) {
+    const rows = utils.getAllByLabelText(`Open ${name}, App Library`);
+    fireEvent.press(rows[rows.length - 1]);
+    return rows[rows.length - 1];
+  }
+
+  it('tapping Photos opens the internal Photos screen instead of launching Google Photos', () => {
+    const nav = makeNav();
+    const utils = renderLibrary(nav, 'Photos');
+    pressRow(utils, 'Photos');
+
+    expect(nav.navigate).toHaveBeenCalledWith('Photos');
+    expect(mockLaunchApp).not.toHaveBeenCalled();
+  });
+
+  it('resolves every listed alias, not just Photos (Google Clock → internal Clock)', () => {
+    const nav = makeNav();
+    const utils = renderLibrary(nav, 'Clock');
+    pressRow(utils, 'Clock');
+
+    expect(nav.navigate).toHaveBeenCalledWith('Clock');
+    expect(mockLaunchApp).not.toHaveBeenCalled();
+  });
+
+  it('the inverse of the fix: a third-party app still launches externally', () => {
+    const nav = makeNav();
+    const utils = renderLibrary(nav, 'Spotify');
+    pressRow(utils, 'Spotify');
+
+    expect(mockLaunchApp).toHaveBeenCalledWith('com.spotify');
+    expect(nav.navigate).not.toHaveBeenCalled();
+  });
+
+  it('a double tap routes internally twice and never falls through to launchApp', () => {
+    const nav = makeNav();
+    const utils = renderLibrary(nav, 'Photos');
+    const row = pressRow(utils, 'Photos');
+    fireEvent.press(row);
+
+    expect(nav.navigate).toHaveBeenCalledTimes(2);
+    expect(nav.navigate).toHaveBeenNthCalledWith(1, 'Photos');
+    expect(nav.navigate).toHaveBeenNthCalledWith(2, 'Photos');
+    expect(mockLaunchApp).not.toHaveBeenCalled();
+  });
+
+  it('an app whose packageName is missing does not crash the row and stays external', () => {
+    // Payload nativo corrompido (#696/#699/#704): resolveInternalRoute recebe
+    // undefined e tem de devolver undefined em vez de rebentar.
+    mockApps([{ name: 'Broken', packageName: undefined, icon: '', isSystem: false } as unknown as AppsStore.InstalledApp]);
+    const nav = makeNav();
+    const utils = renderLibrary(nav, 'Broken');
+    expect(() => pressRow(utils, 'Broken')).not.toThrow();
+    expect(nav.navigate).not.toHaveBeenCalled();
+  });
+
+  it('without a navigation prop the row degrades to the external launch instead of crashing', () => {
+    // AppLibraryContent is also rendered as the last page of the home pager
+    // (#434). If a call site ever forgets to pass navigation, the row must
+    // still do something instead of throwing on `navigation.navigate`.
+    const utils = render(<AppLibraryContent />);
+    fireEvent.changeText(utils.getByPlaceholderText('Search'), 'Photos');
+    const rows = utils.getAllByLabelText('Open Photos, App Library');
+    expect(() => fireEvent.press(rows[rows.length - 1])).not.toThrow();
+    expect(mockLaunchApp).toHaveBeenCalledWith('com.google.android.apps.photos');
+  });
+});
+
+describe('Spotlight — Android duplicates of built-ins open our screen (#701)', () => {
+  function renderSpotlight(nav: AppNavigationProp, query: string) {
+    const utils = render(<SpotlightSearchScreen navigation={nav} />);
+    fireEvent.changeText(utils.getByPlaceholderText('Search'), query);
+    return utils;
+  }
+
+  it('tapping the Photos result navigates to the internal Photos screen', async () => {
+    const nav = makeNav();
+    const utils = renderSpotlight(nav, 'Photos');
+    await act(async () => {
+      fireEvent.press(utils.getAllByLabelText('Photos')[0]);
+    });
+
+    expect(nav.navigate).toHaveBeenCalledWith('Photos');
+    expect(mockLaunchApp).not.toHaveBeenCalled();
+  });
+
+  it('the inverse of the fix: a third-party result still launches externally', async () => {
+    const nav = makeNav();
+    const utils = renderSpotlight(nav, 'Spotify');
+    await act(async () => {
+      fireEvent.press(utils.getAllByLabelText('Spotify')[0]);
+    });
+
+    expect(mockLaunchApp).toHaveBeenCalledWith('com.spotify');
+    expect(nav.navigate).not.toHaveBeenCalled();
+  });
+});

--- a/src/utils/builtInAppRoutes.ts
+++ b/src/utils/builtInAppRoutes.ts
@@ -1,0 +1,84 @@
+import type { RootStackParamList } from '../navigation/types';
+
+// Single source of truth for "which packageName opens one of our own screens".
+//
+// Lived in LauncherHomeScreen.tsx until #701: the home grid resolved a built-in
+// package (and its Android duplicate) to an internal route, but the App Library
+// and Spotlight only ever called launchApp(). Google Photos is labelled
+// "Photos" by the launcher, so tapping "Photos" in the App Library started the
+// Google app instead of our photo library. The table can't live in
+// LauncherHomeScreen because that file imports AppLibraryScreen (the App
+// Library is the pager's last page, #434) — importing it back would be a cycle.
+
+/** Built-in app routing: packageName → navigation screen name. */
+export const BUILT_IN_APPS: Record<string, keyof RootStackParamList> = {
+  'com.iostoandroid.phone': 'Phone',
+  'com.iostoandroid.messages': 'Messages',
+  'com.iostoandroid.contacts': 'Contacts',
+  'com.iostoandroid.settings': 'Settings',
+  'com.iostoandroid.weather': 'Weather',
+  'com.iostoandroid.clock': 'Clock',
+  'com.iostoandroid.camera': 'Camera',
+  'com.iostoandroid.photos': 'Photos',
+  'com.iostoandroid.calendar': 'Calendar',
+  'com.iostoandroid.calculator': 'Calculator',
+  'com.iostoandroid.notes': 'Notes',
+  'com.iostoandroid.reminders': 'Reminders',
+  'com.iostoandroid.mail': 'Mail',
+  'com.iostoandroid.browser': 'Browser',
+};
+
+// Known Android packages that duplicate a built-in app (issue #438).
+//
+// The home screen shows a virtual icon for every entry of BUILT_IN_APPS, which
+// opens the internal iOS-style screen. The real Android app that serves the
+// same function has a different packageName, so it used to pass through the
+// grid filter untouched and render a second icon with the SAME label that
+// launched an external app instead — one "Phone" going to the internal screen,
+// another going to the Google Dialer.
+//
+// Product decision (issue #438, option 1): the Android duplicate is hidden from
+// the home screen grid. This is an explicit alias list, not a heuristic: dialer
+// / messaging package names vary by OEM, so unlisted equivalents are simply not
+// deduped rather than being guessed at. The App Library (AppLibraryScreen) is
+// unaffected and keeps listing everything that is installed — but since #701 it
+// opens our screen for those aliases instead of the Android app.
+export const BUILT_IN_APP_ANDROID_ALIASES: Record<string, readonly string[]> = {
+  'com.iostoandroid.phone': ['com.google.android.dialer', 'com.android.dialer'],
+  'com.iostoandroid.messages': ['com.google.android.apps.messaging', 'com.android.messaging'],
+  'com.iostoandroid.contacts': ['com.google.android.contacts', 'com.android.contacts'],
+  'com.iostoandroid.settings': ['com.android.settings'],
+  'com.iostoandroid.clock': ['com.google.android.deskclock', 'com.android.deskclock'],
+  'com.iostoandroid.camera': ['com.google.android.GoogleCamera', 'com.android.camera2'],
+  'com.iostoandroid.photos': ['com.google.android.apps.photos'],
+  'com.iostoandroid.calendar': ['com.google.android.calendar', 'com.android.calendar'],
+  'com.iostoandroid.calculator': ['com.google.android.calculator', 'com.android.calculator2'],
+};
+
+/** Flat set of every Android package that duplicates a built-in app. */
+export const BUILT_IN_DUPLICATE_PACKAGES: ReadonlySet<string> = new Set(
+  Object.values(BUILT_IN_APP_ANDROID_ALIASES).flat(),
+);
+
+/** Android alias packageName → the internal route its built-in twin owns. */
+const ALIAS_TO_ROUTE: Record<string, keyof RootStackParamList> = Object.fromEntries(
+  Object.entries(BUILT_IN_APP_ANDROID_ALIASES).flatMap(([builtIn, aliases]) => {
+    const route = BUILT_IN_APPS[builtIn];
+    return route ? aliases.map((alias) => [alias, route] as const) : [];
+  }),
+);
+
+/**
+ * The internal screen a packageName must open, or `undefined` when the package
+ * is a genuine third-party app that has to be launched externally.
+ *
+ * Accepts our own virtual packages AND the Android apps listed as their
+ * duplicates, so every entry point (home grid, App Library, Spotlight) resolves
+ * "Photos" to the same place instead of dropping into the Google app.
+ */
+export function resolveInternalRoute(
+  packageName: string | undefined | null,
+): keyof RootStackParamList | undefined {
+  if (typeof packageName !== 'string' || packageName === '') return undefined;
+  return BUILT_IN_APPS[packageName] ?? ALIAS_TO_ROUTE[packageName];
+}


### PR DESCRIPTION
## Resumo

fix/701: App Library e Spotlight abrem o nosso ecrã Photos em vez de lançarem a app Google Photos (aliases dos built-ins resolvidos em todos os pontos de entrada)

## Causa raiz

O launcher tem duas tabelas para os built-ins (agora em `src/utils/builtInAppRoutes.ts`, antes em `LauncherHomeScreen.tsx:151-198`): `BUILT_IN_APPS` (packageName virtual → rota interna) e `BUILT_IN_APP_ANDROID_ALIASES` (#438), que declara que `com.google.android.apps.photos` é o duplicado Android do nosso `com.iostoandroid.photos`.

Só a **grelha da home** usava essas tabelas para decidir o destino de um toque (`LauncherHomeScreen.tsx:886`, `handleAppPress` → `navigation.navigate`), e usava os aliases apenas para *esconder* o ícone duplicado (`LauncherHomeScreen.tsx:1206`). Os outros dois pontos de entrada não:

- `AppLibraryScreen.tsx:688-691` (`handleLaunch`) chamava `launchApp(packageName)` para **todas** as linhas;
- `SpotlightSearchScreen.tsx:367-369` (`case 'app'`) idem.

A app Google Photos é etiquetada pelo `PackageManager` como **"Photos"** — exactamente o nome do nosso ecrã. Na App Library (e no Spotlight) o utilizador vê uma linha "Photos" e ao tocar sai da app pelo intent Android (`LauncherModule.kt:206`) para a app da Google, que abre com a sua UI/página Google. Daí o sintoma "Photos app shows Google page instead of photo library": o `PhotosScreen.tsx` está inteiro e funcional — nunca chegava a ser montado por esse caminho.

O issue descreve o sintoma como se o ecrã Photos mostrasse conteúdo Google. Não é isso: o ecrã nunca abre; é uma app diferente que abre com o mesmo nome. A App Library é também a última página do pager da home (#434), por isso o defeito aparece a partir do gesto normal de "ver as apps".

## O que mudou

- **`src/utils/builtInAppRoutes.ts`** (novo): passa a ser a fonte única de `BUILT_IN_APPS`, `BUILT_IN_APP_ANDROID_ALIASES` e `BUILT_IN_DUPLICATE_PACKAGES` (movidas de `LauncherHomeScreen.tsx`, conteúdo inalterado), e acrescenta `resolveInternalRoute(packageName)`: devolve a rota interna para os nossos packages virtuais **e** para os duplicados Android listados, e `undefined` para tudo o resto (incluindo `undefined`/`null`/string vazia, para payloads nativos corrompidos — #696/#699/#704). Vive em `utils/` porque `LauncherHomeScreen` importa `AppLibraryScreen` (pager, #434) e o import inverso seria um ciclo.
- **`src/screens/LauncherHomeScreen.tsx`**: as três tabelas deixam de ser definidas aqui e passam a ser re-exportadas de `utils/builtInAppRoutes` (consumidores existentes — `SiriScreen`, `FocusScreen`, testes — continuam a importar do mesmo sítio). Passa `navigation` ao `AppLibraryContent` da última página.
- **`src/screens/AppLibraryScreen.tsx`**: `AppLibraryContent` aceita uma prop opcional `navigation`; `handleLaunch` resolve `resolveInternalRoute(packageName)` e, quando há rota e `navigation`, navega para o nosso ecrã em vez de chamar `launchApp`. Sem `navigation` mantém o lançamento externo (não rebenta). `AppLibraryScreen` passa o seu `navigation`.
- **`src/screens/SpotlightSearchScreen.tsx`**: o `case 'app'` do `handleResultPress` resolve primeiro a rota interna e só chama `launchApp` quando não há nenhuma.

## Porque assim

Alternativas descartadas:

1. **Filtrar as apps-duplicado da lista da App Library** (como a home faz na grelha): destrutivo — a App Library é, por desenho (#438, #606), a vista que lista tudo o que está instalado, e o utilizador perderia o acesso à app Google. A escolha menos destrutiva é reencaminhar o toque, não esconder a app.
2. **Deixar o Photos abrir a app Google mas "corrigir" o PhotosScreen**: não havia nada para corrigir — o ecrã funciona; o toque é que ia para outro lado.
3. **Duplicar a tabela nos três ecrãs**: é exactamente a divergência que #384/#438 já pagaram. Uma função exportada num `utils/` mantém uma decisão única.

Nada de `as any` novo no código de produção além do já convencionado no repo para `navigate` de rotas sem params (mesmo `eslint-disable` e mesma justificação que `LauncherHomeScreen.tsx:888`); o Spotlight usa `as never`, o padrão já usado nas linhas vizinhas do mesmo ficheiro.

## Critérios de aceitação

- [x] Tocar em "Photos" na App Library abre o `PhotosScreen` interno e **não** chama `launchApp` — teste `tapping Photos opens the internal Photos screen instead of launching Google Photos`.
- [x] O reencaminhamento aplica-se a **todos** os aliases declarados, não só ao Photos — teste com Google Clock (`com.google.android.deskclock` → rota `Clock`).
- [x] **Não deve mudar:** uma app de terceiros continua a sair pelo intent Android — testes "o inverso do fix" na App Library e no Spotlight (`com.spotify` → `launchApp`, `navigate` nunca chamado).
- [x] **Não deve mudar:** a App Library continua a listar as apps duplicadas (nada foi filtrado); confirmado por as linhas "Photos"/"Clock" existirem e serem premíveis nos testes, e por não haver alteração ao filtro `BUILT_IN_DUPLICATE_PACKAGES` (que só actua na grelha da home, `LauncherHomeScreen.tsx:1206`).
- [x] **Não deve mudar:** os consumidores de `BUILT_IN_APPS` fora da home (SiriScreen, FocusScreen, `routeReachability`, `BrowserScreen.test`) continuam a importar de `./LauncherHomeScreen` e passam — re-export mantido; suite completa sem falhas novas nesses ficheiros.
- [x] Duplo toque numa linha built-in navega duas vezes para a mesma rota e nunca cai em `launchApp` (defeito recorrente neste repo).
- [x] `packageName` ausente/corrompido não rebenta a linha nem navega.
- [x] `AppLibraryContent` sem prop `navigation` continua a funcionar (é montada assim em testes antigos e em qualquer call site futuro): degrada para o lançamento externo, sem `throw`.

## Testes

**Passo vermelho** (`git stash push` dos três ficheiros de produção, teste mantido; `builtInAppRoutes.ts` é untracked e por isso reposto à mão para o import resolver):

```
● App Library — Android duplicates of built-ins open our screen (#701) › tapping Photos opens the internal Photos screen instead of launching Google Photos

    expect(jest.fn()).toHaveBeenCalledWith(...expected)

    Expected: "Photos"

    Number of calls: 0

      93 |     pressRow(utils, 'Photos');
      94 |
    > 95 |     expect(nav.navigate).toHaveBeenCalledWith('Photos');
         |                          ^
      96 |     expect(mockLaunchApp).not.toHaveBeenCalled();

      at Object.toHaveBeenCalledWith (src/screens/__tests__/builtInAliasRouting.test.tsx:95:26)

● Spotlight — Android duplicates of built-ins open our screen (#701) › tapping the Photos result navigates to the internal Photos screen

    expect(jest.fn()).toHaveBeenCalledWith(...expected)

    Expected: "Photos"

    Number of calls: 0

    > 165 |     expect(nav.navigate).toHaveBeenCalledWith('Photos');

Test Suites: 1 failed, 1 total
Tests:       4 failed, 4 passed, 8 total
```

Os 4 que passavam já sem o fix são, de propósito, os do lado inverso (terceiros continuam externos, `packageName` ausente, ausência de `navigation`) — só os 4 que asseguram o reencaminhamento falham, e falham na linha do `expect` certa.

Com o fix:

```
Test Suites: 1 passed, 1 total
Tests:       8 passed, 8 total
```

**Casos cobertos** além do caminho feliz: segundo alias (Clock) para provar que não é um `if` especial ao Photos; o inverso do fix nos dois ecrãs (terceiros continuam a lançar externamente); duplo toque; `packageName: undefined` (payload nativo corrompido); ausência da prop `navigation` (a App Library é montada sem ela como página do pager em testes existentes). Nenhum destes falha pela mesma razão que outro.

**Sanity-check:** com os três ficheiros de produção em `git stash` e os testes no lugar, a suite do ficheiro falhou (4 de 8, output acima); `git stash pop` e volta a 8/8.

**Verificações:**
- `npm run lint`: `✖ 7 problems (0 errors, 7 warnings)` — os mesmos 0 erros da linha de base; nenhum warning nos ficheiros que toquei.
- `npx tsc --noEmit`: limpo (sem output).
- `npm test -- --maxWorkers=2`: `Tests: 23 failed, 1845 passed, 1868 total`, `Test Suites: 6 failed, 191 passed, 197 total`. Linha de base: 25 falhas em 6 suites. Nenhuma falha nova: as falhas restantes (FoldersStore, LockScreen, SettingsScreen, SiriScreen, WeatherScreen, `withLauncherIntent`) constam todas de `baseline.json` — três nomes de teste do `SiriScreen` diferem do baseline apenas no título ("does not throw when launchApp rejects" → "… (real app)"), ficheiro que não toquei.

## Testes

1845 passaram, 23 falharam (baseline: 25 falhas), 197 suites; suite nova builtInAliasRouting: 8 passaram, 0 falharam

## Linked Issue

Fixes #701