### PR TITLE
fix/277: Add availability-gated read-only Health Connect native module (modules/health-connect-module) (#277)

### DIFF
--- a/modules/health-connect-module/android/build.gradle
+++ b/modules/health-connect-module/android/build.gradle
@@ -1,0 +1,37 @@
+apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+apply plugin: 'expo-module-gradle-plugin'
+
+group = 'com.iostoandroid'
+version = '1.0.0'
+
+android {
+    namespace "com.iostoandroid.health"
+    compileSdkVersion safeExtGet("compileSdkVersion", 35)
+
+    defaultConfig {
+        minSdkVersion safeExtGet("minSdkVersion", 24)
+        targetSdkVersion safeExtGet("targetSdkVersion", 35)
+        versionCode 1
+        versionName "1.0.0"
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+}
+
+dependencies {
+    implementation project(':expo-modules-core')
+    implementation 'androidx.health.connect:connect-client:1.1.0-alpha07'
+    testImplementation 'junit:junit:4.13.2'
+}
+
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}

--- a/modules/health-connect-module/android/src/main/java/com/iostoandroid/health/HealthConnectModule.kt
+++ b/modules/health-connect-module/android/src/main/java/com/iostoandroid/health/HealthConnectModule.kt
@@ -1,0 +1,75 @@
+package com.iostoandroid.health
+
+import android.content.Context
+import android.os.Build
+import androidx.health.connect.client.HealthConnectClient
+import androidx.health.connect.client.permission.HealthPermission
+import androidx.health.connect.client.records.StepsRecord
+import androidx.health.connect.client.request.AggregateRequest
+import androidx.health.connect.client.time.TimeRangeFilter
+import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.modules.ModuleDefinition
+import java.time.LocalDate
+import java.time.ZoneId
+
+/**
+ * Read-only, availability-gated Health Connect bridge.
+ *
+ * Health Connect is a separate installable app/service (bundled into the OS
+ * from Android 14, a Play Store app before that), so it is absent on most
+ * emulators and on plenty of real devices. Both functions therefore report
+ * "unavailable"/"no data" instead of throwing: nothing in the app may depend on
+ * Health Connect being present.
+ */
+class HealthConnectModule : Module() {
+
+  override fun definition() = ModuleDefinition {
+    Name("HealthConnectModule")
+
+    /**
+     * true only when the Health Connect SDK reports SDK_AVAILABLE. Anything
+     * else — SDK unavailable, provider update required, or an SDK that is not
+     * present at all on this API level — is false.
+     */
+    AsyncFunction("isAvailable") {
+      isSdkAvailable(appContext.reactContext ?: return@AsyncFunction false)
+    }
+
+    /**
+     * Today's aggregated step total from Health Connect's StepsRecord, or null
+     * when the read permission has not been granted, Health Connect is
+     * unavailable, or there is no data for today. Never returns a fabricated 0:
+     * a real 0 means "no steps", null means "no answer".
+     */
+    AsyncFunction("getTodayStepsFromHealthConnect") {
+      val context = appContext.reactContext ?: return@AsyncFunction null
+      if (!isSdkAvailable(context)) return@AsyncFunction null
+
+      val client = HealthConnectClient.getOrCreate(context)
+      val permission = HealthPermission.getReadPermission(StepsRecord::class)
+      val granted = client.permissionController.getGrantedPermissions()
+      if (!granted.contains(permission)) return@AsyncFunction null
+
+      val zone = ZoneId.systemDefault()
+      val startOfDay = LocalDate.now(zone).atStartOfDay(zone).toInstant()
+      val now = java.time.Instant.now()
+
+      val response = client.aggregate(
+        AggregateRequest(
+          metrics = setOf(StepsRecord.COUNT_TOTAL),
+          timeRangeFilter = TimeRangeFilter.between(startOfDay, now),
+        )
+      )
+      response[StepsRecord.COUNT_TOTAL]?.toInt()
+    }
+  }
+
+  /**
+   * The Health Connect SDK requires API 26+; on older devices getSdkStatus is
+   * not meaningful, so treat those as unavailable rather than calling into it.
+   */
+  private fun isSdkAvailable(context: Context): Boolean {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return false
+    return HealthConnectClient.getSdkStatus(context) == HealthConnectClient.SDK_AVAILABLE
+  }
+}

--- a/modules/health-connect-module/expo-module.config.json
+++ b/modules/health-connect-module/expo-module.config.json
@@ -1,0 +1,6 @@
+{
+  "platforms": ["android"],
+  "android": {
+    "modules": ["com.iostoandroid.health.HealthConnectModule"]
+  }
+}

--- a/modules/health-connect-module/package.json
+++ b/modules/health-connect-module/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "health-connect-module",
+  "version": "1.0.0",
+  "main": "src/index.ts",
+  "private": true
+}

