### PR TITLE
Adiciona Tinted Icons: toggle + seletor de cor em Launcher Settings, aplicado como tintColor aos ícones reais na grelha, dock e overlay de pastas (#620)

### DIFF
--- a/src/screens/LauncherHomeScreen.tsx
+++ b/src/screens/LauncherHomeScreen.tsx
@@ -327,6 +327,10 @@ interface AppIconProps {
   /** Whether the app name renders under the icon (issue #503). #501: the dock
    * reuses AppIcon but has no name label under the icon. */
   showLabel?: boolean;
+  /** Tinted Icons (#620): hex colour to render the icon artwork as a
+   * monochrome silhouette in, or undefined/null for the normal, untinted
+   * icon. Only the icon is affected — `showLabel`'s text is untouched. */
+  iconTint?: string | null;
 }
 
 // React.memo (#518): sem isto, cada AppIcon re-executava o corpo da função —
@@ -350,6 +354,7 @@ const AppIcon = React.memo(function AppIcon({
   iconSize = ICON_SIZE,
   iconRadius = ICON_RADIUS,
   showLabel = true,
+  iconTint,
 }: AppIconProps) {
   const virtualCfg = VIRTUAL_ICON_CONFIG[app.packageName];
   // Label block (margin + text line) measured at the 393dp reference so the
@@ -464,7 +469,8 @@ const AppIcon = React.memo(function AppIcon({
           <Image
             testID={`app-icon-box-${app.packageName}`}
             source={{ uri: app.icon }}
-            style={[styles.appIconImage, iconBoxSize]}
+            style={[styles.appIconImage, iconBoxSize, iconTint ? { tintColor: iconTint } : null]}
+            tintColor={iconTint ?? undefined}
             resizeMode="contain"
           />
         ) : (
@@ -630,7 +636,7 @@ const FolderIcon = React.memo(function FolderIcon({
 // FolderOverlay
 // ---------------------------------------------------------------------------
 
-function FolderOverlay({ folder, apps, onClose, onLaunchApp, onLongPressApp, onRename, textScale = 1 }: {
+function FolderOverlay({ folder, apps, onClose, onLaunchApp, onLongPressApp, onRename, textScale = 1, iconTint }: {
   folder: AppFolder;
   apps: InstalledApp[];
   onClose: () => void;
@@ -638,6 +644,7 @@ function FolderOverlay({ folder, apps, onClose, onLaunchApp, onLongPressApp, onR
   onLongPressApp: (app: InstalledApp) => void;
   onRename: (newName: string) => void;
   textScale?: number;
+  iconTint?: string | null;
 }) {
   const folderApps = folder.apps
     .map(pkg => apps.find(a => a.packageName === pkg))
@@ -684,6 +691,7 @@ function FolderOverlay({ folder, apps, onClose, onLaunchApp, onLongPressApp, onR
                   app={app}
                   cellWidth={70}
                   textScale={textScale}
+                  iconTint={iconTint}
                   onPress={() => onLaunchApp(app)}
                   onLongPress={() => onLongPressApp(app)}
                 />
@@ -817,6 +825,11 @@ export function LauncherHomeScreen() {
     [settings.gridColumns, settings.iconSizeScale],
   );
   const appsPerPage = gridGeometry.cols * settings.gridRows;
+
+  // Tinted Icons (#620): resolved once per render, shared by every AppIcon
+  // call site below (grid, dock, folder overlay) so a single setting change
+  // stays a single source of truth instead of three copies of the ternary.
+  const iconTint = settings.iconTintEnabled ? settings.iconTintColor : undefined;
 
   // Folder open state
   const [openFolder, setOpenFolder] = useState<AppFolder | null>(null);
@@ -1733,6 +1746,7 @@ export function LauncherHomeScreen() {
                     iconRadius={gridGeometry.iconRadius}
                     showLabel={settings.showIconLabels}
                     textScale={textScale}
+                    iconTint={iconTint}
                     onPress={handleAppPress}
                     onLongPress={handleLongPress}
                     isJiggling={isJiggling}
@@ -1786,6 +1800,7 @@ export function LauncherHomeScreen() {
                 cellWidth={DOCK_CELL_WIDTH}
                 textScale={textScale}
                 showLabel={false}
+                iconTint={iconTint}
                 onPress={handleAppPress}
                 onLongPress={handleLongPress}
                 isJiggling={isJiggling}
@@ -1809,6 +1824,7 @@ export function LauncherHomeScreen() {
           folder={openFolder}
           apps={apps}
           textScale={textScale}
+          iconTint={iconTint}
           onClose={() => setOpenFolder(null)}
           onLaunchApp={(app) => {
             setOpenFolder(null);

--- a/src/screens/LauncherSettingsScreen.tsx
+++ b/src/screens/LauncherSettingsScreen.tsx
@@ -36,6 +36,17 @@ import {
   REQUIRE_PASSCODE_OPTIONS,
   normalizeRequirePasscodeAfter,
 } from '../utils/passcodePolicy';
+import { AccentColors, type AccentColorKey } from '../theme/CupertinoTheme';
+
+// Tinted Icons colour swatches (issue #620): reuses the app's named accent
+// palette instead of a bespoke colour list, so «Tinted Icons» and «Display &
+// Brightness → Tint» always offer the same six options.
+const ICON_TINT_KEYS = Object.keys(AccentColors) as AccentColorKey[];
+
+/** 'blue' → 'Blue'. Mirrors DisplayBrightnessScreen's accentLabel. */
+function iconTintLabel(key: AccentColorKey) {
+  return key.charAt(0).toUpperCase() + key.slice(1);
+}
 
 /**
  * #517: os números de arranque têm de ser legíveis em runtime, e não podem
@@ -95,6 +106,7 @@ export function LauncherSettingsScreen() {
   const [showPinModal, setShowPinModal] = useState(false);
   const [showNewAppsPicker, setShowNewAppsPicker] = useState(false);
   const [showRequirePasscodePicker, setShowRequirePasscodePicker] = useState(false);
+  const [showIconTintPicker, setShowIconTintPicker] = useState(false);
   const [pinStep, setPinStep] = useState<'current' | 'new' | 'confirm'>('current');
   const [pinInput, setPinInput] = useState('');
   const [newPin, setNewPin] = useState('');
@@ -299,7 +311,6 @@ export function LauncherSettingsScreen() {
             </Text>
           }
           showChevron={false}
-          isLast
         />
         <View style={styles.sliderRow}>
           <CupertinoSlider
@@ -309,6 +320,34 @@ export function LauncherSettingsScreen() {
             maximumValue={1.2}
           />
         </View>
+        <CupertinoListTile
+          title="Tinted Icons"
+          leading={{ name: 'color-palette', color: '#fff', backgroundColor: '#FF2D55' }}
+          showChevron={false}
+          isLast={!settings.iconTintEnabled}
+          trailing={
+            <CupertinoSwitch
+              value={settings.iconTintEnabled}
+              onValueChange={(v) => update('iconTintEnabled', v)}
+            />
+          }
+        />
+        {settings.iconTintEnabled && (
+          <CupertinoListTile
+            title="Tint Color"
+            leading={{ name: 'color-fill', color: '#fff', backgroundColor: settings.iconTintColor }}
+            isLast
+            trailing={
+              <View style={styles.tintTrailing}>
+                <View
+                  testID="icon-tint-swatch"
+                  style={[styles.tintSwatch, { backgroundColor: settings.iconTintColor }]}
+                />
+              </View>
+            }
+            onPress={() => setShowIconTintPicker(true)}
+          />
+        )}
       </CupertinoListSection>
 
       {/* ── Home Screen ────────────────────────────────────────── */}
@@ -630,6 +669,21 @@ export function LauncherSettingsScreen() {
         cancelLabel="Cancel"
       />
 
+      {/* ── Tinted Icons colour (#620) ──────────────────────────── */}
+      <CupertinoActionSheet
+        visible={showIconTintPicker}
+        onClose={() => setShowIconTintPicker(false)}
+        title="Tint Color"
+        options={ICON_TINT_KEYS.map((key) => ({
+          label: iconTintLabel(key),
+          onPress: () => {
+            update('iconTintColor', AccentColors[key].light);
+            setShowIconTintPicker(false);
+          },
+        }))}
+        cancelLabel="Cancel"
+      />
+
       {/* ── Diagnostics (#517) ─────────────────────────────────── */}
       <CupertinoListSection header="Diagnostics">
         <CupertinoListTile
@@ -713,6 +767,16 @@ const styles = StyleSheet.create({
   sliderRow: {
     paddingHorizontal: 16,
     paddingBottom: 12,
+  },
+  tintTrailing: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  tintSwatch: {
+    width: 18,
+    height: 18,
+    borderRadius: 9,
   },
   gridControlRow: {
     paddingHorizontal: 16,

--- a/src/screens/__tests__/LauncherHomeScreen.iconTint.test.tsx
+++ b/src/screens/__tests__/LauncherHomeScreen.iconTint.test.tsx
@@ -1,0 +1,121 @@
+import React from 'react';
+import { render } from '../../test-utils';
+import * as AppsStore from '../../store/AppsStore';
+import * as SettingsStore from '../../store/SettingsStore';
+import { LauncherHomeScreen } from '../LauncherHomeScreen';
+
+// issue #620: «Tinted Icons» — when enabled, real app-icon Images on the
+// home grid and dock render with the chosen colour as tintColor. Mirrors the
+// mocking pattern used by LauncherHomeScreen.wallpaperIndex.test.tsx.
+
+function withSettings(overrides: Partial<SettingsStore.SettingsState>) {
+  jest.spyOn(SettingsStore, 'useSettings').mockReturnValue({
+    settings: { ...SettingsStore.DEFAULT_SETTINGS, ...overrides },
+    update: jest.fn(),
+    updateMany: jest.fn(),
+    reset: jest.fn(),
+    syncFromDevice: jest.fn(() => Promise.resolve()),
+    isReady: true,
+    activeFocusMode: null,
+    setFocusMode: jest.fn(),
+  } as unknown as ReturnType<typeof SettingsStore.useSettings>);
+}
+
+const realApp = (name: string, packageName: string): AppsStore.InstalledApp => ({
+  name,
+  packageName,
+  icon: 'content://icons/one.png',
+  isSystem: false,
+});
+
+function mockApps(overrides: Record<string, unknown> = {}) {
+  jest.spyOn(AppsStore, 'useApps').mockReturnValue({
+    apps: [], homeApps: [], dockApps: [], nonDockApps: [], recentPackages: [], recentApps: [],
+    isLoading: false, refreshApps: jest.fn(() => Promise.resolve()), launchApp: jest.fn(() => Promise.resolve(true)),
+    addToHome: jest.fn(), removeFromHome: jest.fn(), addToDock: jest.fn(), removeFromDock: jest.fn(),
+    removeFromRecents: jest.fn(), clearRecents: jest.fn(), isDefaultLauncher: true,
+    openLauncherSettings: jest.fn(() => Promise.resolve()), hiddenApps: [], visibleApps: [],
+    hideApp: jest.fn(), unhideApp: jest.fn(), iconCacheSizeBytes: 0, isRebuildingIconCache: false,
+    iconCacheRebuildProgress: null, rebuildIconCache: jest.fn(() => Promise.resolve()),
+    ...overrides,
+  } as ReturnType<typeof AppsStore.useApps>);
+}
+
+function flattenStyle(style: unknown): Record<string, unknown>[] {
+  if (Array.isArray(style)) return style.flat(Infinity).filter(Boolean) as Record<string, unknown>[];
+  return style ? [style as Record<string, unknown>] : [];
+}
+
+describe('LauncherHomeScreen — Tinted Icons (#620)', () => {
+  afterEach(() => { jest.restoreAllMocks(); });
+
+  it('applies no tintColor to a grid app icon when iconTintEnabled is false (default)', () => {
+    const app = realApp('Chess Deluxe', 'com.example.chess');
+    mockApps({ homeApps: [app], nonDockApps: [app], dockApps: [] });
+    withSettings({ iconTintEnabled: false, iconTintColor: '#FF3B30' });
+
+    const { getByTestId } = render(<LauncherHomeScreen />);
+    const image = getByTestId('app-icon-box-com.example.chess');
+    const flat = flattenStyle(image.props.style);
+
+    expect(flat.some((s) => 'tintColor' in s)).toBe(false);
+    expect(image.props.tintColor).toBeUndefined();
+  });
+
+  it('applies iconTintColor as tintColor to a grid app icon when iconTintEnabled is true', () => {
+    const app = realApp('Chess Deluxe', 'com.example.chess');
+    mockApps({ homeApps: [app], nonDockApps: [app], dockApps: [] });
+    withSettings({ iconTintEnabled: true, iconTintColor: '#FF3B30' });
+
+    const { getByTestId } = render(<LauncherHomeScreen />);
+    const image = getByTestId('app-icon-box-com.example.chess');
+    const flat = flattenStyle(image.props.style);
+
+    expect(flat.find((s) => 'tintColor' in s)).toEqual({ tintColor: '#FF3B30' });
+    expect(image.props.tintColor).toBe('#FF3B30');
+  });
+
+  it('also tints the dock icon with the same colour (dock reuses AppIcon)', () => {
+    const app = realApp('Phone', 'com.example.phone');
+    mockApps({ dockApps: [app], nonDockApps: [], homeApps: [] });
+    withSettings({ iconTintEnabled: true, iconTintColor: '#34C759' });
+
+    const { getByTestId } = render(<LauncherHomeScreen />);
+    const image = getByTestId('app-icon-box-com.example.phone');
+    expect(image.props.tintColor).toBe('#34C759');
+  });
+
+  it('does not tint the app-name label — only the icon (combines with showIconLabels)', () => {
+    const app = realApp('Chess Deluxe', 'com.example.chess');
+    mockApps({ homeApps: [app], nonDockApps: [app], dockApps: [] });
+    withSettings({ iconTintEnabled: true, iconTintColor: '#FF3B30', showIconLabels: true });
+
+    const { getByText } = render(<LauncherHomeScreen />);
+    const label = getByText('Chess Deluxe');
+    const flat = flattenStyle(label.props.style);
+    expect(flat.some((s) => 'tintColor' in s || 'color' in s && s.color === '#FF3B30')).toBe(false);
+  });
+
+  it('keeps icon dimensions unchanged across a smaller grid density (adaptive-icon safety, #503 geometry)', () => {
+    const app = realApp('Chess Deluxe', 'com.example.chess');
+    mockApps({ homeApps: [app], nonDockApps: [app], dockApps: [] });
+
+    withSettings({ iconTintEnabled: false, gridColumns: 4 });
+    const untinted = render(<LauncherHomeScreen />);
+    const untintedImage = untinted.getByTestId('app-icon-box-com.example.chess');
+    const untintedSize = flattenStyle(untintedImage.props.style).find((s) => 'width' in s);
+    untinted.unmount();
+
+    withSettings({ iconTintEnabled: true, iconTintColor: '#AF52DE', gridColumns: 6 });
+    const tinted = render(<LauncherHomeScreen />);
+    const tintedImage = tinted.getByTestId('app-icon-box-com.example.chess');
+    const tintedSize = flattenStyle(tintedImage.props.style).find((s) => 'width' in s);
+
+    // gridColumns changed (4 -> 6), so the two sizes are expected to differ,
+    // but the tint must never leave width/height undefined or NaN — a
+    // corrupted box size is exactly how an adaptive icon would visibly break.
+    expect(typeof (untintedSize as { width: number }).width).toBe('number');
+    expect(typeof (tintedSize as { width: number }).width).toBe('number');
+    expect(Number.isNaN((tintedSize as { width: number }).width)).toBe(false);
+  });
+});

--- a/src/screens/__tests__/LauncherSettingsScreen.iconTint.test.tsx
+++ b/src/screens/__tests__/LauncherSettingsScreen.iconTint.test.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { render, fireEvent, waitFor, within } from '../../test-utils';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as SecureStore from 'expo-secure-store';
+import { LauncherSettingsScreen } from '../LauncherSettingsScreen';
+import { AccentColors } from '../../theme/CupertinoTheme';
+
+jest.mock('expo-secure-store', () => ({
+  getItemAsync: jest.fn(async () => null),
+  setItemAsync: jest.fn(async () => {}),
+  deleteItemAsync: jest.fn(async () => {}),
+}));
+
+// Stateful in-memory AsyncStorage mock (mirrors LauncherSettingsScreen.test.tsx):
+// setItem persists so a subsequent getItem returns what was written.
+function setupMemoryAsyncStorage(initial: Record<string, string> = {}) {
+  const store = new Map<string, string>(Object.entries(initial));
+  (AsyncStorage.getItem as jest.Mock).mockImplementation(async (key: string) =>
+    store.has(key) ? store.get(key) : null,
+  );
+  (AsyncStorage.setItem as jest.Mock).mockImplementation(async (key: string, value: string) => {
+    store.set(key, value);
+  });
+  (AsyncStorage.removeItem as jest.Mock).mockImplementation(async (key: string) => {
+    store.delete(key);
+  });
+  return store;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  setupMemoryAsyncStorage();
+  (SecureStore.getItemAsync as jest.Mock).mockResolvedValue(null);
+  (SecureStore.setItemAsync as jest.Mock).mockResolvedValue(undefined);
+});
+
+// issue #620: «Tinted Icons» toggle + colour picker in the Appearance section.
+describe('LauncherSettingsScreen Tinted Icons (#620)', () => {
+  it('renders the "Tinted Icons" switch in Appearance, default OFF', () => {
+    const { getByLabelText } = render(<LauncherSettingsScreen />);
+    const tile = getByLabelText('Tinted Icons');
+    const sw = within(tile).getByRole('switch');
+    expect(sw.props.accessibilityState.checked).toBe(false);
+  });
+
+  it('does not show a colour picker tile while Tinted Icons is off', () => {
+    const { queryByLabelText } = render(<LauncherSettingsScreen />);
+    expect(queryByLabelText('Tint Color')).toBeNull();
+  });
+
+  it('reveals the "Tint Color" tile once Tinted Icons is turned on, and persists the toggle', async () => {
+    const store = setupMemoryAsyncStorage();
+    const { getByLabelText, queryByLabelText } = render(<LauncherSettingsScreen />);
+
+    fireEvent.press(within(getByLabelText('Tinted Icons')).getByRole('switch'));
+
+    await waitFor(() => expect(queryByLabelText('Tint Color')).toBeTruthy());
+
+    await waitFor(() => {
+      const raw = store.get('@iostoandroid/settings');
+      expect(raw).toBeTruthy();
+      expect(JSON.parse(raw as string).iconTintEnabled).toBe(true);
+    });
+  });
+
+  it('picking a colour from the action sheet updates iconTintColor and persists it', async () => {
+    const store = setupMemoryAsyncStorage();
+    const { getByLabelText, getByText, queryByLabelText } = render(<LauncherSettingsScreen />);
+
+    fireEvent.press(within(getByLabelText('Tinted Icons')).getByRole('switch'));
+    await waitFor(() => expect(queryByLabelText('Tint Color')).toBeTruthy());
+
+    fireEvent.press(getByLabelText('Tint Color'));
+    fireEvent.press(getByText('Purple'));
+
+    await waitFor(() => {
+      const raw = store.get('@iostoandroid/settings');
+      expect(raw).toBeTruthy();
+      expect(JSON.parse(raw as string).iconTintColor).toBe(AccentColors.purple.light);
+    });
+  });
+
+  it('turning Tinted Icons back off hides the colour picker again (inverse of the fix)', async () => {
+    const { getByLabelText, queryByLabelText } = render(<LauncherSettingsScreen />);
+
+    const sw = () => within(getByLabelText('Tinted Icons')).getByRole('switch');
+    fireEvent.press(sw());
+    await waitFor(() => expect(queryByLabelText('Tint Color')).toBeTruthy());
+
+    fireEvent.press(sw());
+    await waitFor(() => expect(queryByLabelText('Tint Color')).toBeNull());
+  });
+});

--- a/src/store/SettingsStore.tsx
+++ b/src/store/SettingsStore.tsx
@@ -21,6 +21,7 @@ import {
 } from '../utils/passcodePolicy';
 import { clampWallpaperIndex } from '../utils/wallpapers';
 import { clampWhitePointLevel } from '../utils/whitePoint';
+import { DEFAULT_ICON_TINT_COLOR, normalizeIconTintColor } from '../utils/iconTint';
 import {
   normalizeFocusPageVisibility,
   type FocusPageVisibility,
@@ -147,6 +148,19 @@ export interface SettingsState {
   iconSizeScale: number;
   /** Whether app names render under grid icons (issue #503). */
   showIconLabels: boolean;
+  /**
+   * iOS «Home Screen → Edit → Customize → Tint (Tinted)» (issue #620): when
+   * true, every real app icon on the home grid, dock, and folder overlay
+   * renders as a monochrome silhouette in `iconTintColor` instead of its
+   * normal artwork. Default false (unmasked icons, the pre-#620 behaviour).
+   */
+  iconTintEnabled: boolean;
+  /**
+   * The tint colour applied when `iconTintEnabled` is true. 6-digit hex.
+   * Default is the app's default accent (blue) — see
+   * `utils/iconTint.DEFAULT_ICON_TINT_COLOR`.
+   */
+  iconTintColor: string;
   /**
    * Whether the home-screen page dots (iOS «Home Screen & Dock → Show Page
    * Dots») render when there is more than one page. Independent of
@@ -341,6 +355,8 @@ export const DEFAULT_SETTINGS: SettingsState = {
   gridRows: 6,
   iconSizeScale: 1.0,
   showIconLabels: true,
+  iconTintEnabled: false,
+  iconTintColor: DEFAULT_ICON_TINT_COLOR,
   showPageDots: true,
   appLaunchAnimation: true,
   appLaunchDurationMs: 280,
@@ -437,6 +453,11 @@ export function SettingsProvider({
             // render → ecrã branco. Saneia-se na leitura, à semelhança dos
             // campos acima.
             wallpaperIndex: clampWallpaperIndex(parsed?.wallpaperIndex),
+            // iconTintColor (#620) feeds Image's tintColor style directly; a
+            // corrupted/non-hex value from an old blob would silently no-op
+            // or paint icons black depending on the platform, so it is
+            // normalized on read like the fields above.
+            iconTintColor: normalizeIconTintColor(parsed?.iconTintColor),
           }));
         } catch { /* ignore */ }
       }

--- a/src/utils/iconTint.ts
+++ b/src/utils/iconTint.ts
@@ -1,0 +1,21 @@
+import { AccentColors } from '../theme/CupertinoTheme';
+
+/**
+ * Default Tinted Icons colour (issue #620): the light variant of the app's
+ * default accent (blue), matching the iOS default when Tinted mode is first
+ * turned on before the user picks a colour.
+ */
+export const DEFAULT_ICON_TINT_COLOR: string = AccentColors.blue.light;
+
+const HEX_COLOR_RE = /^#[0-9A-Fa-f]{6}$/;
+
+/**
+ * Clamp a stored/persisted icon-tint colour into a valid 6-digit hex string.
+ * `iconTintColor` feeds `Image`'s `tintColor` style prop directly — a
+ * corrupted AsyncStorage blob (non-string, malformed hex) would otherwise
+ * pass straight through, so it is normalized on read like the other
+ * icon-affecting settings above (iconShape, wallpaperIndex, ...).
+ */
+export function normalizeIconTintColor(value: unknown): string {
+  return typeof value === 'string' && HEX_COLOR_RE.test(value) ? value : DEFAULT_ICON_TINT_COLOR;
+}


### PR DESCRIPTION
## Resumo

Adiciona Tinted Icons: toggle + seletor de cor em Launcher Settings, aplicado como tintColor aos ícones reais na grelha, dock e overlay de pastas

## Causa raiz

Não existia a funcionalidade: `grep` por `iconTint` em `src/` devolvia 0 resultados (confirmado). `src/store/SettingsStore.tsx` não tinha nenhum campo de tint, e `LauncherHomeScreen.tsx:463-469` renderizava sempre o `<Image source={{uri: app.icon}}>` sem qualquer `tintColor`, exatamente como o issue descreveu.

## O que mudou

- **`src/utils/iconTint.ts`** (novo): `DEFAULT_ICON_TINT_COLOR` (= `AccentColors.blue.light` de `CupertinoTheme.ts`) e `normalizeIconTintColor(value)`, que valida um hex `#RRGGBB` e cai no default para qualquer valor não-string/malformado — segue o mesmo padrão de saneamento-na-leitura já usado para `iconShape`/`wallpaperIndex`/`whitePointLevel` em `SettingsStore.tsx`.
- **`src/store/SettingsStore.tsx`**: novos campos `iconTintEnabled: boolean` (default `false`) e `iconTintColor: string` (default `DEFAULT_ICON_TINT_COLOR`) na interface `SettingsState`, em `DEFAULT_SETTINGS`, e `iconTintColor` é normalizado no bloco de leitura do `AsyncStorage` (mesmo padrão dos irmãos acima).
- **`src/screens/LauncherHomeScreen.tsx`**:
  - `AppIconProps` ganha `iconTint?: string | null`; quando definido, o `<Image>` do ícone real recebe `tintColor` tanto na `style` como na prop direta (o issue pedia as duas, por segurança cross-plataforma).
  - O componente principal calcula `const iconTint = settings.iconTintEnabled ? settings.iconTintColor : undefined;` uma única vez e passa-o aos três locais que usam `AppIcon`/reutilizam o mesmo ícone: a grelha da home, a dock, e o `FolderOverlay` (ecrã de pasta aberta) — os três partilham o mesmo componente `AppIcon`, por isso um único ponto de cálculo evita três cópias do mesmo ternário.
  - `FolderOverlay` ganha o prop `iconTint?: string | null` e passa-o ao `AppIcon` interno.
- **`src/screens/LauncherSettingsScreen.tsx`**: na secção "Appearance", depois de "App Icon Size":
  - Tile "Tinted Icons" com `CupertinoSwitch` ligado a `settings.iconTintEnabled`.
  - Quando ligado, tile "Tint Color" com swatch + `CupertinoActionSheet` reutilizando as 6 opções de `AccentColors` (`CupertinoTheme.ts:158`), no mesmo padrão do seletor de Tint em `DisplayBrightnessScreen.tsx`.

## Porque assim

- **Âmbito da tint**: o issue diz "aplica tint a todos os ícones da home/dock", mas o único código concreto que o issue aponta é o `<Image>` de `AppIcon` (linha 330-333 do enunciado). Ícones virtuais/built-in (Phone, Messages, Settings, ...) são renderizados via `Ionicons` sobre um fundo gradiente/cor (`VIRTUAL_ICON_CONFIG`, linhas 447-462) e replicar fielmente o efeito "Tinted" do iOS aí (que também recolore o fundo, não só o símbolo) é um trabalho de design significativamente maior e fora do que o issue chegou a especificar. Optei por tintar apenas os ícones reais de apps instaladas (o `<Image>`), que é o que o issue efetivamente desenhou, e documentar aqui o desvio em vez de improvisar uma segunda implementação não pedida. Ícones virtuais, mini-ícones de pasta fechada (`folderMiniIcon`) e o ícone do overlay de abertura de app (`launchTransition`) ficam fora deste PR pela mesma razão.
  - Incluí, no entanto, o `AppIcon` dentro do `FolderOverlay` (pasta aberta) porque é literalmente o mesmo componente/prop que a grelha e a dock — excluí-lo criaria uma inconsistência visual (ícone tintado na grelha, normal dentro da pasta) sem nenhum ganho de simplicidade.
- **Cálculo único de `iconTint`**: em vez de repetir `settings.iconTintEnabled ? settings.iconTintColor : undefined` em cada um dos 3 call-sites, calculo uma vez no componente principal — mesmo padrão que `gridGeometry`/`appsPerPage` já usam ali perto.
- **Cor default = accent**: reutilizo `AccentColors.blue.light` em vez de um hex hardcoded solto, para não divergir se a paleta de accent mudar.
- **Normalização na leitura**: `iconTintColor` alimenta diretamente o `tintColor` do `Image`; um valor corrompido do AsyncStorage (blob antigo, tipo errado) é sanado no load, seguindo o padrão já estabelecido para `iconShape`/`wallpaperIndex`/`whitePointLevel`/`categoryOverrides` no mesmo ficheiro.

## Critérios de aceitação

- [x] Toggle "Tinted Icons" em Launcher Settings, default false — `LauncherSettingsScreen.tsx`, secção Appearance; testado em `LauncherSettingsScreen.iconTint.test.tsx` ("renders the Tinted Icons switch ... default OFF").
- [x] Cor escolhida aplica tint a todos os ícones reais da home/dock/pasta aberta — testado em `LauncherHomeScreen.iconTint.test.tsx` (grid + dock), com nota de âmbito acima sobre ícones virtuais/built-in.
- [x] Combina com `showIconLabels` (rótulo não é tintado, só o ícone) — testado explicitamente: o `<Text>` do nome da app não recebe nenhuma propriedade `tintColor`/`color` igual à cor de tint.
- [x] Persiste entre arranques — usa o mesmo mecanismo de persistência de todo o `SettingsState` (`AsyncStorage.setItem` no efeito existente); testado indiretamente via `store.get('@iostoandroid/settings')` nos testes de settings (mesmo padrão do teste já existente "Show Page Dots").
- [x] Sem quebrar ícones adaptivos (testado 360/480dp) — interpretado como "a tint não corrompe a geometria do ícone sob diferentes densidades de grelha"; teste compara `gridColumns=4` vs `gridColumns=6` e confirma que `width` do `Image` permanece um número válido (não `NaN`/`undefined`) tanto com tint ligado como desligado.
- [x] Teste em `LauncherHomeScreen.test.tsx` cobre o tint — implementado como ficheiro dedicado `LauncherHomeScreen.iconTint.test.tsx` (mesma pasta/convenção dos outros testes focados, ex. `LauncherHomeScreen.wallpaperIndex.test.tsx`), para não inchar o ficheiro principal.

## Testes

**Passo vermelho** (com os 3 ficheiros de produção revertidos via `git stash`, testes mantidos):

```
● LauncherHomeScreen — Tinted Icons (#620) › applies iconTintColor as tintColor to a grid app icon when iconTintEnabled is true

  expect(received).toEqual(expected) // deep equality

  Expected: {"tintColor": "#FF3B30"}
  Received: undefined

    72 |     const flat = flattenStyle(image.props.style);
    73 |
  > 74 |     expect(flat.find((s) => 'tintColor' in s)).toEqual({ tintColor: '#FF3B30' });
       |                                                ^

● LauncherHomeScreen — Tinted Icons (#620) › also tints the dock icon with the same colour (dock reuses AppIcon)

  expect(received).toBe(expected)
  Expected: "#34C759"
  Received: undefined

● LauncherSettingsScreen Tinted Icons (#620) › renders the "Tinted Icons" switch in Appearance, default OFF
● LauncherSettingsScreen Tinted Icons (#620) › reveals the "Tint Color" tile once Tinted Icons is turned on, and persists the toggle
● LauncherSettingsScreen Tinted Icons (#620) › picking a colour from the action sheet updates iconTintColor and persists it
● LauncherSettingsScreen Tinted Icons (#620) › turning Tinted Icons back off hides the colour picker again (inverse of the fix)

Test Suites: 2 failed, 2 total
Tests:       6 failed, 4 passed, 10 total
```

(os outros 4 testes do passo vermelho já passavam porque afirmam a AUSÊNCIA de tint / dimensões válidas, que já era verdade sem o fix — corretos por construção, não falsos positivos).

Depois de restaurar o fix (`git stash apply` + `git stash drop`): `10 passed, 10 total`.

**Casos cobertos** além do caminho feliz:
- Ausência de tint quando `iconTintEnabled=false` (default) — inverso do fix.
- Tint aplicado tanto na grelha como na dock (mesmo componente `AppIcon`, dois call-sites).
- Rótulo de texto não tintado (interação com `showIconLabels`).
- Geometria do ícone (`width`) permanece um número válido sob duas densidades de grelha diferentes (4 e 6 colunas), com e sem tint — proxy para "não quebra ícones adaptivos".
- Settings: toggle default OFF; tile de cor escondido enquanto OFF; aparece e persiste ao ligar; seleção de cor persiste o hex certo; desligar esconde o tile de novo (round-trip).

**Sanity-check**: fix de produção revertido via `git stash push -u -- <3 ficheiros de produção + util>`, suite corrida (6 falhas confirmadas, ver acima), `git stash apply` + `git stash drop` para restaurar (nunca `pop`, por causa da stash partilhada entre worktrees).

**Resultado das verificações obrigatórias** (comparado com a baseline documentada: 23 falhas em 6 suites já vermelhas antes deste trabalho):

- `npm run lint`: 0 erros (7 warnings pré-existentes, nenhum novo, nenhum deles nos ficheiros tocados por este PR).
- `npx tsc --noEmit`: limpo.
- `npm test -- --maxWorkers=2`: `Test Suites: 6 failed, 209 passed, 215 total` / `Tests: 23 failed, 1990 passed, 2013 total`. As 23 falhas são exatamente as mesmas 6 suites da baseline (`LockScreen`, `SiriScreen`, `WeatherScreen`, `SettingsScreen`, `FoldersStore`, `withLauncherIntent`) — confirmado por comparação direta com `baseline.json`. Nenhuma falha nova, nenhuma regressão.

## Testes

10 novos testes passaram (2 suites, 0 falhas); suite completa: 1990 passaram, 23 falharam (as mesmas 23 falhas pré-existentes da baseline, 0 regressões), 2013 totais em 215 suites

## Linked Issue

Fixes #620