### PR TITLE
qa/issue-760: homeApps.position passa a ser a fonte de verdade da ordem da grelha do Launcher (#760)

### DIFF
--- a/src/screens/LauncherHomeScreen.tsx
+++ b/src/screens/LauncherHomeScreen.tsx
@@ -785,6 +785,7 @@ export function LauncherHomeScreen() {
     apps,
     nonDockApps,
     dockApps,
+    homeApps,
     isLoading,
     launchApp,
     isDefaultLauncher,
@@ -1242,15 +1243,26 @@ export function LauncherHomeScreen() {
     }
 
     // Add real installed apps (not in dock, not in folders, and not an Android
-    // duplicate of a built-in app — see BUILT_IN_APP_ANDROID_ALIASES / #438)
-    for (const app of nonDockApps) {
+    // duplicate of a built-in app — see BUILT_IN_APP_ANDROID_ALIASES / #438),
+    // ordered by homeApps.position (#760) instead of the native scan order
+    // nonDockApps comes in. Apps without a recorded position (shouldn't
+    // happen once AppsStore has assigned one on load, but kept defensive)
+    // sort after every positioned app, in their original relative order —
+    // Array#sort is stable, so ties fall back to scan order.
+    const positionByPackage = new Map(homeApps.map(h => [h.packageName, h.position]));
+    const orderedNonDockApps = [...nonDockApps].sort((a, b) => {
+      const posA = positionByPackage.get(a.packageName) ?? Number.MAX_SAFE_INTEGER;
+      const posB = positionByPackage.get(b.packageName) ?? Number.MAX_SAFE_INTEGER;
+      return posA - posB;
+    });
+    for (const app of orderedNonDockApps) {
       if (BUILT_IN_DUPLICATE_PACKAGES.has(app.packageName)) continue;
       if (!appsInFolders.has(app.packageName)) {
         items.push({ type: 'app', app });
       }
     }
     return items;
-  }, [nonDockApps, dockApps, folders]);
+  }, [nonDockApps, dockApps, folders, homeApps]);
 
   // Paginate grid items — memoizado (#518): sem isto, este array era
   // recriado em TODO o render (incluindo o causado por um simples avanço de

