### PR TITLE
qa/issue-748: add updatePass to WalletStore (#748)

### DIFF
--- a/src/store/WalletStore.tsx
+++ b/src/store/WalletStore.tsx
@@ -19,6 +19,7 @@ export interface WalletPass {
 interface WalletContextValue {
   passes: WalletPass[];
   addPass: (pass: Omit<WalletPass, 'id' | 'createdAt'>) => void;
+  updatePass: (id: string, patch: Partial<Omit<WalletPass, 'id' | 'createdAt'>>) => void;
   deletePass: (id: string) => void;
   getPass: (id: string) => WalletPass | undefined;
   isReady: boolean;
@@ -62,6 +63,10 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
     ]);
   }, []);
 
+  const updatePass = useCallback((id: string, patch: Partial<Omit<WalletPass, 'id' | 'createdAt'>>) => {
+    setPasses((prev) => prev.map((p) => (p.id === id ? { ...p, ...patch } : p)));
+  }, []);
+
   const deletePass = useCallback((id: string) => {
     setPasses((prev) => prev.filter((p) => p.id !== id));
   }, []);
@@ -69,8 +74,8 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
   const getPass = useCallback((id: string) => passes.find((p) => p.id === id), [passes]);
 
   const value = useMemo(() => ({
-    passes, addPass, deletePass, getPass, isReady,
-  }), [passes, addPass, deletePass, getPass, isReady]);
+    passes, addPass, updatePass, deletePass, getPass, isReady,
+  }), [passes, addPass, updatePass, deletePass, getPass, isReady]);
 
   return <WalletContext.Provider value={value}>{children}</WalletContext.Provider>;
 }

--- a/src/store/__tests__/WalletStore.test.tsx
+++ b/src/store/__tests__/WalletStore.test.tsx
@@ -119,6 +119,71 @@ describe('WalletStore', () => {
     expect(result.current.getPass('missing')).toBeUndefined();
   });
 
