### PR TITLE
App Store/AppStoreDetail: apps built-in virtuais (Clock, etc.) abrem o ecrã interno em vez de serem entregues ao launcher nativo (#706) (#706)

### DIFF
--- a/src/screens/AppStoreDetailScreen.tsx
+++ b/src/screens/AppStoreDetailScreen.tsx
@@ -17,6 +17,7 @@ import { CURATED_APPS } from '../data/curatedApps';
 import { playStoreUrl, playStoreWebUrl } from './AppStoreScreen';
 import type { AppNavigationProp, AppRouteProp } from '../navigation/types';
 import { logger } from '../utils/logger';
+import { launchBuiltInOrExternal } from '../utils/launchBuiltIn';
 
 /**
  * Package-name prefix of this app's own virtual built-ins (Phone, Messages, …).
@@ -82,9 +83,12 @@ export function AppStoreDetailScreen({ navigation, route }: AppStoreDetailScreen
   // cannot be removed and virtual built-ins are not packages at all.
   const canUninstall = !!installed && !installed.isSystem && !isVirtualBuiltIn(packageName);
 
+  // Built-in virtual apps (Clock, Calculator, …) are "installed" for this
+  // screen's purposes but are not real APKs — they must open the in-app
+  // iOS-style screen, not be handed to the native launcher bridge (#706).
   const handleOpen = useCallback(() => {
-    launchApp(packageName);
-  }, [launchApp, packageName]);
+    launchBuiltInOrExternal(packageName, navigation, launchApp);
+  }, [navigation, launchApp, packageName]);
 
   // Same probe-then-fallback guard as AppStoreScreen's Get button: market://
   // has no handler on de-Googled devices and on most emulators.

--- a/src/screens/AppStoreScreen.tsx
+++ b/src/screens/AppStoreScreen.tsx
@@ -17,6 +17,7 @@ import { CURATED_APPS, type CuratedApp } from '../data/curatedApps';
 import type { AppNavigationProp } from '../navigation/types';
 import { logger } from '../utils/logger';
 import type { InstalledApp } from '../store/AppsStore';
+import { launchBuiltInOrExternal } from '../utils/launchBuiltIn';
 
 // Segment labels live in one place — inserting/reordering a tab means
 // changing this array only, not the render branches below.
@@ -258,11 +259,14 @@ export function AppStoreScreen({ navigation }: { navigation: AppNavigationProp }
     [apps],
   );
 
+  // Built-in virtual apps (Clock, Calculator, …) surfaced here via the
+  // installed-apps search match must open the in-app iOS-style screen, not be
+  // handed to the native launcher bridge — see launchBuiltInOrExternal (#706).
   const handleOpen = useCallback(
     (packageName: string) => {
-      launchApp(packageName);
+      launchBuiltInOrExternal(packageName, navigation, launchApp);
     },
-    [launchApp],
+    [navigation, launchApp],
   );
 
   // Guarded the same way CupertinoShareSheet guards its Linking calls: probe

--- a/src/screens/__tests__/AppStoreDetailScreen.test.tsx
+++ b/src/screens/__tests__/AppStoreDetailScreen.test.tsx
@@ -232,6 +232,16 @@ describe('AppStoreDetailScreen', () => {
     expect(isVirtualBuiltIn('')).toBe(false);
   });
 
+  it('an installed virtual built-in (Clock) shows Open, which navigates to the internal screen instead of the native launcher bridge (#706)', () => {
+    mockApps([{ name: 'Clock', packageName: 'com.iostoandroid.clock', icon: '', isSystem: false }]);
+    const { getByLabelText } = render(
+      <AppStoreDetailScreen navigation={nav} route={routeFor('com.iostoandroid.clock', 'Clock')} />,
+    );
+    fireEvent.press(getByLabelText('Open Clock'));
+    expect(mockNavigate).toHaveBeenCalledWith('Clock');
+    expect(mockLaunchApp).not.toHaveBeenCalled();
+  });
+
   it('the Back button calls navigation.goBack', () => {
     const { getByLabelText } = render(
       <AppStoreDetailScreen navigation={nav} route={routeFor(FIRST.packageName, FIRST.name)} />,

--- a/src/screens/__tests__/AppStoreScreen.test.tsx
+++ b/src/screens/__tests__/AppStoreScreen.test.tsx
@@ -270,6 +270,16 @@ describe('AppStoreScreen — Search tab', () => {
     fireEvent.press(getByText('Search'));
     expect(getByTestId('app-store-search-disclaimer')).toBeTruthy();
   });
+
+  it('a query matching this app\'s own virtual built-in (Clock) navigates to the internal screen instead of the native launcher bridge (#706)', () => {
+    mockApps([{ name: 'Clock', packageName: 'com.iostoandroid.clock', icon: '', isSystem: false }]);
+    const { getByText, getByPlaceholderText, getByLabelText } = render(<AppStoreScreen navigation={nav} />);
+    fireEvent.press(getByText('Search'));
+    fireEvent.changeText(getByPlaceholderText(/search/i), 'clock');
+    fireEvent.press(getByLabelText('Open Clock'));
+    expect(mockNavigate).toHaveBeenCalledWith('Clock');
+    expect(mockLaunchApp).not.toHaveBeenCalled();
+  });
 });
 
 describe('AppStoreScreen — Categories tab', () => {


### PR DESCRIPTION
## Resumo

App Store/AppStoreDetail: apps built-in virtuais (Clock, etc.) abrem o ecrã interno em vez de serem entregues ao launcher nativo (#706)

## Causa raiz

O issue veio sem corpo ("## What is wrong" vazio) e sem passos de reprodução — seis corridas anteriores (`/tmp/ios2android-team/implement-706.log`) investigaram exaustivamente as superfícies de lançamento de apps e confirmaram que a home grid (`LauncherHomeScreen.handleAppPress`, linha 884-916), o Siri (`SiriScreen`) e, desde a fix do #710 (commit `8f324bb`, já em `main`), a App Library e o Spotlight já encaminham corretamente os built-ins virtuais (`com.iostoandroid.*`) por `navigation.navigate` via o helper partilhado `launchBuiltInOrExternal` (`src/utils/launchBuiltIn.ts`).

A App Store (a "loja de apps" simulada da app) tinha ficado de fora dessa correção. Dois pontos chamavam `launchApp(packageName)` **diretamente**, sem verificar se o package é um built-in virtual:

- `src/screens/AppStoreScreen.tsx:263` (`handleOpen`, usado pelo botão "Open" dos resultados de pesquisa da aba Search — `searchResults` em `AppStoreScreen.tsx:346-351` itera sobre `apps`, que inclui os built-ins virtuais registados em `AppsStore.tsx:202`, e marca-os como `installed: true`).
- `src/screens/AppStoreDetailScreen.tsx:85-87` (`handleOpen`, usado pelo botão "Open" do ecrã de detalhe — `installed` em `AppStoreDetailScreen.tsx:71-74` também encontra o built-in virtual em `apps` e mostra "Open" em vez de "Get").

`com.iostoandroid.clock` (e qualquer outro built-in) não é uma APK real. O comentário já existente em `launchBuiltIn.ts:12-15` documenta exatamente este mecanismo: `getLaunchIntentForPackage` (nativo, `LauncherModule.kt:210-214`) devolve `null` para um package inexistente e o utilizador fica a olhar para o que já estava por trás — no launcher Android real isso é o ecrã/feed do sistema (o "Google" que o título do issue descreve), em vez do `ClockScreen`. A App Store era a única superfície de lançamento que ainda não passava pelo `launchBuiltInOrExternal`.

## O que mudou

- `src/screens/AppStoreScreen.tsx`: importa `launchBuiltInOrExternal`; `handleOpen` passa a chamar `launchBuiltInOrExternal(packageName, navigation, launchApp)` em vez de `launchApp(packageName)` diretamente.
- `src/screens/AppStoreDetailScreen.tsx`: mesma alteração em `handleOpen`.
- `src/screens/__tests__/AppStoreScreen.test.tsx`: novo teste na secção "Search tab" — procurar "clock" e premir "Open Clock" navega para `'Clock'` e nunca chama `launchApp`.
- `src/screens/__tests__/AppStoreDetailScreen.test.tsx`: novo teste — abrir o detalhe de `com.iostoandroid.clock` (marcado como instalado) e premir "Open Clock" navega para `'Clock'` e nunca chama `launchApp`.

## Porque assim

Reutilizei o helper `launchBuiltInOrExternal` já existente (criado pelo fix do #710) em vez de duplicar a lógica de routing — é o mesmo padrão usado pela Home, Siri, App Library e Spotlight, e ambos os ficheiros já recebem `navigation` como prop, sem precisar de `useNavigation()` extra. Não toquei em `launchApp`/`AppsStore.tsx` nem no módulo nativo: o comportamento correto para apps externas reais (ex. Spotify) continua a ser o bridge nativo, só os built-ins virtuais mudam de caminho.

## Critérios de aceitação

- [x] Procurar "clock" na aba Search da App Store e premir "Open" navega para o ecrã Clock interno — testado (`AppStoreScreen.test.tsx`, teste #706).
- [x] Abrir o ecrã de detalhe de `com.iostoandroid.clock` e premir "Open" navega para o ecrã Clock interno — testado (`AppStoreDetailScreen.test.tsx`, teste #706).
- [x] Nenhum built-in virtual é entregue ao `launchApp` nativo a partir da App Store — testado (`expect(mockLaunchApp).not.toHaveBeenCalled()` em ambos os testes novos).
- [x] Apps externas reais continuam a abrir pelo launcher nativo (inverso do fix) — confirmado pelos testes pré-existentes que usam `CURATED_APPS[0]` (Spotify): "the Open button inside a card still launches the app and does NOT navigate" (`AppStoreScreen.test.tsx`) e "an installed app shows Open, which calls launchApp with the packageName" (`AppStoreDetailScreen.test.tsx") — ambos continuam a passar sem alteração, porque Spotify não está em `BUILT_IN_APPS`.
- [x] O botão "Get"/deep-link para o Play Store, o fluxo de Uninstall e a exclusão de built-ins da aba Updates não mudaram — confirmado pelos 61/61 testes das duas suites a passarem, incluindo os regression guards já existentes.

## Testes

**Passo vermelho** (com o fix revertido via `git stash`, output real do jest):
```
● AppStoreDetailScreen › an installed virtual built-in (Clock) shows Open, which navigates to the internal screen instead of the native launcher bridge (#706)

    expect(jest.fn()).toHaveBeenCalledWith(...expected)

    Expected: "Clock"

    Number of calls: 0

      239 |     );
      240 |     fireEvent.press(getByLabelText('Open Clock'));
    > 241 |     expect(mockNavigate).toHaveBeenCalledWith('Clock');
          |                          ^
      242 |     expect(mockLaunchApp).not.toHaveBeenCalled();
      243 |   });

● AppStoreScreen — Search tab › a query matching this app's own virtual built-in (Clock) navigates to the internal screen instead of the native launcher bridge (#706)

    expect(jest.fn()).toHaveBeenCalledWith(...expected)

    Expected: "Clock"

    Number of calls: 0

      278 |     fireEvent.changeText(getByPlaceholderText(/search/i), 'clock');
      279 |     fireEvent.press(getByLabelText('Open Clock'));
    > 280 |     expect(mockNavigate).toHaveBeenCalledWith('Clock');
          |                          ^
      281 |     expect(mockLaunchApp).not.toHaveBeenCalled();

Test Suites: 2 failed, 2 total
Tests:       2 failed, 59 skipped, 61 total
```

**Casos cobertos:** fronteira built-in-vs-externo (Clock navega, Spotify continua a chamar `launchApp` — testes pré-existentes intactos), inverso do fix (apps externas não regridem), a mesma unidade real é montada e clicada (não há reimplementação da lógica dentro do teste).

**Sanity-check:** `git stash push -u` só nos dois ficheiros de produção (mantendo os testes) → os 2 testes novos falharam com o output acima → `git stash apply` + `git stash drop` restaurou o fix → os 61 testes de ambas as suites voltaram a passar.

**Verificações (linha de base: `main`@`c7fc108` tem 23/1892 testes a falhar em 6 suites):**
- `npm run lint`: 0 erros, 7 warnings pré-existentes (iguais à baseline).
- `npx tsc --noEmit`: limpo, sem output.
- `npm test -- --maxWorkers=2`: **23 falharam / 1871 passaram / 1894 totais, 6 suites falhadas de 203** — mesmo número de falhas e de suites que a baseline (a baseline tinha 1892 testes; os meus 2 testes novos elevaram o total para 1894, ambos a passar). Nenhuma falha nova nas duas suites que toquei (`AppStoreScreen.test.tsx` e `AppStoreDetailScreen.test.tsx`: 61/61 a passar quando corridas isoladamente).

## Testes

23 falharam / 1871 passaram / 1894 totais em 203 suites (6 suites falhadas, mesmas da baseline main@c7fc108 que tinha 23/1892); AppStoreScreen.test.tsx + AppStoreDetailScreen.test.tsx: 61 passaram, 0 falharam

## Linked Issue

Fixes #706