--- a/src/screens/__tests__/LauncherHomeScreen.homeAppsPosition.test.tsx
+++ b/src/screens/__tests__/LauncherHomeScreen.homeAppsPosition.test.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { render, waitFor, within } from '../../test-utils';
+import * as AppsStore from '../../store/AppsStore';
+import { LauncherHomeScreen } from '../LauncherHomeScreen';
+
+// #760: homeApps.position passa a ser a fonte de verdade da ordem da grelha —
+// antes deste fix, gridItems/allPages (LauncherHomeScreen.tsx) iteravam
+// nonDockApps pela ordem de state.allApps (ordem do scan nativo), ignorando
+// completamente `position`.
+function mockApps(overrides: Record<string, unknown> = {}) {
+  jest.spyOn(AppsStore, 'useApps').mockReturnValue({
+    apps: [],
+    homeApps: [],
+    dockApps: [],
+    nonDockApps: [],
+    recentPackages: [],
+    recentApps: [],
+    isLoading: false,
+    refreshApps: jest.fn(() => Promise.resolve()),
+    launchApp: jest.fn(() => Promise.resolve(true)),
+    addToHome: jest.fn(),
+    removeFromHome: jest.fn(),
+    addToDock: jest.fn(),
+    removeFromDock: jest.fn(),
+    removeFromRecents: jest.fn(),
+    clearRecents: jest.fn(),
+    isDefaultLauncher: true,
+    openLauncherSettings: jest.fn(() => Promise.resolve()),
+    hiddenApps: [],
+    visibleApps: [],
+    hideApp: jest.fn(),
+    unhideApp: jest.fn(),
+    iconCacheSizeBytes: 0,
+    isRebuildingIconCache: false,
+    iconCacheRebuildProgress: null,
+    rebuildIconCache: jest.fn(() => Promise.resolve()),
+    ...overrides,
+  } as ReturnType<typeof AppsStore.useApps>);
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+const alpha = { name: 'Alpha', packageName: 'com.example.alpha', icon: '', isSystem: false };
+const beta = { name: 'Beta', packageName: 'com.example.beta', icon: '', isSystem: false };
+const gamma = { name: 'Gamma', packageName: 'com.example.gamma', icon: '', isSystem: false };
+
+async function renderOrderedLabels(overrides: Record<string, unknown>) {
+  mockApps(overrides);
+  const { getByTestId } = render(<LauncherHomeScreen />);
+  await waitFor(() => expect(getByTestId('launcher-page-grid-0')).toBeTruthy(), { timeout: 3000 });
+
+  return within(getByTestId('launcher-page-grid-0'))
+    .getAllByRole('button')
+    .map((n) => n.props.accessibilityLabel as string)
+    .filter((l) => ['Open Alpha', 'Open Beta', 'Open Gamma'].includes(l));
+}
+
+describe('LauncherHomeScreen — a grelha ordena por homeApps.position (#760)', () => {
+  it('ordena por position quando diverge da ordem de scan (allApps/nonDockApps)', async () => {
+    // Ordem de scan: Alpha, Beta, Gamma — mas Beta tem a menor position.
+    const order = await renderOrderedLabels({
+      nonDockApps: [alpha, beta, gamma],
+      homeApps: [
+        { packageName: 'com.example.alpha', position: 2 },
+        { packageName: 'com.example.beta', position: 0 },
+        { packageName: 'com.example.gamma', position: 1 },
+      ],
+    });
+
+    expect(order).toEqual(['Open Beta', 'Open Gamma', 'Open Alpha']);
+  });
+
+  it('instalação limpa (sem homeApps persistido) mantém a ordem de scan actual', async () => {
+    const order = await renderOrderedLabels({
+      nonDockApps: [alpha, beta, gamma],
+      homeApps: [],
+    });
+
+    expect(order).toEqual(['Open Alpha', 'Open Beta', 'Open Gamma']);
+  });
+});

--- a/src/store/AppsStore.tsx
+++ b/src/store/AppsStore.tsx
@@ -71,6 +71,30 @@ export function normalizeRecentApps(raw: unknown): RecentApp[] {
   return out.slice(0, MAX_RECENTS);
 }
 
+/**
+ * Garante que toda app em `apps` tem uma entrada em `homeApps` (#760).
+ *
+ * `homeApps` é a fonte de verdade da ordem/pertença na grelha (lida por
+ * LauncherHomeScreen), mas até este fix só era escrita por addToHome/
+ * removeFromHome — nunca por loadApps nem pelo listener de instalação — pelo
+ * que apps carregadas pelo scan nativo nunca tinham `position`. Qualquer app
+ * em falta recebe a próxima posição livre (`maxPos + 1`), na ordem em que
+ * aparece em `apps`: numa instalação limpa isso reproduz a ordem de scan
+ * actual (sem regressão visual); múltiplas apps em falta na mesma chamada
+ * recebem posições sequenciais sem colidir, porque o `maxPos` de referência é
+ * calculado uma única vez, antes do loop. Entradas já existentes em
+ * `homeApps` não são tocadas. Devolve a mesma referência quando não há nada a
+ * acrescentar, para não invalidar memoização a jusante.
+ */
+export function assignHomePositions(homeApps: HomeApp[], apps: InstalledApp[]): HomeApp[] {
+  const known = new Set(homeApps.map(h => h.packageName));
+  const missing = apps.filter(a => !known.has(a.packageName));
+  if (missing.length === 0) return homeApps;
+  let nextPosition = homeApps.reduce((max, h) => Math.max(max, h.position), -1) + 1;
+  const additions: HomeApp[] = missing.map(a => ({ packageName: a.packageName, position: nextPosition++ }));
+  return [...homeApps, ...additions];
+}
+
 // Dynamic import to avoid crashing the module on non-Android. Falls back to a
 // synchronous require when dynamic import() is unavailable (e.g. Jest's VM
 // without --experimental-vm-modules) so moduleNameMapper mocks still apply in tests.
@@ -389,6 +413,14 @@ export function AppsProvider({
     ).slice(0, 4); // max 4 in dock
   }, []);
 
