### PR TITLE
Weather/App Library/Spotlight: built-in apps abrem ecrã interno em vez do launcher nativo Android (#710) (#710)

### DIFF
--- a/src/screens/AppLibraryScreen.tsx
+++ b/src/screens/AppLibraryScreen.tsx
@@ -14,6 +14,7 @@ import {
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
 import * as Haptics from 'expo-haptics';
+import { useNavigation } from '@react-navigation/native';
 
 import { useApps, InstalledApp } from '../store/AppsStore';
 import { useTheme } from '../theme/ThemeContext';
@@ -29,6 +30,7 @@ import { CupertinoSearchBar } from '../components/CupertinoSearchBar';
 import { CupertinoPressable } from '../components/CupertinoPressable';
 import { CupertinoNavigationBar, CupertinoEmptyState } from '../components';
 import type { AppNavigationProp } from '../navigation/types';
+import { launchBuiltInOrExternal } from '../utils/launchBuiltIn';
 import type { CupertinoColors } from '../theme/CupertinoTheme';
 import { hapticImpact } from '../utils/haptics';
 
@@ -576,6 +578,7 @@ function SectionHeader({ title, colors }: { title: string; colors: CupertinoColo
 export function AppLibraryContent() {
   const { theme } = useTheme();
   const { colors } = theme;
+  const navigation = useNavigation<AppNavigationProp>();
   // `apps` é a lista completa (usada só pela procura, para que uma app
   // escondida continue lançável) e `visibleApps` é a lista sem as escondidas
   // (#606), usada nas categorias e nos strips.
@@ -687,8 +690,11 @@ export function AppLibraryContent() {
 
   const handleLaunch = useCallback((packageName: string) => {
     hapticImpact(Haptics.ImpactFeedbackStyle.Light).catch(() => {});
-    launchApp(packageName);
-  }, [launchApp]);
+    // Built-in virtual apps (Weather, Calculator, …) must open the in-app
+    // iOS-style screen via navigation, not the native launcher bridge — see
+    // launchBuiltInOrExternal.
+    launchBuiltInOrExternal(packageName, navigation, launchApp);
+  }, [launchApp, navigation]);
 
   const isSearching = query.trim().length > 0;
 

--- a/src/screens/SpotlightSearchScreen.tsx
+++ b/src/screens/SpotlightSearchScreen.tsx
@@ -20,6 +20,7 @@ import { useTheme } from '../theme/ThemeContext';
 import { CupertinoSearchBar } from '../components/CupertinoSearchBar';
 import { CupertinoPressable } from '../components/CupertinoPressable';
 import type { AppNavigationProp, RootStackParamList } from '../navigation/types';
+import { launchBuiltInOrExternal } from '../utils/launchBuiltIn';
 
 // ---------------------------------------------------------------------------
 // Fuzzy matching
@@ -365,7 +366,10 @@ export function SpotlightSearchScreen({ navigation }: { navigation: AppNavigatio
 
     switch (item.type) {
       case 'app':
-        launchApp(item.app.packageName);
+        // Built-in virtual apps (Weather, Calculator, …) must open the in-app
+        // iOS-style screen, not be handed to the native launcher bridge — see
+        // launchBuiltInOrExternal.
+        launchBuiltInOrExternal(item.app.packageName, navigation, launchApp);
         break;
       case 'contact':
         navigation.navigate('ContactDetail', { contactId: item.contactId });

--- a/src/screens/__tests__/SpotlightSearchScreen.test.tsx
+++ b/src/screens/__tests__/SpotlightSearchScreen.test.tsx
@@ -1,36 +1,75 @@
 import React from 'react';
-import { render, fireEvent } from '../../test-utils';
+import { render, fireEvent, act } from '../../test-utils';
 import { SpotlightSearchScreen } from '../SpotlightSearchScreen';
 import type { AppNavigationProp } from '../../navigation/types';
+import { useApps } from '../../store/AppsStore';
 
-const mockNavigation = { navigate: jest.fn(), goBack: jest.fn(), push: jest.fn() } as unknown as AppNavigationProp;
+jest.mock('../../store/AppsStore', () => {
+  const actual = jest.requireActual('../../store/AppsStore');
+  return {
+    ...actual,
+    useApps: jest.fn(),
+  };
+});
 
+const mockLaunchApp = jest.fn();
+
+function renderWithApps(apps: Array<{ name: string; packageName: string }>) {
+  (useApps as unknown as jest.Mock).mockReturnValue({
+    apps,
+    launchApp: mockLaunchApp,
+  });
+  const nav = { navigate: jest.fn(), goBack: jest.fn(), push: jest.fn() } as unknown as AppNavigationProp;
+  return { nav, ...render(<SpotlightSearchScreen navigation={nav} />) };
+}
+
+const WEATHER_APP = { name: 'Weather', packageName: 'com.iostoandroid.weather' };
 
 describe('SpotlightSearchScreen', () => {
+  beforeEach(() => {
+    mockLaunchApp.mockClear();
+  });
+
   it('renders without crashing', () => {
-    const { toJSON } = render(<SpotlightSearchScreen navigation={mockNavigation} />);
+    const { toJSON } = renderWithApps([WEATHER_APP]);
     expect(toJSON()).toBeTruthy();
   });
 
   it('renders Search title', () => {
-    const { getByText } = render(<SpotlightSearchScreen navigation={mockNavigation} />);
+    const { getByText } = renderWithApps([WEATHER_APP]);
     expect(getByText('Search')).toBeTruthy();
   });
 
   it('renders search bar', () => {
-    const { getByPlaceholderText } = render(<SpotlightSearchScreen navigation={mockNavigation} />);
+    const { getByPlaceholderText } = renderWithApps([WEATHER_APP]);
     expect(getByPlaceholderText('Search')).toBeTruthy();
   });
 
   it('renders Back button', () => {
-    const { getByText } = render(<SpotlightSearchScreen navigation={mockNavigation} />);
+    const { getByText } = renderWithApps([WEATHER_APP]);
     expect(getByText('Back')).toBeTruthy();
   });
 
   it('pressing Back calls navigation.goBack', () => {
-    const nav = { navigate: jest.fn(), goBack: jest.fn(), push: jest.fn() } as unknown as AppNavigationProp;
-    const { getByLabelText } = render(<SpotlightSearchScreen navigation={nav} />);
+    const { nav, getByLabelText } = renderWithApps([WEATHER_APP]);
     fireEvent.press(getByLabelText('Back'));
     expect(nav.goBack).toHaveBeenCalled();
+  });
+
+  // --- issue #710 regression: built-in apps must open the in-app screen ---
+  it('tapping a built-in app (Weather) navigates internally, not via native launch', async () => {
+    const { nav, getByPlaceholderText, getByText } = renderWithApps([WEATHER_APP]);
+    fireEvent.changeText(getByPlaceholderText('Search'), 'weather');
+    const result = getByText('Weather');
+    await act(async () => {
+      fireEvent.press(result);
+      // handleResultPress awaits addToHistory before routing — let it settle.
+      await Promise.resolve();
+    });
+    // Must open the internal Weather screen…
+    expect(nav.navigate).toHaveBeenCalledWith('Weather');
+    // …and must NOT hand the built-in packageName to the native launcher
+    // bridge (that is what dumped the user onto the Android home screen).
+    expect(mockLaunchApp).not.toHaveBeenCalledWith('com.iostoandroid.weather');
   });
 });

--- a/src/utils/__tests__/launchBuiltIn.test.ts
+++ b/src/utils/__tests__/launchBuiltIn.test.ts
@@ -1,0 +1,68 @@
+import type { NavigationProp, ParamListBase } from '@react-navigation/native';
+import { launchBuiltInOrExternal } from '../launchBuiltIn';
+import { BUILT_IN_APPS } from '../../screens/LauncherHomeScreen';
+
+type Navigate = NavigationProp<ParamListBase>['navigate'];
+
+// A real navigation stub — tracks which route navigate() was called with so we
+// can assert a built-in app opened the in-app screen, not the native bridge.
+function makeNavigation() {
+  const navigated: string[] = [];
+  const navigate = ((route: string) => {
+    navigated.push(route);
+  }) as Navigate;
+  return { navigated, navigation: { navigate } };
+}
+
+describe('launchBuiltInOrExternal', () => {
+  it('routes a built-in app (Weather) to the in-app screen, not the native bridge', () => {
+    const { navigated, navigation } = makeNavigation();
+    const launchExternal = jest.fn();
+
+    launchBuiltInOrExternal('com.iostoandroid.weather', navigation, launchExternal);
+
+    // The internal Weather screen must have opened.
+    expect(navigated).toContain('Weather');
+    // And the native launcher bridge must NOT have been used — that is what
+    // made the user land on the Android home screen instead of weather content.
+    expect(launchExternal).not.toHaveBeenCalled();
+  });
+
+  it('routes every built-in app to its internal route via navigate', () => {
+    const { navigated, navigation } = makeNavigation();
+    const launchExternal = jest.fn();
+
+    Object.keys(BUILT_IN_APPS).forEach((pkg) => {
+      launchBuiltInOrExternal(pkg, navigation, launchExternal);
+    });
+
+    // Every built-in must have been routed internally.
+    Object.values(BUILT_IN_APPS).forEach((route) => {
+      expect(navigated).toContain(route);
+    });
+    expect(launchExternal).not.toHaveBeenCalled();
+  });
+
+  it('falls through to the native bridge for a real external app', () => {
+    const { navigated, navigation } = makeNavigation();
+    const launchExternal = jest.fn();
+
+    launchBuiltInOrExternal('com.google.android.gm', navigation, launchExternal);
+
+    // No internal route exists for an external app…
+    expect(navigated).toHaveLength(0);
+    // …so it must be handed to the native launcher.
+    expect(launchExternal).toHaveBeenCalledWith('com.google.android.gm');
+  });
+
+  it('does NOT route an unknown built-in-like package to an internal screen', () => {
+    const { navigated, navigation } = makeNavigation();
+    const launchExternal = jest.fn();
+
+    // A package that looks like ours but is NOT in BUILT_IN_APPS.
+    launchBuiltInOrExternal('com.iostoandroid.unknown', navigation, launchExternal);
+
+    expect(navigated).toHaveLength(0);
+    expect(launchExternal).toHaveBeenCalledWith('com.iostoandroid.unknown');
+  });
+});

--- a/src/utils/launchBuiltIn.ts
+++ b/src/utils/launchBuiltIn.ts
@@ -1,0 +1,31 @@
+import type { NavigationProp, ParamListBase } from '@react-navigation/native';
+import { BUILT_IN_APPS } from '../screens/LauncherHomeScreen';
+
+type Navigate = NavigationProp<ParamListBase>['navigate'];
+
+/**
+ * Launch an app by packageName from any surface (Spotlight, App Library, …).
+ *
+ * Built-in virtual apps (`com.iostoandroid.*`, see `BUILT_IN_APPS`) must open
+ * the in-app iOS-style screen via `navigation.navigate`, exactly like the home
+ * grid does (LauncherHomeScreen.handleAppPress, SiriScreen). Launching them
+ * through the native `launchApp` bridge is wrong: those package names are not
+ * installed Android apps, so the bridge either fails or — worse — resolves to
+ * the real system launcher and the user lands on the Android home screen
+ * instead of the Weather/Calculator/… content.
+ *
+ * Only genuine external (non-built-in) apps fall through to the native launch.
+ */
+export function launchBuiltInOrExternal(
+  packageName: string,
+  navigation: { navigate: Navigate },
+  launchExternal: (packageName: string) => void | Promise<unknown>,
+): void {
+  const internalRoute = BUILT_IN_APPS[packageName];
+  if (internalRoute) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- built-in routes are parameterless
+    navigation.navigate(internalRoute as any);
+    return;
+  }
+  void launchExternal(packageName);
+}


### PR DESCRIPTION
## Resumo

Weather/App Library/Spotlight: built-in apps abrem ecrã interno em vez do launcher nativo Android (#710)

## Causa raiz

O bug "o ecrã Weather mostra a home screen do Android em vez do conteúdo meteorológico" é um sintoma de roteamento errado, não de um defeito de renderização do WeatherScreen. O WeatherScreen em si renderiza o conteúdo correctamente (gradiente, cidade, temperatura, forecast) — confirmado por leitura de src/screens/WeatherScreen.tsx. O problema é que, a partir de certas superfícies, o Weather (e os outros built-ins com.iostoandroid.*) era aberto através da bridge nativa launchApp (AppsStore.launchApp -> LauncherModule.launchApp em Kotlin), que faz startActivity com FLAG_ACTIVITY_NEW_TASK contra um packageName que NAO é uma app Android instalada. O PackageNameValidator ou nao resolve o packageName interno, ou resolve para a app do sistema e foge para o launcher Android, deixando o utilizador na home screen do sistema em vez do ecrã meteorológico iOS-style.

Mecanismo (ficheiro:linha):
- src/screens/AppLibraryScreen.tsx:689-692 — handleLaunch chamava launchApp(packageName) para TODOS os apps, ignorando BUILT_IN_APPS.
- src/screens/SpotlightSearchScreen.tsx:368 — case 'app': launchApp(item.app.packageName) tambem ignorava BUILT_IN_APPS.

A home grid (LauncherHomeScreen.handleAppPress, linha 884-890) e a Siri (#700) ja faziam a coisa certa: consultam BUILT_IN_APPS e usam navigation.navigate(route). O Spotlight e a App Library tinham ficado para tras.

## O que mudou

- src/utils/launchBuiltIn.ts (novo): helper launchBuiltInOrExternal(packageName, navigation, launchExternal). Se BUILT_IN_APPS[packageName] existir, navega para o ecrã interno; caso contrario, passa ao launchApp nativo para apps externas reais. Centraliza a lógica que ja existia na home/Siri.
- src/screens/SpotlightSearchScreen.tsx: case 'app' agora usa launchBuiltInOrExternal(item.app.packageName, navigation, launchApp) em vez de launchApp(...) directo.
- src/screens/AppLibraryScreen.tsx: handleLaunch usa launchBuiltInOrExternal(packageName, navigation, launchApp); adicionado useNavigation() (o AppLibraryContent partilhado pela home e pela App Library nao tinha navigation).
- src/screens/__tests__/SpotlightSearchScreen.test.tsx e src/utils/__tests__/launchBuiltIn.test.ts (novos testes): cobrem o comportamento.

## Porque assim

Centralizar o roteamento built-in-vs-externo num unico helper evita que futuras superfícies (ja aconteceu com Spotlight e App Library apos a home/Siri) voltem a atirar built-ins para o launcher nativo. A alternativa de duplicar o if (BUILT_IN_APPS[...]) navigate em cada call site foi descartada: espalha a lógica e volta a quebrar silenciosamente. O helper mantem o tipo de launchExternal como void | Promise<unknown> para aceitar o launchApp real (Promise<boolean>).

## Critérios de aceitação

- [x] Tocar no Weather na App Library abre o ecrã Weather interno (navegação), não o launcher Android. Coberto pelo teste launchBuiltInOrExternal (route 'Weather') e pelo teste de integração do Spotlight.
- [x] Tocar no Weather no Spotlight abre o ecrã Weather interno. Coberto pelo teste de integração SpotlightSearchScreen > tapping a built-in app (Weather) navigates internally, not via native launch.
- [x] O inverso do fix: apps externas reais (ex.: com.google.android.gm) continuam a ser lançadas via bridge nativa — testado em launchBuiltInOrExternal > falls through to the native bridge for a real external app.
- [x] Fronteiras/todos os built-ins: cada entrada de BUILT_IN_APPS (14 apps) é roteada para a sua route interna — testado em routes every built-in app to its internal route via navigate.
- [x] Inválido/hostil: um packageName tipo com.iostoandroid.unknown (nao em BUILT_IN_APPS) NAO é roteado para ecrã interno e cai no launchApp — testado em does NOT route an unknown built-in-like package to an internal screen.
- [x] O que NAO devia mudar: a home grid (LauncherHomeScreen) e a Siri continuam a abrir built-ins internamente como antes — nao foram tocadas; o helper reutiliza a mesma BUILT_IN_APPS. O WeatherScreen em si nao foi alterado.

## Testes

- Passo vermelho (fix revertido — git stash de SpotlightSearchScreen.tsx/AppLibraryScreen.tsx + remocao de launchBuiltIn.ts):

  SpotlightSearchScreen > tapping a built-in app (Weather) navigates internally, not via native launch (254 ms)
    expect(jest.fn()).toHaveBeenCalledWith(...expected)
    Expected: "Weather"
    Number of calls: 0
      > 70 | expect(nav.navigate).toHaveBeenCalledWith('Weather');

  (Com o fix no sitio, o mesmo teste passa: navigate e chamado com 'Weather' e launchApp nao e chamado com o packageName interno.)

- Casos cobertos alem do caminho feliz: todas as 14 apps built-in (fronteira/totalidade), app externa real cai para a bridge (inverso do fix), packageName interno-desconhecido nao e roteado internamente (invalido/hostil), e teste de integracao que monta o Spotlight real e dispara o press verdadeiro do resultado de pesquisa.

- Sanity-check: reverti o fix (git stash + remocao do helper) e confirmei que a suite falha (Tests: 1 failed, 5 passed, 6 total em launchBuiltIn.test.ts + SpotlightSearchScreen.test.tsx); restaurei e voltou a 10 passed, 10 total.

- Resultado das verificações obrigatórias:
  - npm run lint: 0 erros (8 warnings pre-existentes, nenhum introduzido por mim).
  - npx tsc --noEmit: limpo no meu working tree. NOTA: existe 1 erro pre-existente em src/screens/TodayViewScreen.tsx:260 (Cannot find name 'size') que pertence a origin/main e NAO e meu — confirmei removendo as minhas alteracoes e o erro persistiu.
  - npm test -- --maxWorkers=2: 23 falhas / 1845 passam / 1868 total, em 6 suites. Isto e igual ou melhor que o baseline (25 falhas / 6 suites). As 6 suites que falham (SiriScreen, WeatherScreen, SettingsScreen, FoldersStore, LockScreen, withLauncherIntent) sao exactamente as mesmas do baseline — todas por causa do firstSyncDone/AsyncStorage (SettingsStore) e do android/AndroidManifest.xml em falta, nao por meu codigo. As 3 entradas que aparecem como "novas" na comparacao sao renomeacoes de testes do SiriScreen (ex.: does not throw when launchApp rejects -> does not throw when launchApp rejects (real app)) — sao as mesmas falhas pre-existentes, nao regressoes. Nenhuma falha nova em ficheiro que toquei.

## Testes

10 passaram (launchBuiltIn.test.ts + SpotlightSearchScreen.test.tsx), 0 falharam; suite completa: 1845 passam, 23 falham (baseline 25), 6 suites — sem regressões

## Linked Issue

Fixes #710