### PR TITLE
resolve conflito de merge em SettingsStore.tsx e valida motionIntensity (full/reduced/off) + scrollDeceleration (normal/fast) — háptica independente com 'off' testada nos 3 pontos (#493)

### DIFF
--- a/src/components/AssistiveTouch.tsx
+++ b/src/components/AssistiveTouch.tsx
@@ -24,7 +24,7 @@ import {
 import { useTheme } from '../theme/ThemeContext';
 import { CupertinoPressable } from './CupertinoPressable';
 import { hapticImpact, hapticNotification, hapticSelection } from '../utils/haptics';
-import { useGestureReduceMotion, settle } from '../utils/useGestureReduceMotion';
+import { useMotionIntensity, settle } from '../utils/useGestureReduceMotion';
 import { IDLE_DIM_MS } from '../utils/gestureConfig';
 import { assistiveTouchSnap, assistiveTouchMenuReveal } from '../theme/springPresets';
 
@@ -135,8 +135,8 @@ interface AssistiveTouchProps {
 export function AssistiveTouch({ navigationRef }: AssistiveTouchProps) {
   const insets = useSafeAreaInsets();
   const { theme } = useTheme();
-  const reduceMotion = useGestureReduceMotion();
-  const reduceMotionShared = useSharedValue(reduceMotion);
+  const motionIntensity = useMotionIntensity();
+  const motionIntensityShared = useSharedValue(motionIntensity);
   const {
     enabled,
     idleOpacity,
@@ -174,11 +174,11 @@ export function AssistiveTouch({ navigationRef }: AssistiveTouchProps) {
   const hiddenForFullscreen = autoHideFullscreen && !!currentRoute && FULLSCREEN_ROUTES.has(currentRoute);
   const visible = enabled && !temporarilyHidden && !hiddenForFullscreen;
 
-  // Sync reduceMotion into shared value so worklets can read it
+  // Sync motionIntensity into shared value so worklets can read it
   useEffect(() => {
-    reduceMotionShared.value = reduceMotion;
+    motionIntensityShared.value = motionIntensity;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [reduceMotion]);
+  }, [motionIntensity]);
 
   // ── Drag position (shared values for smooth dragging) ─────────────────────
   const translateX = useSharedValue(edge === 'right' ? SCREEN_W - size - 8 : 8);
@@ -187,10 +187,10 @@ export function AssistiveTouch({ navigationRef }: AssistiveTouchProps) {
   // Re-snap to stored edge when edge prop changes (after settings reset)
   useEffect(() => {
     const targetX = edge === 'right' ? SCREEN_W - size - 8 : 8;
-    translateX.value = reduceMotion ? targetX : withSpring(targetX, SNAP_SPRING);
-    // Shared values are stable refs; reduceMotion and translateX identity don't drive re-runs
+    translateX.value = settle(targetX, SNAP_SPRING, motionIntensity);
+    // Shared values are stable refs; motionIntensity and translateX identity don't drive re-runs
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [edge, size, reduceMotion]);
+  }, [edge, size, motionIntensity]);
 
   // ── Idle dim ──────────────────────────────────────────────────────────────
   const opacity = useSharedValue(1);
@@ -230,12 +230,14 @@ export function AssistiveTouch({ navigationRef }: AssistiveTouchProps) {
     setFullyOpen(false);
     if (fullyOpenTimer.current) clearTimeout(fullyOpenTimer.current);
     fullyOpenTimer.current = setTimeout(() => setFullyOpen(true), 150);
-    menuScale.value = reduceMotion
-      ? withTiming(1, { duration: 150 })
-      : withSpring(1, assistiveTouchMenuReveal);
+    menuScale.value = motionIntensity === 'off'
+      ? 1
+      : motionIntensity === 'reduced'
+        ? withTiming(1, { duration: 150 })
+        : withSpring(1, assistiveTouchMenuReveal);
     menuOpacity.value = withTiming(1, { duration: 160 });
     wake();
-  }, [menuScale, menuOpacity, wake, hapticFeedback, reduceMotion]);
+  }, [menuScale, menuOpacity, wake, hapticFeedback, motionIntensity]);
 
   const closeMenu = useCallback(() => {
     menuScale.value = withTiming(0, { duration: 150 });
@@ -387,7 +389,7 @@ export function AssistiveTouch({ navigationRef }: AssistiveTouchProps) {
     })
     .onEnd((e) => {
       'worklet';
-      const rm = reduceMotionShared.value;
+      const rm = motionIntensityShared.value;
       // Magnetic snap to nearest horizontal edge
       const snapLeft = 8;
       const snapRight = SCREEN_W - size - 8;

--- a/src/components/CupertinoSwipeableRow.tsx
+++ b/src/components/CupertinoSwipeableRow.tsx
@@ -4,13 +4,12 @@ import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
   useSharedValue,
   useAnimatedStyle,
-  withSpring,
   runOnJS,
 } from 'react-native-reanimated';
 import * as Haptics from 'expo-haptics';
 import { hapticImpact } from '../utils/haptics';
 import { useTheme } from '../theme/ThemeContext';
-import { useGestureReduceMotion, settle } from '../utils/useGestureReduceMotion';
+import { useMotionIntensity, settle } from '../utils/useGestureReduceMotion';
 import { feedbackSettle } from '../theme/springPresets';
 
 export interface SwipeAction {
@@ -39,16 +38,16 @@ export function CupertinoSwipeableRow({
   onOpen,
 }: CupertinoSwipeableRowProps) {
   const { typography } = useTheme();
-  const reduceMotion = useGestureReduceMotion();
-  const reduceMotionShared = useSharedValue(reduceMotion);
+  const motionIntensity = useMotionIntensity();
+  const motionIntensityShared = useSharedValue(motionIntensity);
   const translateX = useSharedValue(0);
   const contextX = useSharedValue(0);
 
-  // Sync reduceMotion into shared value so worklets can read it
+  // Sync motionIntensity into shared value so worklets can read it
   useEffect(() => {
-    reduceMotionShared.value = reduceMotion;
+    motionIntensityShared.value = motionIntensity;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [reduceMotion]);
+  }, [motionIntensity]);
 
   // Always hold the latest onOpen so gesture doesn't capture a stale ref
   const onOpenRef = useRef(onOpen);
@@ -57,11 +56,11 @@ export function CupertinoSwipeableRow({
   // Close this row when parent signals another row is now open
   useEffect(() => {
     if (isOpen === false) {
-      translateX.value = reduceMotion ? 0 : withSpring(0, SPRING_CONFIG);
+      translateX.value = settle(0, SPRING_CONFIG, motionIntensity);
     }
-    // Shared values are stable refs; reduceMotion is a reactive dep
+    // Shared values are stable refs; motionIntensity is a reactive dep
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isOpen, reduceMotion]);
+  }, [isOpen, motionIntensity]);
 
   const maxTrailing = trailingActions.length * ACTION_WIDTH;
   const maxLeading = leadingActions.length * ACTION_WIDTH;
@@ -92,7 +91,7 @@ export function CupertinoSwipeableRow({
     .onEnd((e) => {
       'worklet';
       const velocity = e.velocityX;
-      const rm = reduceMotionShared.value;
+      const rm = motionIntensityShared.value;
       // translateX is a literal dp offset — e.velocityX is already dp/sec.
       // Decide snap position
       if (velocity < -500 && trailingActions.length > 0) {
@@ -117,7 +116,7 @@ export function CupertinoSwipeableRow({
   }));
 
   const handleActionPress = (action: SwipeAction) => {
-    translateX.value = reduceMotion ? 0 : withSpring(0, SPRING_CONFIG);
+    translateX.value = settle(0, SPRING_CONFIG, motionIntensity);
     action.onPress();
   };
 

--- a/src/components/NotificationBanner.tsx
+++ b/src/components/NotificationBanner.tsx
@@ -14,7 +14,7 @@ import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTheme } from '../theme/ThemeContext';
 import { hapticNotification } from '../utils/haptics';
-import { useGestureReduceMotion } from '../utils/useGestureReduceMotion';
+import { useMotionIntensity } from '../utils/useGestureReduceMotion';
 import { notificationBannerEnter, notificationBannerScale, feedbackSettle } from '../theme/springPresets';
 
 export interface BannerNotification {
@@ -37,7 +37,7 @@ export function NotificationBanner({ notification, onDismiss }: Props) {
   const insets = useSafeAreaInsets();
   const { theme, typography } = useTheme();
   const { colors } = theme;
-  const reduceMotion = useGestureReduceMotion();
+  const motionIntensity = useMotionIntensity();
 
   const translateY = useSharedValue(-150);
   const scale = useSharedValue(0.95);
@@ -58,12 +58,18 @@ export function NotificationBanner({ notification, onDismiss }: Props) {
     }, 250);
   }, [onDismiss, translateY, scale, opacity]);
 
-  // Show animation
+  // Show animation. §3.2 regra 4 (#493): cortar animação nunca corta háptica —
+  // hapticNotification() dispara incondicionalmente, ANTES do branch por
+  // motionIntensity, para todos os 3 estados incluindo 'off'.
   useEffect(() => {
     if (notification) {
       hapticNotification(Haptics.NotificationFeedbackType.Success).catch(() => {});
       opacity.value = 1;
-      if (reduceMotion) {
+      if (motionIntensity === 'off') {
+        // Salto directo — sem withSpring/withTiming, sem transição.
+        translateY.value = 0;
+        scale.value = 1;
+      } else if (motionIntensity === 'reduced') {
         translateY.value = withTiming(0, { duration: 150 });
         scale.value = withTiming(1, { duration: 150 });
       } else {
@@ -80,7 +86,7 @@ export function NotificationBanner({ notification, onDismiss }: Props) {
         }
       };
     }
-  }, [notification, reduceMotion, translateY, scale, opacity, dismiss]);
+  }, [notification, motionIntensity, translateY, scale, opacity, dismiss]);
 
   // Swipe UP to dismiss (iOS gesture)
   const swipeGesture = Gesture.Pan()

--- a/src/components/__tests__/AssistiveTouch.motionIntensity.test.tsx
+++ b/src/components/__tests__/AssistiveTouch.motionIntensity.test.tsx
@@ -1,0 +1,124 @@
+import React, { useEffect } from 'react';
+import * as Haptics from 'expo-haptics';
+import { render, act } from '../../test-utils';
+import { AssistiveTouch } from '../AssistiveTouch';
+import { AssistiveTouchProvider, useAssistiveTouch } from '../../store/AssistiveTouchStore';
+import { useSettings } from '../../store/SettingsStore';
+import type { NavigationContainerRefWithCurrent } from '@react-navigation/native';
+import type { RootStackParamList } from '../../navigation/types';
+
+// issue #493 — §3.2 regra 4: cortar animação (motionIntensity: 'off') não pode
+// cortar a háptica do snap de arrasto do botão flutuante. Como
+// AssistiveTouch.test.tsx, o mock por omissão de react-native-gesture-handler
+// (jest.setup.js) descarta os callbacks dos gestos, por isso este ficheiro
+// re-mocka o módulo para capturar o único Gesture.Pan() (o arrasto do botão).
+const mockPanRecords: Array<{ onEnd?: (e: { velocityX: number; velocityY: number }) => void }> = [];
+
+jest.mock('react-native-gesture-handler', () => {
+  const chain = (record: Record<string, unknown>) => {
+    const g: Record<string, unknown> = {};
+    ['minDistance', 'maxPointers', 'minPointers', 'enabled', 'hitSlop',
+      'simultaneousWithExternalGesture', 'withRef', 'activeOffsetX', 'activeOffsetY',
+      'failOffsetX', 'failOffsetY', 'averageTouches', 'numberOfTaps', 'minDuration', 'maxDuration',
+    ].forEach((m) => { g[m] = () => g; });
+    g.onBegin = (fn: unknown) => { record.onBegin = fn; return g; };
+    g.onStart = (fn: unknown) => { record.onStart = fn; return g; };
+    g.onUpdate = (fn: unknown) => { record.onUpdate = fn; return g; };
+    g.onChange = (fn: unknown) => { record.onChange = fn; return g; };
+    g.onEnd = (fn: unknown) => { record.onEnd = fn; return g; };
+    g.onFinalize = (fn: unknown) => { record.onFinalize = fn; return g; };
+    return g;
+  };
+  const pan = () => {
+    const record: Record<string, unknown> = {};
+    mockPanRecords.push(record as never);
+    return chain(record);
+  };
+  return {
+    GestureHandlerRootView: 'View',
+    GestureDetector: 'View',
+    Gesture: {
+      Pan: pan,
+      Tap: () => chain({}),
+      LongPress: () => chain({}),
+      Fling: () => chain({}),
+      Exclusive: (...gs: unknown[]) => gs[0],
+      Simultaneous: (...gs: unknown[]) => gs[0],
+      Race: (...gs: unknown[]) => gs[0],
+    },
+    Swipeable: 'View',
+    DrawerLayout: 'View',
+    State: {},
+    PanGestureHandler: 'View',
+    TapGestureHandler: 'View',
+    FlatList: 'FlatList',
+    ScrollView: 'ScrollView',
+  };
+});
+
+const lastPan = () => {
+  const record = mockPanRecords[mockPanRecords.length - 1];
+  if (!record?.onEnd) throw new Error('no Pan onEnd captured');
+  return record;
+};
+
+function EnableAssistiveTouch() {
+  const { update } = useAssistiveTouch();
+  useEffect(() => { update({ enabled: true }); }, [update]);
+  return null;
+}
+
+function SetMotionIntensity({ value }: { value: 'full' | 'reduced' | 'off' }) {
+  const { update } = useSettings();
+  useEffect(() => { update('motionIntensity', value); }, [update, value]);
+  return null;
+}
+
+function makeNavigationRef() {
+  return {
+    isReady: () => true,
+    getCurrentRoute: () => ({ name: 'HomeMain', key: 'home', params: undefined }),
+    addListener: jest.fn(() => () => {}),
+    navigate: jest.fn(),
+  } as unknown as NavigationContainerRefWithCurrent<RootStackParamList>;
+}
+
+function renderAssistiveTouch(motionIntensity: 'full' | 'reduced' | 'off') {
+  return render(
+    <AssistiveTouchProvider>
+      <EnableAssistiveTouch />
+      <SetMotionIntensity value={motionIntensity} />
+      <AssistiveTouch navigationRef={makeNavigationRef()} />
+    </AssistiveTouchProvider>,
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockPanRecords.length = 0;
+});
+
+describe('AssistiveTouch — drag-snap haptic under motionIntensity (#493)', () => {
+  it('fires the selection haptic on drag-end when motionIntensity is "full"', () => {
+    renderAssistiveTouch('full');
+
+    act(() => {
+      lastPan().onEnd!({ velocityX: 0, velocityY: 0 });
+    });
+
+    expect(Haptics.selectionAsync).toHaveBeenCalled();
+  });
+
+  // §3.2 regra 4: cortar animação nunca corta háptica — AssistiveTouch.tsx é
+  // um dos 3 pontos citados no issue como já-conforme; este teste protege
+  // essa garantia contra regressão ao introduzir o novo estado 'off'.
+  it('still fires the selection haptic on drag-end when motionIntensity is "off"', () => {
+    renderAssistiveTouch('off');
+
+    act(() => {
+      lastPan().onEnd!({ velocityX: 0, velocityY: 0 });
+    });
+
+    expect(Haptics.selectionAsync).toHaveBeenCalled();
+  });
+});

--- a/src/components/__tests__/CupertinoSwipeableRow.test.tsx
+++ b/src/components/__tests__/CupertinoSwipeableRow.test.tsx
@@ -1,0 +1,128 @@
+import React from 'react';
+import { Text } from 'react-native';
+import * as Haptics from 'expo-haptics';
+import { render, act } from '../../test-utils';
+import { CupertinoSwipeableRow } from '../CupertinoSwipeableRow';
+import { useSettings } from '../../store/SettingsStore';
+
+// issue #493 — §3.2 regra 4: cortar animação (motionIntensity: 'off') não pode
+// cortar a háptica do swipe-to-reveal. jest.setup.js's default
+// react-native-gesture-handler mock discards every gesture callback (onEnd is
+// `() => g`, the callback itself is never stored), so this file re-mocks it
+// to capture Gesture.Pan()'s onEnd — the same technique
+// AssistiveTouch.test.tsx already uses for Gesture.Tap().
+const mockPanRecords: Array<{ onEnd?: (e: { velocityX: number }) => void }> = [];
+
+jest.mock('react-native-gesture-handler', () => {
+  const chain = (record: Record<string, unknown>) => {
+    const g: Record<string, unknown> = {};
+    ['activeOffsetX', 'activeOffsetY', 'minDistance', 'enabled', 'hitSlop',
+      'simultaneousWithExternalGesture', 'withRef', 'failOffsetX', 'failOffsetY',
+    ].forEach((m) => { g[m] = () => g; });
+    g.onStart = (fn: unknown) => { record.onStart = fn; return g; };
+    g.onUpdate = (fn: unknown) => { record.onUpdate = fn; return g; };
+    g.onEnd = (fn: unknown) => { record.onEnd = fn; return g; };
+    g.onFinalize = (fn: unknown) => { record.onFinalize = fn; return g; };
+    return g;
+  };
+  const pan = () => {
+    const record: Record<string, unknown> = {};
+    mockPanRecords.push(record as never);
+    return chain(record);
+  };
+  return {
+    GestureHandlerRootView: 'View',
+    GestureDetector: 'View',
+    Gesture: {
+      Pan: pan,
+      Tap: () => chain({}),
+      LongPress: () => chain({}),
+      Fling: () => chain({}),
+      Exclusive: (...gs: unknown[]) => gs[0],
+      Simultaneous: (...gs: unknown[]) => gs[0],
+      Race: (...gs: unknown[]) => gs[0],
+    },
+    Swipeable: 'View',
+    DrawerLayout: 'View',
+    State: {},
+    PanGestureHandler: 'View',
+    TapGestureHandler: 'View',
+    FlatList: 'FlatList',
+    ScrollView: 'ScrollView',
+  };
+});
+
+/** Most recently built Pan gesture (this component builds exactly one). */
+const lastPan = () => {
+  const record = mockPanRecords[mockPanRecords.length - 1];
+  if (!record?.onEnd) throw new Error('no Pan onEnd captured');
+  return record;
+};
+
+function SetMotionIntensity({ value, children }: { value: 'full' | 'reduced' | 'off'; children: React.ReactNode }) {
+  const { settings, update } = useSettings();
+  React.useEffect(() => {
+    if (settings.motionIntensity !== value) update('motionIntensity', value);
+  }, [settings.motionIntensity, update, value]);
+  if (settings.motionIntensity !== value) return null;
+  return <>{children}</>;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockPanRecords.length = 0;
+});
+
+describe('CupertinoSwipeableRow — swipe-reveal haptic under motionIntensity (#493)', () => {
+  it('fires the impact haptic on a fast leading swipe when motionIntensity is "full"', async () => {
+    const utils = render(
+      <SetMotionIntensity value="full">
+        <CupertinoSwipeableRow leadingActions={[{ label: 'Pin', color: 'blue', onPress: jest.fn() }]}>
+          <Text>Row</Text>
+        </CupertinoSwipeableRow>
+      </SetMotionIntensity>,
+    );
+    await utils.findByText('Row');
+
+    act(() => {
+      lastPan().onEnd!({ velocityX: 600 });
+    });
+
+    expect(Haptics.impactAsync).toHaveBeenCalledWith(Haptics.ImpactFeedbackStyle.Light);
+  });
+
+  // §3.2 regra 4: cortar a animação nunca corta a háptica.
+  it('still fires the impact haptic when motionIntensity is "off" (no transition, haptic unaffected)', async () => {
+    const utils = render(
+      <SetMotionIntensity value="off">
+        <CupertinoSwipeableRow leadingActions={[{ label: 'Pin', color: 'blue', onPress: jest.fn() }]}>
+          <Text>Row</Text>
+        </CupertinoSwipeableRow>
+      </SetMotionIntensity>,
+    );
+    await utils.findByText('Row');
+
+    act(() => {
+      lastPan().onEnd!({ velocityX: 600 });
+    });
+
+    expect(Haptics.impactAsync).toHaveBeenCalledWith(Haptics.ImpactFeedbackStyle.Light);
+  });
+
+  it('does not fire the haptic when the swipe does not cross any threshold (below velocity and rest position)', async () => {
+    const utils = render(
+      <SetMotionIntensity value="full">
+        <CupertinoSwipeableRow leadingActions={[{ label: 'Pin', color: 'blue', onPress: jest.fn() }]}>
+          <Text>Row</Text>
+        </CupertinoSwipeableRow>
+      </SetMotionIntensity>,
+    );
+    await utils.findByText('Row');
+
+    act(() => {
+      lastPan().onEnd!({ velocityX: 10 });
+    });
+
+    expect(Haptics.impactAsync).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/__tests__/NotificationBanner.motionIntensity.test.tsx
+++ b/src/components/__tests__/NotificationBanner.motionIntensity.test.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import * as Reanimated from 'react-native-reanimated';
+import * as Haptics from 'expo-haptics';
+import { render } from '../../test-utils';
+import { NotificationBanner, BannerNotification } from '../NotificationBanner';
+import { useSettings } from '../../store/SettingsStore';
+
+// issue #493: motionIntensity ('full'|'reduced'|'off') replaces the binary
+// reduceMotion for NotificationBanner's show animation. This file proves the
+// 3 branches are distinct — spying on withSpring/withTiming works here
+// because the effect in NotificationBanner is plain JS (not marked
+// 'worklet' and not a Gesture callback), unlike settle() in
+// AssistiveTouch/CupertinoSwipeableRow, whose reanimated calls are
+// closure-captured by the Babel worklet plugin and can't be spied on (see
+// useGestureReduceMotion.test.ts for that documented limitation).
+
+// Gates mounting `children` until settings.motionIntensity === value, so
+// NotificationBanner's own mount effect only ever runs once, with the target
+// value already in place. Updating motionIntensity via useSettings().update()
+// AFTER NotificationBanner has mounted (e.g. a sibling effect firing post-mount)
+// would make its show-animation effect run twice — once with the 'full'
+// default, once with the target — double-firing the haptic and contaminating
+// the withSpring/withTiming spies this file relies on.
+function WithMotionIntensity({
+  value,
+  children,
+}: {
+  value: 'full' | 'reduced' | 'off';
+  children: React.ReactNode;
+}) {
+  const { settings, update } = useSettings();
+  React.useEffect(() => {
+    if (settings.motionIntensity !== value) update('motionIntensity', value);
+  }, [settings.motionIntensity, update, value]);
+  if (settings.motionIntensity !== value) return null;
+  return <>{children}</>;
+}
+
+function makeNotification(over?: Partial<BannerNotification>): BannerNotification {
+  return { id: 'n1', appName: 'Messages', title: 'Ana', body: 'Olá', ...over };
+}
+
+describe('NotificationBanner — motionIntensity branches (#493)', () => {
+  let withSpringSpy: jest.SpyInstance;
+  let withTimingSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    withSpringSpy = jest.spyOn(Reanimated, 'withSpring');
+    withTimingSpy = jest.spyOn(Reanimated, 'withTiming');
+  });
+
+  afterEach(() => {
+    withSpringSpy.mockRestore();
+    withTimingSpy.mockRestore();
+  });
+
+  it('"full" enters via withSpring, never withTiming', async () => {
+    const utils = render(
+      <WithMotionIntensity value="full">
+        <NotificationBanner notification={makeNotification()} onDismiss={jest.fn()} />
+      </WithMotionIntensity>,
+    );
+    await utils.findByText('Ana');
+    expect(withSpringSpy).toHaveBeenCalled();
+    expect(withTimingSpy).not.toHaveBeenCalled();
+  });
+
+  it('"reduced" enters via withTiming(duration: 150), never withSpring', async () => {
+    const utils = render(
+      <WithMotionIntensity value="reduced">
+        <NotificationBanner notification={makeNotification()} onDismiss={jest.fn()} />
+      </WithMotionIntensity>,
+    );
+    await utils.findByText('Ana');
+    expect(withTimingSpy).toHaveBeenCalledWith(0, { duration: 150 });
+    expect(withTimingSpy).toHaveBeenCalledWith(1, { duration: 150 });
+    expect(withSpringSpy).not.toHaveBeenCalled();
+  });
+
+  it('"off" jumps directly — neither withSpring nor withTiming is called for the enter animation', async () => {
+    const utils = render(
+      <WithMotionIntensity value="off">
+        <NotificationBanner notification={makeNotification()} onDismiss={jest.fn()} />
+      </WithMotionIntensity>,
+    );
+    await utils.findByText('Ana');
+    expect(withSpringSpy).not.toHaveBeenCalled();
+    expect(withTimingSpy).not.toHaveBeenCalled();
+  });
+
+  // §3.2 regra 4 (#493): cortar animação não corta háptica.
+  it('"off" still fires the notification haptic (motion and haptics are independent)', async () => {
+    const utils = render(
+      <WithMotionIntensity value="off">
+        <NotificationBanner notification={makeNotification()} onDismiss={jest.fn()} />
+      </WithMotionIntensity>,
+    );
+    await utils.findByText('Ana');
+    expect(Haptics.notificationAsync).toHaveBeenCalledWith(Haptics.NotificationFeedbackType.Success);
+  });
+});

--- a/src/screens/ContactsScreen.tsx
+++ b/src/screens/ContactsScreen.tsx
@@ -7,9 +7,11 @@ import { StatusBar } from 'expo-status-bar';
 import { useTheme, ResolvedTypography } from '../theme/ThemeContext';
 import { useContacts } from '../store/ContactsStore';
 import { useDevice, DeviceContact } from '../store/DeviceStore';
+import { useSettings } from '../store/SettingsStore';
 import { CupertinoNavigationBar, CupertinoSearchBar, CupertinoActionSheet, CupertinoButton, SkeletonListRow, BackEdgeSwipe } from '../components';
 import type { CupertinoColors } from '../theme/CupertinoTheme';
 import type { AppNavigationProp } from '../navigation/types';
+import { scrollDecelerationValue } from '../utils/motionIntensity';
 
 function groupByLetter(contacts: DeviceContact[]) {
   const groups: Record<string, DeviceContact[]> = {};
@@ -94,6 +96,7 @@ export function ContactsScreen() {
   const navigation = useNavigation<AppNavigationProp>();
   const { toggleFavorite } = useContacts();
   const { contacts: deviceContacts, requestContactsPermission, isReady: deviceReady } = useDevice();
+  const { settings } = useSettings();
   const [searchQuery, setSearchQuery] = useState('');
   const [refreshing, setRefreshing] = useState(false);
   const [contextContact, setContextContact] = useState<DeviceContact | null>(null);
@@ -197,7 +200,7 @@ export function ContactsScreen() {
           renderItem={renderItem}
           renderSectionHeader={renderSectionHeader}
           stickySectionHeadersEnabled
-          decelerationRate={0.998}
+          decelerationRate={scrollDecelerationValue(settings.scrollDeceleration)}
           contentContainerStyle={{ paddingBottom: insets.bottom + 90 }}
           showsVerticalScrollIndicator
           refreshControl={

--- a/src/screens/LauncherHomeScreen.tsx
+++ b/src/screens/LauncherHomeScreen.tsx
@@ -38,6 +38,7 @@ import { addHomePressedListener, LauncherModuleType } from '../../modules/launch
 import { useApps, InstalledApp } from '../store/AppsStore';
 import { AppLibraryContent } from './AppLibraryScreen';
 import { useSettings } from '../store/SettingsStore';
+import { scrollDecelerationValue } from '../utils/motionIntensity';
 import { useTheme } from '../theme/ThemeContext';
 import { Shape } from '../theme/CupertinoTheme';
 import { useDevice } from '../store/DeviceStore';
@@ -1681,7 +1682,7 @@ export function LauncherHomeScreen() {
         ref={scrollViewRef}
         horizontal
         pagingEnabled
-        decelerationRate={0.998}
+        decelerationRate={scrollDecelerationValue(settings.scrollDeceleration)}
         showsHorizontalScrollIndicator={false}
         onScroll={handlePageScroll}
         scrollEventThrottle={16}

--- a/src/screens/MessagesScreen.tsx
+++ b/src/screens/MessagesScreen.tsx
@@ -19,12 +19,14 @@ import type { CupertinoColors } from '../theme/CupertinoTheme';
 import type { AppNavigationProp } from '../navigation/types';
 import * as Haptics from 'expo-haptics';
 import { useDevice, DeviceSms, DeviceContact } from '../store/DeviceStore';
+import { useSettings } from '../store/SettingsStore';
 import { migrateAsyncStorageKey, draftStorageKey, draftLegacyStorageKey } from '../store/storage';
 import { CupertinoButton, CupertinoSwipeableRow, useAlert, SkeletonListRow, CupertinoNavigationBar } from '../components';
 import { findContactByPhone } from '../utils/contacts';
 import { logger } from '../utils/logger';
 import { hapticImpact } from '../utils/haptics';
 import { avatarColorForName } from '../utils/avatarColor';
+import { scrollDecelerationValue } from '../utils/motionIntensity';
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -244,6 +246,7 @@ export function MessagesScreen() {
   const insets = useSafeAreaInsets();
   const navigation = useNavigation<AppNavigationProp>();
   const device = useDevice();
+  const { settings } = useSettings();
   const alert = useAlert();
 
   const [searchQuery, setSearchQuery] = useState('');
@@ -628,7 +631,7 @@ export function MessagesScreen() {
           renderItem={renderItem}
           ListEmptyComponent={ListEmpty}
           showsVerticalScrollIndicator={false}
-          decelerationRate={0.998}
+          decelerationRate={scrollDecelerationValue(settings.scrollDeceleration)}
           contentContainerStyle={
             filtered.length === 0
               ? styles.emptyList

--- a/src/screens/NotificationCenterScreen.tsx
+++ b/src/screens/NotificationCenterScreen.tsx
@@ -16,12 +16,14 @@ import { useNavigation } from '@react-navigation/native';
 import * as Haptics from 'expo-haptics';
 
 import { useApps } from '../store/AppsStore';
+import { useSettings } from '../store/SettingsStore';
 import { useTheme } from '../theme/ThemeContext';
 import { Glass } from '../theme/CupertinoTheme';
 import { CupertinoSwipeableRow } from '../components/CupertinoSwipeableRow';
 import { CupertinoPressable } from '../components/CupertinoPressable';
 import { GlassSurface, useAlert } from '../components';
 import { hapticImpact, hapticNotification } from '../utils/haptics';
+import { scrollDecelerationValue } from '../utils/motionIntensity';
 
 const getLauncher = async () => {
   try {
@@ -87,6 +89,7 @@ export function NotificationCenterScreen() {
   const insets = useSafeAreaInsets();
   const navigation = useNavigation();
   const { apps, launchApp } = useApps();
+  const { settings } = useSettings();
   const alert = useAlert();
 
   const [notifications, setNotifications] = useState<DeviceNotification[]>([]);
@@ -285,7 +288,7 @@ export function NotificationCenterScreen() {
             style={styles.scroll}
             contentContainerStyle={[styles.scrollContent, { paddingBottom: insets.bottom + 40 }]}
             showsVerticalScrollIndicator={false}
-            decelerationRate={0.998}
+            decelerationRate={scrollDecelerationValue(settings.scrollDeceleration)}
           >
             {groups.length === 0 ? (
               <View style={styles.emptyState}>

--- a/src/screens/PhoneScreen.tsx
+++ b/src/screens/PhoneScreen.tsx
@@ -16,6 +16,7 @@ import { StatusBar } from 'expo-status-bar';
 import type { CallLogEntry } from '../../modules/launcher-module/src';
 import { useDevice, DeviceContact } from '../store/DeviceStore';
 import { useContacts, Contact } from '../store/ContactsStore';
+import { useSettings } from '../store/SettingsStore';
 import { useTheme, ResolvedTypography } from '../theme/ThemeContext';
 import { CupertinoSegmentedControl } from '../components/CupertinoSegmentedControl';
 import { SkeletonListRow } from '../components';
@@ -23,6 +24,7 @@ import type { AppNavigationProp } from '../navigation/types';
 import type { CupertinoColors } from '../theme/CupertinoTheme';
 import { hapticImpact, hapticNotification } from '../utils/haptics';
 import { avatarColorForName } from '../utils/avatarColor';
+import { scrollDecelerationValue } from '../utils/motionIntensity';
 
 const getLauncher = async () => {
   try {
@@ -145,6 +147,7 @@ function FavoritesTab({ onCall }: { onCall: (phone: string, name?: string) => vo
   const insets = useSafeAreaInsets();
   const { favorites, toggleFavorite, deviceFavoriteIds } = useContacts();
   const { contacts: deviceContacts } = useDevice();
+  const { settings } = useSettings();
 
   // Merge store favorites + device contacts that are marked as favorite
   const allFavorites = useMemo(() => {
@@ -189,7 +192,7 @@ function FavoritesTab({ onCall }: { onCall: (phone: string, name?: string) => vo
     <FlatList
       data={allFavorites}
       keyExtractor={(item) => item.id}
-      decelerationRate={0.998}
+      decelerationRate={scrollDecelerationValue(settings.scrollDeceleration)}
       contentContainerStyle={{ paddingBottom: insets.bottom + 20 }}
       ItemSeparatorComponent={() => (
         <View style={[styles.separator, { backgroundColor: colors.separator, marginLeft: 72 }]} />
@@ -235,6 +238,7 @@ function RecentsTab({ onCall }: { onCall: (phone: string, name?: string) => void
   const { theme, typography } = useTheme();
   const { colors } = theme;
   const insets = useSafeAreaInsets();
+  const { settings } = useSettings();
   const [callLog, setCallLog] = useState<CallLogEntry[]>([]);
   const [permissionDenied, setPermissionDenied] = useState(false);
   const [callLogLoading, setCallLogLoading] = useState(true);
@@ -306,7 +310,7 @@ function RecentsTab({ onCall }: { onCall: (phone: string, name?: string) => void
   }
 
   return (
-    <ScrollView contentContainerStyle={{ paddingBottom: insets.bottom + 20 }} decelerationRate={0.998}>
+    <ScrollView contentContainerStyle={{ paddingBottom: insets.bottom + 20 }} decelerationRate={scrollDecelerationValue(settings.scrollDeceleration)}>
       <View style={{ backgroundColor: colors.secondarySystemGroupedBackground }}>
         {callLog.map((call, idx) => (
           <CallLogItem
@@ -329,6 +333,7 @@ function ContactsTab({ contacts, onCall, isLoading }: { contacts: DeviceContact[
   const { theme, typography } = useTheme();
   const { colors } = theme;
   const insets = useSafeAreaInsets();
+  const { settings } = useSettings();
 
   const sorted = useMemo(
     () =>
@@ -370,7 +375,7 @@ function ContactsTab({ contacts, onCall, isLoading }: { contacts: DeviceContact[
       testID="contacts-list"
       data={sorted}
       keyExtractor={(item) => item.id}
-      decelerationRate={0.998}
+      decelerationRate={scrollDecelerationValue(settings.scrollDeceleration)}
       contentContainerStyle={{ paddingBottom: insets.bottom + 20 }}
       ItemSeparatorComponent={() => (
         <View style={[styles.separator, { backgroundColor: colors.separator, marginLeft: 72 }]} />

--- a/src/screens/__tests__/LauncherHomeScreen.test.tsx
+++ b/src/screens/__tests__/LauncherHomeScreen.test.tsx
@@ -13,6 +13,7 @@ import {
 } from '../LauncherHomeScreen';
 import * as DeviceStore from '../../store/DeviceStore';
 import * as AppsStore from '../../store/AppsStore';
+import { useSettings } from '../../store/SettingsStore';
 import { Shape } from '../../theme/CupertinoTheme';
 
 function flattenStyle(style: unknown): Record<string, unknown>[] {
@@ -591,6 +592,34 @@ describe('LauncherHomeScreen pagination ScrollView deceleration (#490)', () => {
 
     const paginationScrollView = getByTestId('launcher-pager');
     expect(paginationScrollView.props.decelerationRate).toBe(0.998);
+  });
+
+  // #493: scrollDeceleration exposes the 0.998 literal above as a setting.
+  // 'fast' maps to 0.99 — see src/utils/motionIntensity.ts:scrollDecelerationValue.
+  // Drives the update directly via useSettings() rather than seeding
+  // AsyncStorage — the async hydration path is already covered by
+  // SettingsStore.motionIntensity.test.tsx, and depending on it here made
+  // this assertion flaky under full-suite load (passed in isolation, missed
+  // its waitFor window when 44 sibling tests ran first in the same file).
+  it('sets decelerationRate to 0.99 when scrollDeceleration is "fast"', async () => {
+    mockLoadedApps();
+
+    function SetScrollDeceleration() {
+      const { update } = useSettings();
+      React.useEffect(() => { update('scrollDeceleration', 'fast'); }, [update]);
+      return null;
+    }
+
+    const { getByTestId } = render(
+      <>
+        <SetScrollDeceleration />
+        <LauncherHomeScreen />
+      </>,
+    );
+
+    await waitFor(() =>
+      expect(getByTestId('launcher-pager').props.decelerationRate).toBe(0.99),
+    );
   });
 });
 

--- a/src/screens/settings/AccessibilityScreen.tsx
+++ b/src/screens/settings/AccessibilityScreen.tsx
@@ -19,11 +19,16 @@ const TEXT_SIZE_LABELS = ['Small', 'Default', 'Large', 'XL'];
 const FONT_CHOICE_LABELS = ['Inter', 'System'];
 const PRESS_FEEDBACK_LABELS = ['Scale & Opacity', 'Opacity Only', 'None'];
 const PRESS_FEEDBACK_VALUES = ['scale-opacity', 'opacity', 'none'] as const;
+// #493: 'full' molas + velocidade, 'reduced' o antigo binário Reduce Motion
+// (withTiming 180ms), 'off' salto directo sem transição.
+const MOTION_INTENSITY_LABELS = ['Full', 'Reduced', 'Off'];
+const MOTION_INTENSITY_VALUES = ['full', 'reduced', 'off'] as const;
+const SCROLL_DECELERATION_LABELS = ['Normal', 'Fast'];
+const SCROLL_DECELERATION_VALUES = ['normal', 'fast'] as const;
 
 const A11Y_KEYS = {
   textscale: '@iostoandroid/a11y_textscale',
   bold: '@iostoandroid/a11y_bold',
-  reduceMotion: '@iostoandroid/a11y_reduce_motion',
 } as const;
 
 export function AccessibilityScreen({ navigation }: { navigation: AppNavigationProp }) {
@@ -39,7 +44,6 @@ export function AccessibilityScreen({ navigation }: { navigation: AppNavigationP
   const [largerTextEnabled, setLargerTextEnabled] = useState(false);
   const [largerTextScale, setLargerTextScale] = useState(1.0);
   const [boldTextLocal, setBoldTextLocal] = useState(false);
-  const [reduceMotionLocal, setReduceMotionLocal] = useState(false);
 
   useEffect(() => {
     AsyncStorage.getMany(Object.values(A11Y_KEYS)).then((map) => {
@@ -49,7 +53,6 @@ export function AccessibilityScreen({ navigation }: { navigation: AppNavigationP
         setLargerTextEnabled(scale > 1.0);
       }
       if (map[A11Y_KEYS.bold] !== null) setBoldTextLocal(map[A11Y_KEYS.bold] === 'true');
-      if (map[A11Y_KEYS.reduceMotion] !== null) setReduceMotionLocal(map[A11Y_KEYS.reduceMotion] === 'true');
     });
   }, []);
 
@@ -71,13 +74,6 @@ export function AccessibilityScreen({ navigation }: { navigation: AppNavigationP
     update('boldText', v);
     AsyncStorage.setItem(A11Y_KEYS.bold, String(v));
   }, [update]);
-
-  const toggleReduceMotion = useCallback((v: boolean) => {
-    setReduceMotionLocal(v);
-    update('reduceMotion', v);
-    AsyncStorage.setItem(A11Y_KEYS.reduceMotion, String(v));
-  }, [update]);
-
 
   return (
     <View style={[styles.container, { backgroundColor: colors.systemGroupedBackground }]}>
@@ -105,16 +101,6 @@ export function AccessibilityScreen({ navigation }: { navigation: AppNavigationP
                 <CupertinoSwitch
                   value={boldTextLocal}
                   onValueChange={toggleBoldText}
-                />
-              }
-              showChevron={false}
-            />
-            <CupertinoListTile
-              title="Reduce Motion"
-              trailing={
-                <CupertinoSwitch
-                  value={reduceMotionLocal}
-                  onValueChange={toggleReduceMotion}
                 />
               }
               showChevron={false}
@@ -181,6 +167,41 @@ export function AccessibilityScreen({ navigation }: { navigation: AppNavigationP
                 </Text>
               </View>
             )}
+          </CupertinoListSection>
+        </View>
+
+        {/* Motion (#493) — motionIntensity replaces the old binary Reduce
+            Motion switch. Scroll deceleration lives here too: it's more
+            "General" than accessibility by category, but splitting the two
+            motion controls across two screens is worse than the category
+            mismatch, so they stay together. */}
+        <View style={{ paddingHorizontal: spacing.md }}>
+          <CupertinoListSection
+            header="Motion"
+            footer="Full uses springs with momentum. Reduced fades instead of springing. Off jumps directly with no transition at all. Haptic feedback is unaffected by any of these."
+          >
+            <View style={{ padding: spacing.md }}>
+              <CupertinoSegmentedControl
+                values={MOTION_INTENSITY_LABELS}
+                selectedIndex={MOTION_INTENSITY_VALUES.indexOf(settings.motionIntensity)}
+                onChange={(i) => update('motionIntensity', MOTION_INTENSITY_VALUES[i])}
+              />
+            </View>
+          </CupertinoListSection>
+        </View>
+
+        <View style={{ paddingHorizontal: spacing.md }}>
+          <CupertinoListSection
+            header="Scroll Deceleration"
+            footer="Controls how far lists coast after a swipe. Normal matches iOS's default inertia; Fast stops sooner."
+          >
+            <View style={{ padding: spacing.md }}>
+              <CupertinoSegmentedControl
+                values={SCROLL_DECELERATION_LABELS}
+                selectedIndex={SCROLL_DECELERATION_VALUES.indexOf(settings.scrollDeceleration)}
+                onChange={(i) => update('scrollDeceleration', SCROLL_DECELERATION_VALUES[i])}
+              />
+            </View>
           </CupertinoListSection>
         </View>
 

--- a/src/screens/settings/__tests__/AccessibilityScreen.test.tsx
+++ b/src/screens/settings/__tests__/AccessibilityScreen.test.tsx
@@ -47,10 +47,16 @@ describe('AccessibilityScreen', () => {
     expect(getByText('High Contrast')).toBeTruthy();
   });
 
-  it('renders Bold Text and Reduce Motion toggles unchanged', () => {
+  it('renders Bold Text toggle unchanged', () => {
     const { getByText } = render(<AccessibilityScreen navigation={mockNavigation as never} />);
     expect(getByText('Bold Text')).toBeTruthy();
-    expect(getByText('Reduce Motion')).toBeTruthy();
+  });
+
+  // #493: Reduce Motion (binary) was replaced by the Motion section's 3-way
+  // Full/Reduced/Off control — see the "Motion (#493)" describe block below.
+  it('does not render the old Reduce Motion switch label', () => {
+    const { queryByText } = render(<AccessibilityScreen navigation={mockNavigation as never} />);
+    expect(queryByText('Reduce Motion')).toBeNull();
   });
 
   // Red step: with the old shadow state, pressing the switch only updated local
@@ -66,9 +72,9 @@ describe('AccessibilityScreen', () => {
 
     expect(getByTestId('hc-value').props.children).toBe('false');
 
-    // Switch order in the Vision section: [0] Bold Text, [1] Reduce Motion, [2] High Contrast
+    // Switch order in the Vision section (#493 removed Reduce Motion): [0] Bold Text, [1] High Contrast
     const switches = getAllByRole('switch');
-    fireEvent.press(switches[2]);
+    fireEvent.press(switches[1]);
 
     expect(getByTestId('hc-value').props.children).toBe('true');
   });
@@ -88,10 +94,10 @@ describe('AccessibilityScreen', () => {
 
     expect(getByTestId('rt-value').props.children).toBe('false');
 
-    // Vision section order: [0] Bold Text, [1] Reduce Motion, [2] High Contrast,
-    // [3] Reduce Transparency, [4] Smart Invert, [5] Color Filters
+    // Vision section order (#493 removed Reduce Motion): [0] Bold Text, [1] High Contrast,
+    // [2] Reduce Transparency, [3] Smart Invert, [4] Color Filters
     const switches = getAllByRole('switch');
-    fireEvent.press(switches[3]);
+    fireEvent.press(switches[2]);
 
     expect(getByTestId('rt-value').props.children).toBe('true');
   });
@@ -239,10 +245,10 @@ describe('AccessibilityScreen — Reduce White Point (#614)', () => {
 
     expect(getByTestId('wp-value').props.children).toBe('false|1');
 
-    // Vision section order: Bold Text, Reduce Motion, High Contrast,
+    // Vision section order (#493 removed Reduce Motion): Bold Text, High Contrast,
     // Reduce Transparency, Smart Invert, Color Filters, Reduce White Point
     const switches = getAllByRole('switch');
-    fireEvent.press(switches[6]);
+    fireEvent.press(switches[5]);
 
     expect(getByTestId('wp-value').props.children).toBe('true|1');
   });
@@ -265,7 +271,7 @@ describe('AccessibilityScreen — Reduce White Point (#614)', () => {
 
     // turn on
     const switches = getAllByRole('switch');
-    fireEvent.press(switches[6]);
+    fireEvent.press(switches[5]);
     expect(getByTestId('wp-value').props.children).toBe('true|1');
 
     const sliders = UNSAFE_queryAllByType(CupertinoSlider);
@@ -288,9 +294,99 @@ describe('AccessibilityScreen — Reduce White Point (#614)', () => {
     );
 
     const switches = getAllByRole('switch');
-    fireEvent.press(switches[6]);
+    fireEvent.press(switches[5]);
     expect(getByTestId('wp-value').props.children).toBe('true|1');
-    fireEvent.press(switches[6]);
+    fireEvent.press(switches[5]);
     expect(getByTestId('wp-value').props.children).toBe('false|1');
+  });
+});
+
+// Reads motionIntensity + scrollDeceleration directly from SettingsStore —
+// proves the controls reach the global store, not just local screen state.
+function MotionReader() {
+  const { settings } = useSettings();
+  return (
+    <Text testID="motion-value">
+      {`${settings.motionIntensity}|${settings.scrollDeceleration}|${String(settings.reduceMotion)}`}
+    </Text>
+  );
+}
+
+describe('AccessibilityScreen — Motion (#493: motionIntensity + scrollDeceleration)', () => {
+  it('renders the Motion section with Full/Reduced/Off and defaults to Full', () => {
+    const { getByText, getAllByText, getByTestId } = render(
+      <>
+        <AccessibilityScreen navigation={mockNavigation as never} />
+        <MotionReader />
+      </>,
+    );
+    expect(getByText('Full')).toBeTruthy();
+    expect(getByText('Reduced')).toBeTruthy();
+    // 'Off' also labels the AssistiveTouch subtitle further down the screen
+    // (enabled: false in the mocked store) — the Motion segment is the first match.
+    expect(getAllByText('Off').length).toBeGreaterThanOrEqual(1);
+    expect(getByTestId('motion-value').props.children).toBe('full|normal|false');
+  });
+
+  it('selecting Reduced updates motionIntensity and derives reduceMotion=true', () => {
+    const { getByText, getByTestId } = render(
+      <>
+        <AccessibilityScreen navigation={mockNavigation as never} />
+        <MotionReader />
+      </>,
+    );
+
+    fireEvent.press(getByText('Reduced'));
+
+    expect(getByTestId('motion-value').props.children).toBe('reduced|normal|true');
+  });
+
+  it('selecting Off updates motionIntensity and derives reduceMotion=true', () => {
+    const { getAllByText, getByTestId } = render(
+      <>
+        <AccessibilityScreen navigation={mockNavigation as never} />
+        <MotionReader />
+      </>,
+    );
+
+    // First 'Off' match is the Motion segmented control (AssistiveTouch's
+    // subtitle 'Off' renders further down the screen).
+    fireEvent.press(getAllByText('Off')[0]);
+
+    expect(getByTestId('motion-value').props.children).toBe('off|normal|true');
+  });
+
+  it('selecting Off then Full again returns reduceMotion to false (no stuck state)', () => {
+    const { getByText, getAllByText, getByTestId } = render(
+      <>
+        <AccessibilityScreen navigation={mockNavigation as never} />
+        <MotionReader />
+      </>,
+    );
+
+    fireEvent.press(getAllByText('Off')[0]);
+    expect(getByTestId('motion-value').props.children).toBe('off|normal|true');
+
+    fireEvent.press(getByText('Full'));
+    expect(getByTestId('motion-value').props.children).toBe('full|normal|false');
+  });
+
+  it('renders the Scroll Deceleration section with Normal/Fast, defaults to Normal', () => {
+    const { getByText } = render(<AccessibilityScreen navigation={mockNavigation as never} />);
+    expect(getByText('Normal')).toBeTruthy();
+    expect(getByText('Fast')).toBeTruthy();
+  });
+
+  it('selecting Fast updates scrollDeceleration without touching motionIntensity', () => {
+    const { getByText, getByTestId } = render(
+      <>
+        <AccessibilityScreen navigation={mockNavigation as never} />
+        <MotionReader />
+      </>,
+    );
+
+    fireEvent.press(getByText('Fast'));
+
+    expect(getByTestId('motion-value').props.children).toBe('full|fast|false');
   });
 });

--- a/src/store/SettingsStore.tsx
+++ b/src/store/SettingsStore.tsx
@@ -25,6 +25,14 @@ import {
   normalizeFocusPageVisibility,
   type FocusPageVisibility,
 } from '../utils/focusPageVisibility';
+import {
+  type MotionIntensity,
+  type ScrollDeceleration,
+  DEFAULT_MOTION_INTENSITY,
+  DEFAULT_SCROLL_DECELERATION,
+  normalizeMotionIntensity,
+  normalizeScrollDeceleration,
+} from '../utils/motionIntensity';
 
 const STORAGE_KEY = '@iostoandroid/settings';
 
@@ -105,7 +113,29 @@ export interface SettingsState {
   batteryPercentage: boolean;
   locationServices: boolean;
   wallpaperIndex: number;
+  /**
+   * §3.3 (issue #493): substituído como fonte de verdade por `motionIntensity`.
+   * Mantido apenas como campo derivado (`motionIntensity !== 'full'`), exposto
+   * em runtime pelo SettingsProvider para não quebrar os ~20 consumidores
+   * actuais de useGestureReduceMotion(). Escrever directamente aqui via
+   * `update('reduceMotion', ...)` não tem efeito — a próxima leitura do
+   * contexto sobrepõe sempre o valor derivado.
+   */
   reduceMotion: boolean;
+  /**
+   * Intensidade do movimento (§3.3, issue #493): 'full' = molas com
+   * velocidade, 'reduced' = withTiming 180ms (o que reduceMotion fazia até
+   * aqui), 'off' = salto directo sem transição. Cortar animação nunca corta
+   * háptica (§3.2 regra 4) — verificado em NotificationBanner, AssistiveTouch
+   * e CupertinoSwipeableRow.
+   */
+  motionIntensity: MotionIntensity;
+  /**
+   * Desaceleração do scroll (§3.1, issue #493): 'normal' = 0.998 (o literal
+   * já usado nas listas com paginação/inércia), 'fast' = 0.99 (mais travado).
+   * Ver src/utils/motionIntensity.ts:scrollDecelerationValue.
+   */
+  scrollDeceleration: ScrollDeceleration;
   reduceTransparency: boolean;
   /** iOS «Reduce White Point»: dims the brightest colours via a dark overlay over the root container. */
   reduceWhitePoint: boolean;
@@ -322,6 +352,8 @@ export const DEFAULT_SETTINGS: SettingsState = {
   locationServices: true,
   wallpaperIndex: 0,
   reduceMotion: false,
+  motionIntensity: DEFAULT_MOTION_INTENSITY,
+  scrollDeceleration: DEFAULT_SCROLL_DECELERATION,
   reduceTransparency: false,
   reduceWhitePoint: false,
   whitePointLevel: 1.0,
@@ -437,6 +469,12 @@ export function SettingsProvider({
             // render → ecrã branco. Saneia-se na leitura, à semelhança dos
             // campos acima.
             wallpaperIndex: clampWallpaperIndex(parsed?.wallpaperIndex),
+            // motionIntensity (#493) substitui reduceMotion como fonte de
+            // verdade; um blob pré-#493 só tem `reduceMotion: true|false`, por
+            // isso migra-se para 'reduced'|'full'. Um motionIntensity já
+            // presente e válido vence sempre o campo legado.
+            motionIntensity: normalizeMotionIntensity(parsed?.motionIntensity, parsed?.reduceMotion),
+            scrollDeceleration: normalizeScrollDeceleration(parsed?.scrollDeceleration),
           }));
         } catch { /* ignore */ }
       }
@@ -557,9 +595,26 @@ export function SettingsProvider({
   /** activeFocusMode: null when focus is off, otherwise the current mode string. */
   const activeFocusMode = settings.focusMode === 'off' ? null : settings.focusMode;
 
+  // reduceMotion (#493): derivado de motionIntensity a cada exposição, nunca
+  // lido directamente do state — só assim update('motionIntensity', ...)
+  // propaga instantaneamente para os consumidores legados do booleano.
+  const exposedSettings = useMemo(
+    () => ({ ...settings, reduceMotion: settings.motionIntensity !== 'full' }),
+    [settings],
+  );
+
   const value = useMemo(
-    () => ({ settings, update, updateMany, reset, syncFromDevice, isReady, activeFocusMode, setFocusMode }),
-    [settings, update, updateMany, reset, syncFromDevice, isReady, activeFocusMode, setFocusMode],
+    () => ({
+      settings: exposedSettings,
+      update,
+      updateMany,
+      reset,
+      syncFromDevice,
+      isReady,
+      activeFocusMode,
+      setFocusMode,
+    }),
+    [exposedSettings, update, updateMany, reset, syncFromDevice, isReady, activeFocusMode, setFocusMode],
   );
 
   if (gateFirstRender && !firstSyncDone) return null;

--- a/src/store/__tests__/SettingsStore.motionIntensity.test.tsx
+++ b/src/store/__tests__/SettingsStore.motionIntensity.test.tsx
@@ -1,0 +1,142 @@
+import React from 'react';
+import { Text } from 'react-native';
+import { render, waitFor, act } from '@testing-library/react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { SettingsProvider, useSettings } from '../SettingsStore';
+
+// issue #493: `motionIntensity` ('full'|'reduced'|'off') substitui e
+// generaliza `reduceMotion` (binário). `reduceMotion` continua exposto,
+// derivado de motionIntensity !== 'full', para os ~20 consumidores actuais
+// de useGestureReduceMotion(). Blobs persistidos antes do #493 só tinham
+// `reduceMotion: true|false` — migram para motionIntensity 'reduced'|'full'.
+
+function Probe() {
+  const { settings, isReady } = useSettings();
+  return (
+    <Text>
+      {`ready=${isReady} mi=${settings.motionIntensity} rm=${settings.reduceMotion} sd=${settings.scrollDeceleration}`}
+    </Text>
+  );
+}
+
+function renderWithStored(blob: unknown) {
+  (AsyncStorage.getItem as jest.Mock).mockImplementation((key: string) =>
+    Promise.resolve(key === '@iostoandroid/settings' ? JSON.stringify(blob) : null),
+  );
+  return render(
+    <SettingsProvider gateFirstRender={false}>
+      <Probe />
+    </SettingsProvider>,
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+  (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
+});
+
+describe('SettingsProvider — motionIntensity (#493)', () => {
+  it('default é "full" com reduceMotion derivado false, sem nada persistido', async () => {
+    const utils = renderWithStored(null);
+    await waitFor(() =>
+      expect(utils.getByText('ready=true mi=full rm=false sd=normal')).toBeTruthy(),
+    );
+  });
+
+  it('migra reduceMotion:true legado (pré-#493) para motionIntensity "reduced"', async () => {
+    const utils = renderWithStored({ reduceMotion: true });
+    await waitFor(() =>
+      expect(utils.getByText('ready=true mi=reduced rm=true sd=normal')).toBeTruthy(),
+    );
+  });
+
+  it('migra reduceMotion:false legado para motionIntensity "full"', async () => {
+    const utils = renderWithStored({ reduceMotion: false });
+    await waitFor(() =>
+      expect(utils.getByText('ready=true mi=full rm=false sd=normal')).toBeTruthy(),
+    );
+  });
+
+  it('um motionIntensity já persistido vence o campo reduceMotion legado', async () => {
+    const utils = renderWithStored({ reduceMotion: false, motionIntensity: 'off' });
+    await waitFor(() =>
+      expect(utils.getByText('ready=true mi=off rm=true sd=normal')).toBeTruthy(),
+    );
+  });
+
+  it('saneia motionIntensity corrompido (string inválida) para "full"', async () => {
+    const utils = renderWithStored({ motionIntensity: 'ultra-fast' });
+    await waitFor(() =>
+      expect(utils.getByText('ready=true mi=full rm=false sd=normal')).toBeTruthy(),
+    );
+  });
+
+  it('hidrata scrollDeceleration "fast" persistido', async () => {
+    const utils = renderWithStored({ scrollDeceleration: 'fast' });
+    await waitFor(() =>
+      expect(utils.getByText('ready=true mi=full rm=false sd=fast')).toBeTruthy(),
+    );
+  });
+
+  it('saneia scrollDeceleration corrompido para "normal"', async () => {
+    const utils = renderWithStored({ scrollDeceleration: 'ludicrous' });
+    await waitFor(() =>
+      expect(utils.getByText('ready=true mi=full rm=false sd=normal')).toBeTruthy(),
+    );
+  });
+});
+
+describe('SettingsProvider — reduceMotion derivado (#493)', () => {
+  function Toggler() {
+    const { settings, update } = useSettings();
+    return (
+      <Text
+        testID="toggle"
+        onPress={() => update('motionIntensity', 'off')}
+      >
+        {`mi=${settings.motionIntensity} rm=${settings.reduceMotion}`}
+      </Text>
+    );
+  }
+
+  it('reduceMotion acompanha motionIntensity em tempo real quando actualizado via update()', async () => {
+    const utils = render(
+      <SettingsProvider gateFirstRender={false}>
+        <Toggler />
+      </SettingsProvider>,
+    );
+    await waitFor(() => expect(utils.getByText('mi=full rm=false')).toBeTruthy());
+
+    act(() => {
+      utils.getByText('mi=full rm=false').props.onPress();
+    });
+
+    await waitFor(() => expect(utils.getByText('mi=off rm=true')).toBeTruthy());
+  });
+
+  it('persiste motionIntensity entre "arranques" (escreve no AsyncStorage e a próxima hidratação lê o valor)', async () => {
+    const utils = render(
+      <SettingsProvider gateFirstRender={false}>
+        <Toggler />
+      </SettingsProvider>,
+    );
+    await waitFor(() => expect(utils.getByText('mi=full rm=false')).toBeTruthy());
+
+    act(() => {
+      utils.getByText('mi=full rm=false').props.onPress();
+    });
+    await waitFor(() => expect(utils.getByText('mi=off rm=true')).toBeTruthy());
+
+    await waitFor(() => expect(AsyncStorage.setItem as jest.Mock).toHaveBeenCalled());
+    const [, storedJson] = (AsyncStorage.setItem as jest.Mock).mock.calls.at(-1) as [string, string];
+    const stored = JSON.parse(storedJson);
+    expect(stored.motionIntensity).toBe('off');
+
+    // Novo "arranque": nova instância do provider a ler o blob gravado.
+    const second = renderWithStored(stored);
+    await waitFor(() =>
+      expect(second.getByText('ready=true mi=off rm=true sd=normal')).toBeTruthy(),
+    );
+  });
+});

--- a/src/utils/__tests__/motionIntensity.test.ts
+++ b/src/utils/__tests__/motionIntensity.test.ts
@@ -1,0 +1,59 @@
+import {
+  normalizeMotionIntensity,
+  normalizeScrollDeceleration,
+  scrollDecelerationValue,
+} from '../motionIntensity';
+
+describe('normalizeMotionIntensity (#493)', () => {
+  it('preserva os 3 valores válidos', () => {
+    expect(normalizeMotionIntensity('full')).toBe('full');
+    expect(normalizeMotionIntensity('reduced')).toBe('reduced');
+    expect(normalizeMotionIntensity('off')).toBe('off');
+  });
+
+  it('migra reduceMotion:true legado para "reduced" quando motionIntensity está ausente', () => {
+    expect(normalizeMotionIntensity(undefined, true)).toBe('reduced');
+  });
+
+  it('cai em "full" quando ambos estão ausentes', () => {
+    expect(normalizeMotionIntensity(undefined, undefined)).toBe('full');
+  });
+
+  it('cai em "full" quando reduceMotion legado é false', () => {
+    expect(normalizeMotionIntensity(undefined, false)).toBe('full');
+  });
+
+  it('um motionIntensity já válido vence sempre o campo legado, mesmo contraditório', () => {
+    expect(normalizeMotionIntensity('full', true)).toBe('full');
+    expect(normalizeMotionIntensity('off', false)).toBe('off');
+  });
+
+  it('saneia lixo (número, objecto, string desconhecida, null) para "full"', () => {
+    expect(normalizeMotionIntensity(42)).toBe('full');
+    expect(normalizeMotionIntensity({})).toBe('full');
+    expect(normalizeMotionIntensity('fast')).toBe('full');
+    expect(normalizeMotionIntensity(null)).toBe('full');
+    expect(normalizeMotionIntensity('')).toBe('full');
+  });
+});
+
+describe('normalizeScrollDeceleration (#493)', () => {
+  it('preserva "fast" e "normal"', () => {
+    expect(normalizeScrollDeceleration('fast')).toBe('fast');
+    expect(normalizeScrollDeceleration('normal')).toBe('normal');
+  });
+
+  it('saneia lixo e ausência para "normal"', () => {
+    expect(normalizeScrollDeceleration(undefined)).toBe('normal');
+    expect(normalizeScrollDeceleration(null)).toBe('normal');
+    expect(normalizeScrollDeceleration('rapido')).toBe('normal');
+    expect(normalizeScrollDeceleration(0.99)).toBe('normal');
+  });
+});
+
+describe('scrollDecelerationValue (#493)', () => {
+  it('mapeia normal para 0.998 e fast para 0.99', () => {
+    expect(scrollDecelerationValue('normal')).toBe(0.998);
+    expect(scrollDecelerationValue('fast')).toBe(0.99);
+  });
+});

--- a/src/utils/__tests__/useGestureReduceMotion.test.ts
+++ b/src/utils/__tests__/useGestureReduceMotion.test.ts
@@ -66,4 +66,33 @@ describe('settle()', () => {
     expect(() => settle(100, 'mediumSettle', true, 999)).not.toThrow();
     expect(settle(100, 'mediumSettle', true, 999)).toBe(100);
   });
+
+  // #493: settle() now also accepts the tri-state MotionIntensity directly,
+  // so the 3 named haptic-anchor components can pass it through without a
+  // boolean-collapsing step. Per the file-level note above, the mocked
+  // withSpring/withTiming are both identity here AND settle() is 'worklet'
+  // (closure-captured by the reanimated Babel plugin), so these assertions
+  // are compile/no-throw/pass-through smoke tests, same class as the
+  // pre-existing boolean cases above — they do NOT prove which branch ran.
+  // That proof lives at the component level instead (NotificationBanner's
+  // motionIntensity branch is plain JS, not a worklet, so it CAN be spied on
+  // — see NotificationBanner.motionIntensity.test.tsx).
+  it('accepts "full" as an explicit tri-state value, equivalent to reduceMotion=false', () => {
+    expect(() => settle(100, 'mediumSettle', 'full', 500)).not.toThrow();
+    expect(settle(100, 'mediumSettle', 'full', 500)).toBe(100);
+  });
+
+  it('accepts "reduced" as an explicit tri-state value, equivalent to reduceMotion=true', () => {
+    expect(() => settle(100, 'mediumSettle', 'reduced', 500)).not.toThrow();
+    expect(settle(100, 'mediumSettle', 'reduced', 500)).toBe(100);
+  });
+
+  it('accepts "off" without throwing and resolves to the target value with no velocity requirement', () => {
+    expect(() => settle(100, 'mediumSettle', 'off')).not.toThrow();
+    expect(settle(100, 'mediumSettle', 'off')).toBe(100);
+  });
+
+  it('"off" ignores an extreme velocity — no animation, so momentum is irrelevant', () => {
+    expect(settle(42, 'mediumSettle', 'off', 99999)).toBe(42);
+  });
 });

--- a/src/utils/motionIntensity.ts
+++ b/src/utils/motionIntensity.ts
@@ -1,0 +1,39 @@
+/**
+ * §3.1/§3.3 (issue #493): the launcher used to hard-code its motion feel — a
+ * binary `reduceMotion` and a literal `0.998` scroll deceleration baked into
+ * every ScrollView. Both numbers are estimates the spec itself flags as
+ * needing calibration, so they're exposed as settings instead of constants.
+ */
+export type MotionIntensity = 'full' | 'reduced' | 'off';
+export const DEFAULT_MOTION_INTENSITY: MotionIntensity = 'full';
+
+const VALID_MOTION_INTENSITY: readonly MotionIntensity[] = ['full', 'reduced', 'off'];
+
+/**
+ * Normalizes a persisted `motionIntensity` value on AsyncStorage hydration.
+ * `legacyReduceMotion` migrates pre-#493 blobs that only ever wrote the
+ * boolean `reduceMotion` field: `true` becomes `'reduced'` (the exact
+ * behaviour `reduceMotion` used to produce), anything else falls back to the
+ * default `'full'`. An already-valid `motionIntensity` always wins over the
+ * legacy field, so re-hydrating a blob written by this version never
+ * regresses to the migration path.
+ */
+export function normalizeMotionIntensity(value: unknown, legacyReduceMotion?: unknown): MotionIntensity {
+  if (typeof value === 'string' && (VALID_MOTION_INTENSITY as readonly string[]).includes(value)) {
+    return value as MotionIntensity;
+  }
+  if (legacyReduceMotion === true) return 'reduced';
+  return DEFAULT_MOTION_INTENSITY;
+}
+
+export type ScrollDeceleration = 'normal' | 'fast';
+export const DEFAULT_SCROLL_DECELERATION: ScrollDeceleration = 'normal';
+
+export function normalizeScrollDeceleration(value: unknown): ScrollDeceleration {
+  return value === 'fast' ? 'fast' : DEFAULT_SCROLL_DECELERATION;
+}
+
+/** iOS-observed deceleration constants (§3.1) — 'fast' is the tighter iPadOS-style curve. */
+export function scrollDecelerationValue(pref: ScrollDeceleration): number {
+  return pref === 'fast' ? 0.99 : 0.998;
+}

--- a/src/utils/useGestureReduceMotion.ts
+++ b/src/utils/useGestureReduceMotion.ts
@@ -1,10 +1,21 @@
 import { useSettings } from '../store/SettingsStore';
 import { gestureConfig } from './gestureConfig';
 import { Easing, withSpring, withTiming } from 'react-native-reanimated';
+import type { MotionIntensity } from './motionIntensity';
 
 export function useGestureReduceMotion() {
   const { settings } = useSettings();
   return settings.reduceMotion;
+}
+
+/**
+ * Tri-state motion preference (#493). Consumers that need to distinguish
+ * 'reduced' (withTiming) from 'off' (no transition at all) read this instead
+ * of the boolean useGestureReduceMotion() — settle() below accepts either.
+ */
+export function useMotionIntensity(): MotionIntensity {
+  const { settings } = useSettings();
+  return settings.motionIntensity;
 }
 
 type SpringPreset = keyof typeof gestureConfig.spring | { stiffness: number; damping: number; mass?: number };
@@ -23,9 +34,25 @@ export function resolveSpringConfig(preset: SpringPreset, velocity: number) {
 // Usage: settle(finalValue, 'mediumSettle', reduceMotion, velocity)
 // NOTE: this helper is intended to be CALLED from a worklet; it returns the Reanimated
 // animation primitive to assign to a shared value.
-export function settle(value: number, preset: SpringPreset, reduceMotion: boolean, velocity = 0) {
+//
+// The 3rd param accepts either the legacy boolean (33 existing call-sites,
+// unaffected) or the tri-state MotionIntensity (#493): 'off' returns the raw
+// value with no animation function at all, so `sharedValue.value = settle(...)`
+// snaps instantly instead of interpolating.
+export function settle(
+  value: number,
+  preset: SpringPreset,
+  reduceMotion: boolean | MotionIntensity,
+  velocity = 0,
+) {
   'worklet';
-  if (reduceMotion) {
+  if (reduceMotion === 'off') {
+    return value;
+  }
+  if (reduceMotion === 'full') {
+    return withSpring(value, resolveSpringConfig(preset, velocity));
+  }
+  if (reduceMotion === 'reduced' || reduceMotion === true) {
     return withTiming(value, { duration: 180, easing: Easing.out(Easing.cubic) });
   }
   return withSpring(value, resolveSpringConfig(preset, velocity));


### PR DESCRIPTION
## Resumo

resolve conflito de merge em SettingsStore.tsx e valida motionIntensity (full/reduced/off) + scrollDeceleration (normal/fast) — háptica independente com 'off' testada nos 3 pontos

## Causa raiz

O branch `qa/issue-493` já continha a implementação completa do #493 (committed em `2cd1e94`): `motionIntensity` ('full'|'reduced'|'off') substitui e generaliza o `reduceMotion` binário, `scrollDeceleration` ('normal'|'fast') expõe a inércia `0.998`/`0.99`, `reduceMotion` passa a getter derivado (`motionIntensity !== 'full'`), e os blobs persistidos pré-#493 (`reduceMotion:true`) migram para `'reduced'`. O PR #763 foi bloqueado **apenas** por estar em conflito de merge com `origin/main`, não por problema de código. O conflito situava-se exclusivamente na secção de imports de `src/store/SettingsStore.tsx`: o nosso lado adicionara os imports de `../utils/motionIntensity` e o `origin/main` adicionara `normalizeFocusDockOverride` de `../utils/focusDockOverride`. Eram adições independentes e mutuamente necessárias — não havia sobreposição semântica.

## O que mudou

- `src/store/SettingsStore.tsx` — **resolução do conflito de merge** (únicas linhas que toquei nesta corrida). Mantive ambos os blocos de import: `motionIntensity` (lado #493) e `focusDockOverride` (lado `origin/main`). O resto do ficheiro já tinha o fix issue 493 intacto (campos `motionIntensity`/`scrollDeceleration` em `SettingsState` e `DEFAULT_SETTINGS`, hidratação via `normalizeMotionIntensity`/`normalizeScrollDeceleration`, e derivação `reduceMotion` no `exposedSettings`). Nenhuma outra alteração de produção foi feita — o trabalho do issue já estava feito e confirmado verde no branch.
- Os restantes 19 ficheiros da lista são do commit `2cd1e94` (já no branch antes desta corrida): o util `motionIntensity.ts`, o ecrã `AccessibilityScreen.tsx` (segmentados Full/Reduced/Off + Normal/Fast), os 3 consumidores de háptica (`NotificationBanner.tsx`, `AssistiveTouch.tsx`, `CupertinoSwipeableRow.tsx`), os consumidores de lista (`LauncherHomeScreen.tsx`, `ContactsScreen.tsx`, `MessagesScreen.tsx`, `NotificationCenterScreen.tsx`, `PhoneScreen.tsx`) e os respectivos testes. O dif de `origin/main...HEAD` nestes é do #493, não meu.

## Porque assim

O conflito era puramente aditivo: escolher `--ours` ou `--theirs` apagaria o trabalho do outro lado (o #493 perderia os imports novos, ou o `focusDockOverride` do `origin/main` perder-se-ia). Resolvi por **intenção** — preservei as duas intenções, colando os dois blocos de import sequenciais. O `git add` + suite completa confirmam que não há regressão. Não havia alternativa a considerar: o diff `origin/main...HEAD` mostra que ambos os lados são reais e precisam de coexistir.

## Critérios de aceitação

- [x] `motionIntensity` com 3 estados, com efeito visível em cada — `NotificationBanner.motionIntensity.test.tsx` afirma que 'full' entra via `withSpring`, 'reduced' via `withTiming(150)`, 'off' salta direto (sem `withSpring` nem `withTiming`). `AccessibilityScreen.test.tsx` afirma os 3 segmentos e que cada um escreve o valor no store.
- [x] `reduceMotion` continua a funcionar para os consumidores actuais, derivado do campo novo — `SettingsStore.motionIntensity.test.tsx` (teste "reduceMotion acompanha motionIntensity em tempo real quando actualizado via update()") prova que `update('motionIntensity','off')` propaga `reduceMotion=true` instantaneamente para os ~20 consumidores de `useGestureReduceMotion()`.
- [x] Valores antigos de `reduceMotion` persistidos migram para `'reduced'` — `SettingsStore.motionIntensity.test.tsx` (teste "migra reduceMotion:true legado (pré-#493) para motionIntensity 'reduced'" e "reduceMotion:false legado para 'full'").
- [x] **Teste explícito: com `'off'`, a háptica continua a disparar** nos três pontos — `NotificationBanner.motionIntensity.test.tsx` (`Haptics.notificationAsync` chamado com 'off'), `AssistiveTouch.motionIntensity.test.tsx` (`Haptics.selectionAsync` no drag-end com 'off'), `CupertinoSwipeableRow.test.tsx` (`Haptics.impactAsync` no swipe com 'off'). Isto trava a §3.2 regra 4 (cortar animação não corta háptica).
- [x] `scrollDeceleration` altera de facto a inércia — `motionIntensity.ts:scrollDecelerationValue` mapeia 'normal'→0.998 / 'fast'→0.99; `AccessibilityScreen.test.tsx` afirma que selecionar Fast escreve `scrollDeceleration:'fast'` sem mexer em `motionIntensity`, e as listas (`LauncherHomeScreen`, `Contacts`, `Messages`, `NotificationCenter`, `Phone`) consomem `scrollDecelerationValue(settings.scrollDeceleration)`.
- [x] Definições persistem entre arranques — `SettingsStore.motionIntensity.test.tsx` (teste "persiste motionIntensity entre 'arranques'") grava no AsyncStorage e relê o blob numa segunda instância do provider.
- [x] O que NÃO devia mudar: `focusDockOverride` (do `origin/main`, #619) continua presente e a hidratar-se em `SettingsStore.tsx:465`; os 7 warnings de lint pré-existentes não aumentaram; as 23 falhas de teste da baseline não subiram (ver abaixo).

## Testes

- **Passo vermelho:** reverti seletivamente o mecanismo de produção — `normalizeMotionIntensity` passou a ignorar `legacyReduceMotion` (sempre 'full') e a derivação `reduceMotion` em `SettingsStore.tsx` passou a `false` constante. Corrida real:

```
FAIL Android src/store/__tests__/SettingsStore.motionIntensity.test.tsx (5.608 s)
  ● SettingsProvider — motionIntensity (#493) › migra reduceMotion:true legado (pré-#493) para motionIntensity "reduced"
    Unable to find an element with text: ready=true mi=reduced rm=true sd=normal
    <Text> ready=true mi=full rm=false sd=normal </Text>
      at Object.<anonymous> (src/store/__tests__/SettingsStore.motionIntensity.test.tsx:49:18)
  ● SettingsProvider — motionIntensity (#493) › um motionIntensity já persistido vence o campo reduceMotion legado
      at src/store/__tests__/SettingsStore.motionIntensity.test.tsx:63:18
  ● SettingsProvider — motionIntensity (#493) › hidrata scrollDeceleration "fast" persistido
      at src/store/__tests__/SettingsStore.motionIntensity.test.tsx:77:18
  ● SettingsProvider — reduceMotion derivado (#493) › reduceMotion acompanha motionIntensity em tempo real quando actualizado via update()
      at src/store/__tests__/SettingsStore.motionIntensity.test.tsx:115:18
  ● SettingsProvider — reduceMotion derivado (#493) › persiste motionIntensity entre "arranques"
      at src/store/__tests__/SettingsStore.motionIntensity.test.tsx:129:18
FAIL Android src/screens/settings/__tests__/AccessibilityScreen.test.tsx
  ● AccessibilityScreen — Motion (#493: motionIntensity + scrollDeceleration) › selecting Reduced updates motionIntensity and derives reduceMotion=true
    Expected: "reduced|normal|true"  Received: "reduced|normal|false"
      at src/screens/settings/__tests__/AccessibilityScreen.test.tsx:341:56
  ● ... selecting Off updates motionIntensity and derives reduceMotion=true
      at src/screens/settings/__tests__/AccessibilityScreen.test.tsx:356:56
  ● ... selecting Off then Full again returns reduceMotion to false (no stuck state)
      at src/screens/settings/__tests__/AccessibilityScreen.test.tsx:368:56
Test Suites: 2 failed, 2 total
Tests:       8 failed, 26 passed, 34 total
```

  Após restaurar os ficheiros de produção a partir de backup, os 8 testes voltam a passar — prova que estão ligados ao comportamento, não a um mock.

- **Casos cobertos (além do caminho feliz):** fronteiras/inválido — `normalizeMotionIntensity` saneia string inválida (`'ultra-fast'`) para 'full'; `normalizeScrollDeceleration` saneia valor corrompido (`'ludicrous'`) para 'normal'. Migração — `reduceMotion:true`→'reduced', `reduceMotion:false`→'full', e motionIntensity já presente vence o legacy. Inverso do fix — em 'off' a animação salta mas a háptica dispara (3 pontos). Repetição — Off→Full→Off não deixa estado encravado (`reduceMotion` volta a false). Persistência — grava no AsyncStorage e relê. Cada teste falha por uma razão diferente (migração, derivação em tempo real, persistência, segmento de UI, háptica).

- **Sanity-check:** reverti o mecanismo de produção (backup em `/tmp/redstep/`), a suite falhou com 8 testes (acima), restaurei com `cp` dos backups, e os 52 testes dos 6 ficheiros do #493 voltaram a passar (`6 passed, 52 passed`). Confirmado.

- **Resultados das verificações obrigatórias:**
  - `npm run lint` → 0 erros, 7 warnings (pré-existentes, iguais à baseline).
  - `npx tsc --noEmit` → limpo (exit 0).
  - `npm test -- --maxWorkers=2` → 2069 passaram, 23 falharam, 6 suites falharam. As 23 falhas são **exatamente as da baseline** (`jq -r '.failed_tests[]' state/baseline.json`, comparadas via JSON do jest) — zero falhas novas introduzidas por este trabalho. Diff: as 23 falhas batem 1-a-1 com a baseline (formatação `Suite › test` vs `Suite test`).

## Nota sobre o epic #467

Este issue é filho de #467. O trabalho de código está concluído e o PR #763 (já aberto) volta a ficar integravel em `main` após esta resolução de conflito. Quem fizer o merge deve, no epic #467: (1) marcar a checkbox deste sub-issue; (2) acrescentar `- [x] #493 — motionIntensity + scrollDeceleration (PR #763)`; (3) sem desvios — o escopo do issue cobriu exatamente o que o epic pedia (3 estados de intensidade + inércia do scroll + háptica independente).

## Testes

52 passaram (6 suites do #493), 0 falharam nos testes do issue; npm test completo: 2069 passaram, 23 falharam (idênticas à baseline), 6 suites falharam (pré-existentes)

## Linked Issue

Fixes #493