+  // Moved above the install/uninstall effect below (was declared after it,
+  // near launchApp) so that effect's applyIndex() can persist homeApps
+  // position assignments (#760) without a temporal-dead-zone reference to a
+  // `const` declared later in the component body.
+  const persist = useCallback((dockApps: string[], homeApps: HomeApp[]) => {
+    AsyncStorage.setItem(STORAGE_KEY, JSON.stringify({ dockApps, homeApps }));
+  }, []);
+
   // Forma da máscara dos ícones (#482). Lida do módulo utils/iconShape (mesmo
   // padrão de utils/haptics): o SettingsStore publica-a lá, e este store
   // subscreve — sem acoplar o AppsProvider ao SettingsProvider.
@@ -454,6 +486,14 @@ export function AppsProvider({
     }
 
     if (cachedApps) {
+      // #760: cachedApps paints immediately, so it needs positions of its own
+      // rather than waiting for the native-scan branch below — otherwise the
+      // first paint after a fresh install (no homeApps persisted yet) would
+      // render with every app falling back to "no position" and jump once
+      // the scan-branch setState assigns real ones a moment later. Not
+      // persisted here: it's the ephemeral fast-paint state, immediately
+      // superseded by the canonical merge below.
+      homeApps = assignHomePositions(homeApps, cachedApps);
       setState(prev => ({
         ...prev,
         allApps: cachedApps,
@@ -491,10 +531,16 @@ export function AppsProvider({
           ? [...prev.libraryOnlyApps, ...seeded]
           : prev.libraryOnlyApps;
         if (seeded.length > 0) persistLibraryOnly(libraryOnlyApps);
+        // #760: assign a position to any app the saved layout doesn't know
+        // about yet — first-ever load (homeApps === []) or a package that
+        // was installed while the app wasn't running to catch the broadcast.
+        // In scan order, so a clean install reproduces today's visual order.
+        const mergedHomeApps = assignHomePositions(homeApps, apps);
+        if (mergedHomeApps !== homeApps) persist(dockApps, mergedHomeApps);
         return {
           ...prev,
           allApps: apps,
-          homeApps,
+          homeApps: mergedHomeApps,
           dockApps: resolveDock(apps, dockApps),
           isLoading: false,
           libraryOnlyApps,
@@ -509,7 +555,7 @@ export function AppsProvider({
         setState(prev => ({ ...prev, isLoading: false }));
       }
     }
-  }, [resolveDock, iconMask, iconTreatment, newAppsToHome, persistLibraryOnly]);
+  }, [resolveDock, iconMask, iconTreatment, newAppsToHome, persistLibraryOnly, persist]);
 
   // loadApps depende de iconMask, por isso mudar a forma ou o expoente volta a
   // pedir os ícones ao nativo com a chave de cache nova — a grelha actualiza sem
@@ -535,7 +581,12 @@ export function AppsProvider({
         const next = reduce(prev.allApps);
         if (next === prev.allApps) return prev;
         AsyncStorage.setItem(APPS_INDEX_KEY, JSON.stringify(next));
-        return { ...prev, allApps: next, dockApps: resolveDock(next, prev.dockApps) };
+        // #760: a package installed while the launcher is running (broadcast,
+        // not a fresh loadApps()) needs its own position — the removed case
+        // just shrinks `next`, so assignHomePositions is a no-op for it.
+        const homeApps = assignHomePositions(prev.homeApps, next);
+        if (homeApps !== prev.homeApps) persist(prev.dockApps, homeApps);
+        return { ...prev, allApps: next, homeApps, dockApps: resolveDock(next, prev.dockApps) };
       });
     };
 
@@ -569,11 +620,7 @@ export function AppsProvider({
       mounted = false;
       unsubscribe();
     };
-  }, [resolveDock, iconTreatment]);
-
-  const persist = useCallback((dockApps: string[], homeApps: HomeApp[]) => {
-    AsyncStorage.setItem(STORAGE_KEY, JSON.stringify({ dockApps, homeApps }));
-  }, []);
+  }, [resolveDock, iconTreatment, persist]);
 
   // Returns whether the launch actually succeeded (#509) — callers that show
   // an icon-expand transition need this to revert it on failure instead of

