### PR TITLE
App Icon Size 'Large' agora esconde os nomes das apps automaticamente (preset combinado, issue #621) (#621)

### DIFF
--- a/src/screens/LauncherSettingsScreen.tsx
+++ b/src/screens/LauncherSettingsScreen.tsx
@@ -56,6 +56,10 @@ export function formatPerfValue(value: number | null, budget: PerfBudgetKey): st
   return `${Math.round(value)} ms (${target})`;
 }
 
+// Top of the App Icon Size slider range (#503): the iOS «Large (no text)»
+// preset (#621) — reaching it also hides app-name labels.
+const ICON_SIZE_SCALE_LARGE = 1.2;
+
 // Default dock package names — mirrors AppsStore constant
 const DEFAULT_DOCK = [
   'com.iostoandroid.phone',
@@ -87,7 +91,7 @@ export function LauncherSettingsScreen() {
   const { theme, typography, isDark, toggleTheme, textScale } = themeCtx;
   const { colors } = theme;
   const insets = useSafeAreaInsets();
-  const { settings, update, reset: resetSettings } = useSettings();
+  const { settings, update, updateMany, reset: resetSettings } = useSettings();
   const { dockApps, apps, hiddenApps, unhideApp } = useApps();
   const { folders, deleteFolder } = useFolders();
 
@@ -253,6 +257,18 @@ export function LauncherSettingsScreen() {
 
   const perf = usePerfMetrics();
 
+  // iOS «Grande» esconde os nomes das apps — ao chegar ao topo da gama
+  // (Large), combina-se com showIconLabels=false num único update atómico.
+  // Abaixo do máximo o comportamento fica inalterado: o utilizador continua a
+  // controlar showIconLabels pelo switch "Show App Names".
+  const handleIconSizeChange = (v: number) => {
+    if (v >= ICON_SIZE_SCALE_LARGE) {
+      updateMany({ iconSizeScale: v, showIconLabels: false });
+    } else {
+      update('iconSizeScale', v);
+    }
+  };
+
   const doneButton = (
     <Text
       style={[typography.body, { color: colors.systemBlue, fontWeight: '600' }]}
@@ -304,9 +320,9 @@ export function LauncherSettingsScreen() {
         <View style={styles.sliderRow}>
           <CupertinoSlider
             value={settings.iconSizeScale}
-            onValueChange={(v) => update('iconSizeScale', v)}
+            onValueChange={handleIconSizeChange}
             minimumValue={0.8}
-            maximumValue={1.2}
+            maximumValue={ICON_SIZE_SCALE_LARGE}
           />
         </View>
       </CupertinoListSection>

--- a/src/screens/__tests__/LauncherSettingsScreen.gridSettings.test.tsx
+++ b/src/screens/__tests__/LauncherSettingsScreen.gridSettings.test.tsx
@@ -122,6 +122,46 @@ describe('LauncherSettingsScreen grid density controls (#503)', () => {
     expect(persisted.iconSizeScale).toBe(1.2);
   });
 
+  // issue #621: no iOS, "Grande" é um preset que também esconde os nomes das
+  // apps (visual minimalista) — os dois bits já existiam separados (#503) mas
+  // sem o preset que os combina.
+  it('moving the App Icon Size slider to Large (max) also hides app name labels', async () => {
+    const store = setupMemoryAsyncStorage();
+    const { UNSAFE_getAllByType } = render(<LauncherSettingsScreen />);
+
+    let slider: ReturnType<typeof UNSAFE_getAllByType>[number];
+    await waitFor(() => {
+      [slider] = UNSAFE_getAllByType(CupertinoSlider);
+      expect(slider).toBeTruthy();
+    }, { timeout: 3000 });
+
+    slider!.props.onValueChange(1.2);
+
+    const persisted = await waitForPersisted(
+      store,
+      (s) => s.iconSizeScale === 1.2 && s.showIconLabels === false,
+    );
+    expect(persisted.iconSizeScale).toBe(1.2);
+    expect(persisted.showIconLabels).toBe(false);
+  });
+
+  it('moving the App Icon Size slider to a non-Large value does not force-hide labels', async () => {
+    const store = setupMemoryAsyncStorage();
+    const { UNSAFE_getAllByType } = render(<LauncherSettingsScreen />);
+
+    let slider: ReturnType<typeof UNSAFE_getAllByType>[number];
+    await waitFor(() => {
+      [slider] = UNSAFE_getAllByType(CupertinoSlider);
+      expect(slider).toBeTruthy();
+    }, { timeout: 3000 });
+
+    slider!.props.onValueChange(1.0);
+
+    const persisted = await waitForPersisted(store, (s) => s.iconSizeScale === 1.0);
+    expect(persisted.iconSizeScale).toBe(1.0);
+    expect(persisted.showIconLabels).toBe(true); // default preserved, unaffected
+  });
+
   it('toggling Show App Names persists showIconLabels', async () => {
     const store = setupMemoryAsyncStorage();
     const { getByText } = render(<LauncherSettingsScreen />);


### PR DESCRIPTION
## Resumo

App Icon Size 'Large' agora esconde os nomes das apps automaticamente (preset combinado, issue #621)

## Causa raiz

O issue #621 descrevia "App Icon Size" como um placeholder sem ação (linha 250-256 no enunciado, referindo `main` 1.27.0). Nesta branch (1.83.0) o #503 já tinha aterrado (`fix/503`, PR #596/#599): `src/store/SettingsStore.tsx:147-149` já expõe `iconSizeScale` e `showIconLabels`, e `src/screens/LauncherSettingsScreen.tsx:293-311` já tem um `CupertinoSlider` funcional (0.8–1.2) ligado a `iconSizeScale`, com um `CupertinoSwitch` independente (`LauncherSettingsScreen.tsx:382-393`) para `showIconLabels`. A geometria da grelha (`computeLauncherGridGeometry`, `LauncherHomeScreen.tsx:815-818`) já suporta a combinação `iconSizeScale=1.2` + `showIconLabels=false` sem desalinhar (há inclusive um comentário existente sobre essa combinação em `LauncherHomeScreen.tsx:434-437`).

O gap real, não descrito com precisão no issue (que assumia um `CupertinoActionSheet` de 3 estados que ainda não existe nesta base): os dois controlos são totalmente independentes — mover o slider para o máximo ("Grande", 1.2) não desligava `showIconLabels`, ao contrário do preset "Grande (sem texto)" do iOS.

## O que mudou

`src/screens/LauncherSettingsScreen.tsx`:
- Novo `updateMany` extraído de `useSettings()` (já existia no contexto, só não estava a ser consumido neste ecrã).
- Nova constante `ICON_SIZE_SCALE_LARGE = 1.2` (topo da gama do slider), partilhada entre o `maximumValue` do `CupertinoSlider` e o novo handler.
- Novo `handleIconSizeChange(v)`: quando `v >= ICON_SIZE_SCALE_LARGE`, chama `updateMany({ iconSizeScale: v, showIconLabels: false })` (update atómico); caso contrário mantém o comportamento anterior (`update('iconSizeScale', v)`), não mexendo em `showIconLabels`.
- O slider passa a usar `handleIconSizeChange` em vez de `(v) => update('iconSizeScale', v)`.

`src/screens/__tests__/LauncherSettingsScreen.gridSettings.test.tsx`:
- Novo teste "moving the App Icon Size slider to Large (max) also hides app name labels": confirma que `onValueChange(1.2)` persiste `iconSizeScale===1.2 && showIconLabels===false`.
- Novo teste "moving the App Icon Size slider to a non-Large value does not force-hide labels": confirma que `onValueChange(1.0)` persiste `iconSizeScale===1.0` sem tocar em `showIconLabels` (continua `true`, o default).

## Porque assim

A UI já shipada usa um slider contínuo 0.8–1.2 (não o `CupertinoActionSheet` Small/Default/Large que o issue propunha) — refazer o picker seria scope-creep sobre uma UI já funcional e testada (#503). A leitura mais defensável e menos destrutiva é tratar o topo da gama (1.2) como o equivalente ao "Grande" do iOS e combinar aí, deixando o resto da gama com o comportamento pré-existente intacto — que é exactamente o que "Small/Default mantêm comportamento" pede.

Usei `updateMany` (já existente no `SettingsContextValue`, `SettingsStore.tsx:367`) em vez de duas chamadas a `update` sequenciais, para que a combinação seja um único evento de estado/persistência, e não dois writes distintos que um observador externo (ou um teste) pudesse ver em separado.

Não tranquei o switch "Show App Names" quando `iconSizeScale===1.2` — o issue só pede o preset (ligar automaticamente), não impedir o utilizador de voltar a ligar manualmente as labels a tamanho Grande. Bloquear isso seria uma decisão de produto não pedida.

## Critérios de aceitação

- [x] "App Icon Size" deixa de ser placeholder (abre picker) — já estava resolvido por #503 nesta branch (slider funcional); confirmado por leitura de código, não fazia parte do gap real.
- [x] "Large" esconde labels e aumenta ícones — `handleIconSizeChange` liga `showIconLabels=false` quando `iconSizeScale` atinge 1.2; o aumento do ícone já era feito por `computeLauncherGridGeometry` via `iconSizeScale` (inalterado).
- [x] Small/Default mantêm comportamento — confirmado pelo teste "does not force-hide labels": valores abaixo de 1.2 não tocam em `showIconLabels`.
- [x] Persiste entre arranques — usa o mesmo mecanismo de persistência (`AsyncStorage`) do `SettingsStore`, inalterado; os testes usam `waitForPersisted` contra o blob persistido.
- [x] Não desalinha a grelha (testar 360/480dp) — a geometria (`computeLauncherGridGeometry`) já tratava esta combinação exacta antes deste fix (ver comentário em `LauncherHomeScreen.tsx:434-437`); não mexi em geometria, apenas em quando `showIconLabels` é definido.
- [x] Teste em `LauncherSettingsScreen.test.tsx` — adicionados em `LauncherSettingsScreen.gridSettings.test.tsx` (arquivo-irmão dedicado ao #503, mesmo padrão de teste).

## Testes

**Passo vermelho** (com o fix revertido via `git stash push -u -- src/screens/LauncherSettingsScreen.tsx`, mantendo os testes novos):

```
FAIL Android src/screens/__tests__/LauncherSettingsScreen.gridSettings.test.tsx
  LauncherSettingsScreen grid density controls (#503)
    ✕ moving the App Icon Size slider to Large (max) also hides app name labels

  ● LauncherSettingsScreen grid density controls (#503) › moving the App Icon Size slider to Large (max) also hides app name labels

    expect(received).toBe(expected) // Object.is equality

    Expected: true
    Received: false

      46 |   predicate: (settings: Record<string, unknown>) => boolean,
      47 | ) {
    > 48 |   await waitFor(() => {
         |                ^
      49 |     const raw = store.get('@iostoandroid/settings');
      50 |     expect(raw).toBeTruthy();
      51 |     expect(predicate(JSON.parse(raw as string))).toBe(true);

      at waitForPersisted (src/screens/__tests__/LauncherSettingsScreen.gridSettings.test.tsx:140:29)

Tests: 1 failed, 6 passed, 7 total
```

(os outros 6 testes do ficheiro passavam mesmo sem o fix, porque não exercitam a combinação nova — apenas o novo teste falha, pela razão certa: `showIconLabels` nunca chega a `false`.)

**Com o fix restaurado** (`git stash pop` equivalente, via `stash apply` + `stash drop`):

```
PASS Android src/screens/__tests__/LauncherSettingsScreen.gridSettings.test.tsx
  LauncherSettingsScreen grid density controls (#503)
    ✓ shows Columns and Rows segmented controls, defaulting to 4 and 6
    ✓ changing the Columns control persists gridColumns
    ✓ changing the Rows control persists gridRows
    ✓ moving the App Icon Size slider persists iconSizeScale
    ✓ moving the App Icon Size slider to Large (max) also hides app name labels
    ✓ moving the App Icon Size slider to a non-Large value does not force-hide labels
    ✓ toggling Show App Names persists showIconLabels

Tests: 7 passed, 7 total
```

**Casos cobertos:**
- Caminho feliz: slider ao máximo (1.2) combina os dois settings.
- Inverso do fix: slider abaixo do máximo (1.0) NÃO força `showIconLabels`, preservando o comportamento pré-existente (#503) — prova que a combinação só actua no limite superior, não em qualquer valor.
- Não retestei fronteiras de `iconSizeScale` (0.8, valores intermédios) nem geometria da grelha porque já estavam cobertas por testes pré-existentes (`launcherGridGeometry.test.ts`, `LauncherHomeScreen.gridSettings.test.tsx`, `LauncherHomeScreen.gridDensityExtremes.test.tsx`) e este fix não altera essa lógica.

**Sanity-check:** fix revertido via `git stash push -u -m "implement-621-sanity-check" -- src/screens/LauncherSettingsScreen.tsx` (testes mantidos), suite falhou exactamente no novo teste (ver passo vermelho acima), depois restaurado com `git stash apply` + `git stash drop` (nunca `pop` puro, por partilha do stash stack entre worktrees) e suite voltou a passar por inteiro.

**Resultado das verificações completas:**
- `npm run lint`: 0 erros, 7 warnings (todos pré-existentes, noutros ficheiros não tocados por este PR).
- `npx tsc --noEmit`: limpo, sem output.
- `npm test -- --maxWorkers=2`: 23 falharam, 1982 passaram, 2005 totais, 6 de 213 suites a falhar — os mesmos 23 testes da linha de base (`baseline.json`), comparados nome-a-nome; nenhuma falha nova. O total de testes subiu de 1892→2005 porque a baseline foi medida num commit mais antigo (`c7fc108`); a contagem de falhas (23) manteve-se idêntica.

## Testes

1982 passaram, 23 falharam (pré-existentes, mesmas da baseline), 2005 totais, 213 suites (6 a falhar, mesmas da baseline) — os 2 testes novos deste PR passam

## Linked Issue

Fixes #621