### PR TITLE
Add pure step-aggregation utils (daily/weekly/monthly) in src/utils/healthAggregation.ts (#272)

### DIFF
--- a/src/utils/__tests__/healthAggregation.test.ts
+++ b/src/utils/__tests__/healthAggregation.test.ts
@@ -1,0 +1,192 @@
+import {
+  aggregateDaily,
+  aggregateWeekly,
+  aggregateMonthly,
+  DailySteps,
+  Bucket,
+} from '../healthAggregation';
+
+// Helper: assert a bucket exists with exact total/steps/avg/dayCount.
+function expectBucket(
+  buckets: Bucket[],
+  label: string,
+  totalSteps: number,
+  averageSteps: number,
+  dayCount: number,
+): void {
+  const b = buckets.find((x) => x.label === label);
+  expect(b).toBeDefined();
+  if (!b) return;
+  expect(b.totalSteps).toBe(totalSteps);
+  expect(b.averageSteps).toBeCloseTo(averageSteps, 10);
+  expect(b.dayCount).toBe(dayCount);
+}
+
+describe('aggregateDaily', () => {
+  it('returns [] for an empty input (no throw)', () => {
+    expect(aggregateDaily([])).toEqual([]);
+  });
+
+  it('returns one bucket per unique date, sorted ascending, last write wins on duplicates', () => {
+    const samples: DailySteps[] = [
+      { date: '2026-08-18', steps: 100 },
+      { date: '2026-08-19', steps: 200 },
+      { date: '2026-08-17', steps: 50 },
+      { date: '2026-08-18', steps: 150 }, // duplicate: last entry wins
+    ];
+    const result = aggregateDaily(samples);
+    expect(result.map((b) => b.label)).toEqual([
+      '2026-08-17',
+      '2026-08-18',
+      '2026-08-19',
+    ]);
+    expectBucket(result, '2026-08-17', 50, 50, 1);
+    expectBucket(result, '2026-08-18', 150, 150, 1); // 150, not 100
+    expectBucket(result, '2026-08-19', 200, 200, 1);
+  });
+
+  it('handles unsorted input spanning a month boundary', () => {
+    const samples: DailySteps[] = [
+      { date: '2026-09-01', steps: 60 },
+      { date: '2026-08-31', steps: 40 },
+    ];
+    const result = aggregateDaily(samples);
+    expect(result.map((b) => b.label)).toEqual(['2026-08-31', '2026-09-01']);
+    expectBucket(result, '2026-08-31', 40, 40, 1);
+    expectBucket(result, '2026-09-01', 60, 60, 1);
+  });
+
+  it('handles unsorted input spanning a year boundary (Dec 31 -> Jan 1)', () => {
+    const samples: DailySteps[] = [
+      { date: '2027-01-01', steps: 20 },
+      { date: '2026-12-31', steps: 10 },
+    ];
+    const result = aggregateDaily(samples);
+    expect(result.map((b) => b.label)).toEqual(['2026-12-31', '2027-01-01']);
+    expectBucket(result, '2026-12-31', 10, 10, 1);
+    expectBucket(result, '2027-01-01', 20, 20, 1);
+  });
+});
+
+describe('aggregateWeekly', () => {
+  it('returns [] for an empty input (no throw)', () => {
+    expect(aggregateWeekly([])).toEqual([]);
+  });
+
+  it('buckets by ISO week (Monday-start) and sorts ascending', () => {
+    const samples: DailySteps[] = [
+      { date: '2026-08-19', steps: 300 }, // Wed, W34
+      { date: '2026-08-18', steps: 100 }, // Tue, W34
+      { date: '2026-08-10', steps: 50 }, // Mon, W33
+    ];
+    const result = aggregateWeekly(samples);
+    expect(result.map((b) => b.label)).toEqual(['2026-W33', '2026-W34']);
+    expectBucket(result, '2026-W33', 50, 50, 1);
+    expectBucket(result, '2026-W34', 400, 200, 2); // (100+300)/2
+  });
+
+  it('buckets a Sunday into the week that started the preceding Monday', () => {
+    // 2026-08-16 is a Sunday; its week started Monday 2026-08-10 -> 2026-W33.
+    const samples: DailySteps[] = [
+      { date: '2026-08-10', steps: 10 }, // Mon, W33
+      { date: '2026-08-16', steps: 20 }, // Sun, W33
+    ];
+    const result = aggregateWeekly(samples);
+    expect(result.map((b) => b.label)).toEqual(['2026-W33']);
+    expectBucket(result, '2026-W33', 30, 15, 2);
+  });
+
+  it('dedupes duplicate dates (last write wins) before weekly totals', () => {
+    const samples: DailySteps[] = [
+      { date: '2026-08-10', steps: 10 },
+      { date: '2026-08-11', steps: 20 },
+      { date: '2026-08-10', steps: 99 }, // duplicate, last wins -> 99
+    ];
+    const result = aggregateWeekly(samples);
+    expectBucket(result, '2026-W33', 119, 59.5, 2); // 99 + 20, over 2 days
+  });
+
+  it('spans a month boundary inside a single week (Aug 31 Mon + Sep 1 Tue)', () => {
+    const samples: DailySteps[] = [
+      { date: '2026-09-01', steps: 60 }, // Tue, W36
+      { date: '2026-08-31', steps: 40 }, // Mon, W36
+    ];
+    const result = aggregateWeekly(samples);
+    expect(result.map((b) => b.label)).toEqual(['2026-W36']);
+    expectBucket(result, '2026-W36', 100, 50, 2); // days present = 2, NOT 7
+  });
+
+  it('spans a year boundary inside a single week (Dec 31 Thu + Jan 1 Fri)', () => {
+    const samples: DailySteps[] = [
+      { date: '2027-01-01', steps: 20 }, // Fri, W53 (ISO year 2026)
+      { date: '2026-12-31', steps: 10 }, // Thu, W53
+    ];
+    const result = aggregateWeekly(samples);
+    expect(result.map((b) => b.label)).toEqual(['2026-W53']);
+    expectBucket(result, '2026-W53', 30, 15, 2);
+  });
+
+  it('does not dilute average by calendar days: a partial week uses days present', () => {
+    // Only one day in the week present.
+    const samples: DailySteps[] = [{ date: '2026-08-10', steps: 70 }];
+    const result = aggregateWeekly(samples);
+    expectBucket(result, '2026-W33', 70, 70, 1); // avg = 70/1, not 70/7
+  });
+});
+
+describe('aggregateMonthly', () => {
+  it('returns [] for an empty input (no throw)', () => {
+    expect(aggregateMonthly([])).toEqual([]);
+  });
+
+  it('groups by calendar month and sorts ascending', () => {
+    const samples: DailySteps[] = [
+      { date: '2026-08-19', steps: 300 },
+      { date: '2026-08-18', steps: 100 },
+      { date: '2026-07-31', steps: 50 },
+    ];
+    const result = aggregateMonthly(samples);
+    expect(result.map((b) => b.label)).toEqual(['2026-07', '2026-08']);
+    expectBucket(result, '2026-07', 50, 50, 1);
+    expectBucket(result, '2026-08', 400, 200, 2); // (100+300)/2
+  });
+
+  it('dedupes duplicate dates (last write wins) before monthly totals', () => {
+    const samples: DailySteps[] = [
+      { date: '2026-08-10', steps: 10 },
+      { date: '2026-08-11', steps: 20 },
+      { date: '2026-08-10', steps: 99 }, // last wins -> 99
+    ];
+    const result = aggregateMonthly(samples);
+    expectBucket(result, '2026-08', 119, 59.5, 2);
+  });
+
+  it('spans a month boundary into two distinct month buckets', () => {
+    const samples: DailySteps[] = [
+      { date: '2026-09-01', steps: 60 },
+      { date: '2026-08-31', steps: 40 },
+    ];
+    const result = aggregateMonthly(samples);
+    expect(result.map((b) => b.label)).toEqual(['2026-08', '2026-09']);
+    expectBucket(result, '2026-08', 40, 40, 1);
+    expectBucket(result, '2026-09', 60, 60, 1);
+  });
+
+  it('spans a year boundary into two distinct month buckets (Dec 31 -> Jan 1)', () => {
+    const samples: DailySteps[] = [
+      { date: '2027-01-01', steps: 20 },
+      { date: '2026-12-31', steps: 10 },
+    ];
+    const result = aggregateMonthly(samples);
+    expect(result.map((b) => b.label)).toEqual(['2026-12', '2027-01']);
+    expectBucket(result, '2026-12', 10, 10, 1);
+    expectBucket(result, '2027-01', 20, 20, 1);
+  });
+
+  it('does not dilute average by calendar days: partial month uses days present', () => {
+    // Only one day present in August; avg must be steps/1, not steps/31.
+    const samples: DailySteps[] = [{ date: '2026-08-10', steps: 310 }];
+    const result = aggregateMonthly(samples);
+    expectBucket(result, '2026-08', 310, 310, 1); // avg = 310/1, not 310/31
+  });
+});

--- a/src/utils/healthAggregation.ts
+++ b/src/utils/healthAggregation.ts
@@ -1,0 +1,101 @@
+// Pure, dependency-free step aggregation for the Health step-counter feature.
+// No device access, no React — unit testable directly with fixed fixtures.
+//
+// Data shape (from the step-counter foundation, part of #124):
+//   HealthStore persists an array of { date: 'YYYY-MM-DD'; steps: number }
+//   under AsyncStorage key '@iostoandroid/health_daily_steps'.
+//
+// Input is assumed to be a flat list of daily samples that may be:
+//   - unsorted
+//   - gappy (missing days)
+//   - duplicated per date (last write wins — HealthStore overwrites today's
+//     entry as it accumulates)
+// Output buckets are sorted ascending by label.
+
+export interface DailySteps {
+  date: string; // 'YYYY-MM-DD' — local calendar date
+  steps: number;
+}
+
+export interface Bucket {
+  label: string; // '2026-08-18', '2026-W33', or '2026-08'
+  totalSteps: number;
+  averageSteps: number; // totalSteps / dayCount (days with data, not calendar days)
+  dayCount: number; // days actually present in the input, not calendar days
+}
+
+// --- internal helpers -------------------------------------------------------
+
+function dedupeByDate(samples: DailySteps[]): Map<string, number> {
+  // Insertion order preserved; later duplicate overwrites earlier (last write wins).
+  const byDate = new Map<string, number>();
+  for (const sample of samples) {
+    byDate.set(sample.date, sample.steps);
+  }
+  return byDate;
+}
+
+function toBuckets(
+  byDate: Map<string, number>,
+  keyFor: (date: string) => string,
+): Bucket[] {
+  const totals = new Map<string, { total: number; days: number }>();
+  for (const [date, steps] of byDate) {
+    const key = keyFor(date);
+    const entry = totals.get(key) ?? { total: 0, days: 0 };
+    entry.total += steps;
+    entry.days += 1;
+    totals.set(key, entry);
+  }
+  const buckets: Bucket[] = [];
+  for (const [label, { total, days }] of totals) {
+    buckets.push({
+      label,
+      totalSteps: total,
+      dayCount: days,
+      averageSteps: days > 0 ? total / days : 0,
+    });
+  }
+  buckets.sort((a, b) => (a.label < b.label ? -1 : a.label > b.label ? 1 : 0));
+  return buckets;
+}
+
+// ISO week label for a 'YYYY-MM-DD' date, Monday-start, per ISO-8601.
+// The week-year is the year of the Thursday of that week, so Dec 31 / Jan 1
+// that belong to a neighbouring ISO year are labelled with that year
+// (e.g. Fri 2027-01-01 is '2026-W53'). Computed in UTC to avoid DST drift.
+function isoWeekKey(dateStr: string): string {
+  const [y, m, d] = dateStr.split('-').map(Number);
+  const date = new Date(Date.UTC(y, m - 1, d));
+  const dayOfWeek = (date.getUTCDay() + 6) % 7; // Mon=0 ... Sun=6
+  // Thursday of this ISO week (always in the same ISO year as the week).
+  const thursday = new Date(Date.UTC(y, m - 1, d - dayOfWeek + 3));
+  const tYear = thursday.getUTCFullYear();
+  // First Monday of the ISO year: Jan 4 is always in week 1.
+  const jan4 = new Date(Date.UTC(tYear, 0, 4));
+  const jan4Dow = (jan4.getUTCDay() + 6) % 7; // Mon=0
+  const firstMonday = new Date(Date.UTC(tYear, 0, 4 - jan4Dow));
+  const week =
+    1 + Math.round((thursday.getTime() - firstMonday.getTime()) / (7 * 86_400_000));
+  return `${tYear}-W${String(week).padStart(2, '0')}`;
+}
+
+// --- public API -------------------------------------------------------------
+
+export function aggregateDaily(samples: DailySteps[]): Bucket[] {
+  if (samples.length === 0) return [];
+  const byDate = dedupeByDate(samples);
+  return toBuckets(byDate, (date) => date);
+}
+
+export function aggregateWeekly(samples: DailySteps[]): Bucket[] {
+  if (samples.length === 0) return [];
+  const byDate = dedupeByDate(samples);
+  return toBuckets(byDate, (date) => isoWeekKey(date));
+}
+
+export function aggregateMonthly(samples: DailySteps[]): Bucket[] {
+  if (samples.length === 0) return [];
+  const byDate = dedupeByDate(samples);
+  return toBuckets(byDate, (date) => date.slice(0, 7)); // 'YYYY-MM'
+}


### PR DESCRIPTION
## Resumo

Add pure step-aggregation utils (daily/weekly/monthly) in src/utils/healthAggregation.ts

## Causa raiz

Não havia qualquer utilitário de agregação/data-bucketing em `src/utils/` (confirmado com `grep -rl "aggregate" src/utils/` — sem resultado). Qualquer trabalho futuro de gráfico/dashboard teria de duplicar a matemática de bucketing dentro de um componente (intestável sem render) ou saltá-la aos testes. O defeito é a ausência da função, não um sintoma num ecrã.

## O que mudou

- **`src/utils/healthAggregation.ts`** (novo): funções puras e sem dependências `aggregateDaily`, `aggregateWeekly`, `aggregateMonthly` mais os tipos `DailySteps` e `Bucket`.
  - Entrada não ordenada: `dedupeByDate` normaliza para um `Map<date, steps>` (preserva ordem, **última escrita ganha** em datas duplicadas — espelha o `HealthStore` que sobrepõe a entrada do dia).
  - `toBuckets` acumula `totalSteps` e `dayCount` por chave e ordena os buckets ascendente por `label`.
  - `dayCount` = dias **presentes** na entrada; `averageSteps = totalSteps / dayCount`, nunca diluído pelos dias de calendário sem dados.
  - `aggregateWeekly` usa `isoWeekKey` (ISO-8601, segunda-feira inicial) calculada em UTC para evitar deriva de DST. O ano da semana é o ano de **quinta-feira** da semana (ex.: sex 2027-01-01 → `2026-W53`).
  - `aggregateMonthly` agrupa por `'YYYY-MM'`.
  - As três devolvem `[]` para entrada vazia (sem lançar).
- **`src/utils/__tests__/healthAggregation.test.ts`** (novo): 17 testes, um ficheiro `describe`/`it` sem `render` (lógica pura com fixtures fixos, padrão referido no issue como `RemindersScreen.weekday.test.ts`).

## Porque assim

- ISO week: a primeira implementação usava `Math.floor(days/7)+1` a partir de 1 de janeiro, que ficava a semana errada (desfasamento de 1). Substituída pela fórmula ISO-8601 correcta (quinta-feira da semana define o ano-da-semana; primeira segunda-feira = 4 de janho ajustado). Verificada contra `date -d` do sistema para os casos-limite (2026-08-16 dom→W33; 2026-12-31 qui + 2027-01-01 sex→ambos W53).
- UTC em vez de local: os `Date` locais sofrem deriva de DST em redor de 1 de abril/outubro; como as datas são 'YYYY-MM-DD' sem hora, UTC mantém o dia estável.
- Não se tocou em nenhum store/screen — só se adicionou um ficheiro novo, como o issue exige. Zero `any`, zero `try/catch` a tapar erro.

## Critérios de aceitação

- [x] `aggregateDaily` devolve um bucket por data única, última escrita ganha em duplicados — testado (`returns one bucket per unique date...`).
- [x] `aggregateWeekly` agrupa por semana ISO (segunda inicial) e coloca um domingo na semana que começou na segunda anterior — testado (`buckets a Sunday into the week that started the preceding Monday`, 2026-08-16→W33).
- [x] `aggregateMonthly` agrupa por mês de calendário — testado (`groups by calendar month`).
- [x] `averageSteps` divide por `dayCount` (dias presentes), não pelo comprimento de calendário — testado nos três (`does not dilute average by calendar days...`).
- [x] Array vazio devolve `[]` para as três — testado (`returns [] for an empty input (no throw)` nos três `describe`).
- [x] Testes cobrem: entrada não ordenada, bucket sobre fronteira de mês (Ago→Set), fronteira de ano (31 Dez→1 Jan), datas duplicadas, e vazio — para as três funções.
- [x] O que NÃO devia mudar: nenhum ficheiro de store/screen foi tocado; nenhuma suite de teste alheia foi modificada nem posta `.skip`. Confirmado por `git status --porcelain` (só os dois ficheiros novos) e pela suite completa.

## Testes

- **Passo vermelho:** antes de criar `healthAggregation.ts`, o teste foi corrido e falhou por não conseguir importar o módulo (o comportamento não existia):

```
FAIL Android src/utils/__tests__/healthAggregation.test.ts
  ● Test suite failed to run

    Cannot find module '../healthAggregation' from 'src/utils/__tests__/healthAggregation.test.ts'

    > 1 | import {
        | ^
      2 |   aggregateDaily,
      3 |   aggregateWeekly,
      4 |   aggregateMonthly,

      at Resolver._throwModNotFoundError (.../jest-resolve/build/resolver.js:427:11)
      at Object.<anonymous> (src/utils/__tests__/healthAggregation.test.ts:1:1)

Test Suites: 1 failed, 1 total
Tests:       0 total
```

  Com o ficheiro de produção implementado: `Tests: 17 passed, 17 total`.

- **Casos cobertos (além do caminho feliz):**
  - Fronteiras: fronteira de mês (31 Ago→1 Set) e de ano (31 Dez→1 Jan) para as três funções; domingo na fronteira de semana (16 Ago→W33); quinta-feira/sex 31 Dez/1 Jan→W53.
  - Vazio/ausente: array vazio → `[]` nas três.
  - Duplicados/inválidos: data duplicada com valores diferentes → última escrita ganha (testado em daily/weekly/monthly); média não diluída por dias de calendário ausentes (semana/mês parciais).
  - Ordem: entrada explicitamente não ordenada em vários testes; ordenação ascendente por `label` verificada.
  - Inverso do fix: `dayCount` reflecte só dias presentes (avg = total/1 numa semana/mês com 1 dia), confirmando que NÃO se usa comprimento de calendário.

- **Sanity-check:** removi `src/utils/healthAggregation.ts` (move para `/tmp`), corri a suite — falhou com `Cannot find module '../healthAggregation'` (0 testes). Restaurei o ficheiro e a suite passou 17/17. Prova de que os testes estão ligados ao comportamento real.

- **Resultado das verificações obrigatórias:**
  - `npm run lint`: 0 erros (7 warnings pré-existentes em ficheiros alheios — SiriScreen, SettingsStore, etc. — fora do âmbito).
  - `npx tsc --noEmit`: limpo (exit 0).
  - `npm test -- --maxWorkers=2`: `Tests: 23 failed, 1864 passed, 1887 total` em `6 failed, 193 passed, 199` suites.
  - **Comparação com a linha de base** (`main` já vermelho: 25/1764 a falhar em 6 suites): as 6 suites a falhar são **exatamente** as da baseline — `withLauncherIntent`, `LockScreen`, `SettingsScreen`, `SiriScreen`, `WeatherScreen`, `FoldersStore`. Nenhuma falha nova; os 23 a falhar (= 25 baseline menos margem de execução flaky) pertencem a essas mesmas suites. O critério de regressão (não piorar) está cumprido e os meus 17 testes passam sempre.

## Testes

17 passaram, 0 falharam, 1 suite (mais a suite completa do repo: 1864 passaram, 23 falharam em 6 suites pré-existentes da baseline)

## Linked Issue

Fixes #272