--- a/modules/health-connect-module/src/__tests__/index.test.ts
+++ b/modules/health-connect-module/src/__tests__/index.test.ts
@@ -1,0 +1,197 @@
+// Native module returned by requireNativeModule('HealthConnectModule').
+// Swapped per test so each bridge instance captures the right behaviour.
+let mockNativeModule: unknown;
+
+jest.mock('expo', () => ({
+  requireNativeModule: jest.fn(() => {
+    if (mockNativeModule === undefined) throw new Error('module not found');
+    return mockNativeModule;
+  }),
+}));
+
+// Load a FRESH copy of the real bridge so the module-level
+// requireNativeModule() call re-runs against the current mockNativeModule.
+function loadBridge() {
+  let mod: typeof import('../index');
+  jest.isolateModules(() => {
+    mod = jest.requireActual('../index');
+  });
+  return mod!;
+}
+
+beforeAll(() => {
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+afterAll(() => {
+  (console.error as jest.Mock).mockRestore();
+});
+
+afterEach(() => {
+  mockNativeModule = undefined;
+});
+
+describe('isAvailable', () => {
+  it('is true only when the native module reports SDK_AVAILABLE', async () => {
+    mockNativeModule = { isAvailable: jest.fn(async () => true) };
+    await expect(loadBridge().isAvailable()).resolves.toBe(true);
+  });
+
+  it('is false when the native module reports unavailable', async () => {
+    mockNativeModule = { isAvailable: jest.fn(async () => false) };
+    await expect(loadBridge().isAvailable()).resolves.toBe(false);
+  });
+
+  it('is false (does not throw) when requireNativeModule throws', async () => {
+    mockNativeModule = undefined;
+    await expect(loadBridge().isAvailable()).resolves.toBe(false);
+  });
+
+  it('is false when the native call rejects', async () => {
+    mockNativeModule = {
+      isAvailable: jest.fn(async () => {
+        throw new Error('native failure');
+      }),
+    };
+    await expect(loadBridge().isAvailable()).resolves.toBe(false);
+  });
+
+  it('is false when the native module lacks the function entirely', async () => {
+    mockNativeModule = {};
+    await expect(loadBridge().isAvailable()).resolves.toBe(false);
+  });
+
+  it('is false — not truthy — when native returns a non-boolean truthy value', async () => {
+    mockNativeModule = { isAvailable: jest.fn(async () => 'yes') };
+    await expect(loadBridge().isAvailable()).resolves.toBe(false);
+  });
+});
+
+describe('getTodayStepsFromHealthConnect', () => {
+  function withSteps(steps: unknown, available = true) {
+    mockNativeModule = {
+      isAvailable: jest.fn(async () => available),
+      getTodayStepsFromHealthConnect: jest.fn(async () => steps),
+    };
+    return loadBridge();
+  }
+
+  it('returns the step total when available', async () => {
+    await expect(withSteps(8432).getTodayStepsFromHealthConnect()).resolves.toBe(8432);
+  });
+
+  it('preserves a genuine 0 (no steps today is not the same as no data)', async () => {
+    await expect(withSteps(0).getTodayStepsFromHealthConnect()).resolves.toBe(0);
+  });
+
+  it('returns null without calling native when Health Connect is unavailable', async () => {
+    const bridge = withSteps(5000, false);
+    await expect(bridge.getTodayStepsFromHealthConnect()).resolves.toBeNull();
+    expect(
+      (mockNativeModule as { getTodayStepsFromHealthConnect: jest.Mock })
+        .getTodayStepsFromHealthConnect,
+    ).not.toHaveBeenCalled();
+  });
+
+  it('returns null when the permission is denied (native resolves null)', async () => {
+    await expect(withSteps(null).getTodayStepsFromHealthConnect()).resolves.toBeNull();
+  });
+
+  it('returns null when the native read rejects', async () => {
+    mockNativeModule = {
+      isAvailable: jest.fn(async () => true),
+      getTodayStepsFromHealthConnect: jest.fn(async () => {
+        throw new Error('read failed');
+      }),
+    };
+    await expect(loadBridge().getTodayStepsFromHealthConnect()).resolves.toBeNull();
+  });
+
+  it.each([
+    ['a negative count', -1],
+    ['a fractional count', 12.5],
+    ['NaN', Number.NaN],
+    ['Infinity', Number.POSITIVE_INFINITY],
+    ['a string', '9000'],
+    ['undefined', undefined],
+  ])('returns null for %s', async (_label, value) => {
+    await expect(withSteps(value).getTodayStepsFromHealthConnect()).resolves.toBeNull();
+  });
+
+  it('returns null (no crash) when the module is absent altogether', async () => {
+    mockNativeModule = undefined;
+    await expect(loadBridge().getTodayStepsFromHealthConnect()).resolves.toBeNull();
+  });
+});
+
+describe('applyHealthConnectSteps', () => {
+  it("REPLACES today's entry instead of summing it", () => {
+    const { applyHealthConnectSteps } = loadBridge();
+    const out = applyHealthConnectSteps(
+      [
+        { date: '2026-01-01', steps: 100 },
+        { date: '2026-01-02', steps: 3000 },
+      ],
+      '2026-01-02',
+      8000,
+    );
+    expect(out).toEqual([
+      { date: '2026-01-01', steps: 100 },
+      { date: '2026-01-02', steps: 8000 },
+    ]);
+    // The inverse of a sum: 3000 + 8000 = 11000 must never appear.
+    expect(out.find((e) => e.date === '2026-01-02')!.steps).not.toBe(11000);
+  });
+
+  it('appends when today has no entry yet', () => {
+    const { applyHealthConnectSteps } = loadBridge();
+    expect(applyHealthConnectSteps([{ date: '2026-01-01', steps: 100 }], '2026-01-02', 42)).toEqual([
+      { date: '2026-01-01', steps: 100 },
+      { date: '2026-01-02', steps: 42 },
+    ]);
+  });
+
+  it('handles an empty history', () => {
+    const { applyHealthConnectSteps } = loadBridge();
+    expect(applyHealthConnectSteps([], '2026-01-02', 7)).toEqual([{ date: '2026-01-02', steps: 7 }]);
+  });
+
+  it('is idempotent when applied twice (double-tap must not double-count)', () => {
+    const { applyHealthConnectSteps } = loadBridge();
+    const once = applyHealthConnectSteps([{ date: '2026-01-02', steps: 3000 }], '2026-01-02', 8000);
+    const twice = applyHealthConnectSteps(once, '2026-01-02', 8000);
+    expect(twice).toEqual(once);
+  });
+
+  it('collapses duplicate entries for today into a single replaced entry', () => {
+    const { applyHealthConnectSteps } = loadBridge();
+    const out = applyHealthConnectSteps(
+      [
+        { date: '2026-01-02', steps: 1 },
+        { date: '2026-01-02', steps: 2 },
+      ],
+      '2026-01-02',
+      50,
+    );
+    expect(out).toEqual([{ date: '2026-01-02', steps: 50 }]);
+  });
+
+  it('does not mutate the input array', () => {
+    const { applyHealthConnectSteps } = loadBridge();
+    const input = [{ date: '2026-01-02', steps: 3000 }];
+    applyHealthConnectSteps(input, '2026-01-02', 8000);
+    expect(input).toEqual([{ date: '2026-01-02', steps: 3000 }]);
+  });
+
+  it('leaves other days untouched, including a 0-step day', () => {
+    const { applyHealthConnectSteps } = loadBridge();
+    const out = applyHealthConnectSteps(
+      [
+        { date: '2026-01-01', steps: 0 },
+        { date: '2026-01-02', steps: 5 },
+      ],
+      '2026-01-02',
+      9,
+    );
+    expect(out.find((e) => e.date === '2026-01-01')).toEqual({ date: '2026-01-01', steps: 0 });
+  });
+});

--- a/modules/health-connect-module/src/index.ts
+++ b/modules/health-connect-module/src/index.ts
@@ -1,0 +1,113 @@
+import { requireNativeModule } from 'expo';
+import { Platform } from 'react-native';
+
+/**
+ * Native surface exposed by
+ * `com.iostoandroid.health.HealthConnectModule` (Kotlin).
+ *
+ * Deliberately tiny: this module is read-only and availability-gated. Health
+ * Connect is a separate installable app/service (bundled from Android 14, a
+ * Play Store app before that), so it is absent on most emulators and on plenty
+ * of real devices — every entry point here has to survive that.
+ */
+export interface HealthConnectModuleType {
+  /** true only when `HealthConnectClient.getSdkStatus()` is SDK_AVAILABLE. */
+  isAvailable(): Promise<boolean>;
+  /**
+   * Today's total step count from Health Connect's `StepsRecord`, or `null`
+   * when the read permission is denied or Health Connect has no data.
+   */
+  getTodayStepsFromHealthConnect(): Promise<number | null>;
+}
+
+const isAndroid = Platform.OS === 'android';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- requireNativeModule returns an opaque native object; typing it as any is required for property access
+let nativeModule: any = null;
+if (isAndroid) {
+  try {
+    nativeModule = requireNativeModule('HealthConnectModule');
+  } catch (e) {
+    console.error('HealthConnectModule unavailable, using stub', e);
+  }
+}
+
+/**
+ * Stub used on non-Android and whenever the native module is missing.
+ * Reports "not available" and "no data" rather than throwing, so callers never
+ * need a try/catch of their own.
+ */
+const stub: HealthConnectModuleType = {
+  isAvailable: async () => false,
+  getTodayStepsFromHealthConnect: async () => null,
+};
+
+/**
+ * Availability check. Never throws and never returns anything but a boolean:
+ * a rejected native call, a missing function or a non-boolean return all
+ * collapse to `false`, because "unknown" must behave exactly like "absent".
+ */
+export async function isAvailable(): Promise<boolean> {
+  if (!nativeModule || typeof nativeModule.isAvailable !== 'function') return false;
+  try {
+    return (await nativeModule.isAvailable()) === true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Today's step total from Health Connect, gated on {@link isAvailable}.
+ *
+ * Returns `null` — never a fabricated 0 — when Health Connect is absent, the
+ * permission is denied, the native call rejects, or the value is not a
+ * non-negative finite integer. A `0` genuinely reported by Health Connect is
+ * preserved as `0`: "no steps today" and "no data" are different answers and
+ * callers must be able to tell them apart.
+ */
+export async function getTodayStepsFromHealthConnect(): Promise<number | null> {
+  if (!(await isAvailable())) return null;
+  if (typeof nativeModule?.getTodayStepsFromHealthConnect !== 'function') return null;
+  let raw: unknown;
+  try {
+    raw = await nativeModule.getTodayStepsFromHealthConnect();
+  } catch {
+    return null;
+  }
+  if (typeof raw !== 'number' || !Number.isFinite(raw) || !Number.isInteger(raw) || raw < 0) {
+    return null;
+  }
+  return raw;
+}
+
+/** One day of step history, as persisted by the JS side. */
+export interface StepHistoryEntry {
+  date: string;
+  steps: number;
+}
+
+/**
+ * Writes a Health-Connect-sourced step total into a step history, REPLACING
+ * today's entry instead of adding to it.
+ *
+ * Health Connect's `StepsRecord` is the authoritative daily total; the locally
+ * observed Pedometer delta measures the same steps a second time, so summing
+ * the two would double-count. Other days are returned untouched and the
+ * original array is never mutated.
+ */
+export function applyHealthConnectSteps(
+  history: readonly StepHistoryEntry[],
+  today: string,
+  steps: number,
+): StepHistoryEntry[] {
+  const others = history.filter((e) => e.date !== today);
+  return [...others, { date: today, steps }];
+}
+
+const healthConnect: HealthConnectModuleType = {
+  isAvailable,
+  getTodayStepsFromHealthConnect,
+};
+
+export const nativeStub = stub;
+export default healthConnect;


### PR DESCRIPTION
## Resumo

fix/277: Add availability-gated read-only Health Connect native module (modules/health-connect-module)

## Causa raiz

O issue parte de um pressuposto que o código contradiz. Diz que `HealthStore` (dos issues anteriores do épico #124) "is fully self-sufficient on local `Pedometer` data" e lista como ficheiros a modificar `src/store/HealthStore.tsx`, `src/screens/HealthScreen.tsx` e os respectivos testes. **Nenhum desses ficheiros existe em `main`.**

Prova:

```
$ grep -rn "HealthStore|HealthScreen|isHealthConnectAvailable|Pedometer" --include=*.ts --include=*.tsx --include=*.kt . | grep -v node_modules
(vazio)
$ ls src/store/
appsIndexReducer.ts AppsStore.tsx AssistiveTouchStore.tsx BookmarksStore.tsx
ContactsStore.tsx DeviceStore.tsx FoldersStore.tsx LocationStore.tsx
ProfileStore.tsx ReadingListStore.tsx SettingsStore.tsx storage.ts
$ grep -n "sensors" package.json     # expo-sensors não é dependência
(vazio)
```

Os PRs dos issues irmãos não foram merged — o único que existe é `qa/issue-272`, ainda em branch (`src/utils/healthAggregation.ts`), fora de `main`. O mecanismo é portanto: os pontos 4, 5 e 6 do "Proposed Fix" (adicionar campos a `HealthContextValue`, botão em `HealthScreen`, sobrescrever `stepHistory`) **não têm superfície onde aterrar** nesta base. Escrever `HealthStore`/`HealthScreen` de raiz aqui seria implementar os issues anteriores do épico dentro deste, e o issue diz explicitamente que este é "scoped narrowly to availability-checking and read-only sync".

## O que mudou

Todos os ficheiros são novos; nenhum ficheiro existente foi tocado.

- `modules/health-connect-module/package.json`, `modules/health-connect-module/expo-module.config.json` — declaram o módulo, `platforms: ["android"]`, `com.iostoandroid.health.HealthConnectModule`. Espelham exactamente os do `launcher-module`.
- `modules/health-connect-module/android/build.gradle` — cópia estrutural do `launcher-module/android/build.gradle` (mesmos plugins, `compileOptions`, `jvmTarget`, helper `safeExtGet`), com `namespace "com.iostoandroid.health"` e a dependência nova `androidx.health.connect:connect-client:1.1.0-alpha07`.
- `modules/health-connect-module/android/src/main/java/com/iostoandroid/health/HealthConnectModule.kt` — expõe as duas `AsyncFunction` pedidas. `isAvailable` devolve `true` só para `HealthConnectClient.SDK_AVAILABLE` (e `false` abaixo de API 26, onde `getSdkStatus` não é significativo). `getTodayStepsFromHealthConnect` confirma disponibilidade, verifica `permissionController.getGrantedPermissions()` contra a read-permission de `StepsRecord`, e só então agrega `StepsRecord.COUNT_TOTAL` desde o início do dia local; devolve `null` se indisponível, sem permissão ou sem dados.
- `modules/health-connect-module/src/index.ts` — bridge JS no padrão defensivo de `DeviceStore.tsx:150-155`/`launcher-module/src/index.ts:305-310`: `requireNativeModule` só em Android, dentro de `try/catch`, com stub exportado. `isAvailable()` colapsa qualquer falha (módulo ausente, função ausente, rejeição, retorno não-boolean) em `false`. `getTodayStepsFromHealthConnect()` é gated em `isAvailable()` — não chega a chamar o nativo quando indisponível — e devolve `null` para rejeição, negativo, fraccionário, `NaN`, `Infinity`, string ou `undefined`, preservando um `0` genuíno. Exporta também `applyHealthConnectSteps(history, today, steps)`, a função pura que implementa o ponto 6 do issue: **substitui** a entrada de hoje, nunca soma.
- `modules/health-connect-module/src/__tests__/index.test.ts` — 25 testes contra a unidade real (carregada com `jest.requireActual` dentro de `jest.isolateModules`, para o `requireNativeModule` de topo de módulo re-executar por teste).

## Porque assim

**Âmbito.** Entreguei os pontos 1, 2, 3 e a lógica do 6 do "Proposed Fix" — tudo o que é auto-suficiente nesta base. Os pontos 4 e 5 dependem de `HealthStore.tsx`/`HealthScreen.tsx`, que não existem. Alternativas descartadas:

1. *`blocked`* — descartada: a maior parte do issue (o módulo nativo, que o próprio issue chama "the only issue in the set that touches native/Kotlin code") é implementável já e não depende de nada em falta. Bloquear custaria uma volta para entregar o mesmo.
2. *Escrever `HealthStore` + `HealthScreen` + `Pedometer` de raiz* — descartada: seria implementar 4 issues irmãos dentro deste, adicionar `expo-sensors` como dependência nova, e produzir um diff em que o fix desaparece no ruído. Colide directamente com "só mexes no que o issue pede".

**`applyHealthConnectSteps` no módulo, não no store.** O ponto 6 ("replace, don't sum") é a regra de correcção que o issue mais sublinha ("do not merge/sum the two sources, that would double-count"). Pu-la numa função pura exportada e testada agora, para que o issue que criar `HealthStore` a chame em vez de reimplementar a decisão — que é onde o double-count nasceria.

**Sem `?? 0` a tapar `undefined`.** `null` distingue-se de `0` de propósito: `0` é "zero passos hoje", `null` é "sem resposta". Devolver `0` num caso de permissão negada esconderia o defeito e faria a substituição de hoje apagar dados válidos.

**`1.1.0-alpha07`** é a versão publicada do `connect-client` com a API `getSdkStatus`/`SDK_AVAILABLE` usada aqui. Não corri build Gradle: `android/` é gerado por `expo prebuild` e está fora dos ficheiros que posso tocar; o Gradle deste módulo não entra em `npm run lint`/`tsc`/`jest`.

## Critérios de aceitação

- [x] **O bridge JS é seguro de chamar quando Health Connect está ausente (sem throw, sem crash), com `false`/`null` por omissão.** `isAvailable()` devolve `false` e `getTodayStepsFromHealthConnect()` devolve `null` quando `requireNativeModule` rebenta, quando a função nativa não existe, e quando a chamada rejeita. Coberto por 6 + 12 testes.
- [x] **`getTodayStepsFromHealthConnect()` nunca chega ao nativo com Health Connect indisponível.** Teste "returns null without calling native when Health Connect is unavailable" asserta `not.toHaveBeenCalled()` no mock.
- [x] **Um sync bem-sucedido SUBSTITUI, em vez de somar, a entrada de hoje.** `applyHealthConnectSteps` — teste "REPLACES today's entry instead of summing it" asserta `8000` e, explicitamente, `not.toBe(11000)` (3000+8000).
- [x] **Kotlin devolve `true` só para `SDK_AVAILABLE`.** `HealthConnectModule.kt` compara `getSdkStatus(context) == HealthConnectClient.SDK_AVAILABLE`; qualquer outro status (incluindo provider-update-required) cai em `false`.
- [x] **NÃO devia mudar: nenhum comportamento existente.** Confirmado por `git status --porcelain -uall` — os 6 ficheiros são todos `??` (novos), zero ficheiros modificados. Nenhum ficheiro existente importa este módulo, portanto nada em produção muda de caminho. `npm test` desceu de 25 para 23 falhas (as 2 restantes são variação de baseline, não regressão), 6 suites em ambos, e os 6 snapshots continuam a passar.
- [x] **NÃO devia mudar: `lint` e `tsc` limpos.** `0 errors` no lint e `tsc --noEmit` limpo — igual à baseline. Nenhum `any` novo sem justificação: o único é o `nativeModule`, com o mesmo `eslint-disable-next-line` comentado que `launcher-module/src/index.ts:305` já usa.

## Testes

**Passo vermelho.** O primeiro passo vermelho (com o ficheiro de produção removido) falhava por `Cannot find module '../index'` — razão errada, não prova nada. Refi-lo com a implementação **ingénua** que o issue descreve sem os guards (chamada nativa directa, `applyHealthConnectSteps` a somar), e correu:

```
FAIL Android modules/health-connect-module/src/__tests__/index.test.ts
  isAvailable
    ✓ is true only when the native module reports SDK_AVAILABLE (13 ms)
    ✓ is false when the native module reports unavailable (2 ms)
    ✕ is false (does not throw) when requireNativeModule throws (2 ms)
    ✕ is false when the native call rejects (2 ms)
    ✕ is false when the native module lacks the function entirely (2 ms)
    ✕ is false — not truthy — when native returns a non-boolean truthy value (2 ms)
  getTodayStepsFromHealthConnect
    ✓ returns the step total when available (1 ms)
    ✓ preserves a genuine 0 (no steps today is not the same as no data) (1 ms)
    ✕ returns null without calling native when Health Connect is unavailable (2 ms)
    ✓ returns null when the permission is denied (native resolves null) (1 ms)
    ✕ returns null when the native read rejects (8 ms)
    ✕ returns null for a negative count (2 ms)
    ✕ returns null for a fractional count (2 ms)
    ✕ returns null for NaN (2 ms)
    ✕ returns null for Infinity (1 ms)
    ✕ returns null for a string (1 ms)
    ✕ returns null for undefined (1 ms)
    ✕ returns null (no crash) when the module is absent altogether (1 ms)
  applyHealthConnectSteps
    ✕ REPLACES today's entry instead of summing it (4 ms)
    ✕ appends when today has no entry yet (2 ms)
    ✕ handles an empty history (2 ms)
    ✕ is idempotent when applied twice (double-tap must not double-count) (2 ms)
    ✕ collapses duplicate entries for today into a single replaced entry (2 ms)
    ✓ does not mutate the input array (1 ms)
    ✓ leaves other days untouched, including a 0-step day (1 ms)

  ● isAvailable › is false (does not throw) when requireNativeModule throws

    expect(received).resolves.toBe()

    Received promise rejected instead of resolved
    Rejected to value: [TypeError: Cannot read properties of null (reading 'isAvailable')]

      44 |   it('is false (does not throw) when requireNativeModule throws', async () => {
      45 |     mockNativeModule = undefined;
    > 46 |     await expect(loadBridge().isAvailable()).resolves.toBe(false);
         |           ^
      47 |   });

  ● applyHealthConnectSteps › REPLACES today's entry instead of summing it

    expect(received).toEqual(expected) // deep equality

      Array [
        Object { "date": "2026-01-01", "steps": 100 },
        Object {
          "date": "2026-01-02",
    -     "steps": 8000,
    +     "steps": 11000,
        },
      ]

     > 141 |     expect(out).toEqual([
           |                 ^

  ● applyHealthConnectSteps › collapses duplicate entries for today into a single replaced entry

    - Expected  - 1
    + Received  + 5

      Array [
        Object {
          "date": "2026-01-02",
    -     "steps": 50,
    +     "steps": 51,
    +   },
    +   Object {
    +     "date": "2026-01-02",
    +     "steps": 52,
        },
      ]

    > 175 |     expect(out).toEqual([{ date: '2026-01-02', steps: 50 }]);
          |                 ^

Test Suites: 1 failed, 1 total
Tests:       18 failed, 7 passed, 25 total
```

O `11000` no output é a prova directa do double-count que o ponto 6 do issue proíbe. Com a implementação real: `Tests: 25 passed, 25 total`.

**Casos cobertos** além do caminho felizosos:
- *Ausente* — módulo nativo em falta (`requireNativeModule` lança), função em falta no objecto nativo, `undefined` como retorno, histórico vazio.
- *Fronteiras* — `0` passos preservado como `0` (e não confundido com "sem dados"), `-1` rejeitado, `12.5` rejeitado, `Infinity` e `NaN` rejeitados.
- *Inválido/hostil* — string `'9000'` onde se espera número, `'yes'` truthy onde se espera boolean (o caso que um `!!` ingénuo deixaria passar).
- *Repetição* — `applyHealthConnectSteps` aplicado duas vezes é idempotente (o duplo toque no botão de sync não pode duplicar passos), e histórico com duas entradas para hoje colapsa numa só.
- *Assíncrono* — rejeição da promessa nativa em `isAvailable` e em `getTodayStepsFromHealthConnect`, tratadas em separado.
- *O inverso do fix* — a gate ao contrário: com `isAvailable=false` o nativo **não é chamado** (`not.toHaveBeenCalled()`), não basta ignorar o resultado; e a imutabilidade do array de entrada.

**Sanity-check.** Removi `modules/health-connect-module/src/index.ts` mantendo o teste: `Tests: 25 failed, 25 total`, `Test Suites: 1 failed`. Restaurei: `Tests: 25 passed, 25 total`, `1 passed`.

**Verificações:**
- `npm run lint` — `✖ 7 problems (0 errors, 7 warnings)`. 0 erros, igual à baseline; nenhum dos 7 warnings está em ficheiros meus (são `SiriScreen.test.tsx`, `SettingsStore.tsx`, etc.).
- `npx tsc --noEmit` — limpo, exit 0.
- `npm test -- --maxWorkers=2` — `Test Suites: 6 failed, 195 passed, 201 total` / `Tests: 23 failed, 1883 passed, 1906 total` / `Snapshots: 6 passed`. Baseline: 25 falhas em 6 de 182 suites. As falhas **desceram** (25 → 23) e continuam confinadas às mesmas 6 suites, nenhuma delas tocada por mim (`WeatherScreen.test.tsx` e companhia, todas o defeito conhecido do `firstSyncDone` em `SettingsStore.tsx`). Zero falhas novas. Nenhum teste alheio apagado ou `.skip`.

## Testes

1906 testes: 1883 passaram, 23 falharam (baseline: 25 falhas), 201 suites (195 passaram, 6 falharam — as mesmas da baseline). Suite nova: 25 passaram, 0 falharam.

## Linked Issue

Fixes #277