--- a/src/store/__tests__/AppsStore.packageEvents.test.tsx
+++ b/src/store/__tests__/AppsStore.packageEvents.test.tsx
@@ -155,6 +155,51 @@ describe('AppsStore — reacts to package install/uninstall broadcasts', () => {
     expect(result.current.apps.map(a => a.packageName)).toEqual(['com.example.cherry']);
   });
 
+  // #760: homeApps.position é a fonte de verdade da ordem/pertença — uma app
+  // instalada via broadcast (sem passar por loadApps) também precisa de uma
+  // entrada, senão fica sem posição atribuída até ao próximo arranque.
+  it('atribui a próxima position livre a uma app instalada via broadcast', async () => {
+    const { result } = renderHook(() => useApps(), { wrapper });
+    await act(async () => {});
+    await act(async () => {});
+    // cherry (única app do getInstalledApps deste ficheiro) já ganhou position: 0 no loadApps.
+    expect(result.current.homeApps).toEqual([{ packageName: 'com.example.cherry', position: 0 }]);
+
+    await act(async () => {
+      await getHandler()({ action: 'added', packageName: 'com.example.banana' });
+    });
+
+    expect(result.current.homeApps).toEqual(expect.arrayContaining([
+      { packageName: 'com.example.cherry', position: 0 },
+      { packageName: 'com.example.banana', position: 1 },
+    ]));
+  });
+
+  it('N instalações em rápida sucessão recebem positions sequenciais sem colidir', async () => {
+    (LauncherModule.getAppInfo as jest.Mock).mockImplementation((packageName: string) =>
+      Promise.resolve({ name: packageName, packageName, icon: '', isSystem: false }),
+    );
+    const { result } = renderHook(() => useApps(), { wrapper });
+    await act(async () => {});
+    await act(async () => {});
+
+    const handler = getHandler();
+    await act(async () => {
+      await Promise.all([
+        handler({ action: 'added', packageName: 'com.example.a1' }),
+        handler({ action: 'added', packageName: 'com.example.a2' }),
+        handler({ action: 'added', packageName: 'com.example.a3' }),
+      ]);
+    });
+
+    const positions = result.current.homeApps.map(h => h.position);
+    // Sem duplicados: cada app instalada em concorrência ficou com a sua própria position.
+    expect(new Set(positions).size).toBe(positions.length);
+    expect(result.current.homeApps.map(h => h.packageName)).toEqual(
+      expect.arrayContaining(['com.example.cherry', 'com.example.a1', 'com.example.a2', 'com.example.a3']),
+    );
+  });
+
   it('a removal for an unknown package leaves the list untouched', async () => {
     const { result } = renderHook(() => useApps(), { wrapper });
     await act(async () => {});

--- a/src/store/__tests__/AppsStore.test.tsx
+++ b/src/store/__tests__/AppsStore.test.tsx
@@ -474,6 +474,74 @@ describe('AppsStore — new apps destination (#601: newAppsToHome)', () => {
   });
 });
 
