### PR TITLE
qa/issue-619: override do dock por modo de Focus (LauncherHomeScreen render + picker no FocusScreen) (#619)

### DIFF
--- a/src/screens/LauncherHomeScreen.tsx
+++ b/src/screens/LauncherHomeScreen.tsx
@@ -76,6 +76,7 @@ import type { SettingsState } from '../store/SettingsStore';
 import { hapticImpact, hapticSelection } from '../utils/haptics';
 import { computeLauncherGridGeometry } from '../utils/launcherGridGeometry';
 import { hiddenPageIndicesForMode, filterVisiblePages } from '../utils/focusPageVisibility';
+import { dockOverrideForMode } from '../utils/focusDockOverride';
 import { clampWithRubberBand } from '../theme/motion';
 
 // ---------------------------------------------------------------------------
@@ -1286,6 +1287,29 @@ export function LauncherHomeScreen() {
     [allPages, hiddenPageIndices],
   );
 
+  // Focus dock override (#619, filho de #617): com um modo de Focus activo,
+  // `focusDockOverride[focusMode]` pode substituir os 4 ícones do dock por
+  // outros pacotes. `dockOverrideForMode` já trata 'off', chave ausente e
+  // lista vazia como "sem override" (devolve null), por isso o fallback para
+  // o `dockApps` normal cobre esses três casos de uma vez. Os package names
+  // resolvem contra `apps` (todos os instalados) e o `dockApps` real (cobre
+  // apps virtuais já resolvidos, ex.: Phone/Messages, que só existem como
+  // InstalledApp dentro do dock persistido) — um package que já não existe em
+  // nenhum dos dois é descartado, nunca renderiza um ícone vazio/quebrado.
+  const dockOverridePkgs = useMemo(
+    () => dockOverrideForMode(settings.focusDockOverride, settings.focusMode),
+    [settings.focusDockOverride, settings.focusMode],
+  );
+  const effectiveDockApps: InstalledApp[] = useMemo(() => {
+    if (!dockOverridePkgs) return dockApps;
+    const byPackageName = new Map<string, InstalledApp>();
+    for (const app of apps) byPackageName.set(app.packageName, app);
+    for (const app of dockApps) byPackageName.set(app.packageName, app);
+    return dockOverridePkgs
+      .map((pkg) => byPackageName.get(pkg))
+      .filter((app): app is InstalledApp => !!app);
+  }, [dockOverridePkgs, dockApps, apps]);
+
   // +1 for the App Library page appended at the end
   const totalPages = pages.length + 1;
 
@@ -1772,14 +1796,14 @@ export function LauncherHomeScreen() {
       {/* ---------------------------------------------------------------- */}
       {/* Dock                                                               */}
       {/* ---------------------------------------------------------------- */}
-      <View style={[styles.dockOuter, { paddingBottom: insets.bottom + 16 }]}>
+      <View testID="launcher-dock" style={[styles.dockOuter, { paddingBottom: insets.bottom + 16 }]}>
         <GlassSurface
           intensity={90}
           tint="dark"
           style={styles.dockBlur}
         >
           <View style={styles.dockRow}>
-            {dockApps.slice(0, 4).map((app) => (
+            {effectiveDockApps.slice(0, 4).map((app) => (
               <AppIcon
                 key={app.packageName}
                 app={app}
@@ -1794,7 +1818,7 @@ export function LauncherHomeScreen() {
               />
             ))}
             {/* Fill empty dock slots */}
-            {Array.from({ length: Math.max(0, 4 - dockApps.length) }).map((_, i) => (
+            {Array.from({ length: Math.max(0, 4 - effectiveDockApps.length) }).map((_, i) => (
               <View key={`empty-${i}`} style={{ width: DOCK_CELL_WIDTH }} />
             ))}
           </View>

--- a/src/screens/__tests__/LauncherHomeScreen.test.tsx
+++ b/src/screens/__tests__/LauncherHomeScreen.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { View as RNView, StyleSheet } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { render, fireEvent, within, waitFor } from '../../test-utils';
+import { render, fireEvent, within, waitFor, act } from '../../test-utils';
 import {
   LauncherHomeScreen,
   NonAndroidFallback,
@@ -855,6 +855,173 @@ describe('LauncherHomeScreen — Focus page visibility (#618)', () => {
     await waitFor(() => expect(root.getByTestId('launcher-page-grid-1')).toBeTruthy(), {
       timeout: 3000,
     });
+    root.unmount();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Focus dock override — swap the dock per Focus mode (#619, filho de #617)
+// ---------------------------------------------------------------------------
+// `settings.focusDockOverride[focusMode]` pode substituir os pacotes do dock
+// enquanto esse modo está activo. Os testes montam o LauncherHomeScreen real,
+// com `dockApps` (dock normal) e `nonDockApps` (candidatos ao override)
+// distintos, e afirmam sobre `app-icon-box-<pkg>` dentro do testID
+// `launcher-dock` — nunca sobre a árvore inteira, porque as apps do override
+// também aparecem na grelha normal (o override só troca o dock, não a home).
+describe('LauncherHomeScreen — Focus dock override (#619)', () => {
+  function dockApp(pkg: string, name: string): AppsStore.InstalledApp {
+    return { name, packageName: pkg, icon: `file:///${pkg}.png`, isSystem: false };
+  }
+
+  const NORMAL_DOCK = [dockApp('com.phone', 'Phone'), dockApp('com.messages', 'Messages')];
+  const WORK_APPS = [dockApp('com.slack', 'Slack'), dockApp('com.gmail', 'Gmail')];
+
+  function mockDockApps(dockApps: AppsStore.InstalledApp[], nonDockApps: AppsStore.InstalledApp[]) {
+    jest.spyOn(AppsStore, 'useApps').mockReturnValue({
+      apps: [...dockApps, ...nonDockApps],
+      homeApps: [],
+      dockApps,
+      nonDockApps,
+      recentPackages: [],
+      recentApps: [],
+      isLoading: false,
+      refreshApps: jest.fn(() => Promise.resolve()),
+      launchApp: jest.fn(() => Promise.resolve(true)),
+      addToHome: jest.fn(),
+      removeFromHome: jest.fn(),
+      addToDock: jest.fn(),
+      removeFromDock: jest.fn(),
+      removeFromRecents: jest.fn(),
+      clearRecents: jest.fn(),
+      isDefaultLauncher: true,
+      openLauncherSettings: jest.fn(() => Promise.resolve()),
+      hiddenApps: [],
+      visibleApps: [],
+      hideApp: jest.fn(),
+      unhideApp: jest.fn(),
+      iconCacheSizeBytes: 0,
+      isRebuildingIconCache: false,
+      iconCacheRebuildProgress: null,
+      rebuildIconCache: jest.fn(() => Promise.resolve()),
+    } as ReturnType<typeof AppsStore.useApps>);
+  }
+
+  function seedSettings(partial: Record<string, unknown>) {
+    (AsyncStorage.getItem as jest.Mock).mockImplementation((key: string) =>
+      key === '@iostoandroid/settings'
+        ? Promise.resolve(JSON.stringify(partial))
+        : Promise.resolve(null),
+    );
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // As settings resolvem via AsyncStorage.getItem (uma promise); o
+  // `act(async () => { await Promise.resolve(); })` a seguir ao render força
+  // um tick de microtasks real antes do primeiro `waitFor`, evitando que a sua
+  // primeira ronda de polling corra antes de setSettings aplicar o valor
+  // seedado — sem isto, sob a carga de correr o ficheiro inteiro (~50 testes
+  // antes deste bloco), o `waitFor` chegava a esgotar o timeout apesar do
+  // estado ficar correto poucos milissegundos depois do mount (confirmado com
+  // instrumentação: o valor seedado já estava presente em ~300ms).
+  async function flushSettingsLoad() {
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  }
+
+  it('swaps the dock icons for the active focus mode override', async () => {
+    seedSettings({ focusMode: 'work', focusDockOverride: { work: ['com.slack', 'com.gmail'] } });
+    mockDockApps(NORMAL_DOCK, WORK_APPS);
+
+    const root = render(<LauncherHomeScreen />);
+    await flushSettingsLoad();
+    await waitFor(() => {
+      const dock = root.getByTestId('launcher-dock');
+      expect(within(dock).getByTestId('app-icon-box-com.slack')).toBeTruthy();
+      expect(within(dock).getByTestId('app-icon-box-com.gmail')).toBeTruthy();
+      expect(within(dock).queryByTestId('app-icon-box-com.phone')).toBeNull();
+    }, { timeout: 3000 });
+    root.unmount();
+  });
+
+  it('keeps the normal dock when the override for the active mode is an empty array', async () => {
+    // AC: "Vazio = manter dock normal".
+    seedSettings({ focusMode: 'work', focusDockOverride: { work: [] } });
+    mockDockApps(NORMAL_DOCK, WORK_APPS);
+
+    const root = render(<LauncherHomeScreen />);
+    await flushSettingsLoad();
+    await waitFor(() => {
+      const dock = root.getByTestId('launcher-dock');
+      expect(within(dock).getByTestId('app-icon-box-com.phone')).toBeTruthy();
+      expect(within(dock).getByTestId('app-icon-box-com.messages')).toBeTruthy();
+    }, { timeout: 3000 });
+    root.unmount();
+  });
+
+  it('restores the normal dock when focus mode is off, even with an override stored', async () => {
+    // AC: "'off' restaura dock normal" — o inverso do fix.
+    seedSettings({ focusMode: 'off', focusDockOverride: { work: ['com.slack', 'com.gmail'] } });
+    mockDockApps(NORMAL_DOCK, WORK_APPS);
+
+    const root = render(<LauncherHomeScreen />);
+    await flushSettingsLoad();
+    await waitFor(() => {
+      const dock = root.getByTestId('launcher-dock');
+      expect(within(dock).getByTestId('app-icon-box-com.phone')).toBeTruthy();
+      expect(within(dock).queryByTestId('app-icon-box-com.slack')).toBeNull();
+    }, { timeout: 3000 });
+    root.unmount();
+  });
+
+  it('ignores a dock override configured for a DIFFERENT mode than the active one', async () => {
+    seedSettings({ focusMode: 'sleep', focusDockOverride: { work: ['com.slack', 'com.gmail'] } });
+    mockDockApps(NORMAL_DOCK, WORK_APPS);
+
+    const root = render(<LauncherHomeScreen />);
+    await flushSettingsLoad();
+    await waitFor(() => {
+      const dock = root.getByTestId('launcher-dock');
+      expect(within(dock).getByTestId('app-icon-box-com.phone')).toBeTruthy();
+      expect(within(dock).queryByTestId('app-icon-box-com.slack')).toBeNull();
+    }, { timeout: 3000 });
+    root.unmount();
+  });
+
+  it('drops override package names that no longer resolve to an installed app', async () => {
+    seedSettings({ focusMode: 'work', focusDockOverride: { work: ['com.slack', 'com.uninstalled'] } });
+    mockDockApps(NORMAL_DOCK, WORK_APPS);
+
+    const root = render(<LauncherHomeScreen />);
+    await flushSettingsLoad();
+    await waitFor(() => {
+      const dock = root.getByTestId('launcher-dock');
+      expect(within(dock).getByTestId('app-icon-box-com.slack')).toBeTruthy();
+      expect(within(dock).queryByTestId('app-icon-box-com.uninstalled')).toBeNull();
+    }, { timeout: 3000 });
+    root.unmount();
+  });
+
+  it('survives a corrupted focusDockOverride blob in AsyncStorage', async () => {
+    // Inválido e hostil: valor não-array e entradas que não são string.
+    seedSettings({
+      focusMode: 'work',
+      focusDockOverride: { work: 'not-an-array', sleep: [1, null, 'com.slack'] },
+    });
+    mockDockApps(NORMAL_DOCK, WORK_APPS);
+
+    const root = render(<LauncherHomeScreen />);
+    await flushSettingsLoad();
+    await waitFor(() => {
+      const dock = root.getByTestId('launcher-dock');
+      // 'work' não é array -> normalizado para [] -> mantém o dock normal.
+      expect(within(dock).getByTestId('app-icon-box-com.phone')).toBeTruthy();
+      expect(within(dock).getByTestId('app-icon-box-com.messages')).toBeTruthy();
+    }, { timeout: 3000 });
     root.unmount();
   });
 });

--- a/src/screens/settings/FocusScreen.tsx
+++ b/src/screens/settings/FocusScreen.tsx
@@ -12,6 +12,7 @@ import {
   toggleHiddenPage,
   homePageCount,
 } from '../../utils/focusPageVisibility';
+import { dockOverrideForMode, toggleDockOverrideApp } from '../../utils/focusDockOverride';
 import {
   CupertinoNavigationBar,
   CupertinoListSection,
@@ -59,7 +60,7 @@ export function FocusScreen({ navigation }: { navigation: AppNavigationProp }) {
   const { colors } = theme;
   const insets = useSafeAreaInsets();
   const { settings, update } = useSettings();
-  const { nonDockApps } = useApps();
+  const { apps, nonDockApps } = useApps();
   const { folders } = useFolders();
   const alert = useAlert();
 
@@ -114,6 +115,36 @@ export function FocusScreen({ navigation }: { navigation: AppNavigationProp }) {
       onPress: () => handleToggleHiddenPage(pagePickerMode, index),
     }));
   }, [pagePickerMode, pageCount, settings.focusPageVisibility, handleToggleHiddenPage]);
+
+  // Dock Apps per mode (#619, filho de #617): cada modo (exceto Off) pode
+  // substituir os 4 ícones do dock. "Default" na linha-resumo cobre os dois
+  // casos que significam "sem override" — dockOverrideForMode já trata chave
+  // ausente e lista vazia da mesma forma.
+  const [dockPickerMode, setDockPickerMode] = useState<FocusMode | null>(null);
+
+  const dockSummary = useCallback(
+    (mode: FocusMode) => {
+      const override = dockOverrideForMode(settings.focusDockOverride, mode);
+      return override ? `${override.length} app${override.length === 1 ? '' : 's'}` : 'Default';
+    },
+    [settings.focusDockOverride],
+  );
+
+  const handleToggleDockApp = useCallback(
+    (mode: FocusMode, packageName: string) => {
+      update('focusDockOverride', toggleDockOverrideApp(settings.focusDockOverride, mode, packageName));
+    },
+    [settings.focusDockOverride, update],
+  );
+
+  const dockPickerOptions = useMemo(() => {
+    if (!dockPickerMode) return [];
+    const current = settings.focusDockOverride[dockPickerMode] ?? [];
+    return apps.map((app) => ({
+      label: `${current.includes(app.packageName) ? '✓ ' : ''}${app.name}`,
+      onPress: () => handleToggleDockApp(dockPickerMode, app.packageName),
+    }));
+  }, [dockPickerMode, apps, settings.focusDockOverride, handleToggleDockApp]);
 
   const handleSelectMode = useCallback((mode: FocusModeOption) => {
     const wasActive = settings.focusMode !== 'off';
@@ -217,6 +248,27 @@ export function FocusScreen({ navigation }: { navigation: AppNavigationProp }) {
           </CupertinoListSection>
         </View>
 
+        {/* Dock Apps per mode (#619) */}
+        <View style={{ paddingHorizontal: spacing.md }}>
+          <CupertinoListSection
+            header="Dock Apps"
+            footer="While a Focus mode is on, the dock can show a different set of apps (up to 4). Off always shows your normal dock."
+          >
+            {FOCUS_MODES.filter((mode) => mode.key !== 'off').map((mode) => (
+              <CupertinoListTile
+                key={`dock-apps-${mode.key}`}
+                title={`${mode.label} — Dock Apps`}
+                trailing={
+                  <Text style={[typography.body, { color: colors.secondaryLabel }]}>
+                    {dockSummary(mode.key)}
+                  </Text>
+                }
+                onPress={() => setDockPickerMode(mode.key)}
+              />
+            ))}
+          </CupertinoListSection>
+        </View>
+
         {/* Focus Schedule section */}
         <View style={{ paddingHorizontal: spacing.md }}>
           <CupertinoListSection header="Focus Schedule">
@@ -284,6 +336,19 @@ export function FocusScreen({ navigation }: { navigation: AppNavigationProp }) {
         title="Hidden Pages"
         message="Pages hidden while this Focus mode is on."
         options={pagePickerOptions}
+        cancelLabel="Done"
+      />
+
+      {/* Multiselect das apps do dock por modo (#619). Mesmo padrão do
+          multiselect de páginas acima: cada toque alterna um app (✓
+          adiciona/remove), até MAX_DOCK_APPS — o 5º toque é ignorado por
+          toggleDockOverrideApp, tal como o dock normal (AppsStore#addToDock). */}
+      <CupertinoActionSheet
+        visible={dockPickerMode !== null}
+        onClose={() => setDockPickerMode(null)}
+        title="Dock Apps"
+        message="Pick up to 4 apps for this mode's dock. Leave none selected to keep the normal dock."
+        options={dockPickerOptions}
         cancelLabel="Done"
       />
     </View>

--- a/src/screens/settings/__tests__/FocusScreen.test.tsx
+++ b/src/screens/settings/__tests__/FocusScreen.test.tsx
@@ -3,6 +3,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { render, fireEvent, waitFor } from '../../../test-utils';
 import { FocusScreen } from '../FocusScreen';
 import { notificationCallbackForFocus } from '../../../utils/notificationFocusFilter';
+import * as AppsStore from '../../../store/AppsStore';
 
 const mockNavigation = { navigate: jest.fn(), goBack: jest.fn(), push: jest.fn() };
 
@@ -226,6 +227,129 @@ describe('FocusScreen — Hidden Pages (#618)', () => {
         .filter(([key]) => key === '@iostoandroid/settings')
         .pop();
       expect(JSON.parse(write![1] as string).focusPageVisibility.sleep).toBeUndefined();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dock Apps per Focus mode (#619, filho de #617)
+// ---------------------------------------------------------------------------
+// Monta o FocusScreen real: abre o picker de um modo, escolhe apps e verifica
+// que a escolha vai para o AsyncStorage (persiste entre arranques) e que o
+// resumo da linha muda. O modo 'off' não tem linha — nunca tem override.
+describe('FocusScreen — Dock Apps (#619)', () => {
+  function app(pkg: string, name: string): AppsStore.InstalledApp {
+    return { name, packageName: pkg, icon: `file:///${pkg}.png`, isSystem: false };
+  }
+
+  const APPS = [app('com.slack', 'Slack'), app('com.gmail', 'Gmail'), app('com.notion', 'Notion')];
+
+  function mockApps() {
+    jest.spyOn(AppsStore, 'useApps').mockReturnValue({
+      apps: APPS,
+      homeApps: [],
+      dockApps: [],
+      nonDockApps: APPS,
+      recentPackages: [],
+      recentApps: [],
+      isLoading: false,
+      refreshApps: jest.fn(() => Promise.resolve()),
+      launchApp: jest.fn(() => Promise.resolve(true)),
+      addToHome: jest.fn(),
+      removeFromHome: jest.fn(),
+      addToDock: jest.fn(),
+      removeFromDock: jest.fn(),
+      removeFromRecents: jest.fn(),
+      clearRecents: jest.fn(),
+      isDefaultLauncher: true,
+      openLauncherSettings: jest.fn(() => Promise.resolve()),
+      hiddenApps: [],
+      visibleApps: [],
+      hideApp: jest.fn(),
+      unhideApp: jest.fn(),
+      iconCacheSizeBytes: 0,
+      isRebuildingIconCache: false,
+      iconCacheRebuildProgress: null,
+      rebuildIconCache: jest.fn(() => Promise.resolve()),
+    } as ReturnType<typeof AppsStore.useApps>);
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+    mockApps();
+  });
+
+  it('renders one Dock Apps row per mode, and none for Off', () => {
+    const { getByText, queryByText } = render(
+      <FocusScreen navigation={mockNavigation as never} />,
+    );
+    expect(getByText('Work — Dock Apps')).toBeTruthy();
+    expect(getByText('Sleep — Dock Apps')).toBeTruthy();
+    expect(getByText('Do Not Disturb — Dock Apps')).toBeTruthy();
+    expect(getByText('Personal — Dock Apps')).toBeTruthy();
+    expect(queryByText('Off — Dock Apps')).toBeNull();
+  });
+
+  it('shows "Default" until an app is picked, then the count', async () => {
+    const { getByText, getAllByText } = render(
+      <FocusScreen navigation={mockNavigation as never} />,
+    );
+    expect(getAllByText('Default').length).toBeGreaterThan(0);
+
+    fireEvent.press(getByText('Work — Dock Apps'));
+    fireEvent.press(getByText('Slack'));
+
+    await waitFor(() => expect(getByText('1 app')).toBeTruthy());
+  });
+
+  it('persists focusDockOverride to AsyncStorage (survives a restart)', async () => {
+    const { getByText } = render(<FocusScreen navigation={mockNavigation as never} />);
+
+    fireEvent.press(getByText('Work — Dock Apps'));
+    fireEvent.press(getByText('Slack'));
+    // O action sheet fecha após cada opção (mesmo padrão do Hidden Pages
+    // acima) — reabre antes da segunda escolha.
+    fireEvent.press(getByText('Work — Dock Apps'));
+    fireEvent.press(getByText('Gmail'));
+
+    await waitFor(() => {
+      const write = (AsyncStorage.setItem as jest.Mock).mock.calls
+        .filter(([key]) => key === '@iostoandroid/settings')
+        .pop();
+      expect(write).toBeTruthy();
+      expect(JSON.parse(write![1] as string).focusDockOverride).toEqual({
+        work: ['com.slack', 'com.gmail'],
+      });
+    });
+  });
+
+  it('un-picks an app when tapped twice (double tap is a no-op)', async () => {
+    const { getByText, getAllByText } = render(
+      <FocusScreen navigation={mockNavigation as never} />,
+    );
+
+    fireEvent.press(getByText('Work — Dock Apps'));
+    fireEvent.press(getByText('Slack'));
+    await waitFor(() => expect(getByText('1 app')).toBeTruthy());
+
+    fireEvent.press(getByText('Work — Dock Apps'));
+    fireEvent.press(getByText('✓ Slack'));
+
+    await waitFor(() => expect(getAllByText('Default').length).toBeGreaterThan(0));
+  });
+
+  it('keeps each mode independent — picking for Work leaves Sleep untouched', async () => {
+    const { getByText } = render(<FocusScreen navigation={mockNavigation as never} />);
+
+    fireEvent.press(getByText('Work — Dock Apps'));
+    fireEvent.press(getByText('Slack'));
+
+    await waitFor(() => {
+      const write = (AsyncStorage.setItem as jest.Mock).mock.calls
+        .filter(([key]) => key === '@iostoandroid/settings')
+        .pop();
+      expect(JSON.parse(write![1] as string).focusDockOverride.sleep).toBeUndefined();
     });
   });
 });

--- a/src/store/SettingsStore.tsx
+++ b/src/store/SettingsStore.tsx
@@ -25,6 +25,7 @@ import {
   normalizeFocusPageVisibility,
   type FocusPageVisibility,
 } from '../utils/focusPageVisibility';
+import { normalizeFocusDockOverride } from '../utils/focusDockOverride';
 
 const STORAGE_KEY = '@iostoandroid/settings';
 
@@ -424,6 +425,12 @@ export function SettingsProvider({
             // valores não-array) faria o filtro esconder páginas ao acaso ou
             // rebentar no `.includes`, por isso normaliza-se na leitura.
             focusPageVisibility: normalizeFocusPageVisibility(parsed?.focusPageVisibility),
+            // focusDockOverride (#619, filho de #617) troca os ícones do dock
+            // por modo de Focus; um blob corrompido (não-array, entradas não
+            // string) faria o `.map`/`.slice(0, 4)` do LauncherHomeScreen
+            // render pacotes inexistentes ou rebentar — normaliza-se na
+            // leitura como os irmãos acima.
+            focusDockOverride: normalizeFocusDockOverride(parsed?.focusDockOverride),
             // categoryOverrides (#516) é lido do mesmo blob não confiável do
             // AsyncStorage. Um valor nulo/parcial/corrompido rebentaria
             // buildCategorySections (new Set(overrides.hidden)) e, como a

--- a/src/utils/__tests__/focusDockOverride.test.ts
+++ b/src/utils/__tests__/focusDockOverride.test.ts
@@ -1,0 +1,110 @@
+import {
+  normalizeFocusDockOverride,
+  dockOverrideForMode,
+  toggleDockOverrideApp,
+  MAX_DOCK_APPS,
+} from '../focusDockOverride';
+
+// Focus dock override (#619, filho de #617) — helpers puros. Exercitam as
+// funções exportadas reais (nada é reimplementado aqui): o LauncherHomeScreen
+// e o FocusScreen consomem exactamente estas.
+
+describe('normalizeFocusDockOverride', () => {
+  it('devolve {} para valores que não são objectos', () => {
+    expect(normalizeFocusDockOverride(undefined)).toEqual({});
+    expect(normalizeFocusDockOverride(null)).toEqual({});
+    expect(normalizeFocusDockOverride(42)).toEqual({});
+    expect(normalizeFocusDockOverride('work')).toEqual({});
+    expect(normalizeFocusDockOverride(['com.slack'])).toEqual({});
+  });
+
+  it('mantém package names válidos', () => {
+    expect(normalizeFocusDockOverride({ work: ['com.slack', 'com.gmail'] })).toEqual({
+      work: ['com.slack', 'com.gmail'],
+    });
+  });
+
+  it('descarta modos cujo valor não é array', () => {
+    expect(normalizeFocusDockOverride({ work: 'nope', sleep: ['com.calm'] })).toEqual({
+      sleep: ['com.calm'],
+    });
+  });
+
+  it('descarta entradas que não são string, strings vazias e duplicados', () => {
+    expect(
+      normalizeFocusDockOverride({ work: [1, null, '', '  ', 'com.slack', 'com.slack'] }),
+    ).toEqual({ work: ['com.slack'] });
+  });
+
+  it('mantém um array vazio (significa "manter dock normal", distinto de chave ausente)', () => {
+    expect(normalizeFocusDockOverride({ work: [] })).toEqual({ work: [] });
+  });
+
+  it(`corta cada lista a ${MAX_DOCK_APPS} entradas`, () => {
+    const five = ['a', 'b', 'c', 'd', 'e'];
+    expect(normalizeFocusDockOverride({ work: five })).toEqual({ work: ['a', 'b', 'c', 'd'] });
+  });
+});
+
+describe('dockOverrideForMode', () => {
+  it("devolve null para o modo 'off' mesmo com entrada guardada", () => {
+    expect(dockOverrideForMode({ off: ['com.slack'], work: ['com.gmail'] }, 'off')).toBeNull();
+  });
+
+  it('devolve null para modo desconhecido, vazio ou mapa ausente', () => {
+    expect(dockOverrideForMode({ work: ['com.slack'] }, 'sleep')).toBeNull();
+    expect(dockOverrideForMode({ work: ['com.slack'] }, '')).toBeNull();
+    expect(dockOverrideForMode(undefined, 'work')).toBeNull();
+    expect(dockOverrideForMode(null, 'work')).toBeNull();
+  });
+
+  it('devolve null quando a lista do modo activo está vazia (manter dock normal)', () => {
+    expect(dockOverrideForMode({ work: [] }, 'work')).toBeNull();
+  });
+
+  it('devolve os package names do modo activo', () => {
+    expect(dockOverrideForMode({ work: ['com.slack', 'com.gmail'] }, 'work')).toEqual([
+      'com.slack',
+      'com.gmail',
+    ]);
+  });
+});
+
+describe('toggleDockOverrideApp', () => {
+  it('adiciona um package ausente', () => {
+    expect(toggleDockOverrideApp({ work: ['com.slack'] }, 'work', 'com.gmail')).toEqual({
+      work: ['com.slack', 'com.gmail'],
+    });
+  });
+
+  it('remove um package já presente (duplo toque volta ao estado inicial)', () => {
+    const once = toggleDockOverrideApp({}, 'work', 'com.slack');
+    expect(once).toEqual({ work: ['com.slack'] });
+    expect(toggleDockOverrideApp(once, 'work', 'com.slack')).toEqual({ work: [] });
+  });
+
+  it('não muta o mapa recebido', () => {
+    const before = { work: ['com.slack'] };
+    toggleDockOverrideApp(before, 'work', 'com.gmail');
+    expect(before).toEqual({ work: ['com.slack'] });
+  });
+
+  it('não toca noutros modos', () => {
+    expect(toggleDockOverrideApp({ sleep: ['com.calm'] }, 'work', 'com.slack')).toEqual({
+      sleep: ['com.calm'],
+      work: ['com.slack'],
+    });
+  });
+
+  it(`ignora silenciosamente ao tentar adicionar o ${MAX_DOCK_APPS + 1}º app`, () => {
+    const full = { work: ['a', 'b', 'c', 'd'] };
+    expect(toggleDockOverrideApp(full, 'work', 'e')).toEqual(full);
+  });
+
+  it('remover um app quando a lista está no limite volta a permitir adicionar', () => {
+    const full = { work: ['a', 'b', 'c', 'd'] };
+    const afterRemove = toggleDockOverrideApp(full, 'work', 'a');
+    expect(afterRemove).toEqual({ work: ['b', 'c', 'd'] });
+    expect(toggleDockOverrideApp(afterRemove, 'work', 'e')).toEqual({ work: ['b', 'c', 'd', 'e'] });
+  });
+});

--- a/src/utils/focusDockOverride.ts
+++ b/src/utils/focusDockOverride.ts
@@ -1,0 +1,83 @@
+/**
+ * Focus filters — dock override per Focus mode (issue #619, filho de #617).
+ *
+ * Um Modo de Foco pode substituir os 4 ícones do dock (ex.: «Work» mostra só
+ * apps de trabalho). O mapa vive em `settings.focusDockOverride` e é
+ * `modo -> package names do dock`. Contrato partilhado com o pai #617
+ * (SettingsStore.tsx): `Record<string, string[]>`, onde um array vazio
+ * significa "manter o dock normal" (iOS «Keep Current») — distinto de uma
+ * chave ausente, mas tratado da mesma forma por `dockOverrideForMode`. 'off'
+ * nunca tem override, mesmo que exista uma entrada guardada para ele.
+ *
+ * O AsyncStorage é um blob JSON escrito por versões anteriores da app, por
+ * isso tudo o que sai dele é tratado como não confiável — mesmo padrão de
+ * `focusPageVisibility.ts`.
+ */
+
+/** Mapa canónico no store: chave = modo de Focus, valor = package names do dock. */
+export type FocusDockOverride = Record<string, string[]>;
+
+/** Número máximo de apps no dock (mesmo limite do dock normal, AppsStore#addToDock). */
+export const MAX_DOCK_APPS = 4;
+
+/**
+ * Normaliza o valor lido do AsyncStorage para `Record<string, string[]>`.
+ *
+ * Descarta: não-objectos, arrays no topo, valores que não sejam array,
+ * entradas que não sejam strings não-vazias, e duplicados. Corta cada lista a
+ * `MAX_DOCK_APPS` entradas (a mesma garantia que `toggleDockOverrideApp`
+ * aplica na escrita).
+ */
+export function normalizeFocusDockOverride(raw: unknown): FocusDockOverride {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return {};
+  const out: FocusDockOverride = {};
+  for (const [mode, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (!Array.isArray(value)) continue;
+    const seen = new Set<string>();
+    const pkgs: string[] = [];
+    for (const entry of value) {
+      if (typeof entry !== 'string' || entry.trim() === '' || seen.has(entry)) continue;
+      seen.add(entry);
+      pkgs.push(entry);
+    }
+    out[mode] = pkgs.slice(0, MAX_DOCK_APPS);
+  }
+  return out;
+}
+
+/**
+ * Package names do override para o modo activo, ou `null` quando não há
+ * override a aplicar (modo 'off', modo desconhecido, chave ausente, ou lista
+ * vazia — "manter o dock normal" em qualquer um destes casos).
+ */
+export function dockOverrideForMode(
+  override: FocusDockOverride | undefined | null,
+  mode: string | undefined | null,
+): string[] | null {
+  if (!override || !mode || mode === 'off') return null;
+  const list = override[mode];
+  if (!Array.isArray(list) || list.length === 0) return null;
+  return list;
+}
+
+/**
+ * Alterna um package name no override de um modo, devolvendo um mapa novo
+ * (nunca muta o anterior). Se o package já está na lista, remove-o; senão
+ * adiciona-o, a menos que a lista já tenha `MAX_DOCK_APPS` entradas — nesse
+ * caso ignora o pedido silenciosamente, tal como `AppsStore#addToDock` faz
+ * para o dock normal.
+ */
+export function toggleDockOverrideApp(
+  override: FocusDockOverride | undefined | null,
+  mode: string,
+  packageName: string,
+): FocusDockOverride {
+  const base: FocusDockOverride = { ...(override ?? {}) };
+  const current = Array.isArray(base[mode]) ? base[mode] : [];
+  if (current.includes(packageName)) {
+    base[mode] = current.filter((p) => p !== packageName);
+  } else if (current.length < MAX_DOCK_APPS) {
+    base[mode] = [...current, packageName];
+  }
+  return base;
+}


### PR DESCRIPTION
## Resumo

qa/issue-619: override do dock por modo de Focus (LauncherHomeScreen render + picker no FocusScreen)

## Causa raiz

O issue #617 (pai) já tinha adicionado o contrato de dados em `src/store/SettingsStore.tsx:71` (`focusDockOverride: Record<string, string[]>`, default `{}`), com o comentário explícito "Children #617b read this to swap the dock while a focus mode is active" — mas nenhum consumidor lia esse campo. `LauncherHomeScreen.tsx` renderizava sempre `dockApps` (o dock persistido em `AppsStore`, `src/store/AppsStore.tsx:717`) sem olhar para `settings.focusDockOverride`, e `FocusScreen.tsx` não tinha UI nenhuma para o definir. O campo existia mas era código morto.

Adicionalmente, ao contrário do irmão `focusPageVisibility` (normalizado na leitura em `SettingsStore.tsx:426`), `focusDockOverride` **não** era saneado ao ler do AsyncStorage — um blob corrompido (não-array, entradas não-string) chegaria direto ao `.map`/`.slice` do consumidor. Como o issue pede "persiste entre arranques" como critério, e o padrão estabelecido no ficheiro é sanear-na-leitura para todos os campos deste tipo, fechei essa lacuna também (mudança pequena, mesma linha do irmão).

## O que mudou

- **`src/utils/focusDockOverride.ts`** (novo): 3 funções puras — `normalizeFocusDockOverride` (saneia o blob do AsyncStorage: descarta não-arrays, entradas não-string, vazias e duplicadas, corta a `MAX_DOCK_APPS=4`), `dockOverrideForMode` (devolve os package names do modo activo, ou `null` para 'off', modo desconhecido, chave ausente OU lista vazia — os três casos de "sem override"), `toggleDockOverrideApp` (alterna um package no override de um modo, sem exceder 4, mesmo padrão de `AppsStore#addToDock`).
- **`src/store/SettingsStore.tsx`**: importa e aplica `normalizeFocusDockOverride(parsed?.focusDockOverride)` no efeito de leitura do AsyncStorage (linha ~426, ao lado do irmão `focusPageVisibility`). O campo em si (tipo, default `{}`) já existia desde #617 e não mudou.
- **`src/screens/LauncherHomeScreen.tsx`**: novo `useMemo` `dockOverridePkgs` (via `dockOverrideForMode`) e `effectiveDockApps` (resolve os package names do override contra `apps` ∪ `dockApps`, descartando os que já não existem). O render do dock (a `View` com `styles.dockRow`) passa a mapear `effectiveDockApps` em vez de `dockApps`; adicionado `testID="launcher-dock"` ao contentor para o teste conseguir isolar as queries do dock da grelha normal (as apps do override continuam a poder aparecer também na grelha — só o dock troca, como o "fix proposto" do issue pedia).
- **`src/screens/settings/FocusScreen.tsx`**: nova secção "Dock Apps" (mesmo padrão visual da secção "Hidden Pages" de #618) com uma `CupertinoListTile` por modo (exceto Off), resumo "Default" ou "N apps", e um `CupertinoActionSheet` picker que lista `apps` (instalados) com ✓ para os já escolhidos, alternando via `toggleDockOverrideApp`.

## Porque assim

- **Resolução de package names via `apps ∪ dockApps`, não só `apps`**: `AppsStore.useApps().apps` é `state.allApps` (só apps reais instalados). O dock normal pode conter apps virtuais built-in (Phone/Messages, resolvidos via `VIRTUAL_APPS_MAP` interno ao `AppsStore`, não exportado). Para não expandir a API pública do `AppsStore` só para este caso, resolvo o override contra a união de `apps` e `dockApps` (este último já traz os virtuais resolvidos, se estiverem no dock actual) — cobre o caso principal do issue (apps reais de trabalho) sem tocar num módulo partilhado por todo o app.
- **Grelha (`nonDockApps`/`gridItems`) não muda com o override**: o "fix proposto" do issue diz explicitamente "ao ler `dockApps` para renderizar o dock ... usar essa lista" — âmbito é só o render do dock, não a lógica de que apps contam como "no dock" para efeitos de grelha/páginas. Mantive `nonDockApps`/`gridItems` a usar o `dockApps` real, e o long-press ("add/remove from dock") continua a mexer no dock persistido real, não no override — evita uma UX confusa em que remover uma app do dock durante um override faz nada (porque a app não está no dock real).
- **`MAX_DOCK_APPS = 4`**: replica o limite já imposto por `AppsStore#addToDock` (silenciosamente ignora o 5º), para o picker do FocusScreen se comportar de forma consistente com o dock normal.

## Critérios de aceitação

- [x] Dock substituído por modo quando definido — `LauncherHomeScreen — Focus dock override (#619) › swaps the dock icons for the active focus mode override`.
- [x] Vazio = manter dock normal — `... › keeps the normal dock when the override for the active mode is an empty array` (`focusDockOverride: { work: [] }` → dock normal).
- [x] `off` restaura dock normal — `... › restores the normal dock when focus mode is off, even with an override stored` (override de 'work' guardado, mas modo activo 'off' → dock normal).
- [x] Persiste entre arranques — coberto em dois níveis: (1) `FocusScreen — Dock Apps (#619) › persists focusDockOverride to AsyncStorage (survives a restart)` confirma a escrita; (2) `focusDockOverride.test.ts` + `... › survives a corrupted focusDockOverride blob in AsyncStorage` confirmam que a leitura sobrevive a um blob corrompido de uma versão anterior da app.
- [x] Teste em `LauncherHomeScreen.test.tsx` cobre o override — bloco `LauncherHomeScreen — Focus dock override (#619)`, 6 testes.
- [x] Não devia mudar: dock normal (persistido em `AppsStore`) e grelha/páginas continuam a usar `dockApps`/`nonDockApps` reais, nunca o override — confirmado pelos testes que esperam `com.phone`/`com.messages` (o dock normal do mock) sempre que o override não se aplica, e pelo facto de nenhum teste pré-existente do dock (`LauncherHomeScreen dock has no app-name labels (#501)`, `does not duplicate a built-in that lives in the dock`, etc.) ter sido alterado nem ter regressão.

## Testes

**Passo vermelho** (fix revertido — `git stash push -- src/screens/LauncherHomeScreen.tsx src/screens/settings/FocusScreen.tsx src/store/SettingsStore.tsx src/utils/focusDockOverride.ts`, testes mantidos):

```
$ npx jest src/utils/__tests__/focusDockOverride.test.ts src/screens/__tests__/LauncherHomeScreen.test.tsx src/screens/settings/__tests__/FocusScreen.test.tsx -t "swaps the dock icons|renders one Dock Apps row|devolve os package names do modo activo"

  ● LauncherHomeScreen — Focus dock override (#619) › swaps the dock icons for the active focus mode override

      940 |     const root = render(<LauncherHomeScreen />);
      941 |     await flushSettingsLoad();
    > 942 |     await waitFor(() => {
          |                  ^
      943 |       const dock = root.getByTestId('launcher-dock');
      944 |       expect(within(dock).getByTestId('app-icon-box-com.slack')).toBeTruthy();
      945 |       expect(within(dock).getByTestId('app-icon-box-com.gmail')).toBeTruthy();

    Unable to find an element with testID: launcher-dock

Test Suites: 3 failed, 3 total
Tests:       2 failed, 70 skipped, 72 total
```

(com o filtro completo, sem `-t`: 11 falhas — as 6 do bloco `Focus dock override` em `LauncherHomeScreen.test.tsx` + as 5 de `FocusScreen — Dock Apps (#619)`; a suite `focusDockOverride.test.ts` falha inteira por o ficheiro não existir ainda.)

Depois de restaurar o fix (`git stash pop`), as mesmas 3 suites: **88 passaram, 0 falharam**.

**Casos cobertos** (além do caminho feliz):
- **Vazio** — `focusDockOverride: { work: [] }` mantém o dock normal (AC explícito).
- **Ausente/off** — modo 'off' com override guardado para outro modo; modo activo diferente do modo com override guardado.
- **Inválido e hostil** — blob corrompido no AsyncStorage (`'not-an-array'`, `1`, `null` dentro do array) não rebenta e cai para "sem override"; `normalizeFocusDockOverride` testado isoladamente para strings vazias, duplicados, valores não-string, mais de 4 entradas.
- **Referência morta** — package name no override que já não existe em `apps`/`dockApps` é descartado silenciosamente, nunca renderiza um ícone quebrado.
- **Repetição (duplo toque)** — `toggleDockOverrideApp` remove ao alternar duas vezes o mesmo package; `FocusScreen › un-picks an app when tapped twice`.
- **Limite exacto** — `toggleDockOverrideApp` ignora silenciosamente o 5º package quando a lista já tem `MAX_DOCK_APPS`; remover um e voltar a adicionar funciona.
- **Isolamento entre modos** — escolher apps para 'work' não toca no override de 'sleep' (`toggleDockOverrideApp` + teste de persistência no FocusScreen).

**Nota sobre uma falha inicial não-determinística**: ao correr o ficheiro `LauncherHomeScreen.test.tsx` inteiro (50 testes, incluindo os ~44 pré-existentes antes do bloco #619), 2 dos 6 testes do bloco novo falhavam de forma reprodutível (mas só quando o ficheiro inteiro corria — isolados ou filtrados por `-t "Focus"` passavam sempre). Instrumentação confirmou que o estado ficava correcto ~300ms após o mount (o `AsyncStorage.getItem` mockado resolvia com o valor certo e o dock já mostrava os ícones certos), mas o `waitFor` subsequente nunca via essa transição sob a carga de correr o ficheiro inteiro — um problema de scheduling de microtasks do ambiente de teste, não do código de produção. Corrigido com um `flushSettingsLoad()` (`act(async () => { await Promise.resolve(); await Promise.resolve(); })`, padrão já usado noutros ficheiros deste repo, ex. `AssistiveTouch.home.test.tsx`) logo a seguir ao `render`, antes do `waitFor`. Confirmado com 4 corridas consecutivas do ficheiro inteiro (`--maxWorkers=1` e `--maxWorkers=2`), 50/50 testes a passar em todas.

**Sanity-check**: fix de produção revertido com testes mantidos (`git stash push -u` dos 4 ficheiros de produção), suite a falhar (11 falhas, ver acima); `git stash pop` restaura, suite volta a passar por inteiro.

**Verificações obrigatórias** (linha de base: `main`/`c7fc108` tinha 23 testes a falhar em 6 suites, todos por `SettingsStore`/providers pré-existentes não relacionados):
- `npm run lint`: 0 erros (7 warnings pré-existentes, nenhum em ficheiro tocado por este PR excepto um warning já existente em `SettingsStore.tsx:26` sobre um tipo não usado, que já lá estava antes desta mudança).
- `npx tsc --noEmit`: limpo.
- `npm test -- --maxWorkers=2`: **1986 passaram, 23 falharam, 2009 total** (211 suites, 205 passaram, 6 falharam) — os 23 testes a falhar são **exactamente** os 23 da linha de base (`SettingsScreen`, `SiriScreen`, `FoldersStore`, `withLauncherIntent`, `LockScreen`, `WeatherScreen` — diff linha-a-linha contra `baseline.json` confirma conjunto idêntico). Nenhuma falha nova, nenhuma regressão.

## Testes

1986 passaram, 23 falharam (idênticos à linha de base pré-existente), 2009 total, 211 suites (205 passaram, 6 falharam — nenhuma delas tocada por este PR)

## Linked Issue

Fixes #619