+  describe('updatePass', () => {
+    it('updates the given field and keeps the rest of the pass unchanged', async () => {
+      const { result } = renderHook(() => useWallet(), { wrapper });
+      await act(async () => {});
+
+      await act(async () => {
+        result.current.addPass({
+          type: 'boarding',
+          title: 'Original',
+          subtitle: 'Flight 123',
+          code: 'ABC123',
+          color: '#007AFF',
+        });
+      });
+      const original = result.current.passes[0];
+
+      await act(async () => {
+        result.current.updatePass(original.id, { title: 'Novo' });
+      });
+
+      const updated = result.current.getPass(original.id);
+      expect(updated?.title).toBe('Novo');
+      expect(updated?.subtitle).toBe(original.subtitle);
+      expect(updated?.code).toBe(original.code);
+      expect(updated?.color).toBe(original.color);
+      expect(updated?.type).toBe(original.type);
+      expect(updated?.createdAt).toBe(original.createdAt);
+      expect(updated?.id).toBe(original.id);
+    });
+
+    it('on a missing id is a no-op (does not alter passes)', async () => {
+      const { result } = renderHook(() => useWallet(), { wrapper });
+      await act(async () => {});
+
+      await act(async () => {
+        result.current.addPass({ type: 'ticket', title: 'Kept', code: 'X', color: '#000' });
+      });
+
+      await act(async () => {
+        expect(() => result.current.updatePass('nope', { title: 'x' })).not.toThrow();
+      });
+
+      expect(result.current.passes).toHaveLength(1);
+      expect(result.current.passes[0].title).toBe('Kept');
+    });
+
+    it('with an empty patch does not alter the pass', async () => {
+      const { result } = renderHook(() => useWallet(), { wrapper });
+      await act(async () => {});
+
+      await act(async () => {
+        result.current.addPass({
+          type: 'loyalty', title: 'Untouched', subtitle: 'Sub', code: 'C', color: '#111',
+        });
+      });
+      const original = result.current.passes[0];
+
+      await act(async () => {
+        result.current.updatePass(original.id, {});
+      });
+
+      expect(result.current.getPass(original.id)).toEqual(original);
+    });
+  });
+
   it('hydrates passes from AsyncStorage on mount', async () => {
     const stored = [
       { id: 'p1', type: 'loyalty', title: 'Stored Card', code: 'STORED', color: '#FF3B30', createdAt: '2025-01-01T00:00:00Z' },


### PR DESCRIPTION
## Resumo

qa/issue-748: add updatePass to WalletStore

## Causa raiz

`src/store/WalletStore.tsx` (introduzido pelo PR #744, issue #280) expõe `useWallet()` com `addPass`, `deletePass` e `getPass`, mas nunca implementou `updatePass`. Sem ele, qualquer editor de pass (#746/#281, ainda não implementados) não tem forma de alterar uma `WalletPass` existente sem apagar e recriar (o que mudaria `id` e `createdAt`).

## O que mudou

- `src/store/WalletStore.tsx`:
  - `WalletContextValue.updatePass: (id: string, patch: Partial<Omit<WalletPass, 'id' | 'createdAt'>>) => void` adicionado à interface (junto de `addPass`/`deletePass`).
  - `updatePass` implementado com `useCallback`, seguindo o padrão exacto de `deletePass`: `setPasses((prev) => prev.map((p) => (p.id === id ? { ...p, ...patch } : p)))`. Um `id` inexistente não faz `map` mudar nada (nenhum item bate a condição), sem crash.
  - `updatePass` incluído no objecto `value` memoizado e nas dependências do `useMemo`.
- `src/store/__tests__/WalletStore.test.tsx`: novo `describe('updatePass', ...)` com 3 testes.

## Porque assim

Segui literalmente o padrão pedido no issue (idêntico a `deletePass`) em vez de, por exemplo, validar campos individualmente — mantém o store simples e consistente com o resto do ficheiro. Não toquei em `id`/`createdAt`: o tipo `Partial<Omit<WalletPass, 'id' | 'createdAt'>>` impede-o em tempo de compilação, não só por convenção.

## Critérios de aceitação

- [x] `useWallet()` expõe `updatePass(id, patch)` — adicionado à interface e ao `value` memoizado.
- [x] `updatePass(id, { title: 'Novo' })` altera `getPass(id).title` e mantém `subtitle`, `code`, `color`, `type`, `createdAt`, `id` — testado explicitamente, campo a campo.
- [x] `updatePass` com `id` inexistente não altera `passes` — testado (`length` e conteúdo inalterados, sem throw).
- [x] `addPass`, `deletePass`, `getPass` sem regressão — os 9 testes pré-existentes da suite continuam a passar sem alteração ao seu código.
- [x] Forma persistida em `AsyncStorage` inalterada — `updatePass` só faz `setPasses`, o `useEffect` de persistência (linha 54-56, não tocado) continua a gravar o mesmo array de `WalletPass`; nenhum teste de persistência existente falhou.

## Testes

**Passo vermelho** (com o fix revertido via `git stash push -u` só em `WalletStore.tsx`, mantendo o teste):

```
Tests:       3 failed, 9 passed, 12 total

● WalletStore › updatePass › updates the given field and keeps the rest of the pass unchanged
  TypeError: result.current.updatePass is not a function

● WalletStore › updatePass › on a missing id is a no-op (does not alter passes)
  TypeError: result.current.updatePass is not a function

● WalletStore › updatePass › with an empty patch does not alter the pass
  TypeError: result.current.updatePass is not a function
```

Com o fix restaurado: `Tests: 12 passed, 12 total`.

**Casos cobertos:**
- Caminho feliz: patch parcial altera só o campo indicado, resto intacto (incluindo `id`/`createdAt`, que nunca deviam mudar).
- `id` inexistente: no-op, sem crash, sem entrada nova.
- Patch vazio (`{}`): guarda contra um `map` mal implementado que apagasse campos por engano.

**Sanity-check:** `git stash push -u -m "issue-748-sanity-check" -- src/store/WalletStore.tsx` (só o ficheiro de produção, teste mantido) → suite caiu para 3 falhas/9 passes (as 3 de `updatePass`) → `git stash apply` + `git stash drop` para restaurar o fix. Confirmado que o teste falha pela razão certa sem o fix.

**Verificações:**
- `npm run lint`: 0 erros (7 warnings pré-existentes, não relacionados: `ClockScreen.tsx`, `SiriScreen.tsx`, `SettingsStore.tsx`, `BridgeErrorReporting.test.tsx`).
- `npx tsc --noEmit`: limpo, sem output.
- `npm test -- --maxWorkers=2`: `Test Suites: 6 failed, 200 passed, 206 total` / `Tests: 23 failed, 1890 passed, 1913 total` — mesmas 23 falhas da baseline (`baseline.json`, medida em `c7fc108`), nenhuma nova, nenhuma em `WalletStore`. Sem regressão.

## Testes

12 passed, 0 failed (WalletStore.test.tsx); suite completa: 1890 passed, 23 failed (== baseline, sem regressão), 206 suites

## Linked Issue

Fixes #748