+// ─── #760: homeApps.position é a fonte de verdade da ordem/pertença ────────
+//
+// addToHome/removeFromHome já escreviam `position`, mas nada mais o fazia:
+// uma app carregada pelo scan nativo (loadApps) nunca ganhava entrada em
+// homeApps. Sem posição, LauncherHomeScreen não tem por onde ordenar a
+// grelha que não seja a ordem de scan — daí este fix atribuir a próxima
+// posição livre (maxPos + 1) a qualquer app em falta, na primeira leitura.
+describe('AppsStore — homeApps.position atribuída ao carregar (#760)', () => {
+  it('instalação limpa (sem homeApps persistido) atribui position sequencial na ordem de scan', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+    const apps = [
+      { name: 'Alpha', packageName: 'com.example.alpha', icon: '', isSystem: false },
+      { name: 'Beta', packageName: 'com.example.beta', icon: '', isSystem: false },
+      { name: 'Gamma', packageName: 'com.example.gamma', icon: '', isSystem: false },
+    ];
+    (LauncherModule.getInstalledApps as jest.Mock).mockResolvedValue(apps);
+
+    const { result } = renderHook(() => useApps(), { wrapper });
+    await act(async () => {});
+    await act(async () => {});
+
+    expect(result.current.homeApps).toEqual([
+      { packageName: 'com.example.alpha', position: 0 },
+      { packageName: 'com.example.beta', position: 1 },
+      { packageName: 'com.example.gamma', position: 2 },
+    ]);
+  });
+
+  it('uma app já com position guardada não é reatribuída, e as em falta continuam a partir do maxPos', async () => {
+    const savedLayout = JSON.stringify({
+      dockApps: [],
+      homeApps: [{ packageName: 'com.example.beta', position: 5 }],
+    });
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(savedLayout);
+    const apps = [
+      { name: 'Alpha', packageName: 'com.example.alpha', icon: '', isSystem: false },
+      { name: 'Beta', packageName: 'com.example.beta', icon: '', isSystem: false },
+    ];
+    (LauncherModule.getInstalledApps as jest.Mock).mockResolvedValue(apps);
+
+    const { result } = renderHook(() => useApps(), { wrapper });
+    await act(async () => {});
+    await act(async () => {});
+
+    // Beta mantém a position persistida (5); Alpha (nova para o homeApps) fica
+    // a seguir ao maxPos existente, não reinicia do zero.
+    expect(result.current.homeApps).toEqual(expect.arrayContaining([
+      { packageName: 'com.example.beta', position: 5 },
+      { packageName: 'com.example.alpha', position: 6 },
+    ]));
+  });
+
+  it('persiste o homeApps calculado para que o próximo arranque não repita o cálculo', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+    const apps = [{ name: 'Alpha', packageName: 'com.example.alpha', icon: '', isSystem: false }];
+    (LauncherModule.getInstalledApps as jest.Mock).mockResolvedValue(apps);
+
+    renderHook(() => useApps(), { wrapper });
+    await act(async () => {});
+    await act(async () => {});
+
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      '@iostoandroid/apps_layout',
+      JSON.stringify({ dockApps: ['com.iostoandroid.phone', 'com.iostoandroid.messages', 'com.iostoandroid.contacts', 'com.iostoandroid.settings'], homeApps: [{ packageName: 'com.example.alpha', position: 0 }] }),
+    );
+  });
+});
+
 describe('AppsStore — hide app (#606: App Library only, sem desinstalar)', () => {
   const banana = { name: 'Banana', packageName: 'com.example.banana', icon: 'file:///icons/b_1.png', isSystem: false };
   const cherry = { name: 'Cherry', packageName: 'com.example.cherry', icon: 'file:///icons/c_1.png', isSystem: false };


### PR DESCRIPTION
## Resumo

qa/issue-760: homeApps.position passa a ser a fonte de verdade da ordem da grelha do Launcher

## Causa raiz

`HomeApp.position` (src/store/AppsStore.tsx:32-35) era escrito por `addToHome`/`removeFromHome` (linhas ~598-619, na numeração pré-fix) mas nunca lido em lado nenhum, e nunca atribuído no carregamento normal das apps. `gridItems`/`allPages` em `src/screens/LauncherHomeScreen.tsx:1221-1274` iteravam `nonDockApps` (que vem de `AppsStore.tsx` filtrando `state.allApps` por dock/libraryOnly/hidden) na ordem em que o scan nativo devolveu os pacotes — a ordem de `position` nunca era consultada. Confirmado por grep: `addToHome`/`removeFromHome` só eram chamados a partir de `src/store/__tests__/AppsStore.test.tsx`, nunca de um caminho de produção real.

## O que mudou

**`src/store/AppsStore.tsx`**
- Nova função pura exportada `assignHomePositions(homeApps, apps)`: para cada app em `apps` sem entrada em `homeApps`, atribui a próxima posição livre (`maxPos + 1`, calculado uma única vez antes do loop, para que múltiplas apps em falta na mesma chamada recebam posições sequenciais sem colidir). Entradas já existentes não são tocadas; devolve a mesma referência quando não há nada a acrescentar.
- `loadApps`: tanto o "fast paint" a partir do índice em cache como o resultado do scan nativo passam por `assignHomePositions` antes de entrar no estado. O merge do scan nativo é persistido (`persist(dockApps, mergedHomeApps)`) quando muda, para o próximo arranque não repetir o cálculo.
- O listener de `addPackageChangedListener` (instalação/actualização em runtime, sem reiniciar a app) também chama `assignHomePositions` dentro de `applyIndex`, e persiste quando adiciona uma entrada nova — cobre uma app instalada enquanto o launcher está aberto, não só no arranque.
- `persist` (que grava `STORAGE_KEY`) foi movida para antes do `useEffect` de instalação/desinstalação, porque esse efeito passou a precisar dela e a declaração original (mais abaixo no componente, como `const`) causaria um erro de "usado antes de declarado".

**`src/screens/LauncherHomeScreen.tsx`**
- `homeApps` passou a ser lido de `useApps()`.
- Em `gridItems`, antes de empurrar as apps reais para a grelha, `nonDockApps` é copiado e ordenado por `position` (via `Map<packageName, position>`), com `Number.MAX_SAFE_INTEGER` como fallback estável para qualquer app sem entrada (não deveria acontecer depois do fix acima, mas mantém o `sort` estável — ou seja, sem regressão de ordem — nesse caso defensivo). Dock, pastas e apps virtuais/`BUILT_IN_APPS` continuam completamente fora desta indexação, tal como antes.
- `homeApps` foi acrescentado às dependências do `useMemo` de `gridItems`.

## Porque assim

A alternativa seria reordenar `nonDockApps` dentro do próprio `AppsStore` (no `useMemo` que já filtra dock/libraryOnly/hidden). Optei por manter essa reordenação no ecrã, como o próprio issue especifica ("gridItems/allPages... passam a ordenar"), porque `nonDockApps` é consumido por vários sítios (ex.: contagem de apps, pesquisa) onde a ordem de scan nativo continua a ser a semântica correta — só a apresentação da grelha do Launcher precisa da ordem posicional.

A atribuição de posições acontece em dois pontos (`loadApps` e o listener de package-changed) em vez de um único local centralizado, porque são dois caminhos de dados genuinamente distintos: um roda no arranque com o resultado completo do scan, o outro reage a um único pacote via broadcast sem nunca tocar no resto do índice (ver o comentário existente sobre o custo de scans completos, #485). `assignHomePositions` é a peça pura e testada partilhada pelos dois.

## Critérios de aceitação

- [x] `gridItems`/`allPages` ordenam por `homeApps.position`, não pela ordem de `state.allApps` — `LauncherHomeScreen.tsx` gridItems agora ordena `nonDockApps` por `position` antes de as empurrar para `items`.
- [x] Uma instalação limpa (sem `homeApps` persistido) produz a mesma ordem visível que hoje — `assignHomePositions([], apps)` atribui `0,1,2,...` na ordem de `apps` (= ordem de scan); testado em `AppsStore.test.tsx` e em `LauncherHomeScreen.homeAppsPosition.test.tsx`.
- [x] Instalar uma app nova atribui-lhe a próxima posição livre e ela aparece no fim da grelha — testado via o listener de `addPackageChangedListener` em `AppsStore.packageEvents.test.tsx`.
- [x] Nenhuma das ~15 suites `LauncherHomeScreen.*.test.tsx` existentes regride — todas já estubavam `homeApps: []` nos seus mocks de `useApps()`; com array vazio, o fallback (`MAX_SAFE_INTEGER` para todas) mantém o `sort` estável na ordem original. Confirmado a correr a suite completa (ver Testes).
- [x] `removeFromHome`/`hideApp`/`unhideApp` continuam com o comportamento actual (sem buracos ainda) — não tocados; os testes existentes em `AppsStore.test.tsx` (secções #601 e #606) continuam a passar sem alteração de asserções.

## Testes

**Passo vermelho** (fix revertido via `git stash push -u` só nos ficheiros de produção, testes mantidos):

```
FAIL Android src/screens/__tests__/LauncherHomeScreen.homeAppsPosition.test.tsx
  LauncherHomeScreen — a grelha ordena por homeApps.position (#760)
    ✕ ordena por position quando diverge da ordem de scan (allApps/nonDockApps)

  ● ... › ordena por position quando diverge da ordem de scan (allApps/nonDockApps)

    expect(received).toEqual(expected) // deep equality
    - Expected  - 1
    + Received  + 1
      Array [
    +   "Open Alpha",
        "Open Beta",
        "Open Gamma",
    -   "Open Alpha",
      ]
      72 |     expect(order).toEqual(['Open Beta', 'Open Gamma', 'Open Alpha']);
         |                   ^

FAIL Android src/store/__tests__/AppsStore.test.tsx
  AppsStore — homeApps.position atribuída ao carregar (#760)
    ✕ instalação limpa (sem homeApps persistido) atribui position sequencial na ordem de scan
    ✕ uma app já com position guardada não é reatribuída, e as em falta continuam a partir do maxPos
    ✕ persiste o homeApps calculado para que o próximo arranque não repita o cálculo

FAIL Android src/store/__tests__/AppsStore.packageEvents.test.tsx
  AppsStore — reacts to package install/uninstall broadcasts
    ✕ atribui a próxima position livre a uma app instalada via broadcast
    ✕ N instalações em rápida sucessão recebem positions sequenciais sem colidir

Tests: 6 failed, 40 passed (nos 3 ficheiros), pela razão certa: sem o fix `homeApps` fica `[]` (ninguém a povoa) e a grelha usa sempre a ordem de scan.
```

Com o fix restaurado, os mesmos 3 ficheiros: `2 passed` / `33 passed` / `11 passed` — todos verdes.

**Casos cobertos** (além do caminho feliz):
- Ordem de posição divergente da ordem de scan (o caso central do issue).
- Instalação limpa sem regressão visual (homeApps vazio → ordem de scan preservada).
- App já com `position` persistida não é reatribuída; uma app em falta soma a partir do `maxPos` existente, não reinicia do zero.
- Persistência do `homeApps` calculado (para não recalcular no próximo arranque).
- Instalação via broadcast (sem reiniciar a app) recebe a próxima posição livre.
- N instalações concorrentes (`Promise.all` de 3 handlers) não colidem em posição — prova directa do critério "duas apps instaladas na mesma sessão sem position prévio não podem colidir".

**Sanity-check:** `git stash push -u -m "issue-760-temp-revert-prod-fix" -- src/screens/LauncherHomeScreen.tsx src/store/AppsStore.tsx`, corri os 3 ficheiros de teste (6 falhas, ver passo vermelho acima), depois `git stash apply <sha>` para restaurar o fix e `git stash drop <sha>` para limpar a stash partilhada. Confirmei com `git rev-parse stash@{0}` antes de dropar, para não apagar trabalho de outra worktree.

**Verificações:**
- `npm run lint`: 0 erros (7 warnings pré-existentes, nenhum nos ficheiros tocados).
- `npx tsc --noEmit`: limpo.
- `npm test -- --maxWorkers=2`: 2001 passaram, 23 falharam, 216 suites (210 passaram) — os mesmos 23 testes da linha de base (`baseline.json`), byte a byte iguais por nome; nenhuma falha nova.

## Testes

2001 passaram, 23 falharam (idênticos à baseline pré-existente), 216 suites (210 passaram, 6 falharam — mesmas 6 da baseline)

## Linked Issue

Fixes #760